### PR TITLE
feat(config): support custom regex links on windows

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -30,7 +30,7 @@ const font = @import("font/main.zig");
 const Command = @import("Command.zig");
 const terminal = @import("terminal/main.zig");
 const configpkg = @import("config.zig");
-const config_url = @import("config/url.zig");
+const configUrl = @import("config/url.zig");
 const Duration = configpkg.Config.Duration;
 const input = @import("input.zig");
 const App = @import("App.zig");
@@ -450,7 +450,7 @@ const DerivedConfig = struct {
 
         if (config.@"link-url") {
             var regex = try oni.Regex.init(
-                config_url.regex,
+                configUrl.regex,
                 .{},
                 oni.Encoding.utf8,
                 oni.Syntax.default,
@@ -472,6 +472,7 @@ const DerivedConfig = struct {
 
         var config = try configpkg.Config.default(testing.allocator);
         defer config.deinit();
+        config.@"link-url" = true;
 
         const alloc = config._arena.?.allocator();
         try config.link.links.append(alloc, .{

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -30,6 +30,7 @@ const font = @import("font/main.zig");
 const Command = @import("Command.zig");
 const terminal = @import("terminal/main.zig");
 const configpkg = @import("config.zig");
+const config_url = @import("config/url.zig");
 const Duration = configpkg.Config.Duration;
 const input = @import("input.zig");
 const App = @import("App.zig");
@@ -367,22 +368,7 @@ const DerivedConfig = struct {
         errdefer arena.deinit();
         const alloc = arena.allocator();
 
-        // Build all of our links
-        const links = links: {
-            var links: std.ArrayList(DerivedConfig.Link) = .empty;
-            defer links.deinit(alloc);
-            for (config.link.links.items) |link| {
-                var regex = try link.oniRegex();
-                errdefer regex.deinit();
-                try links.append(alloc, .{
-                    .regex = regex,
-                    .action = link.action,
-                    .highlight = link.highlight,
-                });
-            }
-
-            break :links try links.toOwnedSlice(alloc);
-        };
+        const links = try buildLinks(alloc, config);
         errdefer {
             for (links) |*link| link.regex.deinit();
             alloc.free(links);
@@ -443,6 +429,65 @@ const DerivedConfig = struct {
     pub fn deinit(self: *DerivedConfig) void {
         for (self.links) |*link| link.regex.deinit();
         self.arena.deinit();
+    }
+
+    fn buildLinks(alloc: Allocator, config: *const configpkg.Config) ![]DerivedConfig.Link {
+        var links: std.ArrayList(DerivedConfig.Link) = .empty;
+        defer links.deinit(alloc);
+
+        try links.ensureTotalCapacity(alloc, config.link.links.items.len + @intFromBool(config.@"link-url"));
+
+        for (config.link.links.items) |link| {
+            var regex = try link.oniRegex();
+            errdefer regex.deinit();
+            try links.append(alloc, .{
+                .regex = regex,
+                .action = link.action,
+                .highlight = link.highlight,
+            });
+        }
+
+        if (config.@"link-url") {
+            var regex = try oni.Regex.init(
+                config_url.regex,
+                .{},
+                oni.Encoding.utf8,
+                oni.Syntax.default,
+                null,
+            );
+            errdefer regex.deinit();
+            try links.append(alloc, .{
+                .regex = regex,
+                .action = .{ .open = {} },
+                .highlight = .{ .hover_mods = input.ctrlOrSuper(.{}) },
+            });
+        }
+
+        return try links.toOwnedSlice(alloc);
+    }
+
+    test "DerivedConfig init keeps custom links ahead of builtin URL matcher" {
+        const testing = std.testing;
+
+        var config = try configpkg.Config.default(testing.allocator);
+        defer config.deinit();
+
+        const alloc = config._arena.?.allocator();
+        try config.link.links.append(alloc, .{
+            .regex = try alloc.dupe(u8, "^foo://bar$"),
+            .action = .{ .open = {} },
+            .highlight = .hover,
+        });
+
+        var derived = try DerivedConfig.init(testing.allocator, &config);
+        defer derived.deinit();
+
+        try testing.expectEqual(@as(usize, 2), derived.links.len);
+        try testing.expectEqual(input.Link.Highlight.hover, derived.links[0].highlight);
+        try testing.expectEqualDeep(
+            input.Link.Highlight{ .hover_mods = input.ctrlOrSuper(.{}) },
+            derived.links[1].highlight,
+        );
     }
 
     fn scaledPadding(self: *const DerivedConfig, x_dpi: f32, y_dpi: f32) rendererpkg.Padding {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -434,6 +434,7 @@ const DerivedConfig = struct {
     fn buildLinks(alloc: Allocator, config: *const configpkg.Config) ![]DerivedConfig.Link {
         var links: std.ArrayList(DerivedConfig.Link) = .empty;
         defer links.deinit(alloc);
+        errdefer for (links.items) |*link| link.regex.deinit();
 
         try links.ensureTotalCapacity(alloc, config.link.links.items.len + @intFromBool(config.@"link-url"));
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -439,9 +439,8 @@ const DerivedConfig = struct {
         try links.ensureTotalCapacity(alloc, config.link.links.items.len + @intFromBool(config.@"link-url"));
 
         for (config.link.links.items) |link| {
-            var regex = try link.oniRegex();
-            errdefer regex.deinit();
-            try links.append(alloc, .{
+            const regex = try link.oniRegex();
+            links.appendAssumeCapacity(.{
                 .regex = regex,
                 .action = link.action,
                 .highlight = link.highlight,
@@ -449,15 +448,14 @@ const DerivedConfig = struct {
         }
 
         if (config.@"link-url") {
-            var regex = try oni.Regex.init(
+            const regex = try oni.Regex.init(
                 configUrl.regex,
                 .{},
                 oni.Encoding.utf8,
                 oni.Syntax.default,
                 null,
             );
-            errdefer regex.deinit();
-            try links.append(alloc, .{
+            links.appendAssumeCapacity(.{
                 .regex = regex,
                 .action = .{ .open = {} },
                 .highlight = .{ .hover_mods = input.ctrlOrSuper(.{}) },

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7907,11 +7907,12 @@ pub const RepeatableLink = struct {
         }
 
         const regex = try parseRegexValue(alloc, input);
-        errdefer alloc.free(regex);
         if (regex.len == 0) {
+            alloc.free(regex);
             self.links.clearRetainingCapacity();
             return;
         }
+        errdefer alloc.free(regex);
         try self.links.append(alloc, .{
             .regex = regex,
             .action = .{ .open = {} },

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1414,7 +1414,11 @@ scrollbar: Scrollbar = .system,
 /// A default link that matches a URL and opens it in the system opener always
 /// exists. This can be disabled using `link-url`.
 ///
-/// TODO: This can't currently be set!
+/// Each configured value is a regular expression. When it matches terminal
+/// text, the matched text opens with the system opener using the same hover
+/// modifier behavior as `link-url`.
+///
+/// Specify this multiple times to configure multiple link matchers.
 link: RepeatableLink = .{},
 
 /// Enable URL matching. URLs are matched on hover with control (Linux) or
@@ -3291,13 +3295,6 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // Add our default command palette entries
     try result.@"command-palette-entry".init(alloc);
 
-    // Add our default link for URL detection
-    try result.link.links.append(alloc, .{
-        .regex = url.regex,
-        .action = .{ .open = {} },
-        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
-    });
-
     return result;
 }
 
@@ -4056,10 +4053,6 @@ pub fn finalize(self: *Config) !void {
     // Minimum window size
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
-
-    // If URLs are disabled, cut off the first link. The first link is
-    // always the URL matcher.
-    if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
 
     // We warn when the quit-after-last-window-closed-delay is set to a very
     // short value because it can cause Ghostty to quit before the first
@@ -7898,10 +7891,21 @@ pub const RepeatableLink = struct {
     links: std.ArrayListUnmanaged(inputpkg.Link) = .{},
 
     pub fn parseCLI(self: *Self, alloc: Allocator, input_: ?[]const u8) !void {
-        _ = self;
-        _ = alloc;
-        _ = input_;
-        return error.NotImplemented;
+        const input = std.mem.trim(u8, input_ orelse "", &std.ascii.whitespace);
+
+        // Empty input clears custom links. The built-in URL matcher is
+        // appended later during surface derived-config construction.
+        if (input.len == 0) {
+            self.links.clearRetainingCapacity();
+            return;
+        }
+
+        const regex = try parseRegexValue(alloc, input);
+        try self.links.append(alloc, .{
+            .regex = regex,
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        });
     }
 
     /// Deep copy of the struct. Required by Config.
@@ -7936,9 +7940,69 @@ pub const RepeatableLink = struct {
 
     /// Used by Formatter
     pub fn formatEntry(self: Self, formatter: formatterpkg.EntryFormatter) !void {
-        // This currently can't be set so we don't format anything.
-        _ = self;
-        _ = formatter;
+        if (self.links.items.len == 0) {
+            try formatter.formatEntry(void, {});
+            return;
+        }
+
+        for (self.links.items) |item| {
+            var buf: [4096]u8 = undefined;
+            var writer: std.Io.Writer = .fixed(&buf);
+            writer.print("\"{f}\"", .{std.zig.fmtString(item.regex)}) catch {
+                return error.OutOfMemory;
+            };
+            try formatter.formatEntry([]const u8, writer.buffered());
+        }
+    }
+
+    fn parseRegexValue(alloc: Allocator, input: []const u8) ![]const u8 {
+        if (input.len >= 2 and input[0] == '"' and input[input.len - 1] == '"') {
+            var buf: std.Io.Writer.Allocating = .init(alloc);
+            defer buf.deinit();
+
+            const parsed = try std.zig.string_literal.parseWrite(&buf.writer, input);
+            if (parsed == .failure) return error.InvalidValue;
+
+            return try alloc.dupe(u8, buf.written());
+        }
+
+        return try alloc.dupe(u8, input);
+    }
+
+    test "RepeatableLink parseCLI bare regex uses system opener defaults" {
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var links: Self = .{};
+        try links.parseCLI(alloc, "^foo://bar$");
+
+        try testing.expectEqual(@as(usize, 1), links.links.items.len);
+        try testing.expectEqualStrings("^foo://bar$", links.links.items[0].regex);
+        try testing.expectEqual(inputpkg.Link.Action{ .open = {} }, links.links.items[0].action);
+        try testing.expectEqualDeep(
+            inputpkg.Link.Highlight{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+            links.links.items[0].highlight,
+        );
+
+        try links.parseCLI(alloc, "");
+        try testing.expectEqual(@as(usize, 0), links.links.items.len);
+    }
+
+    test "RepeatableLink formatEntry quotes regex values" {
+        const testing = std.testing;
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var links: Self = .{};
+        try links.parseCLI(alloc, "^foo,bar$");
+        try links.formatEntry(formatterpkg.entryFormatter("link", &buf.writer));
+        try testing.expectEqualSlices(u8, "link = \"^foo,bar$\"\n", buf.written());
     }
 };
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -16,6 +16,7 @@ const build_config = @import("../build_config.zig");
 const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
+const allocpkg = @import("../lib/allocator.zig");
 const deepEqual = @import("../datastruct/comparison.zig").deepEqual;
 const FontCodepointMap = @import("../font/CodepointMap.zig");
 const FontMetrics = @import("../font/Metrics.zig");
@@ -7945,13 +7946,16 @@ pub const RepeatableLink = struct {
             return;
         }
 
+        const alloc = allocpkg.default(null);
         for (self.links.items) |item| {
-            var buf: [4096]u8 = undefined;
-            var writer: std.Io.Writer = .fixed(&buf);
-            writer.print("\"{f}\"", .{std.zig.fmtString(item.regex)}) catch {
-                return error.OutOfMemory;
-            };
-            try formatter.formatEntry([]const u8, writer.buffered());
+            const value = try std.fmt.allocPrint(
+                alloc,
+                "\"{f}\"",
+                .{std.zig.fmtString(item.regex)},
+            );
+            defer alloc.free(value);
+
+            try formatter.formatEntry([]const u8, value);
         }
     }
 
@@ -8003,6 +8007,26 @@ pub const RepeatableLink = struct {
         try links.parseCLI(alloc, "^foo,bar$");
         try links.formatEntry(formatterpkg.entryFormatter("link", &buf.writer));
         try testing.expectEqualSlices(u8, "link = \"^foo,bar$\"\n", buf.written());
+    }
+
+    test "RepeatableLink formatEntry supports long regex values" {
+        const testing = std.testing;
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        const regex = try alloc.alloc(u8, 5000);
+        @memset(regex, 'a');
+
+        var links: Self = .{};
+        try links.parseCLI(alloc, regex);
+        try links.formatEntry(formatterpkg.entryFormatter("link", &buf.writer));
+
+        const expected = try std.fmt.allocPrint(alloc, "link = \"{s}\"\n", .{regex});
+        try testing.expectEqualStrings(expected, buf.written());
     }
 };
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7907,6 +7907,11 @@ pub const RepeatableLink = struct {
         }
 
         const regex = try parseRegexValue(alloc, input);
+        errdefer alloc.free(regex);
+        if (regex.len == 0) {
+            self.links.clearRetainingCapacity();
+            return;
+        }
         try self.links.append(alloc, .{
             .regex = regex,
             .action = .{ .open = {} },
@@ -7965,11 +7970,7 @@ pub const RepeatableLink = struct {
     }
 
     fn parseRegexValue(alloc: Allocator, input: []const u8) ![]const u8 {
-        if (input.len > 0 and (input[0] == '"' or input[input.len - 1] == '"')) {
-            if (input.len < 2 or input[0] != '"' or input[input.len - 1] != '"') {
-                return error.InvalidValue;
-            }
-
+        if (input.len >= 2 and input[0] == '"' and input[input.len - 1] == '"') {
             var buf: std.Io.Writer.Allocating = .init(alloc);
             defer buf.deinit();
 
@@ -7999,6 +8000,9 @@ pub const RepeatableLink = struct {
             links.links.items[0].highlight,
         );
 
+        try links.parseCLI(alloc, "\"\"");
+        try testing.expectEqual(@as(usize, 0), links.links.items.len);
+
         try links.parseCLI(alloc, "");
         try testing.expectEqual(@as(usize, 0), links.links.items.len);
     }
@@ -8012,15 +8016,19 @@ pub const RepeatableLink = struct {
         try testing.expectError(error.ValueRequired, links.parseCLI(arena.allocator(), null));
     }
 
-    test "RepeatableLink parseCLI rejects unmatched quoted regex values" {
+    test "RepeatableLink parseCLI treats partially quoted regex values as bare input" {
         const testing = std.testing;
         var arena = ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
         const alloc = arena.allocator();
 
         var links: Self = .{};
-        try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "\"^foo"));
-        try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "^foo\""));
+        try links.parseCLI(alloc, "\"^foo");
+        try links.parseCLI(alloc, "^foo\"");
+
+        try testing.expectEqual(@as(usize, 2), links.links.items.len);
+        try testing.expectEqualStrings("\"^foo", links.links.items[0].regex);
+        try testing.expectEqualStrings("^foo\"", links.links.items[1].regex);
     }
 
     test "RepeatableLink parseCLI quoted regex uses Zig string literal escaping" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1404,10 +1404,9 @@ input: RepeatableReadableIO = .{},
 ///     a scrollbar.
 scrollbar: Scrollbar = .system,
 
-/// Match a regular expression against the terminal text and associate clicking
-/// it with an action. This can be used to match URLs, file paths, etc. Actions
-/// can be opening using the system opener (e.g. `open` or `xdg-open`) or
-/// executing any arbitrary binding action.
+/// Match a regular expression against the terminal text and open the matched
+/// text with the system opener. This can be used to match URLs, file paths,
+/// etc.
 ///
 /// Links that are configured earlier take precedence over links that are
 /// configured later.
@@ -1415,9 +1414,11 @@ scrollbar: Scrollbar = .system,
 /// A default link that matches a URL and opens it in the system opener always
 /// exists. This can be disabled using `link-url`.
 ///
-/// Each configured value is a regular expression. When it matches terminal
-/// text, the matched text opens with the system opener using the same hover
-/// modifier behavior as `link-url`.
+/// Each configured value is a regular expression. Bare values are used as-is.
+/// Quoted values are parsed using Zig string literal syntax, so backslashes,
+/// quotes, and commas must be escaped the same way they are in Zig source.
+/// When it matches terminal text, the matched text opens with the system
+/// opener using the same hover modifier behavior as `link-url`.
 ///
 /// Specify this multiple times to configure multiple link matchers.
 link: RepeatableLink = .{},
@@ -7892,7 +7893,11 @@ pub const RepeatableLink = struct {
     links: std.ArrayListUnmanaged(inputpkg.Link) = .{},
 
     pub fn parseCLI(self: *Self, alloc: Allocator, input_: ?[]const u8) !void {
-        const input = std.mem.trim(u8, input_ orelse "", &std.ascii.whitespace);
+        const input = std.mem.trim(
+            u8,
+            input_ orelse return error.ValueRequired,
+            &std.ascii.whitespace,
+        );
 
         // Empty input clears custom links. The built-in URL matcher is
         // appended later during surface derived-config construction.
@@ -7960,7 +7965,11 @@ pub const RepeatableLink = struct {
     }
 
     fn parseRegexValue(alloc: Allocator, input: []const u8) ![]const u8 {
-        if (input.len >= 2 and input[0] == '"' and input[input.len - 1] == '"') {
+        if (input.len > 0 and (input[0] == '"' or input[input.len - 1] == '"')) {
+            if (input.len < 2 or input[0] != '"' or input[input.len - 1] != '"') {
+                return error.InvalidValue;
+            }
+
             var buf: std.Io.Writer.Allocating = .init(alloc);
             defer buf.deinit();
 
@@ -7992,6 +8001,26 @@ pub const RepeatableLink = struct {
 
         try links.parseCLI(alloc, "");
         try testing.expectEqual(@as(usize, 0), links.links.items.len);
+    }
+
+    test "RepeatableLink parseCLI missing value returns ValueRequired" {
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+
+        var links: Self = .{};
+        try testing.expectError(error.ValueRequired, links.parseCLI(arena.allocator(), null));
+    }
+
+    test "RepeatableLink parseCLI rejects unmatched quoted regex values" {
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var links: Self = .{};
+        try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "\"^foo"));
+        try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "^foo\""));
     }
 
     test "RepeatableLink formatEntry quotes regex values" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7976,7 +7976,7 @@ pub const RepeatableLink = struct {
             const parsed = try std.zig.string_literal.parseWrite(&buf.writer, input);
             if (parsed == .failure) return error.InvalidValue;
 
-            return try alloc.dupe(u8, buf.written());
+            return try buf.toOwnedSlice();
         }
 
         return try alloc.dupe(u8, input);
@@ -8021,6 +8021,19 @@ pub const RepeatableLink = struct {
         var links: Self = .{};
         try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "\"^foo"));
         try testing.expectError(error.InvalidValue, links.parseCLI(alloc, "^foo\""));
+    }
+
+    test "RepeatableLink parseCLI quoted regex uses Zig string literal escaping" {
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var links: Self = .{};
+        try links.parseCLI(alloc, "\"^foo,\\\\d+$\"");
+
+        try testing.expectEqual(@as(usize, 1), links.links.items.len);
+        try testing.expectEqualStrings("^foo,\\d+$", links.links.items[0].regex);
     }
 
     test "RepeatableLink formatEntry quotes regex values" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -595,9 +595,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 font_styles.set(.bold_italic, config.@"font-style-bold-italic" != .false);
 
                 // Our link configs
-                const links = try link.Set.fromConfig(
+                const links = try link.Set.fromConfigWithUrl(
                     alloc,
                     config.link.links.items,
+                    config.@"link-url",
                 );
 
                 return .{

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const oni = @import("oniguruma");
-const config_url = @import("../config/url.zig");
+const configUrl = @import("../config/url.zig");
 const inputpkg = @import("../input.zig");
 const terminal = @import("../terminal/main.zig");
 const point = terminal.point;
@@ -60,7 +60,7 @@ pub const Set = struct {
 
         if (link_url) {
             var regex = try oni.Regex.init(
-                config_url.regex,
+                configUrl.regex,
                 .{},
                 oni.Encoding.utf8,
                 oni.Syntax.default,
@@ -366,8 +366,8 @@ test "fromConfigWithUrl adds builtin URL matcher only when enabled" {
     defer state.deinit(alloc);
     try state.update(alloc, &t);
 
-    const mouse_point: point.Coordinate = .{ .x = 6, .y = 0 };
-    const hover_mods = inputpkg.ctrlOrSuper(.{});
+    const mousePoint: point.Coordinate = .{ .x = 6, .y = 0 };
+    const hoverMods = inputpkg.ctrlOrSuper(.{});
 
     {
         var set = try Set.fromConfigWithUrl(alloc, &.{}, false);
@@ -379,8 +379,8 @@ test "fromConfigWithUrl adds builtin URL matcher only when enabled" {
             alloc,
             &result,
             &state,
-            mouse_point,
-            hover_mods,
+            mousePoint,
+            hoverMods,
         );
         try testing.expect(!result.contains(.{ .x = 3, .y = 0 }));
     }
@@ -395,8 +395,8 @@ test "fromConfigWithUrl adds builtin URL matcher only when enabled" {
             alloc,
             &result,
             &state,
-            mouse_point,
-            hover_mods,
+            mousePoint,
+            hoverMods,
         );
         try testing.expect(result.contains(.{ .x = 3, .y = 0 }));
         try testing.expect(result.contains(.{ .x = 6, .y = 0 }));

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -50,24 +50,22 @@ pub const Set = struct {
         try links.ensureTotalCapacity(alloc, config.len + @intFromBool(link_url));
 
         for (config) |link| {
-            var regex = try link.oniRegex();
-            errdefer regex.deinit();
-            try links.append(alloc, .{
+            const regex = try link.oniRegex();
+            links.appendAssumeCapacity(.{
                 .regex = regex,
                 .highlight = link.highlight,
             });
         }
 
         if (link_url) {
-            var regex = try oni.Regex.init(
+            const regex = try oni.Regex.init(
                 configUrl.regex,
                 .{},
                 oni.Encoding.utf8,
                 oni.Syntax.default,
                 null,
             );
-            errdefer regex.deinit();
-            try links.append(alloc, .{
+            links.appendAssumeCapacity(.{
                 .regex = regex,
                 .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
             });

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -45,6 +45,7 @@ pub const Set = struct {
     ) !Set {
         var links: std.ArrayList(Link) = .empty;
         defer links.deinit(alloc);
+        errdefer for (links.items) |*link| link.regex.deinit();
 
         try links.ensureTotalCapacity(alloc, config.len + @intFromBool(link_url));
 

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const oni = @import("oniguruma");
+const config_url = @import("../config/url.zig");
 const inputpkg = @import("../input.zig");
 const terminal = @import("../terminal/main.zig");
 const point = terminal.point;
@@ -34,8 +35,18 @@ pub const Set = struct {
         alloc: Allocator,
         config: []const inputpkg.Link,
     ) !Set {
+        return try fromConfigWithUrl(alloc, config, false);
+    }
+
+    pub fn fromConfigWithUrl(
+        alloc: Allocator,
+        config: []const inputpkg.Link,
+        link_url: bool,
+    ) !Set {
         var links: std.ArrayList(Link) = .empty;
         defer links.deinit(alloc);
+
+        try links.ensureTotalCapacity(alloc, config.len + @intFromBool(link_url));
 
         for (config) |link| {
             var regex = try link.oniRegex();
@@ -43,6 +54,21 @@ pub const Set = struct {
             try links.append(alloc, .{
                 .regex = regex,
                 .highlight = link.highlight,
+            });
+        }
+
+        if (link_url) {
+            var regex = try oni.Regex.init(
+                config_url.regex,
+                .{},
+                oni.Encoding.utf8,
+                oni.Syntax.default,
+                null,
+            );
+            errdefer regex.deinit();
+            try links.append(alloc, .{
+                .regex = regex,
+                .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
             });
         }
 
@@ -319,4 +345,59 @@ test "renderCellMap mods no match" {
     try testing.expect(!result.contains(.{ .x = 3, .y = 0 }));
     try testing.expect(!result.contains(.{ .x = 1, .y = 1 }));
     try testing.expect(!result.contains(.{ .x = 1, .y = 2 }));
+}
+
+test "fromConfigWithUrl adds builtin URL matcher only when enabled" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 28,
+        .rows = 1,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("go https://example.com now");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    const mouse_point: point.Coordinate = .{ .x = 6, .y = 0 };
+    const hover_mods = inputpkg.ctrlOrSuper(.{});
+
+    {
+        var set = try Set.fromConfigWithUrl(alloc, &.{}, false);
+        defer set.deinit(alloc);
+
+        var result: terminal.RenderState.CellSet = .empty;
+        defer result.deinit(alloc);
+        try set.renderCellMap(
+            alloc,
+            &result,
+            &state,
+            mouse_point,
+            hover_mods,
+        );
+        try testing.expect(!result.contains(.{ .x = 3, .y = 0 }));
+    }
+
+    {
+        var set = try Set.fromConfigWithUrl(alloc, &.{}, true);
+        defer set.deinit(alloc);
+
+        var result: terminal.RenderState.CellSet = .empty;
+        defer result.deinit(alloc);
+        try set.renderCellMap(
+            alloc,
+            &result,
+            &state,
+            mouse_point,
+            hover_mods,
+        );
+        try testing.expect(result.contains(.{ .x = 3, .y = 0 }));
+        try testing.expect(result.contains(.{ .x = 6, .y = 0 }));
+    }
 }


### PR DESCRIPTION
## Summary
- implements custom regex link parsing for repeatable link config entries
- keeps custom links ahead of the built-in URL matcher in derived config
- preserves system opener defaults and hover modifier behavior

## Validation
- zig build test -Dtest-filter="RepeatableLink"
- zig build test -Dtest-filter="DerivedConfig init keeps custom links ahead of builtin URL matcher"
- git diff --check

## Summary by Sourcery

Add configurable regex-based terminal links that integrate with the existing URL matcher while preserving default opener and hover behavior.

New Features:
- Allow configuring repeatable regex-based links via the `link` option, including CLI parsing and config formatting with Zig string literal support.

Enhancements:
- Build derived and renderer link sets by combining user-defined regex links with the optional built-in URL matcher while keeping custom links first when enabled.

Tests:
- Add unit tests for `RepeatableLink` parsing/formatting and for ensuring the built-in URL matcher is only added when enabled and ordered after custom links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repeatable custom regex link entries with CLI parsing and entry formatting.

* **Improvements**
  * Robust parsing/formatting for link entries (clearing, quoted/escaped regexes) and consistent hover-modifier behavior.
  * Optional built-in URL matcher appended only when enabled; custom matchers remain ordered before it.
  * Renderer now respects the link-url setting when building link matchers.

* **Tests**
  * Unit tests for matcher ordering, parsing/formatting behaviors, and URL-detection on/off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->