### PR TITLE
refactor(win32): centralize backdrop eligibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: In Zig `union(enum)` tests, `Type.tag` names the tag enum, not a union value; cast to `Type` before calling union methods in assertions.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -12853,7 +12853,8 @@ fn resolveTheme(config: *const configpkg.Config) ThemeColors {
 }
 
 fn shouldUseSystemBackdrop(config: *const configpkg.Config) bool {
-    return config.@"background-opacity" < 1.0 and config.@"background-blur".enabled();
+    return config.@"background-opacity" < 1.0 and
+        config.@"background-blur".win32SystemBackdropEnabled();
 }
 
 fn configuredHostWindowPosition(config: *const configpkg.Config) ?struct { x: i32, y: i32 } {

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -715,7 +715,7 @@ pub const SettingsWindow = struct {
     fn displayBgBlurInCheckbox(self: *SettingsWindow) void {
         const chk = self.chk_bg_blur orelse return;
         const p = self.pending orelse return;
-        const enabled = p.@"background-blur".enabled();
+        const enabled = p.@"background-blur".win32SystemBackdropEnabled();
         self.suppress_edit_events = true;
         _ = SendMessageW(
             chk,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -8941,12 +8941,27 @@ pub const BackgroundBlur = union(enum) {
         };
     }
 
+    /// Windows currently exposes background blur as a system-backdrop
+    /// toggle, so any positive radius behaves the same as `true`.
+    pub fn win32SystemBackdropEnabled(self: BackgroundBlur) bool {
+        return self.enabled();
+    }
+
     pub fn cval(self: BackgroundBlur) i16 {
         return switch (self) {
             .false => 0,
             .true => 20,
             .radius => |v| v,
         };
+    }
+
+    test "BackgroundBlur win32SystemBackdropEnabled" {
+        const testing = std.testing;
+
+        try testing.expect(!(@as(BackgroundBlur, .false)).win32SystemBackdropEnabled());
+        try testing.expect((@as(BackgroundBlur, .true)).win32SystemBackdropEnabled());
+        try testing.expect(!(BackgroundBlur{ .radius = 0 }).win32SystemBackdropEnabled());
+        try testing.expect((BackgroundBlur{ .radius = 42 }).win32SystemBackdropEnabled());
     }
 
     pub fn formatEntry(


### PR DESCRIPTION
## Summary
- centralizes Win32 system backdrop eligibility for blur/opacity
- reuses the helper from runtime and settings UI

## Validation
- zig build test -Dtest-filter="BackgroundBlur win32SystemBackdropEnabled"
- zig build test -Dtest-filter="win32 shouldUseSystemBackdrop requires opacity and blur"
- zig build test -Dtest-filter="settings background blur checkbox"

## Summary by Sourcery

Centralize Win32 system backdrop eligibility logic for background blur and apply it consistently across runtime and settings UI.

Enhancements:
- Add a BackgroundBlur.win32SystemBackdropEnabled helper to encapsulate Win32 backdrop eligibility semantics.
- Use the shared Win32 backdrop eligibility helper in the Win32 runtime and settings checkbox state handling.

Tests:
- Add unit tests covering BackgroundBlur.win32SystemBackdropEnabled behavior across tag variants.

Chores:
- Update AGENTS self-correction log with guidance on Zig union(enum) testing patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows system backdrop handling when background opacity is set below 100%.
  * Fixed settings window to accurately reflect system backdrop state.

* **Documentation**
  * Updated documentation on Zig union testing patterns.

* **Tests**
  * Added test coverage for backdrop behavior mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->