### PR TITLE
docs(windows): add capability matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: In this fork, plain `gh pr view <n>` can resolve the upstream Ghostty repo instead of `amanthanvi/winghostty`; pass `--repo amanthanvi/winghostty` or verify the target before trusting PR metadata.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ First public releases: 2026-04-16.
 - **Coexistence:** winghostty runs as its own top-level app window. It does
   not register as a Windows Terminal profile provider; installing it
   alongside Windows Terminal, WezTerm, or Alacritty is fine.
-- **Accessibility:** screen reader / UI Automation support is planned and
-  is not yet shipping.
+- **Accessibility:** partial UI Automation support ships today, but
+  terminal scrollback and broader screen reader coverage are still
+  incomplete.
 
 ## What works today
 
@@ -90,16 +91,16 @@ official Ghostty docs, see
 ## Install
 
 Latest stable release:
-**[winghostty 1.3.106](https://github.com/amanthanvi/winghostty/releases/tag/v1.3.106)**,
-published 2026-04-24.
+**[winghostty 1.3.109](https://github.com/amanthanvi/winghostty/releases/tag/v1.3.109)**,
+published 2026-05-01.
 
 Download directly from **[Releases](https://github.com/amanthanvi/winghostty/releases)**:
 
 | File | Use when |
 | --- | --- |
-| [`winghostty-1.3.106-windows-x64-setup.exe`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.106/winghostty-1.3.106-windows-x64-setup.exe) | You want a normal install with a Start menu entry. |
-| [`winghostty-1.3.106-windows-x64-portable.zip`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.106/winghostty-1.3.106-windows-x64-portable.zip) | You want to run without installing. |
-| [`SHA256SUMS.txt`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.106/SHA256SUMS.txt) | Verifying downloads. |
+| [`winghostty-1.3.109-windows-x64-setup.exe`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/winghostty-1.3.109-windows-x64-setup.exe) | You want a normal install with a Start menu entry. |
+| [`winghostty-1.3.109-windows-x64-portable.zip`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/winghostty-1.3.109-windows-x64-portable.zip) | You want to run without installing. |
+| [`SHA256SUMS.txt`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/SHA256SUMS.txt) | Verifying downloads. |
 
 Scoop users can install from the fork-owned bucket:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   ·
   <a href="docs/status.md">Status</a>
   ·
+  <a href="docs/windows-capability-matrix.md">Windows capability matrix</a>
+  ·
   <a href="HACKING.md">Hacking</a>
   ·
   <a href="CONTRIBUTING.md">Contributing</a>
@@ -81,7 +83,9 @@ First public releases: 2026-04-16.
 - `libghostty-vt` as a retained Zig / C library deliverable.
 
 A precise list, including what is experimental and what is out of scope,
-is in **[docs/status.md](docs/status.md)**.
+is in **[docs/status.md](docs/status.md)**. For a row-by-row mapping against
+official Ghostty docs, see
+**[docs/windows-capability-matrix.md](docs/windows-capability-matrix.md)**.
 
 ## Install
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -123,7 +123,8 @@ extractions will land as they stabilize.
 
 No formal roadmap. Indicative next areas:
 
-- Initial UI Automation / screen reader support
+- Broader UI Automation / screen reader coverage, including terminal text
+  exposure and more per-widget support
 - Continuing the `src/apprt/win32.zig` extraction begun in commit
   `a759eb6`
 - Code signing for Windows releases

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,7 +85,7 @@ planned.
 
 ### Win32 runtime extraction
 
-The Win32 application runtime is currently a single ~13.7k LOC file at
+The Win32 application runtime is still centered on a single large file at
 `src/apprt/win32.zig`. Extraction into focused modules is in progress:
 commit `a759eb6 refactor(win32): extract theme module from monolithic
 win32.zig` moved theme helpers to `src/apprt/win32_theme.zig`. Further

--- a/docs/status.md
+++ b/docs/status.md
@@ -3,7 +3,10 @@
 What currently works in winghostty, what is experimental, and what is out of
 scope. When this page disagrees with a commit message, trust this page.
 
-Last updated: 2026-04-16, against `main` HEAD.
+Last updated: 2026-05-01, against current fork HEAD.
+
+For a row-by-row mapping against official Ghostty docs, see
+[windows-capability-matrix.md](windows-capability-matrix.md).
 
 ## Supported platform
 
@@ -73,10 +76,12 @@ Last updated: 2026-04-16, against `main` HEAD.
 
 ### Windows UI Automation (accessibility)
 
-Screen reader / UI Automation support is **planned near-term work and not
-yet shipping**. The Win32 runtime does not yet expose per-widget UIA
-providers; Narrator and NVDA coverage is part of the upcoming phase. See
-the roadmap below.
+UI Automation is **partial, not complete**. The Win32 host answers
+`WM_GETOBJECT` with a root provider, caption buttons still chain through the
+system host provider, and the command palette exposes a list provider so
+Narrator/NVDA can announce selection changes. Terminal scrollback is not yet
+exposed through `ITextProvider`, and broader per-widget coverage remains
+planned.
 
 ### Win32 runtime extraction
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -1,0 +1,62 @@
+# Windows Capability Matrix
+
+Maps current official Ghostty docs surfaces to winghostty behavior on
+Windows. Keep this short. Update rows when Windows behavior changes or when
+upstream docs add or remove a surface that this fork cares about.
+
+Last reviewed: 2026-05-01.
+
+## Status legend
+
+- `supported` — works on current Windows builds and matches upstream docs
+  closely enough to rely on them.
+- `partial` — some of the surface works, but Windows behavior is narrower,
+  differently scoped, or still filling in.
+- `no-op compatibility` — the option or surface exists for compatibility,
+  but currently reduces to placeholder or weaker behavior.
+- `windows-specific` — added or materially changed by this fork; upstream
+  Ghostty docs do not describe it accurately yet.
+
+## Supported
+
+| Ghostty docs surface | winghostty note |
+| --- | --- |
+| [Configuration](https://ghostty.org/docs/config) and [option reference](https://ghostty.org/docs/config/reference) | Same config grammar and generated docs surface. On Windows the config file lives at `%LOCALAPPDATA%\winghostty\config.ghostty`, and live reload is available via `Ctrl+Shift+,`. |
+| [Custom keybindings](https://ghostty.org/docs/config/keybind) | Same `keybind = trigger=action` grammar and `+list-keybinds` flow. Default bindings are Windows-native rather than macOS/Linux defaults. |
+| [Color Theme](https://ghostty.org/docs/features/theme) | Built-in themes, separate light/dark themes, custom themes, and `+list-themes` ship on Windows. |
+| [Terminal API (VT)](https://ghostty.org/docs/vt) and [VT reference](https://ghostty.org/docs/vt/reference) | The shared Ghostty terminal core carries the documented VT/OSC/Kitty surface used by terminal apps. |
+| [Features overview: windows, tabs, and splits](https://ghostty.org/docs/features) | Native Win32 windows, tabs, and splits ship today in winghostty. |
+
+## Partial
+
+| Ghostty docs surface | winghostty note |
+| --- | --- |
+| [Shell integration](https://ghostty.org/docs/features/shell-integration) | PowerShell auto-injection is supported on Windows. Broader Git Bash, WSL, and other non-PowerShell flows share the same surface but are still maturing and should not be treated as full parity with upstream docs. |
+| [Action reference](https://ghostty.org/docs/config/keybind/reference) | Shared action grammar is intact, but upstream docs still mix shared actions with macOS/Linux-specific behavior. For Windows-specific truth on a disputed action, prefer `winghostty +show-config --default --docs` plus the current defaults from `+list-keybinds`. |
+| [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and notify-only update prompts backed by GitHub Releases. Background download/install behavior is not implemented. |
+| [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |
+
+## No-op Compatibility
+
+| Ghostty docs surface | winghostty note |
+| --- | --- |
+| [Configuration: `auto-update = download`](https://ghostty.org/docs/config/reference) | Accepted on Windows, but today behaves the same as `auto-update = check`; no background download or install path runs. |
+
+## Windows-Specific
+
+| Ghostty docs surface | winghostty note |
+| --- | --- |
+| [Features overview](https://ghostty.org/docs/features) | Upstream Ghostty docs still say Windows support is planned. winghostty ships a native Win32 app on Windows 10/11 x64. |
+| [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Upstream highlights Metal on macOS and OpenGL on Linux. winghostty renders on Windows with OpenGL 4.3+ via WGL; no D3D/DirectX backend ships. |
+| [Configuration](https://ghostty.org/docs/config) | Windows state/config paths live under `%LOCALAPPDATA%\winghostty\...`, not the macOS/Linux paths documented upstream. |
+| [Features overview](https://ghostty.org/docs/features) | Win32-specific UX includes DWM dark title bar integration, high-contrast palette switching, IME, drag-and-drop, and native context menus. |
+
+## Maintenance Anchors
+
+- `src/config/Config.zig` — config docs, keybinds, `auto-update` docstrings.
+- `src/termio/shell_integration.zig` and `src/config/windows_shell.zig` —
+  shell integration and Windows shell detection.
+- `src/apprt/win32.zig`, `src/apprt/win32_theme.zig`, and
+  `src/apprt/win32_uia/` — Win32 runtime, chrome/input, accessibility.
+- `docs/status.md` and `docs/getting-started.md` — user-facing summaries that
+  should stay aligned with this matrix.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -31,7 +31,7 @@ Last reviewed: 2026-05-01.
 
 | Ghostty docs surface | winghostty note |
 | --- | --- |
-| [Shell integration](https://ghostty.org/docs/features/shell-integration) | PowerShell auto-injection is supported on Windows. Broader Git Bash, WSL, and other non-PowerShell flows share the same surface but are still maturing and should not be treated as full parity with upstream docs. |
+| [Shell integration](https://ghostty.org/docs/features/shell-integration) | Upstream docs for automatic `bash` / `elvish` / `fish` / `nushell` / `zsh` injection still apply when those shells are launched on Windows. winghostty additionally supports automatic PowerShell injection (`powershell.exe`, `pwsh.exe`) plus a manual fallback under `%LOCALAPPDATA%\winghostty\shell-integration\powershell\integration.ps1`, which upstream docs do not cover. |
 | [Action reference](https://ghostty.org/docs/config/keybind/reference) | Shared action grammar is intact, but upstream docs still mix shared actions with macOS/Linux-specific behavior. For Windows-specific truth on a disputed action, prefer `winghostty +show-config --default --docs` plus the current defaults from `+list-keybinds`. |
 | [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and notify-only update prompts backed by GitHub Releases. Background download/install behavior is not implemented. |
 | [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |


### PR DESCRIPTION
## Summary
- adds a Windows capability matrix covering supported, partial, no-op, compatibility, and Windows-specific behavior
- links the matrix from README and status docs

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/check-site-copy.ps1
- doc consistency check

## Summary by Sourcery

Document Windows capabilities and align Windows-related documentation with current behavior and release state.

Documentation:
- Add a Windows capability matrix mapping official Ghostty documentation surfaces to current winghostty behavior on Windows, including supported, partial, no-op, and Windows-specific areas.
- Link the new Windows capability matrix from the README and status documentation for easier discovery.
- Update README and status text to describe current partial Windows accessibility / UI Automation coverage instead of planned-only support, and refresh status metadata and maintenance anchors.
- Refresh README install section to point to the latest Windows release version and artifacts.
- Extend the AGENTS self-correction log with guidance on ensuring `gh pr view` targets the fork repository when inspecting pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation now points to v1.3.109 with updated download links and checksums.
  * README navigation adds a “Windows capability matrix” link.
  * New Windows capability matrix added for row-by-row feature mapping to official docs.
  * Project status updated to reflect partial UI Automation support and remaining coverage gaps.
  * Status snapshot updated (last updated 2026-05-01) and linked capability matrix.
  * Wording around Win32 runtime extraction clarified.
  * Added a self-correction note advising explicit repo selection when resolving PRs via CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->