### PR TITLE
feat(scripts): add interactive Win11 validation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ CMakeFiles/
 /build.zig.zon.bak
 /result*
 /.nixos-test-history
+/.sandbox/
 example/*.wasm
 test/ghostty
 test/cases/**/*.actual.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-04-18: In PowerShell interpolated strings, wrap a variable in `${...}` before a literal colon (`:`); `"$path: $value"` parses `$path:` as a scoped variable and fails.
 - 2026-04-12: Once Win32 can stay alive with zero windows, `wakeup()` must post to the UI thread queue, not only a window HWND, or mailbox work and quit timers will stall headless.
 - 2026-04-12: GDI brush handles (HBRUSH) returned from `WM_CTLCOLOR*` handlers must use `@bitCast` not `@intCast` to convert to LRESULT; GDI handles can have the high bit set on x64, causing `@intCast` to panic.
 - 2026-04-14: On Win32, hiding a surface HWND is not enough; tab/window visibility changes must also drive `core_surface.occlusionCallback` or hidden tabs keep rendering and can crash the WGL/NVIDIA present path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-04-18: In Win32 path-normalization helpers, never blindly `TrimEnd('\')` on a fully-qualified path; preserve drive and UNC roots (`C:\`, `\\server\share\`) or you silently turn rooted paths into relative ones.
 - 2026-04-18: In PowerShell interpolated strings, wrap a variable in `${...}` before a literal colon (`:`); `"$path: $value"` parses `$path:` as a scoped variable and fails.
 - 2026-04-12: Once Win32 can stay alive with zero windows, `wakeup()` must post to the UI thread queue, not only a window HWND, or mailbox work and quit timers will stall headless.
 - 2026-04-12: GDI brush handles (HBRUSH) returned from `WM_CTLCOLOR*` handlers must use `@bitCast` not `@intCast` to convert to LRESULT; GDI handles can have the high bit set on x64, causing `@intCast` to panic.

--- a/HACKING.md
+++ b/HACKING.md
@@ -42,6 +42,14 @@ The repo also ships `scripts/dev-windows.ps1` and `scripts/dev-windows.cmd`
 to open a Windows-native shell with the expected Visual Studio and Zig cache
 environment already configured.
 
+For manual app validation on Windows, use
+`powershell -ExecutionPolicy Bypass -File scripts/interactive-win11.ps1`.
+This launches the worktree executable with repo-local runtime state under
+`.sandbox/win11/<worktree-id>/` instead of global `%LOCALAPPDATA%\winghostty`.
+Pass `-Rebuild` when you need a fresh executable after source edits. Use
+`-ResetState` for clean first-run repros and `-OpenShell` to open a shell with
+the same sandbox environment.
+
 ## Runtime Notes
 
 - The application runtime is Win32.
@@ -87,7 +95,8 @@ If your change touches input, rendering, or chrome behavior, manually verify:
 2. Precision touchpad scrolling, if available.
 3. Fast sustained scrolling for flicker, title churn, or dropped repaint.
 4. Keybindings affected by the change.
-5. A fresh `zig build -Demit-exe=true` launch of `zig-out/bin/winghostty.exe`.
+5. Launch `scripts/interactive-win11.ps1 -Rebuild`; add `-ResetState` when
+   validating first-run behavior.
 
 ## Scope Guard
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -50,6 +50,10 @@ Pass `-Rebuild` when you need a fresh executable after source edits. Use
 `-ResetState` for clean first-run repros and `-OpenShell` to open a shell with
 the same sandbox environment.
 
+For a mechanical smoke check that the launched app can start its initial
+terminal under the same sandboxed env, run
+`powershell -ExecutionPolicy Bypass -File test/windows/interactive-win11-smoke.ps1`.
+
 ## Runtime Notes
 
 - The application runtime is Win32.

--- a/docs/superpowers/specs/2026-04-17-interactive-win11-validation-design.md
+++ b/docs/superpowers/specs/2026-04-17-interactive-win11-validation-design.md
@@ -1,0 +1,321 @@
+# Interactive Win11 Validation Environment Design
+
+Date: 2026-04-17
+Status: Draft
+Scope: Repo-owned local harness for manual interactive Windows validation
+
+## Problem
+
+Agents and contributors can build and unit-test `winghostty`, but many worktrees
+do not have a repeatable way to launch the app in an isolated Windows runtime
+state for manual validation. The common result is a turn-ending caveat like
+"interactive Win11 validation in this environment" because the repo provides
+build-shell helpers, not an interactive validation harness.
+
+The missing capability is narrower than VM provisioning and broader than
+"double-click the exe": we need a repo-owned command that launches the current
+worktree's build in a predictable, isolated, resettable Windows sandbox so a
+human or agent can manually exercise the app.
+
+## Goals
+
+- Provide a one-command path to launch `winghostty` for manual interactive
+  validation on Windows 11.
+- Isolate app runtime state per worktree so `main` and sibling worktrees do not
+  clobber one another's config, cache, MRU, shell-integration payloads, crash
+  files, or logs.
+- Reuse the repo's existing Windows toolchain bootstrap instead of inventing a
+  second environment bootstrap path.
+- Make first-run reproduction cheap via a resettable sandbox.
+- Keep the implementation repo-local, low-dependency, and understandable by
+  contributors who are not using Codex.
+
+## Non-Goals
+
+- Provisioning a VM, Hyper-V guest, remote desktop, or disposable Windows
+  image.
+- Automating UI interaction or asserting GUI correctness.
+- Replacing targeted Zig tests or CI checks.
+- Creating a release-packaging workflow. This harness validates the worktree
+  build, not the installer.
+- Overriding the user's full Windows profile by default.
+
+## User Stories
+
+- As a contributor in a worktree, I can run one script and get an isolated
+  `winghostty.exe` instance for manual testing.
+- As an agent working in a detached worktree, I can launch the app without
+  polluting `%LOCALAPPDATA%\winghostty` used by another branch.
+- As a debugger reproducing a first-run bug, I can wipe only this worktree's
+  runtime state and relaunch.
+- As a contributor investigating a shell/profile/config issue, I can open a
+  shell with the exact same sandbox environment that the launcher uses.
+
+## Proposed Solution
+
+Add a repo-owned interactive validation harness:
+
+- `scripts/interactive-win11.ps1`
+- `scripts/interactive-win11.cmd`
+
+The PowerShell script is the real implementation. The `.cmd` file is a thin
+wrapper for users who launch from `cmd.exe` or File Explorer.
+
+The harness will:
+
+1. Resolve the current worktree root.
+2. Derive a stable sandbox path under:
+   `.sandbox/win11/<worktree-id>/`
+3. Create the sandbox directory structure.
+4. Reuse the existing Windows bootstrap conventions from `scripts/dev-windows.*`
+   so toolchain discovery stays consistent.
+5. Optionally build `zig-out/bin/winghostty.exe` if requested or if the binary
+   is missing.
+6. Launch `zig-out/bin/winghostty.exe` with environment overrides that redirect
+   app state into the sandbox.
+7. Optionally open an interactive shell with the same environment.
+
+## Sandbox Model
+
+Each worktree gets a stable sandbox rooted at:
+
+```text
+<repo>\.sandbox\win11\<worktree-id>\
+```
+
+`<worktree-id>` should be deterministic for the current worktree path and safe
+for Windows paths. A simple implementation is:
+
+- canonical worktree path
+- normalize path separators
+- hash that normalized path
+- combine a short slug plus a short hash suffix
+
+Example layout:
+
+```text
+.sandbox/win11/<worktree-id>/
+  appdata/
+  localappdata/
+  cache/
+  state/
+  temp/
+  logs/
+```
+
+Runtime paths within that sandbox:
+
+- `APPDATA` -> `.sandbox/win11/<id>/appdata`
+- `LOCALAPPDATA` -> `.sandbox/win11/<id>/localappdata`
+- `XDG_CONFIG_HOME` -> `.sandbox/win11/<id>/localappdata`
+- `XDG_CACHE_HOME` -> `.sandbox/win11/<id>/cache`
+- `XDG_STATE_HOME` -> `.sandbox/win11/<id>/state`
+- `TEMP` / `TMP` -> `.sandbox/win11/<id>/temp`
+
+This aligns with existing app behavior:
+
+- config defaults to `$LOCALAPPDATA/winghostty/config.ghostty`
+- shell integration installs under `%LOCALAPPDATA%\winghostty\shell-integration`
+- MRU persists under `%LOCALAPPDATA%\winghostty\palette-mru.txt`
+- crash/state files already follow XDG / local-app-data style resolution
+
+## Deliberate Environment Choice
+
+The harness will **not** override `USERPROFILE`, `HOMEDRIVE`, or `HOMEPATH` by
+default.
+
+Reasoning:
+
+- The target is app-state isolation, not full user-profile emulation.
+- Keeping the real Windows user profile makes child shells and user-installed
+  tools behave normally during manual testing.
+- `winghostty` already resolves its state/config paths through
+  `LOCALAPPDATA` / XDG-style directories, so overriding those variables is
+  sufficient for the primary isolation goal.
+
+If full-profile isolation is ever needed later, it should be an explicit opt-in
+mode rather than the default.
+
+## CLI Surface
+
+Expected operator entrypoints:
+
+```powershell
+scripts/interactive-win11.ps1
+scripts/interactive-win11.ps1 -Rebuild
+scripts/interactive-win11.ps1 -ResetState
+scripts/interactive-win11.ps1 -OpenShell
+scripts/interactive-win11.ps1 -NoBuild
+```
+
+Semantics:
+
+- default: launch the app in the sandbox, building only if needed
+- `-Rebuild`: force `zig build -Demit-exe=true` before launch
+- `-ResetState`: remove this worktree's sandbox state before continuing
+- `-OpenShell`: open a Windows shell with the same sandbox env instead of
+  launching the app directly
+- `-NoBuild`: fail if the binary is missing instead of building it
+
+The `.cmd` wrapper should forward arguments to the PowerShell script.
+
+## Implementation Outline
+
+### `scripts/interactive-win11.ps1`
+
+Core responsibilities:
+
+- resolve repo root from the script location
+- compute `worktree-id`
+- create sandbox directories
+- assemble the sandbox environment block
+- validate prerequisites using the same conventions as `dev-windows`
+- launch one of:
+  - `zig build -Demit-exe=true`
+  - `zig-out/bin/winghostty.exe`
+  - an interactive shell in sandbox mode
+
+Implementation should prefer:
+
+- explicit parameters
+- narrow helper functions
+- logging the effective sandbox paths before launch
+- `Start-Process` for GUI launch so the calling shell is not tied to the app
+
+### `scripts/interactive-win11.cmd`
+
+Responsibilities:
+
+- locate the PowerShell script next to itself
+- invoke it with `-ExecutionPolicy Bypass`
+- forward all arguments unchanged
+
+### Docs
+
+Update:
+
+- `HACKING.md` with a new "Interactive Win11 Validation" section
+
+Add:
+
+- brief dedicated doc if needed, but prefer keeping the first implementation
+  documented in `HACKING.md` unless that file becomes noisy
+
+## Build And Launch Policy
+
+The harness should not always rebuild.
+
+Default policy:
+
+- if `zig-out/bin/winghostty.exe` exists, launch it
+- if missing, build it with `zig build -Demit-exe=true`
+- if `-Rebuild` is set, always rebuild first
+- if `-NoBuild` is set and the binary is missing, fail with an actionable error
+
+This keeps the manual loop fast while still giving contributors a one-command
+happy path from a fresh worktree.
+
+## Reset Semantics
+
+`-ResetState` removes only:
+
+```text
+.sandbox/win11/<worktree-id>/
+```
+
+It must not touch:
+
+- the global `%LOCALAPPDATA%\winghostty`
+- sibling worktree sandboxes
+- `.zig-cache`
+- `zig-out`
+
+The purpose is clean runtime-state reproduction, not full build cleanup.
+
+## Logging
+
+The launcher should print:
+
+- repo root
+- resolved sandbox root
+- effective `LOCALAPPDATA`
+- effective `APPDATA`
+- whether it is building, launching, or opening a shell
+
+Optional follow-up: persist a small launcher log under:
+
+```text
+.sandbox/win11/<worktree-id>/logs/
+```
+
+This is useful but not required in the first pass if console output is already
+clear.
+
+## Failure Handling
+
+Expected failures should be actionable:
+
+- missing Visual Studio dev shell bootstrap
+- missing Git for Windows runtime
+- missing Zig
+- failed `zig build`
+- missing `winghostty.exe` when `-NoBuild` is used
+
+Failure messages should tell the operator exactly which path or tool is
+missing and what command to run next.
+
+## Testing Strategy
+
+This feature is primarily an operator harness, so tests should focus on
+deterministic helper logic rather than GUI automation.
+
+Recommended coverage:
+
+- path-to-worktree-id normalization and stability
+- sandbox path construction
+- argument-surface behavior for conflicting flags
+- reset target confinement to the current worktree sandbox
+
+Manual verification checklist for the first implementation:
+
+1. Run the launcher from a fresh worktree with no existing sandbox.
+2. Confirm the script creates `.sandbox/win11/<id>/...`.
+3. Confirm first launch writes config under the sandboxed `LOCALAPPDATA`, not
+   the user's global `%LOCALAPPDATA%\winghostty`.
+4. Confirm `-ResetState` recreates a clean first-run experience.
+5. Confirm `-OpenShell` exposes the same sandbox env variables.
+6. Confirm sibling worktrees produce different sandbox roots.
+
+## Acceptance Criteria
+
+- A contributor on Windows can launch `winghostty` for manual testing with one
+  repo-owned command.
+- The launched app uses a stable per-worktree sandbox under
+  `.sandbox/win11/<worktree-id>/`.
+- Runtime state from one worktree does not overwrite runtime state from another
+  worktree.
+- The harness supports clean-state reproduction without deleting global app
+  state.
+- Repo docs point future agents and contributors to this harness as the default
+  path for interactive Win11 validation.
+
+## Risks
+
+- Some downstream child processes may still consult non-overridden user-profile
+  locations. This is acceptable for v1 because the requirement is app-state
+  isolation, not total system emulation.
+- A poor `worktree-id` scheme could create collisions or unreadable paths.
+  The implementation should keep the human-readable slug short and rely on a
+  hash suffix for uniqueness.
+- Reusing `dev-windows` logic by copy-paste could create drift. Prefer shared
+  conventions and minimal duplication.
+
+## Recommendation
+
+Implement the harness as a PowerShell-first repo script with a `.cmd` wrapper,
+per-worktree sandboxing under `.sandbox/win11/<worktree-id>/`, and explicit
+support for launch, rebuild, reset, and sandbox-shell workflows.
+
+This is the smallest change that closes the real workflow gap: future agents
+and contributors get a concrete, documented, repeatable way to interactively
+validate the Windows app from any worktree without trampling shared state.

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -96,6 +96,17 @@ function Get-InteractiveWin11Environment {
     }
 }
 
+function Get-InteractiveWin11LaunchArguments {
+    param(
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
+    )
+
+    return @(
+        '--single-instance=false'
+        "--class=winghostty-interactive-$($Layout.WorktreeId)"
+    )
+}
+
 function Get-InteractiveWin11LaunchAction {
     param(
         [Parameter(Mandatory)] [string] $ExePath,

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -3,8 +3,14 @@ function Get-InteractiveWin11NormalizedPath {
         [Parameter(Mandatory)] [string] $Path
     )
 
-    $full = [System.IO.Path]::GetFullPath($Path)
-    return $full.TrimEnd('\').Replace('/', '\')
+    $full = [System.IO.Path]::GetFullPath($Path).Replace('/', '\')
+    $root = [System.IO.Path]::GetPathRoot($full).Replace('/', '\')
+
+    if ($full.Length -gt $root.Length) {
+        return $full.TrimEnd('\')
+    }
+
+    return $full
 }
 
 function Get-InteractiveWin11WorktreeId {

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = 'Stop'
-
 function Get-InteractiveWin11NormalizedPath {
     param(
         [Parameter(Mandatory)] [string] $Path
@@ -76,7 +74,7 @@ function New-InteractiveWin11Sandbox {
         $Layout.Temp,
         $Layout.Logs
     )) {
-        New-Item -ItemType Directory -Force -Path $path | Out-Null
+        New-Item -ItemType Directory -Force -Path $path -ErrorAction Stop | Out-Null
     }
 }
 
@@ -147,7 +145,7 @@ function Reset-InteractiveWin11Sandbox {
         throw "Refusing to reset sandbox outside ${sandboxBase}: $target"
     }
 
-    if (Test-Path -LiteralPath $target) {
-        Remove-Item -LiteralPath $target -Recurse -Force
+    if (Test-Path -LiteralPath $target -ErrorAction Stop) {
+        Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction Stop
     }
 }

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -1,0 +1,115 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-InteractiveWin11NormalizedPath {
+    param(
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    return $full.TrimEnd('\').Replace('/', '\')
+}
+
+function Get-InteractiveWin11WorktreeId {
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot
+    )
+
+    $normalized = Get-InteractiveWin11NormalizedPath -Path $RepoRoot
+    $leaf = Split-Path -Path $normalized -Leaf
+    $parentLeaf = Split-Path -Path (Split-Path -Path $normalized -Parent) -Leaf
+    $slugSource = "$parentLeaf-$leaf".ToLowerInvariant()
+    $slug = ($slugSource -replace '[^a-z0-9.-]', '-').Trim('-')
+    if ([string]::IsNullOrWhiteSpace($slug)) {
+        $slug = 'worktree'
+    }
+    if ($slug.Length -gt 32) {
+        $slug = $slug.Substring(0, 32).TrimEnd('-')
+    }
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalized.ToLowerInvariant())
+        $hash = [System.BitConverter]::ToString($sha256.ComputeHash($bytes)).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha256.Dispose()
+    }
+
+    return '{0}-{1}' -f $slug, $hash.Substring(0, 12)
+}
+
+function Get-InteractiveWin11SandboxLayout {
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot
+    )
+
+    $normalizedRepoRoot = Get-InteractiveWin11NormalizedPath -Path $RepoRoot
+    $worktreeId = Get-InteractiveWin11WorktreeId -RepoRoot $normalizedRepoRoot
+    $sandboxRoot = Join-Path $normalizedRepoRoot ".sandbox\win11\$worktreeId"
+    $localAppData = Join-Path $sandboxRoot 'localappdata'
+
+    return [ordered]@{
+        RepoRoot      = $normalizedRepoRoot
+        WorktreeId    = $worktreeId
+        SandboxRoot   = $sandboxRoot
+        AppData       = Join-Path $sandboxRoot 'appdata'
+        LocalAppData  = $localAppData
+        XdgConfigHome = $localAppData
+        XdgCacheHome  = Join-Path $sandboxRoot 'cache'
+        XdgStateHome  = Join-Path $sandboxRoot 'state'
+        Temp          = Join-Path $sandboxRoot 'temp'
+        Logs          = Join-Path $sandboxRoot 'logs'
+    }
+}
+
+function New-InteractiveWin11Sandbox {
+    param(
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
+    )
+
+    foreach ($path in @(
+        $Layout.SandboxRoot,
+        $Layout.AppData,
+        $Layout.LocalAppData,
+        $Layout.XdgCacheHome,
+        $Layout.XdgStateHome,
+        $Layout.Temp,
+        $Layout.Logs
+    )) {
+        New-Item -ItemType Directory -Force -Path $path | Out-Null
+    }
+}
+
+function Get-InteractiveWin11Environment {
+    param(
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
+    )
+
+    return [ordered]@{
+        APPDATA         = $Layout.AppData
+        LOCALAPPDATA    = $Layout.LocalAppData
+        XDG_CONFIG_HOME = $Layout.XdgConfigHome
+        XDG_CACHE_HOME  = $Layout.XdgCacheHome
+        XDG_STATE_HOME  = $Layout.XdgStateHome
+        TEMP            = $Layout.Temp
+        TMP             = $Layout.Temp
+    }
+}
+
+function Reset-InteractiveWin11Sandbox {
+    param(
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
+    )
+
+    $sandboxBase = Get-InteractiveWin11NormalizedPath -Path (Join-Path $Layout.RepoRoot '.sandbox\win11')
+    $target = Get-InteractiveWin11NormalizedPath -Path $Layout.SandboxRoot
+    $sandboxPrefix = '{0}\' -f $sandboxBase
+
+    if (-not $target.StartsWith($sandboxPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to reset sandbox outside ${sandboxBase}: $target"
+    }
+
+    if (Test-Path -LiteralPath $target) {
+        Remove-Item -LiteralPath $target -Recurse -Force
+    }
+}

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -96,6 +96,33 @@ function Get-InteractiveWin11Environment {
     }
 }
 
+function Get-InteractiveWin11LaunchAction {
+    param(
+        [Parameter(Mandatory)] [string] $ExePath,
+        [switch] $Rebuild,
+        [switch] $NoBuild
+    )
+
+    $resolvedExePath = Get-InteractiveWin11NormalizedPath -Path $ExePath
+    if ($Rebuild -and $NoBuild) {
+        throw 'Cannot use -Rebuild with -NoBuild together.'
+    }
+
+    if ($Rebuild) {
+        return 'build'
+    }
+
+    if ([System.IO.File]::Exists($resolvedExePath)) {
+        return 'launch'
+    }
+
+    if ($NoBuild) {
+        throw "Missing winghostty.exe at $resolvedExePath"
+    }
+
+    return 'build'
+}
+
 function Reset-InteractiveWin11Sandbox {
     param(
         [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout

--- a/scripts/interactive-win11.cmd
+++ b/scripts/interactive-win11.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0interactive-win11.ps1" %*
+exit /b %ERRORLEVEL%

--- a/scripts/interactive-win11.ps1
+++ b/scripts/interactive-win11.ps1
@@ -78,6 +78,7 @@ if ($OpenShell) {
 
 $exePath = Get-InteractiveWin11NormalizedPath -Path (Join-Path $repoRoot 'zig-out\bin\winghostty.exe')
 $launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -NoBuild:$NoBuild
+$launchArgs = Get-InteractiveWin11LaunchArguments -Layout $layout
 
 if ($launchAction -eq 'build') {
     Push-Location $repoRoot
@@ -96,4 +97,4 @@ if (-not [System.IO.File]::Exists($exePath)) {
     throw "Missing winghostty.exe at $exePath"
 }
 
-Start-Process -FilePath $exePath -WorkingDirectory $repoRoot | Out-Null
+Start-Process -FilePath $exePath -ArgumentList $launchArgs -WorkingDirectory $repoRoot | Out-Null

--- a/scripts/interactive-win11.ps1
+++ b/scripts/interactive-win11.ps1
@@ -22,12 +22,13 @@ if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED) {
     if ($NoBuild) { $forwardedArgs += '-NoBuild' }
 
     $bootstrapCmd = Join-Path $PSScriptRoot 'dev-windows.cmd'
+    $quotedLauncherPath = '"{0}"' -f $launcherPath
     $exitCode = 0
     $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED = '1'
 
     Push-Location $repoRoot
     try {
-        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $launcherPath @forwardedArgs
+        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $quotedLauncherPath @forwardedArgs
         if ($null -ne $LASTEXITCODE) {
             $exitCode = $LASTEXITCODE
         }

--- a/scripts/interactive-win11.ps1
+++ b/scripts/interactive-win11.ps1
@@ -1,0 +1,99 @@
+param(
+    [switch] $Rebuild,
+    [switch] $ResetState,
+    [switch] $OpenShell,
+    [switch] $NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Rebuild -and $NoBuild) {
+    throw 'Cannot use -Rebuild with -NoBuild together.'
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$launcherPath = Join-Path $PSScriptRoot 'interactive-win11.ps1'
+
+if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED) {
+    $forwardedArgs = @()
+    if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+    if ($ResetState) { $forwardedArgs += '-ResetState' }
+    if ($OpenShell) { $forwardedArgs += '-OpenShell' }
+    if ($NoBuild) { $forwardedArgs += '-NoBuild' }
+
+    $bootstrapCmd = Join-Path $PSScriptRoot 'dev-windows.cmd'
+    $exitCode = 0
+    $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED = '1'
+
+    Push-Location $repoRoot
+    try {
+        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $launcherPath @forwardedArgs
+        if ($null -ne $LASTEXITCODE) {
+            $exitCode = $LASTEXITCODE
+        }
+    }
+    finally {
+        Pop-Location
+        Remove-Item Env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED -ErrorAction SilentlyContinue
+    }
+
+    exit $exitCode
+}
+
+$libPath = Join-Path $PSScriptRoot 'interactive-win11-lib.ps1'
+. $libPath
+
+$repoRoot = Get-InteractiveWin11NormalizedPath -Path $repoRoot
+$layout = Get-InteractiveWin11SandboxLayout -RepoRoot $repoRoot
+
+if ($ResetState) {
+    Reset-InteractiveWin11Sandbox -Layout $layout
+}
+
+New-InteractiveWin11Sandbox -Layout $layout
+
+$sandboxEnv = Get-InteractiveWin11Environment -Layout $layout
+foreach ($entry in $sandboxEnv.GetEnumerator()) {
+    [System.Environment]::SetEnvironmentVariable([string] $entry.Key, [string] $entry.Value, 'Process')
+}
+
+if ($OpenShell) {
+    Write-Host "RepoRoot: $($layout.RepoRoot)"
+    Write-Host "WorktreeId: $($layout.WorktreeId)"
+    Write-Host "SandboxRoot: $($layout.SandboxRoot)"
+    foreach ($entry in $sandboxEnv.GetEnumerator()) {
+        Write-Host "$($entry.Key)=$($entry.Value)"
+    }
+
+    Push-Location $repoRoot
+    try {
+        & cmd.exe /k
+    }
+    finally {
+        Pop-Location
+    }
+
+    exit 0
+}
+
+$exePath = Get-InteractiveWin11NormalizedPath -Path (Join-Path $repoRoot 'zig-out\bin\winghostty.exe')
+$launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -NoBuild:$NoBuild
+
+if ($launchAction -eq 'build') {
+    Push-Location $repoRoot
+    try {
+        & zig build -Demit-exe=true
+        if ($LASTEXITCODE -ne 0) {
+            throw "zig build -Demit-exe=true failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if (-not [System.IO.File]::Exists($exePath)) {
+    throw "Missing winghostty.exe at $exePath"
+}
+
+Start-Process -FilePath $exePath -WorkingDirectory $repoRoot | Out-Null

--- a/scripts/interactive-win11.ps1
+++ b/scripts/interactive-win11.ps1
@@ -12,7 +12,7 @@ if ($Rebuild -and $NoBuild) {
 }
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$launcherPath = Join-Path $PSScriptRoot 'interactive-win11.ps1'
+$launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
 
 if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED) {
     $forwardedArgs = @()
@@ -22,13 +22,12 @@ if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED) {
     if ($NoBuild) { $forwardedArgs += '-NoBuild' }
 
     $bootstrapCmd = Join-Path $PSScriptRoot 'dev-windows.cmd'
-    $quotedLauncherPath = '"{0}"' -f $launcherPath
     $exitCode = 0
     $env:WINGHOSTTY_INTERACTIVE_WIN11_BOOTSTRAPPED = '1'
 
     Push-Location $repoRoot
     try {
-        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $quotedLauncherPath @forwardedArgs
+        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $launcherPath @forwardedArgs
         if ($null -ne $LASTEXITCODE) {
             $exitCode = $LASTEXITCODE
         }

--- a/test/windows/interactive-win11-smoke.ps1
+++ b/test/windows/interactive-win11-smoke.ps1
@@ -1,0 +1,150 @@
+param(
+    [switch] $Rebuild,
+    [switch] $ResetState,
+    [int] $TimeoutSeconds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TimeoutSeconds -le 0) {
+    throw 'TimeoutSeconds must be greater than 0.'
+}
+
+$launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+
+if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_SMOKE_BOOTSTRAPPED) {
+    $forwardedArgs = @('-TimeoutSeconds', $TimeoutSeconds.ToString())
+    if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+    if ($ResetState) { $forwardedArgs += '-ResetState' }
+
+    $bootstrapCmd = Join-Path $repoRoot 'scripts\dev-windows.cmd'
+    $exitCode = 0
+    $env:WINGHOSTTY_INTERACTIVE_WIN11_SMOKE_BOOTSTRAPPED = '1'
+
+    Push-Location $repoRoot
+    try {
+        & $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $launcherPath @forwardedArgs
+        if ($null -ne $LASTEXITCODE) {
+            $exitCode = $LASTEXITCODE
+        }
+    }
+    finally {
+        Pop-Location
+        Remove-Item Env:WINGHOSTTY_INTERACTIVE_WIN11_SMOKE_BOOTSTRAPPED -ErrorAction SilentlyContinue
+    }
+
+    exit $exitCode
+}
+
+$libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+. $libPath
+
+$repoRoot = Get-InteractiveWin11NormalizedPath -Path $repoRoot
+$layout = Get-InteractiveWin11SandboxLayout -RepoRoot $repoRoot
+
+if ($ResetState) {
+    Reset-InteractiveWin11Sandbox -Layout $layout
+}
+
+New-InteractiveWin11Sandbox -Layout $layout
+
+$sandboxEnv = Get-InteractiveWin11Environment -Layout $layout
+foreach ($entry in $sandboxEnv.GetEnumerator()) {
+    [System.Environment]::SetEnvironmentVariable([string] $entry.Key, [string] $entry.Value, 'Process')
+}
+
+$exePath = Get-InteractiveWin11NormalizedPath -Path (Join-Path $repoRoot 'zig-out\bin\winghostty.exe')
+$launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild
+$launchArgs = @(Get-InteractiveWin11LaunchArguments -Layout $layout)
+$stdoutPath = Join-Path $layout.Logs 'interactive-win11-smoke-stdout.log'
+$stderrPath = Join-Path $layout.Logs 'interactive-win11-smoke-stderr.log'
+
+if ($launchAction -eq 'build') {
+    Push-Location $repoRoot
+    try {
+        & zig build -Demit-exe=true
+        if ($LASTEXITCODE -ne 0) {
+            throw "zig build -Demit-exe=true failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if (-not [System.IO.File]::Exists($exePath)) {
+    throw "Missing winghostty.exe at $exePath"
+}
+
+Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+
+$process = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList $launchArgs `
+    -WorkingDirectory $repoRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -PassThru
+
+$successPattern = 'started subcommand path='
+$failurePattern = 'error starting IO thread:'
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+$smokePassed = $false
+$failureReason = $null
+
+try {
+    while ([DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 250
+
+        $stderr = if (Test-Path -LiteralPath $stderrPath) {
+            Get-Content -LiteralPath $stderrPath -Raw
+        } else {
+            ''
+        }
+
+        if ($stderr.Contains($successPattern)) {
+            $smokePassed = $true
+            break
+        }
+
+        if ($stderr.Contains($failurePattern)) {
+            $failureReason = 'terminal startup failure detected in stderr log'
+            break
+        }
+
+        if ($process.HasExited) {
+            $failureReason = "winghostty exited before shell startup was observed (exit code $($process.ExitCode))"
+            break
+        }
+    }
+}
+finally {
+    if (-not $process.HasExited) {
+        Stop-Process -Id $process.Id -Force
+        $process.WaitForExit()
+    }
+}
+
+if (-not $smokePassed) {
+    if (-not $failureReason) {
+        $failureReason = "timed out after $TimeoutSeconds seconds waiting for initial shell startup"
+    }
+
+    $stderrTail = if (Test-Path -LiteralPath $stderrPath) {
+        (Get-Content -LiteralPath $stderrPath | Select-Object -Last 40) -join [Environment]::NewLine
+    } else {
+        '<stderr log missing>'
+    }
+
+    throw @"
+interactive Win11 smoke test failed: $failureReason
+stderr log: $stderrPath
+stdout log: $stdoutPath
+
+Recent stderr:
+$stderrTail
+"@
+}
+
+Write-Host "interactive-win11 smoke test: PASS ($stderrPath)"

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -39,24 +39,30 @@ $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
 . $libPath
 
-$samePathA = 'C:\Users\amant\.codex\worktrees\162b\winghostty'
-$samePathB = 'C:/Users/amant/.codex/worktrees/162b/winghostty\'
-$otherPath = 'C:\Users\amant\.codex\worktrees\main\winghostty'
+$pathScratch = Join-Path $env:TEMP 'winghostty-interactive-win11-path-test'
+$samePathA = Join-Path $pathScratch 'worktrees\feature-a\repo'
+$samePathB = '{0}\' -f ($samePathA.Replace('\', '/'))
+$otherPath = Join-Path $pathScratch 'worktrees\feature-b\repo'
 
 $idA = Get-InteractiveWin11WorktreeId -RepoRoot $samePathA
 $idB = Get-InteractiveWin11WorktreeId -RepoRoot $samePathB
 $idC = Get-InteractiveWin11WorktreeId -RepoRoot $otherPath
 
 Assert-Equal $idA $idB 'worktree id should normalize slash direction and trailing slash'
-Assert-Match $idA '^162b-winghostty-[0-9a-f]{12}$' 'worktree id should include short slug and hash suffix'
+Assert-Match $idA '^[a-z0-9.-]+-[0-9a-f]{12}$' 'worktree id should include slug and hash suffix'
 Assert-True ($idA -ne $idC) 'different worktree paths should produce different ids'
 
 $layout = Get-InteractiveWin11SandboxLayout -RepoRoot $samePathA
 
-Assert-Equal $layout.RepoRoot 'C:\Users\amant\.codex\worktrees\162b\winghostty' 'layout should preserve normalized repo root'
-Assert-True ($layout.SandboxRoot.StartsWith('C:\Users\amant\.codex\worktrees\162b\winghostty\.sandbox\win11\', [System.StringComparison]::OrdinalIgnoreCase)) 'sandbox root should live under repo-local .sandbox\win11'
+Assert-Equal $layout.RepoRoot (Get-InteractiveWin11NormalizedPath -Path $samePathA) 'layout should preserve normalized repo root'
+Assert-True ($layout.SandboxRoot.StartsWith((Join-Path $layout.RepoRoot '.sandbox\win11\'), [System.StringComparison]::OrdinalIgnoreCase)) 'sandbox root should live under repo-local .sandbox\win11'
 Assert-Equal $layout.XdgConfigHome $layout.LocalAppData 'config home should reuse localappdata'
 Assert-Equal $layout.Temp (Join-Path $layout.SandboxRoot 'temp') 'temp path should be rooted in sandbox'
+
+$launchArgs = @(Get-InteractiveWin11LaunchArguments -Layout $layout)
+Assert-Equal $launchArgs.Count 2 'launch args should include the isolation overrides'
+Assert-True ($launchArgs -contains '--single-instance=false') 'launch args should disable single-instance forwarding'
+Assert-True ($launchArgs -contains "--class=winghostty-interactive-$($layout.WorktreeId)") 'launch args should include a sandbox-unique class'
 
 $scratchRepo = Join-Path $env:TEMP 'winghostty-interactive-win11-test'
 $scratchLayout = Get-InteractiveWin11SandboxLayout -RepoRoot $scratchRepo

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -1,0 +1,90 @@
+$ErrorActionPreference = 'Stop'
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory)] $Actual,
+        [Parameter(Mandatory)] $Expected,
+        [Parameter(Mandatory)] [string] $Message
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "$Message`nExpected: $Expected`nActual:   $Actual"
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)] [bool] $Condition,
+        [Parameter(Mandatory)] [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Match {
+    param(
+        [Parameter(Mandatory)] [string] $Value,
+        [Parameter(Mandatory)] [string] $Pattern,
+        [Parameter(Mandatory)] [string] $Message
+    )
+
+    if ($Value -notmatch $Pattern) {
+        throw "$Message`nPattern: $Pattern`nValue:   $Value"
+    }
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+. $libPath
+
+$samePathA = 'C:\Users\amant\.codex\worktrees\162b\winghostty'
+$samePathB = 'C:/Users/amant/.codex/worktrees/162b/winghostty\'
+$otherPath = 'C:\Users\amant\.codex\worktrees\main\winghostty'
+
+$idA = Get-InteractiveWin11WorktreeId -RepoRoot $samePathA
+$idB = Get-InteractiveWin11WorktreeId -RepoRoot $samePathB
+$idC = Get-InteractiveWin11WorktreeId -RepoRoot $otherPath
+
+Assert-Equal $idA $idB 'worktree id should normalize slash direction and trailing slash'
+Assert-Match $idA '^162b-winghostty-[0-9a-f]{12}$' 'worktree id should include short slug and hash suffix'
+Assert-True ($idA -ne $idC) 'different worktree paths should produce different ids'
+
+$layout = Get-InteractiveWin11SandboxLayout -RepoRoot $samePathA
+
+Assert-Equal $layout.RepoRoot 'C:\Users\amant\.codex\worktrees\162b\winghostty' 'layout should preserve normalized repo root'
+Assert-True ($layout.SandboxRoot.StartsWith('C:\Users\amant\.codex\worktrees\162b\winghostty\.sandbox\win11\', [System.StringComparison]::OrdinalIgnoreCase)) 'sandbox root should live under repo-local .sandbox\win11'
+Assert-Equal $layout.XdgConfigHome $layout.LocalAppData 'config home should reuse localappdata'
+Assert-Equal $layout.Temp (Join-Path $layout.SandboxRoot 'temp') 'temp path should be rooted in sandbox'
+
+$scratchRepo = Join-Path $env:TEMP 'winghostty-interactive-win11-test'
+$scratchLayout = Get-InteractiveWin11SandboxLayout -RepoRoot $scratchRepo
+New-Item -ItemType Directory -Force -Path $scratchLayout.Temp | Out-Null
+Set-Content -Path (Join-Path $scratchLayout.Temp 'marker.txt') -Value 'ok'
+
+Reset-InteractiveWin11Sandbox -Layout $scratchLayout
+Assert-True (-not (Test-Path $scratchLayout.SandboxRoot)) 'reset should remove only the current worktree sandbox'
+
+$escapeRoot = Join-Path $scratchRepo '.sandbox\win11-escape'
+New-Item -ItemType Directory -Force -Path $escapeRoot | Out-Null
+Set-Content -Path (Join-Path $escapeRoot 'marker.txt') -Value 'keep'
+
+$escapeLayout = [ordered]@{
+    RepoRoot    = $scratchRepo
+    SandboxRoot = $escapeRoot
+}
+
+$resetBlocked = $false
+try {
+    Reset-InteractiveWin11Sandbox -Layout $escapeLayout
+}
+catch {
+    $resetBlocked = $true
+    Assert-True ($_.Exception.Message -like '*Refusing to reset sandbox outside*') 'out-of-sandbox reset should mention refusal'
+}
+
+Assert-True $resetBlocked 'prefix-collision sandbox target should be refused'
+Assert-True (Test-Path $escapeRoot) 'refused sandbox target should not be deleted'
+
+Write-Host 'interactive-win11 helper tests: PASS'

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -87,4 +87,53 @@ catch {
 Assert-True $resetBlocked 'prefix-collision sandbox target should be refused'
 Assert-True (Test-Path $escapeRoot) 'refused sandbox target should not be deleted'
 
+$launchScratch = Join-Path $env:TEMP 'winghostty-interactive-win11-launch-test'
+Remove-Item -LiteralPath $launchScratch -Recurse -Force -ErrorAction SilentlyContinue
+
+$missingExe = Join-Path $launchScratch 'zig-out\bin\winghostty.exe'
+$existingExe = Join-Path $launchScratch 'ready\zig-out\bin\winghostty.exe'
+$directoryExe = Join-Path $launchScratch 'dir\zig-out\bin\winghostty.exe'
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $existingExe) | Out-Null
+Set-Content -Path $existingExe -Value 'stub'
+New-Item -ItemType Directory -Force -Path $directoryExe | Out-Null
+
+Assert-Equal (
+    Get-InteractiveWin11LaunchAction -ExePath $missingExe
+) 'build' 'missing binary without flags should build'
+
+Assert-Equal (
+    Get-InteractiveWin11LaunchAction -ExePath $existingExe -Rebuild
+) 'build' 'rebuild flag should force build even when binary exists'
+
+Assert-Equal (
+    Get-InteractiveWin11LaunchAction -ExePath $existingExe
+) 'launch' 'existing binary without rebuild should launch'
+
+Assert-Equal (
+    Get-InteractiveWin11LaunchAction -ExePath $directoryExe
+) 'build' 'directory at exe path should not count as launchable'
+
+$missingBinaryBlocked = $false
+try {
+    Get-InteractiveWin11LaunchAction -ExePath $missingExe -NoBuild | Out-Null
+}
+catch {
+    $missingBinaryBlocked = $true
+    Assert-True ($_.Exception.Message -like '*winghostty.exe*') 'missing binary with no-build should mention winghostty.exe'
+}
+
+Assert-True $missingBinaryBlocked 'missing binary with no-build should throw'
+
+$conflictingFlagsBlocked = $false
+try {
+    Get-InteractiveWin11LaunchAction -ExePath $existingExe -Rebuild -NoBuild | Out-Null
+}
+catch {
+    $conflictingFlagsBlocked = $true
+    Assert-True ($_.Exception.Message -like '*-Rebuild*') 'conflicting flags should mention -Rebuild'
+    Assert-True ($_.Exception.Message -like '*-NoBuild*') 'conflicting flags should mention -NoBuild'
+}
+
+Assert-True $conflictingFlagsBlocked 'rebuild and no-build together should throw'
+
 Write-Host 'interactive-win11 helper tests: PASS'

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -47,6 +47,7 @@ $pathScratch = Join-Path $env:TEMP 'winghostty-interactive-win11-path-test'
 $samePathA = Join-Path $pathScratch 'worktrees\feature-a\repo'
 $samePathB = '{0}\' -f ($samePathA.Replace('\', '/'))
 $otherPath = Join-Path $pathScratch 'worktrees\feature-b\repo'
+$driveRoot = [System.IO.Path]::GetPathRoot((Get-Location).Path)
 
 $idA = Get-InteractiveWin11WorktreeId -RepoRoot $samePathA
 $idB = Get-InteractiveWin11WorktreeId -RepoRoot $samePathB
@@ -55,6 +56,7 @@ $idC = Get-InteractiveWin11WorktreeId -RepoRoot $otherPath
 Assert-Equal $idA $idB 'worktree id should normalize slash direction and trailing slash'
 Assert-Match $idA '^[a-z0-9.-]+-[0-9a-f]{12}$' 'worktree id should include slug and hash suffix'
 Assert-True ($idA -ne $idC) 'different worktree paths should produce different ids'
+Assert-Equal (Get-InteractiveWin11NormalizedPath -Path $driveRoot) ([System.IO.Path]::GetFullPath($driveRoot).Replace('/', '\')) 'normalization should preserve rooted drive paths'
 
 $layout = Get-InteractiveWin11SandboxLayout -RepoRoot $samePathA
 

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -37,7 +37,11 @@ function Assert-Match {
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+$callerErrorActionPreference = 'Continue'
+$ErrorActionPreference = $callerErrorActionPreference
 . $libPath
+Assert-Equal $ErrorActionPreference $callerErrorActionPreference 'dot-sourcing the helper library should not overwrite caller ErrorActionPreference'
+$ErrorActionPreference = 'Stop'
 
 $pathScratch = Join-Path $env:TEMP 'winghostty-interactive-win11-path-test'
 $samePathA = Join-Path $pathScratch 'worktrees\feature-a\repo'


### PR DESCRIPTION
## Summary
- add a repo-owned interactive Win11 launcher with per-worktree sandboxed state under `.sandbox/win11/<worktree-id>/`
- add portable PowerShell coverage for sandbox helpers, launch policy, reset confinement, and isolated-instance launch arguments
- document the sandboxed validation workflow in `HACKING.md`, including `-Rebuild`, `-ResetState`, and `-OpenShell`

## Test Plan
- [x] `powershell -ExecutionPolicy Bypass -File test/windows/interactive-win11.ps1`
- [x] `zig build`
- [x] `powershell -ExecutionPolicy Bypass -File scripts/interactive-win11.ps1 -ResetState -Rebuild`
- [x] verified the launched `winghostty.exe` process command line includes `--single-instance=false` and a worktree-unique `--class=...`

## Summary by Sourcery

Add a repo-owned interactive Windows 11 validation harness with per-worktree sandboxed state and basic smoke-testing support.

New Features:
- Introduce PowerShell and CMD launchers for interactive Win11 app validation with per-worktree sandboxed runtime state.
- Expose a sandboxed shell entrypoint sharing the same isolated environment as the interactive launcher.

Enhancements:
- Factor shared PowerShell helpers for sandbox path layout, environment construction, launch policy, and reset confinement.
- Record new Win32 and PowerShell self-correction notes for future agents and contributors.

Documentation:
- Document the interactive Win11 validation workflow, including rebuild, reset-state, shell entrypoints, and a smoke-test helper, in HACKING.md and a dedicated design spec.
- Update manual validation checklist to use the new interactive Win11 script instead of launching the binary directly.

Tests:
- Add a PowerShell test script covering interactive harness helpers such as normalization, worktree ID generation, sandbox layout, reset confinement, and launch-action selection.
- Add a smoke-test script that builds as needed, launches the app under the sandbox, and verifies initial terminal startup via log inspection.