### PR TITLE
feat(win32): add read-only window listing action

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -250,6 +250,13 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
                 defer msg.deinit(self.alloc);
                 try self.newWindow(rt_app, msg);
             },
+            .automation_window_list => |request| {
+                defer request.done.set();
+                request.result = rt_app.buildAutomationWindowListJson(request.alloc) catch |err| blk: {
+                    request.err = err;
+                    break :blk null;
+                };
+            },
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
             .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
@@ -556,6 +563,9 @@ pub const Message = union(enum) {
     /// Create a new terminal window.
     new_window: NewWindow,
 
+    /// Produce a read-only automation window snapshot on the app thread.
+    automation_window_list: *AutomationWindowListRequest,
+
     /// Close a surface. This notifies the runtime that a surface
     /// should close.
     close: *Surface,
@@ -574,6 +584,13 @@ pub const Message = union(enum) {
     /// wake up the renderer thread. The renderer thread will send this
     /// message if it needs to.
     redraw_surface: *apprt.Surface,
+
+    pub const AutomationWindowListRequest = struct {
+        alloc: Allocator,
+        done: std.Thread.ResetEvent = .{},
+        result: ?[]u8 = null,
+        err: ?anyerror = null,
+    };
 
     const NewWindow = struct {
         /// The parent surface

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -53,6 +53,49 @@ pub const Target = union(Key) {
     }
 };
 
+pub const automation_window_list_schema = "winghostty.windows.v1";
+
+pub const AutomationWindowList = struct {
+    schema: []const u8 = automation_window_list_schema,
+    windows: []AutomationWindow,
+
+    pub fn deinit(self: *AutomationWindowList, alloc: Allocator) void {
+        for (self.windows) |*window| window.deinit(alloc);
+        alloc.free(self.windows);
+        self.* = undefined;
+    }
+};
+
+pub const AutomationWindow = struct {
+    window_id: u32,
+    focused: bool,
+    active_tab_id: ?u32,
+    tabs: []AutomationTab,
+
+    pub fn deinit(self: *AutomationWindow, alloc: Allocator) void {
+        for (self.tabs) |*tab| tab.deinit(alloc);
+        alloc.free(self.tabs);
+        self.* = undefined;
+    }
+};
+
+pub const AutomationTab = struct {
+    tab_id: u32,
+    active: bool,
+    focused_surface_id: ?u64,
+    panes: []AutomationPane,
+
+    pub fn deinit(self: *AutomationTab, alloc: Allocator) void {
+        alloc.free(self.panes);
+        self.* = undefined;
+    }
+};
+
+pub const AutomationPane = struct {
+    surface_id: u64,
+    focused: bool,
+};
+
 pub const Action = union(enum) {
     // A GUIDE TO ADDING NEW ACTIONS:
     //

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -15,5 +15,19 @@ pub const App = struct {
     ) !bool {
         return false;
     }
+
+    pub fn queryAutomationWindowList(
+        _: Allocator,
+        _: apprt.ipc.Target,
+    ) !?[]u8 {
+        return null;
+    }
+
+    pub fn buildAutomationWindowListJson(
+        _: *App,
+        _: Allocator,
+    ) ![]u8 {
+        return error.Unsupported;
+    }
 };
 pub const Surface = struct {};

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -755,6 +755,7 @@ const ipc_pipe_prefix = "\\\\.\\pipe\\winghostty.";
 const ipc_wire_version: u32 = 1;
 const ipc_ack_success: u8 = 0;
 const ipc_ack_failure: u8 = 1;
+const ipc_max_data_response_len: u32 = 16 * 1024 * 1024;
 
 const IpcRequestKind = enum(u8) {
     new_window = 1,
@@ -1671,6 +1672,7 @@ fn readIpcDataResponse(
     }
 
     const len = readU32(&len_buf);
+    if (len > ipc_max_data_response_len) return error.InvalidIpcResponse;
     const body = try alloc.alloc(u8, len);
     errdefer alloc.free(body);
     if (len > 0) try readExactHandle(pipe, body);
@@ -26121,6 +26123,31 @@ test "win32 readIpcDataResponse treats legacy failure ack as IPCFailed" {
 
     try std.testing.expectError(
         error.IPCFailed,
+        readIpcDataResponse(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 readIpcDataResponse rejects oversized body length" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-response-too-large.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var header: [9]u8 = undefined;
+    std.mem.writeInt(u32, header[0..4], ipc_wire_version, .little);
+    header[4] = ipc_ack_success;
+    std.mem.writeInt(u32, header[5..9], ipc_max_data_response_len + 1, .little);
+    try file.writeAll(&header);
+    try file.seekTo(0);
+
+    try std.testing.expectError(
+        error.InvalidIpcResponse,
         readIpcDataResponse(std.testing.allocator, file.handle),
     );
 }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -756,6 +756,7 @@ const ipc_wire_version: u32 = 1;
 const ipc_ack_success: u8 = 0;
 const ipc_ack_failure: u8 = 1;
 const ipc_max_data_response_len: u32 = 16 * 1024 * 1024;
+const ipc_max_new_window_argc: u32 = 4096;
 
 const IpcRequestKind = enum(u8) {
     new_window = 1,
@@ -1596,6 +1597,7 @@ fn decodeNewWindowIpcPayload(
 
     const argc = readU32(&argc_buf);
     if (argc == 0) return null;
+    if (argc > ipc_max_new_window_argc) return error.InvalidIpcRequest;
 
     const argv = try alloc.alloc([:0]const u8, argc);
     errdefer freeOwnedArguments(alloc, argv);
@@ -1637,6 +1639,8 @@ fn writeIpcDataResponse(
     success: bool,
     body: []const u8,
 ) !void {
+    if (body.len > ipc_max_data_response_len) return error.InvalidIpcResponse;
+
     var header: [9]u8 = undefined;
     std.mem.writeInt(u32, header[0..4], ipc_wire_version, .little);
     header[4] = if (success) ipc_ack_success else ipc_ack_failure;
@@ -26168,6 +26172,50 @@ test "win32 readIpcDataResponse rejects oversized body length" {
     try std.testing.expectError(
         error.InvalidIpcResponse,
         readIpcDataResponse(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 decodeNewWindowIpcPayload rejects oversized argc" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-request-too-many-args.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var argc_buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &argc_buf, ipc_max_new_window_argc + 1, .little);
+    try file.writeAll(&argc_buf);
+    try file.seekTo(0);
+
+    try std.testing.expectError(
+        error.InvalidIpcRequest,
+        decodeNewWindowIpcPayload(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 writeIpcDataResponse rejects oversized body" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-response-write-too-large.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    const body = try std.testing.allocator.alloc(u8, ipc_max_data_response_len + 1);
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expectError(
+        error.InvalidIpcResponse,
+        writeIpcDataResponse(file.handle, true, body),
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -756,6 +756,11 @@ const ipc_wire_version: u32 = 1;
 const ipc_ack_success: u8 = 0;
 const ipc_ack_failure: u8 = 1;
 
+const IpcRequestKind = enum(u8) {
+    new_window = 1,
+    list_windows = 2,
+};
+
 const POINT = win32_types.POINT;
 const RECT = win32_types.RECT;
 const PIXELFORMATDESCRIPTOR = extern struct {
@@ -1542,7 +1547,7 @@ fn encodeNewWindowIpcRequest(
     errdefer encoded.deinit(alloc);
 
     try appendU32(&encoded, alloc, ipc_wire_version);
-    try encoded.append(alloc, 1);
+    try encoded.append(alloc, @intFromEnum(IpcRequestKind.new_window));
 
     const argc: u32 = if (arguments) |argv| @intCast(argv.len) else 0;
     try appendU32(&encoded, alloc, argc);
@@ -1557,17 +1562,34 @@ fn encodeNewWindowIpcRequest(
     return try encoded.toOwnedSlice(alloc);
 }
 
-fn decodeNewWindowIpcRequest(
-    alloc: Allocator,
+fn encodeListWindowsIpcRequest(alloc: Allocator) ![]u8 {
+    var encoded: std.ArrayList(u8) = .empty;
+    errdefer encoded.deinit(alloc);
+
+    try appendU32(&encoded, alloc, ipc_wire_version);
+    try encoded.append(alloc, @intFromEnum(IpcRequestKind.list_windows));
+
+    return try encoded.toOwnedSlice(alloc);
+}
+
+fn decodeIpcRequestKind(
     pipe: windows.HANDLE,
-) !?[]const [:0]const u8 {
-    var header: [9]u8 = undefined;
+) !IpcRequestKind {
+    var header: [5]u8 = undefined;
     try readExactHandle(pipe, &header);
 
     if (readU32(header[0..4]) != ipc_wire_version) return error.InvalidIpcRequest;
-    if (header[4] != 1) return error.InvalidIpcRequest;
+    return std.meta.intToEnum(IpcRequestKind, header[4]) catch error.InvalidIpcRequest;
+}
 
-    const argc = readU32(header[5..9]);
+fn decodeNewWindowIpcPayload(
+    alloc: Allocator,
+    pipe: windows.HANDLE,
+) !?[]const [:0]const u8 {
+    var argc_buf: [4]u8 = undefined;
+    try readExactHandle(pipe, &argc_buf);
+
+    const argc = readU32(&argc_buf);
     if (argc == 0) return null;
 
     const argv = try alloc.alloc([:0]const u8, argc);
@@ -1603,6 +1625,39 @@ fn readIpcAck(pipe: windows.HANDLE) !bool {
         ipc_ack_failure => error.IPCFailed,
         else => error.InvalidIpcResponse,
     };
+}
+
+fn writeIpcDataResponse(
+    pipe: windows.HANDLE,
+    success: bool,
+    body: []const u8,
+) !void {
+    var header: [9]u8 = undefined;
+    std.mem.writeInt(u32, header[0..4], ipc_wire_version, .little);
+    header[4] = if (success) ipc_ack_success else ipc_ack_failure;
+    std.mem.writeInt(u32, header[5..9], @intCast(body.len), .little);
+    try writeAllHandle(pipe, &header);
+    if (body.len > 0) try writeAllHandle(pipe, body);
+}
+
+fn readIpcDataResponse(
+    alloc: Allocator,
+    pipe: windows.HANDLE,
+) ![]u8 {
+    var header: [9]u8 = undefined;
+    try readExactHandle(pipe, &header);
+    if (readU32(header[0..4]) != ipc_wire_version) return error.InvalidIpcResponse;
+    switch (header[4]) {
+        ipc_ack_success => {},
+        ipc_ack_failure => return error.IPCFailed,
+        else => return error.InvalidIpcResponse,
+    }
+
+    const len = readU32(header[5..9]);
+    const body = try alloc.alloc(u8, len);
+    errdefer alloc.free(body);
+    if (len > 0) try readExactHandle(pipe, body);
+    return body;
 }
 
 fn historyEntrySortsAfter(
@@ -1699,6 +1754,24 @@ fn sendNewWindowIpc(
 
     try writeAllHandle(pipe, request);
     return try readIpcAck(pipe);
+}
+
+fn sendListWindowsIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+) !?[]u8 {
+    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.PipeBusy => return error.IPCFailed,
+        else => return err,
+    };
+    defer _ = windows.CloseHandle(pipe);
+
+    const request = try encodeListWindowsIpcRequest(alloc);
+    defer alloc.free(request);
+
+    try writeAllHandle(pipe, request);
+    return try readIpcDataResponse(alloc, pipe);
 }
 
 fn applyNewWindowArguments(
@@ -1828,7 +1901,6 @@ fn ipcServerMain(app: *App) void {
 
         handleIpcClient(app, pipe) catch |err| {
             log.warn("failed to process win32 IPC client err={}", .{err});
-            writeIpcAck(pipe, false) catch {};
         };
 
         _ = FlushFileBuffers(pipe);
@@ -1838,7 +1910,22 @@ fn ipcServerMain(app: *App) void {
 }
 
 fn handleIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const arguments = try decodeNewWindowIpcRequest(app.core_app.alloc, pipe);
+    const kind = try decodeIpcRequestKind(pipe);
+
+    switch (kind) {
+        .new_window => handleNewWindowIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 new-window IPC request err={}", .{err});
+            try writeIpcAck(pipe, false);
+        },
+        .list_windows => handleListWindowsIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation list IPC request err={}", .{err});
+            try writeIpcDataResponse(pipe, false, "");
+        },
+    }
+}
+
+fn handleNewWindowIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    const arguments = try decodeNewWindowIpcPayload(app.core_app.alloc, pipe);
     errdefer freeOwnedArguments(app.core_app.alloc, arguments);
 
     const mailbox: CoreApp.Mailbox = .{
@@ -1850,6 +1937,29 @@ fn handleIpcClient(app: *App, pipe: windows.HANDLE) !void {
     } }, .forever);
 
     try writeIpcAck(pipe, true);
+}
+
+fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    const json = try requestAutomationWindowListJson(app, app.core_app.alloc);
+    defer app.core_app.alloc.free(json);
+    try writeIpcDataResponse(pipe, true, json);
+}
+
+fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
+    var request: CoreApp.Message.AutomationWindowListRequest = .{
+        .alloc = alloc,
+    };
+    const mailbox: CoreApp.Mailbox = .{
+        .rt_app = app,
+        .mailbox = &app.core_app.mailbox,
+    };
+    if (mailbox.push(.{ .automation_window_list = &request }, .{ .forever = {} }) == 0) {
+        return error.IPCFailed;
+    }
+
+    request.done.wait();
+    if (request.err) |err| return err;
+    return request.result orelse error.IPCFailed;
 }
 
 pub fn getProcAddress(name: [*:0]const u8) callconv(.c) ?*const anyopaque {
@@ -3601,6 +3711,99 @@ pub const App = struct {
                 return try spawnWindowProcess(alloc, target, value);
             },
         }
+    }
+
+    pub fn queryAutomationWindowList(
+        alloc: Allocator,
+        target: apprt.ipc.Target,
+    ) !?[]u8 {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
+        defer alloc.free(pipe_name);
+        return try sendListWindowsIpc(alloc, pipe_name);
+    }
+
+    pub fn buildAutomationWindowListJson(
+        self: *App,
+        alloc: Allocator,
+    ) ![]u8 {
+        var snapshot = try self.buildAutomationWindowList(alloc);
+        defer snapshot.deinit(alloc);
+
+        var buf: std.Io.Writer.Allocating = .init(alloc);
+        errdefer buf.deinit();
+        try buf.writer.print("{f}", .{std.json.fmt(snapshot, .{})});
+        return try buf.toOwnedSlice();
+    }
+
+    fn buildAutomationWindowList(
+        self: *App,
+        alloc: Allocator,
+    ) !apprt.ipc.AutomationWindowList {
+        const window_entries = try alloc.alloc(apprt.ipc.AutomationWindow, self.hosts.items.len);
+        var built: usize = 0;
+        errdefer {
+            for (window_entries[0..built]) |*window| window.deinit(alloc);
+            alloc.free(window_entries);
+        }
+
+        for (self.hosts.items, 0..) |host, i| {
+            window_entries[i] = try buildAutomationWindow(alloc, host);
+            built += 1;
+        }
+
+        return .{ .windows = window_entries };
+    }
+
+    fn buildAutomationWindow(
+        alloc: Allocator,
+        host: *Host,
+    ) !apprt.ipc.AutomationWindow {
+        const tabs = try alloc.alloc(apprt.ipc.AutomationTab, host.tabs.items.len);
+        var built: usize = 0;
+        errdefer {
+            for (tabs[0..built]) |*tab| tab.deinit(alloc);
+            alloc.free(tabs);
+        }
+
+        var active_tab_id: ?u32 = null;
+        for (host.tabs.items, 0..) |*tab, i| {
+            const active = i == host.active_tab;
+            tabs[i] = try buildAutomationTab(alloc, tab, active);
+            if (active) active_tab_id = tab.id;
+            built += 1;
+        }
+
+        return .{
+            .window_id = host.id,
+            .focused = if (host.activeSurface()) |surface| surface.window_focused else false,
+            .active_tab_id = active_tab_id,
+            .tabs = tabs,
+        };
+    }
+
+    fn buildAutomationTab(
+        alloc: Allocator,
+        tab: *const Tab,
+        active: bool,
+    ) !apprt.ipc.AutomationTab {
+        var panes: std.ArrayList(apprt.ipc.AutomationPane) = .empty;
+        defer panes.deinit(alloc);
+
+        const focused_surface = tab.focusedSurface();
+        var it = tab.tree.iterator();
+        while (it.next()) |entry| {
+            try panes.append(alloc, .{
+                .surface_id = entry.view.core().id,
+                .focused = if (focused_surface) |surface| surface == entry.view else false,
+            });
+        }
+
+        return .{
+            .tab_id = tab.id,
+            .active = active,
+            .focused_surface_id = if (focused_surface) |surface| surface.core().id else null,
+            .panes = try panes.toOwnedSlice(alloc),
+        };
     }
 
     fn spawnWindowProcess(
@@ -25751,6 +25954,76 @@ test "win32 hostSurfaceCount tracks surfaces attached to one host" {
     try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &second));
     try std.testing.expectEqual(@as(usize, 2), first.hostSurfaceCount());
     try std.testing.expect(!shouldResizeHostForInitialSize(first.hostSurfaceCount()));
+}
+
+test "automation-window-list win32 json includes host tab and pane ids" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var app: App = undefined;
+    app.windows = .empty;
+    app.hosts = .empty;
+    defer app.windows.deinit(std.testing.allocator);
+    defer app.hosts.deinit(std.testing.allocator);
+
+    var host: Host = undefined;
+    host.id = 17;
+    host.tabs = .empty;
+    host.active_tab = 1;
+    defer {
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    var tab0_surface: Surface = undefined;
+    tab0_surface.core_surface = undefined;
+    tab0_surface.core_surface.id = 701;
+    tab0_surface.host = &host;
+    tab0_surface.host_id = host.id;
+
+    var tab1_primary: Surface = undefined;
+    tab1_primary.core_surface = undefined;
+    tab1_primary.core_surface.id = 702;
+    tab1_primary.host = &host;
+    tab1_primary.host_id = host.id;
+    tab1_primary.window_focused = true;
+
+    var tab1_split: Surface = undefined;
+    tab1_split.core_surface = undefined;
+    tab1_split.core_surface.id = 703;
+    tab1_split.host = &host;
+    tab1_split.host_id = host.id;
+
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 3, &tab0_surface));
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 4, &tab1_primary));
+
+    const inserted = try SplitTreeSurface.init(std.testing.allocator, &tab1_split);
+    defer {
+        var cleanup = inserted;
+        cleanup.deinit();
+    }
+    var prev_tree = host.tabs.items[1].tree;
+    const next_tree = try prev_tree.split(
+        std.testing.allocator,
+        host.tabs.items[1].focused,
+        .right,
+        0.5,
+        &inserted,
+    );
+    host.tabs.items[1].tree = next_tree;
+    host.tabs.items[1].focused = host.tabs.items[1].findHandle(&tab1_primary) orelse host.tabs.items[1].focused;
+    prev_tree.deinit();
+
+    try app.hosts.append(std.testing.allocator, &host);
+    try app.windows.append(std.testing.allocator, &tab0_surface);
+    try app.windows.append(std.testing.allocator, &tab1_primary);
+
+    const json = try app.buildAutomationWindowListJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+
+    try std.testing.expectEqualStrings(
+        "{\"schema\":\"winghostty.windows.v1\",\"windows\":[{\"window_id\":17,\"focused\":true,\"active_tab_id\":4,\"tabs\":[{\"tab_id\":3,\"active\":false,\"focused_surface_id\":701,\"panes\":[{\"surface_id\":701,\"focused\":true}]},{\"tab_id\":4,\"active\":true,\"focused_surface_id\":702,\"panes\":[{\"surface_id\":703,\"focused\":false},{\"surface_id\":702,\"focused\":true}]}]}]}",
+        json,
+    );
 }
 
 test "win32 shouldDispatchOcclusion dispatches initial hidden state" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1644,16 +1644,33 @@ fn readIpcDataResponse(
     alloc: Allocator,
     pipe: windows.HANDLE,
 ) ![]u8 {
-    var header: [9]u8 = undefined;
+    var header: [5]u8 = undefined;
     try readExactHandle(pipe, &header);
     if (readU32(header[0..4]) != ipc_wire_version) return error.InvalidIpcResponse;
-    switch (header[4]) {
-        ipc_ack_success => {},
-        ipc_ack_failure => return error.IPCFailed,
+
+    const success = switch (header[4]) {
+        ipc_ack_success => true,
+        ipc_ack_failure => false,
         else => return error.InvalidIpcResponse,
+    };
+
+    var len_buf: [4]u8 = undefined;
+    readExactHandle(pipe, &len_buf) catch |err| switch (err) {
+        // Older instances only return the legacy 5-byte ack. Treat their
+        // unsupported-request failure as a normal IPC failure instead of
+        // bubbling a raw transport EOF up through the CLI.
+        error.EndOfStream => {
+            if (!success) return error.IPCFailed;
+            return error.InvalidIpcResponse;
+        },
+        else => return err,
+    };
+
+    if (!success) {
+        return error.IPCFailed;
     }
 
-    const len = readU32(header[5..9]);
+    const len = readU32(&len_buf);
     const body = try alloc.alloc(u8, len);
     errdefer alloc.free(body);
     if (len > 0) try readExactHandle(pipe, body);
@@ -3739,19 +3756,29 @@ pub const App = struct {
         self: *App,
         alloc: Allocator,
     ) !apprt.ipc.AutomationWindowList {
-        const window_entries = try alloc.alloc(apprt.ipc.AutomationWindow, self.hosts.items.len);
+        const window_entries = try alloc.alloc(apprt.ipc.AutomationWindow, self.automationWindowCount());
         var built: usize = 0;
         errdefer {
             for (window_entries[0..built]) |*window| window.deinit(alloc);
             alloc.free(window_entries);
         }
 
-        for (self.hosts.items, 0..) |host, i| {
-            window_entries[i] = try buildAutomationWindow(alloc, host);
+        for (self.hosts.items) |host| {
+            if (host.tabs.items.len == 0) continue;
+            window_entries[built] = try buildAutomationWindow(alloc, host);
             built += 1;
         }
 
         return .{ .windows = window_entries };
+    }
+
+    fn automationWindowCount(self: *const App) usize {
+        var count: usize = 0;
+        for (self.hosts.items) |host| {
+            if (host.tabs.items.len == 0) continue;
+            count += 1;
+        }
+        return count;
     }
 
     fn buildAutomationWindow(
@@ -26023,6 +26050,78 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     try std.testing.expectEqualStrings(
         "{\"schema\":\"winghostty.windows.v1\",\"windows\":[{\"window_id\":17,\"focused\":true,\"active_tab_id\":4,\"tabs\":[{\"tab_id\":3,\"active\":false,\"focused_surface_id\":701,\"panes\":[{\"surface_id\":701,\"focused\":true}]},{\"tab_id\":4,\"active\":true,\"focused_surface_id\":702,\"panes\":[{\"surface_id\":703,\"focused\":false},{\"surface_id\":702,\"focused\":true}]}]}]}",
         json,
+    );
+}
+
+test "automation-window-list win32 json skips empty undo hosts" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var app: App = undefined;
+    app.windows = .empty;
+    app.hosts = .empty;
+    defer app.windows.deinit(std.testing.allocator);
+    defer app.hosts.deinit(std.testing.allocator);
+
+    var empty_host: Host = undefined;
+    empty_host.id = 16;
+    empty_host.tabs = .empty;
+    empty_host.active_tab = 0;
+    defer {
+        for (empty_host.tabs.items) |*tab| tab.deinit();
+        empty_host.tabs.deinit(std.testing.allocator);
+    }
+
+    var live_host: Host = undefined;
+    live_host.id = 17;
+    live_host.tabs = .empty;
+    live_host.active_tab = 0;
+    defer {
+        for (live_host.tabs.items) |*tab| tab.deinit();
+        live_host.tabs.deinit(std.testing.allocator);
+    }
+
+    var surface: Surface = undefined;
+    surface.core_surface = undefined;
+    surface.core_surface.id = 801;
+    surface.host = &live_host;
+    surface.host_id = live_host.id;
+    surface.window_focused = true;
+
+    try live_host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 5, &surface));
+    try app.hosts.append(std.testing.allocator, &empty_host);
+    try app.hosts.append(std.testing.allocator, &live_host);
+    try app.windows.append(std.testing.allocator, &surface);
+
+    const json = try app.buildAutomationWindowListJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+
+    try std.testing.expectEqualStrings(
+        "{\"schema\":\"winghostty.windows.v1\",\"windows\":[{\"window_id\":17,\"focused\":true,\"active_tab_id\":5,\"tabs\":[{\"tab_id\":5,\"active\":true,\"focused_surface_id\":801,\"panes\":[{\"surface_id\":801,\"focused\":true}]}]}]}",
+        json,
+    );
+}
+
+test "win32 readIpcDataResponse treats legacy failure ack as IPCFailed" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-response.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var header: [5]u8 = undefined;
+    std.mem.writeInt(u32, header[0..4], ipc_wire_version, .little);
+    header[4] = ipc_ack_failure;
+    try file.writeAll(&header);
+    try file.seekTo(0);
+
+    try std.testing.expectError(
+        error.IPCFailed,
+        readIpcDataResponse(std.testing.allocator, file.handle),
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1569,6 +1569,10 @@ fn encodeListWindowsIpcRequest(alloc: Allocator) ![]u8 {
 
     try appendU32(&encoded, alloc, ipc_wire_version);
     try encoded.append(alloc, @intFromEnum(IpcRequestKind.list_windows));
+    // Keep the legacy zero-argc trailer so older servers that still decode
+    // through the new-window payload path fail with a bounded ack instead of
+    // blocking on a missing payload length.
+    try appendU32(&encoded, alloc, 0);
 
     return try encoded.toOwnedSlice(alloc);
 }
@@ -1929,7 +1933,10 @@ fn ipcServerMain(app: *App) void {
 }
 
 fn handleIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const kind = try decodeIpcRequestKind(pipe);
+    const kind = decodeIpcRequestKind(pipe) catch |err| {
+        writeIpcAck(pipe, false) catch {};
+        return err;
+    };
 
     switch (kind) {
         .new_window => handleNewWindowIpcClient(app, pipe) catch |err| {
@@ -26055,7 +26062,7 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     );
 }
 
-test "automation-window-list win32 json skips empty undo hosts" {
+test "automation-window-list win32 json skips empty hosts kept alive for undo history" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     var app: App = undefined;
@@ -26103,6 +26110,18 @@ test "automation-window-list win32 json skips empty undo hosts" {
     );
 }
 
+test "win32 encodeListWindowsIpcRequest preserves legacy zero-argc trailer" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const request = try encodeListWindowsIpcRequest(std.testing.allocator);
+    defer std.testing.allocator.free(request);
+
+    try std.testing.expectEqual(@as(usize, 9), request.len);
+    try std.testing.expectEqual(ipc_wire_version, readU32(request[0..4]));
+    try std.testing.expectEqual(@intFromEnum(IpcRequestKind.list_windows), request[4]);
+    try std.testing.expectEqual(@as(u32, 0), readU32(request[5..9]));
+}
+
 test "win32 readIpcDataResponse treats legacy failure ack as IPCFailed" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -26148,6 +26167,33 @@ test "win32 readIpcDataResponse rejects oversized body length" {
 
     try std.testing.expectError(
         error.InvalidIpcResponse,
+        readIpcDataResponse(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 handleIpcClient bounds truncated request failures with an ack" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-request-truncated.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var request: [4]u8 = undefined;
+    std.mem.writeInt(u32, request[0..4], ipc_wire_version, .little);
+    try file.writeAll(&request);
+    try file.seekTo(0);
+
+    var app: App = undefined;
+    try std.testing.expectError(error.EndOfStream, handleIpcClient(&app, file.handle));
+
+    try file.seekTo(request.len);
+    try std.testing.expectError(
+        error.IPCFailed,
         readIpcDataResponse(std.testing.allocator, file.handle),
     );
 }

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -19,6 +19,7 @@ const crash_report = @import("crash_report.zig");
 const show_face = @import("show_face.zig");
 const boo = @import("boo.zig");
 const new_window = @import("new_window.zig");
+const list_windows = @import("list_windows.zig");
 
 pub const Action = @import("ghostty_action.zig").Action;
 
@@ -71,6 +72,7 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .@"show-face" => try show_face.run(alloc),
         .boo => try boo.run(alloc),
         .@"new-window" => try new_window.run(alloc),
+        .@"list-windows" => try list_windows.run(alloc),
     };
 }
 
@@ -96,6 +98,7 @@ pub fn options(comptime self: Action) type {
             .@"show-face" => show_face.Options,
             .boo => boo.Options,
             .@"new-window" => new_window.Options,
+            .@"list-windows" => list_windows.Options,
         };
     }
 }

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -54,6 +54,9 @@ pub const Action = enum {
     // Use IPC to tell the running Ghostty to open a new window.
     @"new-window",
 
+    // List read-only automation state for the running winghostty instance.
+    @"list-windows",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -49,8 +49,8 @@ pub fn run(alloc: Allocator) !u8 {
     const stderr = &stderr_writer.interface;
 
     const result = runArgs(alloc, &iter, stdout, stderr);
-    stdout.flush() catch {};
-    stderr.flush() catch {};
+    try stdout.flush();
+    try stderr.flush();
     return result;
 }
 

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -93,6 +93,10 @@ fn runArgsWithQuery(
             try stderr.print("Listing automation windows via IPC failed.\n", .{});
             return 1;
         },
+        error.InvalidIpcResponse => {
+            try stderr.print("Listing automation windows via IPC failed: invalid response from the target instance.\n", .{});
+            return 1;
+        },
         else => return err,
     };
     defer if (payload) |bytes| alloc.free(bytes);
@@ -193,6 +197,43 @@ test "automation-window-list cli reports ipc failure" {
     try testing.expectEqualStrings("", stdout_buf.written());
     try testing.expectEqualStrings(
         "Listing automation windows via IPC failed.\n",
+        stderr_buf.written(),
+    );
+}
+
+test "automation-window-list cli reports invalid ipc response" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn query(_: Allocator, _: apprt.ipc.Target) !?[]u8 {
+            return error.InvalidIpcResponse;
+        }
+    };
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "",
+    );
+    defer iter.deinit();
+
+    var stdout_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stdout_buf.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithQuery(
+        testing.allocator,
+        &iter,
+        &stdout_buf.writer,
+        &stderr_buf.writer,
+        &Hook.query,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings("", stdout_buf.written());
+    try testing.expectEqualStrings(
+        "Listing automation windows via IPC failed: invalid response from the target instance.\n",
         stderr_buf.written(),
     );
 }

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -1,0 +1,192 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+
+pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
+    _arena: ?ArenaAllocator = null,
+
+    /// If set, query a custom single-instance namespace instead of the
+    /// default local winghostty instance.
+    class: ?[:0]const u8 = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return actionpkg.help_error;
+    }
+};
+
+/// The `list-windows` command prints a read-only automation snapshot for the
+/// matching local winghostty instance as JSON.
+///
+/// The current schema exposes only stable host/tab/pane identifiers and focus
+/// state. It does not expose terminal text, shell input, working directories,
+/// or any write/control actions.
+///
+/// Flags:
+///
+///   * `--class=<class>`: Query a custom instance namespace instead of the
+///     default local winghostty instance.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
+
+    var stderr_buf: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buf);
+    const stderr = &stderr_writer.interface;
+
+    const result = runArgs(alloc, &iter, stdout, stderr);
+    stdout.flush() catch {};
+    stderr.flush() catch {};
+    return result;
+}
+
+fn runArgs(
+    alloc: Allocator,
+    args_iter: anytype,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+    try args.parse(Options, alloc, &opts, args_iter);
+
+    const payload = queryAutomationWindowList(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+    ) catch |err| switch (err) {
+        error.IPCFailed => {
+            try stderr.print("Listing automation windows via IPC failed.\n", .{});
+            return 1;
+        },
+        else => return err,
+    };
+    defer if (payload) |bytes| alloc.free(bytes);
+
+    const json = payload orelse {
+        try stderr.print("No matching winghostty instance is listening for automation queries.\n", .{});
+        return 1;
+    };
+
+    try stdout.writeAll(json);
+    try stdout.writeByte('\n');
+    return 0;
+}
+
+const QueryAutomationWindowListFn = *const fn (
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+) anyerror!?[]u8;
+
+var test_query_automation_window_list: ?QueryAutomationWindowListFn = null;
+
+fn queryAutomationWindowList(
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+) !?[]u8 {
+    if (builtin.is_test) {
+        const func = test_query_automation_window_list orelse unreachable;
+        return try func(alloc, target);
+    }
+
+    return try apprt.App.queryAutomationWindowList(alloc, target);
+}
+
+test "automation-window-list cli prints json payload" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var seen_class: ?[]u8 = null;
+
+        fn query(alloc: Allocator, target: apprt.ipc.Target) !?[]u8 {
+            seen_class = try testing.allocator.dupe(u8, target.class);
+            return try alloc.dupe(u8, "{\"schema\":\"winghostty.windows.v1\",\"windows\":[]}");
+        }
+    };
+    defer if (Hook.seen_class) |value| testing.allocator.free(value);
+
+    test_query_automation_window_list = &Hook.query;
+    defer test_query_automation_window_list = null;
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "--class=lane9",
+    );
+    defer iter.deinit();
+
+    var stdout_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stdout_buf.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgs(
+        testing.allocator,
+        &iter,
+        &stdout_buf.writer,
+        &stderr_buf.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), exit_code);
+    try testing.expectEqualStrings(
+        "{\"schema\":\"winghostty.windows.v1\",\"windows\":[]}\n",
+        stdout_buf.written(),
+    );
+    try testing.expectEqualStrings("", stderr_buf.written());
+    try testing.expect(Hook.seen_class != null);
+    try testing.expectEqualStrings("lane9", Hook.seen_class.?);
+}
+
+test "automation-window-list cli reports missing instance" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn query(_: Allocator, target: apprt.ipc.Target) !?[]u8 {
+            try testing.expectEqual(apprt.ipc.Target.detect, target);
+            return null;
+        }
+    };
+
+    test_query_automation_window_list = &Hook.query;
+    defer test_query_automation_window_list = null;
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "",
+    );
+    defer iter.deinit();
+
+    var stdout_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stdout_buf.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgs(
+        testing.allocator,
+        &iter,
+        &stdout_buf.writer,
+        &stderr_buf.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings("", stdout_buf.written());
+    try testing.expectEqualStrings(
+        "No matching winghostty instance is listening for automation queries.\n",
+        stderr_buf.written(),
+    );
+}

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const actionpkg = @import("action.zig");
@@ -61,11 +60,32 @@ fn runArgs(
     stdout: *std.Io.Writer,
     stderr: *std.Io.Writer,
 ) !u8 {
+    return runArgsWithQuery(
+        alloc,
+        args_iter,
+        stdout,
+        stderr,
+        queryAutomationWindowList,
+    );
+}
+
+const QueryAutomationWindowListFn = *const fn (
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+) anyerror!?[]u8;
+
+fn runArgsWithQuery(
+    alloc: Allocator,
+    args_iter: anytype,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    queryAutomationWindowListFn: QueryAutomationWindowListFn,
+) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
     try args.parse(Options, alloc, &opts, args_iter);
 
