### PR TITLE
feat(win32): add job object planning helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: In Zig Win32 FFI, `std.os.windows.HANDLE` is non-null; APIs like `CreateJobObjectW` that signal failure with `NULL` must use `?HANDLE` in extern declarations or future callers cannot model failure correctly.
 - 2026-05-01: On Win32 x64, `JOBOBJECT_BASIC_LIMIT_INFORMATION` is 64 bytes, not 56; `SIZE_T`/`Affinity` padding also shifts `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` to 144 bytes with `JobMemoryLimit` at offset 120. Keep ABI tests on real offsets before wiring Job Object FFI.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: On Win32 x64, `JOBOBJECT_BASIC_LIMIT_INFORMATION` is 64 bytes, not 56; `SIZE_T`/`Affinity` padding also shifts `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` to 144 bytes with `JobMemoryLimit` at offset 120. Keep ABI tests on real offsets before wiring Job Object FFI.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -15,6 +15,7 @@ pub const action = @import("apprt/action.zig");
 pub const ipc = @import("apprt/ipc.zig");
 pub const none = @import("apprt/none.zig");
 pub const win32 = @import("apprt/win32.zig");
+pub const win32_job_object = @import("apprt/win32_job_object.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = none;
 pub const surface = @import("apprt/surface.zig");
@@ -55,4 +56,5 @@ test {
     _ = runtime;
     _ = action;
     _ = structs;
+    _ = win32_job_object;
 }

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -65,7 +65,7 @@ pub extern "kernel32" fn CreateJobObjectW(
 pub extern "kernel32" fn SetInformationJobObject(
     hJob: HANDLE,
     JobObjectInfoClass: JOBOBJECTINFOCLASS,
-    lpJobObjectInfo: ?*anyopaque,
+    lpJobObjectInfo: *const anyopaque,
     cbJobObjectInfoLength: DWORD,
 ) callconv(.winapi) BOOL;
 
@@ -96,21 +96,17 @@ pub const Plan = struct {
     active_process_limit: ?DWORD = null,
     job_memory_limit_bytes: ?SIZE_T = null,
 
-    // First slice safety rule: never opt into close-time child termination.
-    terminate_on_job_close: bool = false,
-
     pub fn wantsJobObject(self: Plan) bool {
         return self.mode != .never;
     }
 
     pub fn hasLimits(self: Plan) bool {
         return self.active_process_limit != null or
-            self.job_memory_limit_bytes != null or
-            self.terminate_on_job_close;
+            self.job_memory_limit_bytes != null;
     }
 
     pub fn extendedLimitInformation(self: Plan) ?JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
-        if (!self.hasLimits()) return null;
+        if (!self.wantsJobObject() or !self.hasLimits()) return null;
 
         var info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = .{};
 
@@ -122,10 +118,6 @@ pub const Plan = struct {
         if (self.job_memory_limit_bytes) |limit| {
             info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
             info.JobMemoryLimit = limit;
-        }
-
-        if (self.terminate_on_job_close) {
-            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         }
 
         return info;
@@ -161,6 +153,7 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
 
 test "win32 job object ABI declarations match expected Win32 values" {
     const create_fn = @typeInfo(@TypeOf(CreateJobObjectW)).@"fn";
+    const set_info_fn = @typeInfo(@TypeOf(SetInformationJobObject)).@"fn";
 
     try std.testing.expectEqual(@as(i32, 9), @intFromEnum(JOBOBJECTINFOCLASS.extended_limit_information));
     try std.testing.expectEqual(@as(DWORD, 0x00000008), JOB_OBJECT_LIMIT_ACTIVE_PROCESS);
@@ -169,6 +162,7 @@ test "win32 job object ABI declarations match expected Win32 values" {
     try std.testing.expect(create_fn.params[0].type.? == ?*SECURITY_ATTRIBUTES);
     try std.testing.expect(create_fn.params[1].type.? == ?LPCWSTR);
     try std.testing.expect(create_fn.return_type.? == ?HANDLE);
+    try std.testing.expect(set_info_fn.params[2].type.? == *const anyopaque);
 }
 
 test "win32 job object ABI layouts stay compatible on x64" {
@@ -193,7 +187,6 @@ test "win32 job object plan stays disabled for default config" {
     try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
     try std.testing.expect(!plan.wantsJobObject());
     try std.testing.expect(!plan.hasLimits());
-    try std.testing.expect(!plan.terminate_on_job_close);
     try std.testing.expect(plan.extendedLimitInformation() == null);
 }
 
@@ -210,7 +203,6 @@ test "win32 job object plan maps compatibility limits without kill-on-close" {
     try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
     try std.testing.expect(plan.wantsJobObject());
     try std.testing.expect(plan.hasLimits());
-    try std.testing.expect(!plan.terminate_on_job_close);
     try std.testing.expectEqual(
         JOB_OBJECT_LIMIT_ACTIVE_PROCESS | JOB_OBJECT_LIMIT_JOB_MEMORY,
         limits.BasicLimitInformation.LimitFlags,
@@ -231,6 +223,17 @@ test "win32 job object plan ignores compatibility limits when mode is never" {
     try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
     try std.testing.expect(!plan.wantsJobObject());
     try std.testing.expect(!plan.hasLimits());
+    try std.testing.expect(plan.extendedLimitInformation() == null);
+}
+
+test "win32 job object never plan cannot synthesize limit blob" {
+    const plan: Plan = .{
+        .mode = .never,
+        .active_process_limit = 1,
+        .job_memory_limit_bytes = 1024,
+    };
+
+    try std.testing.expect(plan.hasLimits());
     try std.testing.expect(plan.extendedLimitInformation() == null);
 }
 

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -16,6 +16,8 @@ pub const BOOL = windows.BOOL;
 pub const SIZE_T = windows.SIZE_T;
 pub const SECURITY_ATTRIBUTES = windows.SECURITY_ATTRIBUTES;
 pub const LPCWSTR = win32_types.LPCWSTR;
+pub const ULONG_PTR = win32_types.UINT_PTR;
+pub const KAFFINITY = ULONG_PTR;
 
 pub const JOB_OBJECT_LIMIT_ACTIVE_PROCESS: DWORD = 0x00000008;
 pub const JOB_OBJECT_LIMIT_JOB_MEMORY: DWORD = 0x00000200;
@@ -43,7 +45,7 @@ pub const JOBOBJECT_BASIC_LIMIT_INFORMATION = extern struct {
     MinimumWorkingSetSize: SIZE_T = 0,
     MaximumWorkingSetSize: SIZE_T = 0,
     ActiveProcessLimit: DWORD = 0,
-    Affinity: usize = 0,
+    Affinity: KAFFINITY = 0,
     PriorityClass: DWORD = 0,
     SchedulingClass: DWORD = 0,
 };

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -18,7 +18,6 @@ pub const SECURITY_ATTRIBUTES = windows.SECURITY_ATTRIBUTES;
 pub const LPCWSTR = win32_types.LPCWSTR;
 
 pub const JOB_OBJECT_LIMIT_ACTIVE_PROCESS: DWORD = 0x00000008;
-pub const JOB_OBJECT_LIMIT_PROCESS_MEMORY: DWORD = 0x00000100;
 pub const JOB_OBJECT_LIMIT_JOB_MEMORY: DWORD = 0x00000200;
 pub const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x00002000;
 
@@ -255,4 +254,14 @@ test "win32 job object plan rejects process limits that exceed DWORD" {
     config.@"linux-cgroup-processes-limit" = @as(u64, std.math.maxInt(u32)) + 1;
 
     try std.testing.expectError(error.ProcessLimitOverflow, configPlan(&config));
+}
+
+test "win32 job object plan rejects memory limits that exceed SIZE_T" {
+    if (@sizeOf(SIZE_T) >= @sizeOf(u64)) return error.SkipZigTest;
+
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup" = .always;
+    config.@"linux-cgroup-memory-limit" = @as(u64, std.math.maxInt(SIZE_T)) + 1;
+
+    try std.testing.expectError(error.JobMemoryLimitOverflow, configPlan(&config));
 }

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -59,9 +59,9 @@ pub const JOBOBJECT_EXTENDED_LIMIT_INFORMATION = extern struct {
 };
 
 pub extern "kernel32" fn CreateJobObjectW(
-    lpJobAttributes: ?*const SECURITY_ATTRIBUTES,
+    lpJobAttributes: ?*SECURITY_ATTRIBUTES,
     lpName: ?LPCWSTR,
-) callconv(.winapi) HANDLE;
+) callconv(.winapi) ?HANDLE;
 
 pub extern "kernel32" fn SetInformationJobObject(
     hJob: HANDLE,
@@ -161,10 +161,15 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
 }
 
 test "win32 job object ABI declarations match expected Win32 values" {
+    const create_fn = @typeInfo(@TypeOf(CreateJobObjectW)).@"fn";
+
     try std.testing.expectEqual(@as(i32, 9), @intFromEnum(JOBOBJECTINFOCLASS.extended_limit_information));
     try std.testing.expectEqual(@as(DWORD, 0x00000008), JOB_OBJECT_LIMIT_ACTIVE_PROCESS);
     try std.testing.expectEqual(@as(DWORD, 0x00000200), JOB_OBJECT_LIMIT_JOB_MEMORY);
     try std.testing.expectEqual(@as(DWORD, 0x00002000), JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE);
+    try std.testing.expect(create_fn.params[0].type.? == ?*SECURITY_ATTRIBUTES);
+    try std.testing.expect(create_fn.params[1].type.? == ?LPCWSTR);
+    try std.testing.expect(create_fn.return_type.? == ?HANDLE);
 }
 
 test "win32 job object ABI layouts stay compatible on x64" {

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -1,0 +1,253 @@
+//! Minimal Windows Job Object ABI and config planning.
+//!
+//! This first slice is intentionally inert: it only exposes the Win32
+//! declarations and a pure mapping from existing compatibility config to a
+//! future Job Object plan. No live process spawning or enforcement is wired
+//! here yet.
+
+const std = @import("std");
+const windows = std.os.windows;
+const configpkg = @import("../config.zig");
+const win32_types = @import("win32_types.zig");
+
+pub const HANDLE = windows.HANDLE;
+pub const DWORD = windows.DWORD;
+pub const BOOL = windows.BOOL;
+pub const SIZE_T = windows.SIZE_T;
+pub const SECURITY_ATTRIBUTES = windows.SECURITY_ATTRIBUTES;
+pub const LPCWSTR = win32_types.LPCWSTR;
+
+pub const JOB_OBJECT_LIMIT_ACTIVE_PROCESS: DWORD = 0x00000008;
+pub const JOB_OBJECT_LIMIT_PROCESS_MEMORY: DWORD = 0x00000100;
+pub const JOB_OBJECT_LIMIT_JOB_MEMORY: DWORD = 0x00000200;
+pub const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x00002000;
+
+pub const JOBOBJECTINFOCLASS = enum(i32) {
+    basic_limit_information = 2,
+    extended_limit_information = 9,
+    _,
+};
+
+pub const IO_COUNTERS = extern struct {
+    ReadOperationCount: u64 = 0,
+    WriteOperationCount: u64 = 0,
+    OtherOperationCount: u64 = 0,
+    ReadTransferCount: u64 = 0,
+    WriteTransferCount: u64 = 0,
+    OtherTransferCount: u64 = 0,
+};
+
+pub const JOBOBJECT_BASIC_LIMIT_INFORMATION = extern struct {
+    PerProcessUserTimeLimit: i64 = 0,
+    PerJobUserTimeLimit: i64 = 0,
+    LimitFlags: DWORD = 0,
+    MinimumWorkingSetSize: SIZE_T = 0,
+    MaximumWorkingSetSize: SIZE_T = 0,
+    ActiveProcessLimit: DWORD = 0,
+    Affinity: usize = 0,
+    PriorityClass: DWORD = 0,
+    SchedulingClass: DWORD = 0,
+};
+
+pub const JOBOBJECT_EXTENDED_LIMIT_INFORMATION = extern struct {
+    BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION = .{},
+    IoInfo: IO_COUNTERS = .{},
+    ProcessMemoryLimit: SIZE_T = 0,
+    JobMemoryLimit: SIZE_T = 0,
+    PeakProcessMemoryUsed: SIZE_T = 0,
+    PeakJobMemoryUsed: SIZE_T = 0,
+};
+
+pub extern "kernel32" fn CreateJobObjectW(
+    lpJobAttributes: ?*const SECURITY_ATTRIBUTES,
+    lpName: ?LPCWSTR,
+) callconv(.winapi) HANDLE;
+
+pub extern "kernel32" fn SetInformationJobObject(
+    hJob: HANDLE,
+    JobObjectInfoClass: JOBOBJECTINFOCLASS,
+    lpJobObjectInfo: ?*anyopaque,
+    cbJobObjectInfoLength: DWORD,
+) callconv(.winapi) BOOL;
+
+pub extern "kernel32" fn AssignProcessToJobObject(
+    hJob: HANDLE,
+    hProcess: HANDLE,
+) callconv(.winapi) BOOL;
+
+pub const Mode = enum {
+    never,
+    always,
+    single_instance,
+};
+
+pub const AttachPolicy = enum {
+    best_effort,
+    hard_fail,
+};
+
+pub const ConfigPlanError = error{
+    ProcessLimitOverflow,
+    JobMemoryLimitOverflow,
+};
+
+pub const Plan = struct {
+    mode: Mode,
+    attach_policy: AttachPolicy = .best_effort,
+    active_process_limit: ?DWORD = null,
+    job_memory_limit_bytes: ?SIZE_T = null,
+
+    // First slice safety rule: never opt into close-time child termination.
+    terminate_on_job_close: bool = false,
+
+    pub fn wantsJobObject(self: Plan) bool {
+        return self.mode != .never;
+    }
+
+    pub fn hasLimits(self: Plan) bool {
+        return self.active_process_limit != null or
+            self.job_memory_limit_bytes != null or
+            self.terminate_on_job_close;
+    }
+
+    pub fn extendedLimitInformation(self: Plan) ?JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        if (!self.hasLimits()) return null;
+
+        var info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = .{};
+
+        if (self.active_process_limit) |limit| {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
+            info.BasicLimitInformation.ActiveProcessLimit = limit;
+        }
+
+        if (self.job_memory_limit_bytes) |limit| {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
+            info.JobMemoryLimit = limit;
+        }
+
+        if (self.terminate_on_job_close) {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        }
+
+        return info;
+    }
+};
+
+pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
+    const mode = switch (config.@"linux-cgroup") {
+        .never => Mode.never,
+        .always => Mode.always,
+        .@"single-instance" => Mode.single_instance,
+    };
+
+    // Preserve current Windows behavior unless the explicit compat mode opts in.
+    if (mode == .never) return .{ .mode = .never };
+
+    return .{
+        .mode = mode,
+        .attach_policy = if (config.@"linux-cgroup-hard-fail")
+            .hard_fail
+        else
+            .best_effort,
+        .active_process_limit = if (config.@"linux-cgroup-processes-limit") |limit|
+            std.math.cast(DWORD, limit) orelse return error.ProcessLimitOverflow
+        else
+            null,
+        .job_memory_limit_bytes = if (config.@"linux-cgroup-memory-limit") |limit|
+            std.math.cast(SIZE_T, limit) orelse return error.JobMemoryLimitOverflow
+        else
+            null,
+    };
+}
+
+test "win32 job object ABI declarations match expected Win32 values" {
+    try std.testing.expectEqual(@as(i32, 9), @intFromEnum(JOBOBJECTINFOCLASS.extended_limit_information));
+    try std.testing.expectEqual(@as(DWORD, 0x00000008), JOB_OBJECT_LIMIT_ACTIVE_PROCESS);
+    try std.testing.expectEqual(@as(DWORD, 0x00000200), JOB_OBJECT_LIMIT_JOB_MEMORY);
+    try std.testing.expectEqual(@as(DWORD, 0x00002000), JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE);
+}
+
+test "win32 job object ABI layouts stay compatible on x64" {
+    if (@sizeOf(usize) != 8) return error.SkipZigTest;
+
+    try std.testing.expectEqual(@as(usize, 48), @sizeOf(IO_COUNTERS));
+    try std.testing.expectEqual(@as(usize, 64), @sizeOf(JOBOBJECT_BASIC_LIMIT_INFORMATION));
+    try std.testing.expectEqual(@as(usize, 144), @sizeOf(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+
+    try std.testing.expectEqual(@as(usize, 16), @offsetOf(JOBOBJECT_BASIC_LIMIT_INFORMATION, "LimitFlags"));
+    try std.testing.expectEqual(@as(usize, 40), @offsetOf(JOBOBJECT_BASIC_LIMIT_INFORMATION, "ActiveProcessLimit"));
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(JOBOBJECT_EXTENDED_LIMIT_INFORMATION, "BasicLimitInformation"));
+    try std.testing.expectEqual(@as(usize, 64), @offsetOf(JOBOBJECT_EXTENDED_LIMIT_INFORMATION, "IoInfo"));
+    try std.testing.expectEqual(@as(usize, 120), @offsetOf(JOBOBJECT_EXTENDED_LIMIT_INFORMATION, "JobMemoryLimit"));
+}
+
+test "win32 job object plan stays disabled for default config" {
+    var config: configpkg.Config = .{};
+    const plan = try configPlan(&config);
+
+    try std.testing.expectEqual(Mode.never, plan.mode);
+    try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
+    try std.testing.expect(!plan.wantsJobObject());
+    try std.testing.expect(!plan.hasLimits());
+    try std.testing.expect(!plan.terminate_on_job_close);
+    try std.testing.expect(plan.extendedLimitInformation() == null);
+}
+
+test "win32 job object plan maps compatibility limits without kill-on-close" {
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup" = .always;
+    config.@"linux-cgroup-memory-limit" = 512 * 1024 * 1024;
+    config.@"linux-cgroup-processes-limit" = 4;
+
+    const plan = try configPlan(&config);
+    const limits = plan.extendedLimitInformation().?;
+
+    try std.testing.expectEqual(Mode.always, plan.mode);
+    try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
+    try std.testing.expect(plan.wantsJobObject());
+    try std.testing.expect(plan.hasLimits());
+    try std.testing.expect(!plan.terminate_on_job_close);
+    try std.testing.expectEqual(
+        JOB_OBJECT_LIMIT_ACTIVE_PROCESS | JOB_OBJECT_LIMIT_JOB_MEMORY,
+        limits.BasicLimitInformation.LimitFlags,
+    );
+    try std.testing.expectEqual(@as(u32, 4), limits.BasicLimitInformation.ActiveProcessLimit);
+    try std.testing.expectEqual(@as(usize, 512 * 1024 * 1024), limits.JobMemoryLimit);
+}
+
+test "win32 job object plan ignores compatibility limits when mode is never" {
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup-memory-limit" = 512 * 1024 * 1024;
+    config.@"linux-cgroup-processes-limit" = 4;
+    config.@"linux-cgroup-hard-fail" = true;
+
+    const plan = try configPlan(&config);
+
+    try std.testing.expectEqual(Mode.never, plan.mode);
+    try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
+    try std.testing.expect(!plan.wantsJobObject());
+    try std.testing.expect(!plan.hasLimits());
+    try std.testing.expect(plan.extendedLimitInformation() == null);
+}
+
+test "win32 job object single-instance mode can request hard-fail attachment without limits" {
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup" = .@"single-instance";
+    config.@"linux-cgroup-hard-fail" = true;
+
+    const plan = try configPlan(&config);
+
+    try std.testing.expectEqual(Mode.single_instance, plan.mode);
+    try std.testing.expectEqual(AttachPolicy.hard_fail, plan.attach_policy);
+    try std.testing.expect(plan.wantsJobObject());
+    try std.testing.expect(!plan.hasLimits());
+    try std.testing.expect(plan.extendedLimitInformation() == null);
+}
+
+test "win32 job object plan rejects process limits that exceed DWORD" {
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup" = .always;
+    config.@"linux-cgroup-processes-limit" = @as(u64, std.math.maxInt(u32)) + 1;
+
+    try std.testing.expectError(error.ProcessLimitOverflow, configPlan(&config));
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3034,29 +3034,34 @@ keybind: Keybinds = .{},
 
 /// Retained compatibility settings from Linux-specific runtime features.
 ///
-/// These keys continue to parse so existing configs remain loadable, but they
-/// have no effect in the Windows-only fork unless a field explicitly documents
-/// otherwise.
+/// These keys continue to parse so existing configs remain loadable.
+///
+/// In the Windows-only fork they are compatibility-only inputs to the inert
+/// Win32 Job Object planning layer. They do not attach processes to a job or
+/// enforce limits unless future runtime wiring explicitly opts in.
 ///
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// This continues to parse so existing configs remain loadable, but it has no
-/// effect in the Windows-only fork.
+/// Selects whether the inert Win32 Job Object planning layer should synthesize
+/// a compatibility plan. `.never` preserves current Windows behavior.
 @"linux-cgroup": LinuxCgroup = .never,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// This has no effect in the Windows-only fork.
+/// Compatibility-only input for inert Win32 Job Object planning. No live
+/// memory limit is enforced in the current Windows runtime.
 @"linux-cgroup-memory-limit": ?u64 = null,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// This has no effect in the Windows-only fork.
+/// Compatibility-only input for inert Win32 Job Object planning. No live
+/// process-count limit is enforced in the current Windows runtime.
 @"linux-cgroup-processes-limit": ?u64 = null,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// This has no effect in the Windows-only fork.
+/// Compatibility-only input for inert Win32 Job Object planning. No current
+/// runtime attach path hard-fails based on this setting.
 @"linux-cgroup-hard-fail": bool = false,
 
 /// Retained compatibility settings from the removed GTK runtime.


### PR DESCRIPTION
## Summary
- adds inert Win32 Job Object FFI/config planning foundation
- maps existing compatibility config without enabling termination behavior

## Validation
- scripts/dev-windows.cmd zig build test -Dtest-filter="win32 job object"
- scripts/dev-windows.cmd zig build test -Dtest-filter="shared Win32 type layouts"

## Summary by Sourcery

Introduce an initial, non-enforcing Windows Job Object planning layer and wire it into the application runtime module exports.

New Features:
- Define minimal Win32 Job Object FFI types, constants, and kernel32 bindings for future process management on Windows.
- Add a configuration-driven Job Object planning struct that maps existing Linux cgroup compatibility settings into a Windows job object plan without changing current behavior.

Enhancements:
- Record Windows Job Object HANDLE nullability and struct layout details in the self-correction log for future ABI correctness.
- Extend the apprt module surface to expose the new Win32 job object planning helper.

Tests:
- Add ABI and layout tests for Win32 Job Object structures and functions on x64, plus behavioral tests for the new job object planning logic under various configuration scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Publicly exported an inert Windows Job Object planning layer to synthesize optional process and memory limits from compatibility config (no live enforcement or attachment yet).

* **Documentation**
  * Clarified compatibility-only config behavior and added guidance on Win32 Job Object ABI/handle-nullability for correct wiring.

* **Tests**
  * Added tests validating ABI struct sizes/offsets, kernel bindings, and planning behavior including limit mapping and overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->