-    const payload = queryAutomationWindowList(
+    const payload = queryAutomationWindowListFn(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
     ) catch |err| switch (err) {
@@ -87,22 +107,10 @@ fn runArgs(
     return 0;
 }
 
-const QueryAutomationWindowListFn = *const fn (
-    alloc: Allocator,
-    target: apprt.ipc.Target,
-) anyerror!?[]u8;
-
-var test_query_automation_window_list: ?QueryAutomationWindowListFn = null;
-
 fn queryAutomationWindowList(
     alloc: Allocator,
     target: apprt.ipc.Target,
 ) !?[]u8 {
-    if (builtin.is_test) {
-        const func = test_query_automation_window_list orelse unreachable;
-        return try func(alloc, target);
-    }
-
     return try apprt.App.queryAutomationWindowList(alloc, target);
 }
 
@@ -113,14 +121,14 @@ test "automation-window-list cli prints json payload" {
         var seen_class: ?[]u8 = null;
 
         fn query(alloc: Allocator, target: apprt.ipc.Target) !?[]u8 {
-            seen_class = try testing.allocator.dupe(u8, target.class);
+            seen_class = switch (target) {
+                .class => |class| try testing.allocator.dupe(u8, class),
+                .detect => return error.UnexpectedTarget,
+            };
             return try alloc.dupe(u8, "{\"schema\":\"winghostty.windows.v1\",\"windows\":[]}");
         }
     };
     defer if (Hook.seen_class) |value| testing.allocator.free(value);
-
-    test_query_automation_window_list = &Hook.query;
-    defer test_query_automation_window_list = null;
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         testing.allocator,
@@ -134,11 +142,12 @@ test "automation-window-list cli prints json payload" {
     var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
     defer stderr_buf.deinit();
 
-    const exit_code = try runArgs(
+    const exit_code = try runArgsWithQuery(
         testing.allocator,
         &iter,
         &stdout_buf.writer,
         &stderr_buf.writer,
+        &Hook.query,
     );
 
     try testing.expectEqual(@as(u8, 0), exit_code);
@@ -151,18 +160,14 @@ test "automation-window-list cli prints json payload" {
     try testing.expectEqualStrings("lane9", Hook.seen_class.?);
 }
 
-test "automation-window-list cli reports missing instance" {
+test "automation-window-list cli reports ipc failure" {
     const testing = std.testing;
 
     const Hook = struct {
-        fn query(_: Allocator, target: apprt.ipc.Target) !?[]u8 {
-            try testing.expectEqual(apprt.ipc.Target.detect, target);
-            return null;
+        fn query(_: Allocator, _: apprt.ipc.Target) !?[]u8 {
+            return error.IPCFailed;
         }
     };
-
-    test_query_automation_window_list = &Hook.query;
-    defer test_query_automation_window_list = null;
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         testing.allocator,
@@ -176,11 +181,50 @@ test "automation-window-list cli reports missing instance" {
     var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
     defer stderr_buf.deinit();
 
-    const exit_code = try runArgs(
+    const exit_code = try runArgsWithQuery(
         testing.allocator,
         &iter,
         &stdout_buf.writer,
         &stderr_buf.writer,
+        &Hook.query,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings("", stdout_buf.written());
+    try testing.expectEqualStrings(
+        "Listing automation windows via IPC failed.\n",
+        stderr_buf.written(),
+    );
+}
+
+test "automation-window-list cli reports missing instance" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn query(_: Allocator, target: apprt.ipc.Target) !?[]u8 {
+            try testing.expectEqual(apprt.ipc.Target.detect, target);
+            return null;
+        }
+    };
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "",
+    );
+    defer iter.deinit();
+
+    var stdout_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stdout_buf.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithQuery(
+        testing.allocator,
+        &iter,
+        &stdout_buf.writer,
+        &stderr_buf.writer,
+        &Hook.query,
     );
 
     try testing.expectEqual(@as(u8, 1), exit_code);


### PR DESCRIPTION
## Summary
- adds read-only winghostty +list-windows JSON plumbing through local IPC
- exposes window/tab/surface/focus identifiers only
- avoids terminal text, cwd, titles, input, and control verbs

## Validation
- zig build test -Dtest-filter=automation-window-list
- zig build test -Dtest-filter="parse action plus"

## Summary by Sourcery

Add a Win32 automation IPC endpoint and CLI command to list running window/tab/pane state as read-only JSON, with schema and tests.

New Features:
- Introduce a win32 IPC request type and server/client plumbing to return a JSON snapshot of window, tab, and pane identifiers and focus state.
- Add a `ghostty list-windows` CLI action to query a running winghostty instance (optionally by class) and print the automation window list JSON.

Enhancements:
- Define structured automation window list types and JSON schema in the IPC layer, and add helpers on the app to build and query this snapshot while skipping empty hosts.
- Extend the Win32 IPC protocol to support typed requests and length-prefixed data responses with bounded payload size and backward-compatible handling of legacy peers.

Tests:
- Add unit tests covering automation window list JSON shape and host filtering, new IPC request/response behaviors, and CLI handling of success, IPC failures, and missing instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a list-windows command that outputs a JSON snapshot of open windows/tabs/panes, accepts --class to target an instance, prints JSON+newline and returns 0 on success; returns nonzero with a clear message when no instance responds.
  * Added support for querying and returning automation window snapshots via IPC.

* **Bug Fixes / Reliability**
  * Improved IPC handling for legacy responses and protection against oversized/truncated data.

* **Tests**
  * Added tests covering JSON structure, filtering, IPC failures, legacy behaviors, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->