### PR TITLE
feat(win32): add session state schema foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: In this repo's worktrees, plain `gh repo` / `gh pr` commands can resolve to upstream `ghostty-org/ghostty` despite `origin=amanthanvi/winghostty`; pin review ops with `--repo amanthanvi/winghostty`.
 - 2026-05-01: Direct `zig test src/apprt.zig` bypasses the repo build graph and fails on missing generated `build_options`; verify `apprt` package changes with `zig build test -Dtest-filter=...` instead.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: Direct `zig test src/apprt.zig` bypasses the repo build graph and fails on missing generated `build_options`; verify `apprt` package changes with `zig build test -Dtest-filter=...` instead.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -15,6 +15,7 @@ pub const action = @import("apprt/action.zig");
 pub const ipc = @import("apprt/ipc.zig");
 pub const none = @import("apprt/none.zig");
 pub const win32 = @import("apprt/win32.zig");
+pub const win32_session_state = @import("apprt/win32_session_state.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = none;
 pub const surface = @import("apprt/surface.zig");
@@ -55,4 +56,5 @@ test {
     _ = runtime;
     _ = action;
     _ = structs;
+    _ = win32_session_state;
 }

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -1,0 +1,341 @@
+//! Windows session-state schema for a future restore flow.
+//!
+//! First slice only: layout, working-directory, profile, and explicit title
+//! overrides. Deliberately excludes terminal contents, scrollback, command
+//! lines, and other runtime process state.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const current_schema_version: u32 = 1;
+
+pub const ValidationError = error{
+    UnsupportedVersion,
+    EmptyTabs,
+    EmptyLayout,
+    InvalidRootNode,
+    InvalidSelectedTab,
+    InvalidSelectedLeaf,
+    InvalidNodeIndex,
+    InvalidTreeShape,
+    InvalidSplitRatio,
+    UnreachableNode,
+};
+
+pub const ValidateError = ValidationError || Allocator.Error;
+
+pub const SessionState = struct {
+    schema_version: u32 = current_schema_version,
+    windows: []const Window = &.{},
+};
+
+pub const Window = struct {
+    selected_tab: usize = 0,
+    tabs: []const Tab = &.{},
+};
+
+pub const Tab = struct {
+    selected_leaf: usize = 0,
+    layout: LayoutTree,
+};
+
+pub const LayoutTree = struct {
+    root: u16 = 0,
+    nodes: []const Node = &.{},
+};
+
+pub const Node = union(enum) {
+    pane: Pane,
+    split: Split,
+};
+
+pub const Pane = struct {
+    cwd: ?[]const u8 = null,
+    profile: ?[]const u8 = null,
+    title_override: ?[]const u8 = null,
+    tab_title_override: ?[]const u8 = null,
+};
+
+pub const Split = struct {
+    axis: Axis,
+    ratio: f32,
+    first: u16,
+    second: u16,
+};
+
+pub const Axis = enum {
+    horizontal,
+    vertical,
+};
+
+pub fn encodeAlloc(alloc: Allocator, state: SessionState) ![]u8 {
+    try validateAlloc(alloc, state);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+
+    try std.json.Stringify.value(state, .{
+        .whitespace = .minified,
+        .emit_null_optional_fields = false,
+    }, &out.writer);
+
+    return try out.toOwnedSlice();
+}
+
+pub fn parseAlloc(alloc: Allocator, raw: []const u8) !std.json.Parsed(SessionState) {
+    var parsed = try std.json.parseFromSlice(SessionState, alloc, raw, .{
+        .ignore_unknown_fields = false,
+    });
+    errdefer parsed.deinit();
+
+    try validateAlloc(alloc, parsed.value);
+    return parsed;
+}
+
+pub fn validateAlloc(alloc: Allocator, state: SessionState) ValidateError!void {
+    if (state.schema_version != current_schema_version) {
+        return error.UnsupportedVersion;
+    }
+
+    for (state.windows) |window| {
+        if (window.tabs.len == 0) return error.EmptyTabs;
+        if (window.selected_tab >= window.tabs.len) return error.InvalidSelectedTab;
+
+        for (window.tabs) |tab| {
+            const leaf_count = try validateLayoutTree(alloc, tab.layout);
+            if (tab.selected_leaf >= leaf_count) return error.InvalidSelectedLeaf;
+        }
+    }
+}
+
+fn validateLayoutTree(alloc: Allocator, layout: LayoutTree) ValidateError!usize {
+    if (layout.nodes.len == 0) return error.EmptyLayout;
+
+    const root_index: usize = layout.root;
+    if (root_index >= layout.nodes.len) return error.InvalidRootNode;
+
+    const visited = try alloc.alloc(u8, layout.nodes.len);
+    defer alloc.free(visited);
+    @memset(visited, 0);
+
+    const leaf_count = try visitNode(layout.nodes, visited, root_index);
+    if (leaf_count == 0) return error.EmptyLayout;
+
+    for (visited) |seen| {
+        if (seen == 0) return error.UnreachableNode;
+    }
+
+    return leaf_count;
+}
+
+fn visitNode(nodes: []const Node, visited: []u8, index: usize) ValidationError!usize {
+    if (index >= nodes.len) return error.InvalidNodeIndex;
+    if (visited[index] != 0) return error.InvalidTreeShape;
+
+    visited[index] = 1;
+
+    return switch (nodes[index]) {
+        .pane => 1,
+        .split => |split| blk: {
+            if (!std.math.isFinite(split.ratio) or split.ratio < 0 or split.ratio > 1) {
+                break :blk error.InvalidSplitRatio;
+            }
+
+            const first_index: usize = split.first;
+            const second_index: usize = split.second;
+            if (first_index >= nodes.len or second_index >= nodes.len) {
+                break :blk error.InvalidNodeIndex;
+            }
+
+            const first_count = try visitNode(nodes, visited, first_index);
+            const second_count = try visitNode(nodes, visited, second_index);
+            break :blk first_count + second_count;
+        },
+    };
+}
+
+fn expectSessionStateEqual(expected: SessionState, actual: SessionState) !void {
+    try std.testing.expectEqual(expected.schema_version, actual.schema_version);
+    try std.testing.expectEqual(expected.windows.len, actual.windows.len);
+
+    for (expected.windows, actual.windows) |expected_window, actual_window| {
+        try std.testing.expectEqual(expected_window.selected_tab, actual_window.selected_tab);
+        try std.testing.expectEqual(expected_window.tabs.len, actual_window.tabs.len);
+
+        for (expected_window.tabs, actual_window.tabs) |expected_tab, actual_tab| {
+            try std.testing.expectEqual(expected_tab.selected_leaf, actual_tab.selected_leaf);
+            try std.testing.expectEqual(expected_tab.layout.root, actual_tab.layout.root);
+            try std.testing.expectEqual(expected_tab.layout.nodes.len, actual_tab.layout.nodes.len);
+
+            for (expected_tab.layout.nodes, actual_tab.layout.nodes) |expected_node, actual_node| {
+                try expectNodeEqual(expected_node, actual_node);
+            }
+        }
+    }
+}
+
+fn expectNodeEqual(expected: Node, actual: Node) !void {
+    try std.testing.expectEqual(std.meta.activeTag(expected), std.meta.activeTag(actual));
+
+    switch (expected) {
+        .pane => |expected_pane| {
+            const actual_pane = actual.pane;
+            try expectOptionalStringEqual(expected_pane.cwd, actual_pane.cwd);
+            try expectOptionalStringEqual(expected_pane.profile, actual_pane.profile);
+            try expectOptionalStringEqual(expected_pane.title_override, actual_pane.title_override);
+            try expectOptionalStringEqual(expected_pane.tab_title_override, actual_pane.tab_title_override);
+        },
+        .split => |expected_split| {
+            const actual_split = actual.split;
+            try std.testing.expectEqual(expected_split.axis, actual_split.axis);
+            try std.testing.expectEqual(expected_split.ratio, actual_split.ratio);
+            try std.testing.expectEqual(expected_split.first, actual_split.first);
+            try std.testing.expectEqual(expected_split.second, actual_split.second);
+        },
+    }
+}
+
+fn expectOptionalStringEqual(expected: ?[]const u8, actual: ?[]const u8) !void {
+    if (expected) |expected_value| {
+        try std.testing.expect(actual != null);
+        try std.testing.expectEqualStrings(expected_value, actual.?);
+        return;
+    }
+
+    try std.testing.expect(actual == null);
+}
+
+test "win32 session state round-trips split layout metadata" {
+    const left: Pane = .{
+        .cwd = "C:\\src\\winghostty",
+        .profile = "pwsh",
+        .title_override = "Build",
+        .tab_title_override = "Docs",
+    };
+    const right: Pane = .{
+        .cwd = "C:\\logs",
+        .profile = "cmd.exe",
+    };
+    const nodes = [_]Node{
+        .{ .split = .{
+            .axis = .horizontal,
+            .ratio = 0.5,
+            .first = 1,
+            .second = 2,
+        } },
+        .{ .pane = left },
+        .{ .pane = right },
+    };
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = 1,
+            .layout = .{
+                .root = 0,
+                .nodes = &nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+    const state: SessionState = .{
+        .windows = &windows,
+    };
+
+    const encoded = try encodeAlloc(std.testing.allocator, state);
+    defer std.testing.allocator.free(encoded);
+
+    try std.testing.expectEqualStrings(
+        "{\"schema_version\":1,\"windows\":[{\"selected_tab\":0,\"tabs\":[{\"selected_leaf\":1,\"layout\":{\"root\":0,\"nodes\":[{\"split\":{\"axis\":\"horizontal\",\"ratio\":0.5,\"first\":1,\"second\":2}},{\"pane\":{\"cwd\":\"C:\\\\src\\\\winghostty\",\"profile\":\"pwsh\",\"title_override\":\"Build\",\"tab_title_override\":\"Docs\"}},{\"pane\":{\"cwd\":\"C:\\\\logs\",\"profile\":\"cmd.exe\"}}]}}]}]}",
+        encoded,
+    );
+
+    var parsed = try parseAlloc(std.testing.allocator, encoded);
+    defer parsed.deinit();
+
+    try expectSessionStateEqual(state, parsed.value);
+}
+
+test "win32 session state omits unset optional pane metadata" {
+    const nodes = [_]Node{
+        .{ .pane = .{ .cwd = "C:\\src\\winghostty" } },
+    };
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = 0,
+            .layout = .{
+                .root = 0,
+                .nodes = &nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+    const state: SessionState = .{
+        .windows = &windows,
+    };
+
+    const encoded = try encodeAlloc(std.testing.allocator, state);
+    defer std.testing.allocator.free(encoded);
+
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"profile\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"title_override\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"tab_title_override\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"command\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"scrollback\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"contents\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "null") == null);
+}
+
+test "win32 session state parse rejects unsupported schema version" {
+    const raw =
+        \\{"schema_version":9,"windows":[]}
+    ;
+
+    try std.testing.expectError(
+        error.UnsupportedVersion,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state encode rejects invalid split child index" {
+    const nodes = [_]Node{
+        .{ .split = .{
+            .axis = .vertical,
+            .ratio = 0.5,
+            .first = 1,
+            .second = 9,
+        } },
+        .{ .pane = .{ .cwd = "C:\\src\\winghostty" } },
+    };
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = 0,
+            .layout = .{
+                .root = 0,
+                .nodes = &nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+    const state: SessionState = .{
+        .windows = &windows,
+    };
+
+    try std.testing.expectError(
+        error.InvalidNodeIndex,
+        encodeAlloc(std.testing.allocator, state),
+    );
+}

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -173,6 +173,9 @@ fn validateLayoutTree(alloc: Allocator, layout: LayoutTree) ValidateError!usize 
                 if (first_index >= layout.nodes.len or second_index >= layout.nodes.len) {
                     return error.InvalidNodeIndex;
                 }
+                if (stack_len + 2 > stack.len) {
+                    return error.InvalidTreeShape;
+                }
 
                 stack[stack_len] = .{ .index = second_index, .expanded = false };
                 stack_len += 1;
@@ -358,12 +361,10 @@ test "win32 session state parse keeps current schema strict about unknown fields
         \\{"schema_version":1,"windows":[],"future":{"layout_generation":1}}
     ;
 
-    if (parseAlloc(std.testing.allocator, raw)) |parsed| {
-        parsed.deinit();
-        return error.TestUnexpectedResult;
-    } else |err| {
-        try std.testing.expect(err != error.UnsupportedVersion);
-    }
+    try std.testing.expectError(
+        error.UnknownField,
+        parseAlloc(std.testing.allocator, raw),
+    );
 }
 
 test "win32 session state encode rejects invalid split child index" {
@@ -449,4 +450,15 @@ test "win32 session state validates deep split layout without recursion" {
     try validateAlloc(std.testing.allocator, .{
         .windows = &windows,
     });
+}
+
+test "win32 session state parse rejects shared-node layout before DFS stack overflow" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"split":{"axis":"horizontal","ratio":0.5,"first":1,"second":2}},{"split":{"axis":"vertical","ratio":0.5,"first":2,"second":3}},{"pane":{"cwd":"C:\\src\\winghostty"}},{"pane":{"cwd":"C:\\logs"}}]}}]}]}
+    ;
+
+    try std.testing.expectError(
+        error.InvalidTreeShape,
+        parseAlloc(std.testing.allocator, raw),
+    );
 }

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -25,7 +25,7 @@ pub const ValidationError = error{
 pub const ValidateError = ValidationError || Allocator.Error;
 
 const VersionHeader = struct {
-    schema_version: u32 = current_schema_version,
+    schema_version: u32,
 };
 
 const VisitFrame = struct {
@@ -345,6 +345,17 @@ test "win32 session state parse rejects unsupported schema version" {
     );
 }
 
+test "win32 session state parse requires explicit schema version" {
+    const raw =
+        \\{"windows":[]}
+    ;
+
+    try std.testing.expectError(
+        error.MissingField,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
 test "win32 session state parse rejects newer schema before unknown field errors" {
     const raw =
         \\{"schema_version":2,"windows":[],"future":{"layout_generation":1}}
@@ -455,6 +466,17 @@ test "win32 session state validates deep split layout without recursion" {
 test "win32 session state parse rejects shared-node layout before DFS stack overflow" {
     const raw =
         \\{"schema_version":1,"windows":[{"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"split":{"axis":"horizontal","ratio":0.5,"first":1,"second":2}},{"split":{"axis":"vertical","ratio":0.5,"first":2,"second":3}},{"pane":{"cwd":"C:\\src\\winghostty"}},{"pane":{"cwd":"C:\\logs"}}]}}]}]}
+    ;
+
+    try std.testing.expectError(
+        error.InvalidTreeShape,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state parse rejects self-referential layout before DFS stack overflow" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"split":{"axis":"horizontal","ratio":0.5,"first":0,"second":1}},{"pane":{"cwd":"C:\\src\\winghostty"}}]}}]}]}
     ;
 
     try std.testing.expectError(

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -24,6 +24,15 @@ pub const ValidationError = error{
 
 pub const ValidateError = ValidationError || Allocator.Error;
 
+const VersionHeader = struct {
+    schema_version: u32 = current_schema_version,
+};
+
+const VisitFrame = struct {
+    index: usize,
+    expanded: bool,
+};
+
 pub const SessionState = struct {
     schema_version: u32 = current_schema_version,
     windows: []const Window = &.{},
@@ -83,6 +92,15 @@ pub fn encodeAlloc(alloc: Allocator, state: SessionState) ![]u8 {
 }
 
 pub fn parseAlloc(alloc: Allocator, raw: []const u8) !std.json.Parsed(SessionState) {
+    var header = try std.json.parseFromSlice(VersionHeader, alloc, raw, .{
+        .ignore_unknown_fields = true,
+    });
+    defer header.deinit();
+
+    if (header.value.schema_version != current_schema_version) {
+        return error.UnsupportedVersion;
+    }
+
     var parsed = try std.json.parseFromSlice(SessionState, alloc, raw, .{
         .ignore_unknown_fields = false,
     });
@@ -118,7 +136,52 @@ fn validateLayoutTree(alloc: Allocator, layout: LayoutTree) ValidateError!usize 
     defer alloc.free(visited);
     @memset(visited, 0);
 
-    const leaf_count = try visitNode(layout.nodes, visited, root_index);
+    const stack = try alloc.alloc(VisitFrame, layout.nodes.len);
+    defer alloc.free(stack);
+
+    stack[0] = .{ .index = root_index, .expanded = false };
+
+    var stack_len: usize = 1;
+    var leaf_count: usize = 0;
+
+    while (stack_len > 0) {
+        var frame = &stack[stack_len - 1];
+
+        if (visited[frame.index] != 0) {
+            if (!frame.expanded or visited[frame.index] != 1) return error.InvalidTreeShape;
+            visited[frame.index] = 2;
+            stack_len -= 1;
+            continue;
+        }
+
+        visited[frame.index] = 1;
+        frame.expanded = true;
+
+        switch (layout.nodes[frame.index]) {
+            .pane => {
+                visited[frame.index] = 2;
+                leaf_count += 1;
+                stack_len -= 1;
+            },
+            .split => |split| {
+                if (!std.math.isFinite(split.ratio) or split.ratio < 0 or split.ratio > 1) {
+                    return error.InvalidSplitRatio;
+                }
+
+                const first_index: usize = split.first;
+                const second_index: usize = split.second;
+                if (first_index >= layout.nodes.len or second_index >= layout.nodes.len) {
+                    return error.InvalidNodeIndex;
+                }
+
+                stack[stack_len] = .{ .index = second_index, .expanded = false };
+                stack_len += 1;
+                stack[stack_len] = .{ .index = first_index, .expanded = false };
+                stack_len += 1;
+            },
+        }
+    }
+
     if (leaf_count == 0) return error.EmptyLayout;
 
     for (visited) |seen| {
@@ -126,32 +189,6 @@ fn validateLayoutTree(alloc: Allocator, layout: LayoutTree) ValidateError!usize 
     }
 
     return leaf_count;
-}
-
-fn visitNode(nodes: []const Node, visited: []u8, index: usize) ValidationError!usize {
-    if (index >= nodes.len) return error.InvalidNodeIndex;
-    if (visited[index] != 0) return error.InvalidTreeShape;
-
-    visited[index] = 1;
-
-    return switch (nodes[index]) {
-        .pane => 1,
-        .split => |split| blk: {
-            if (!std.math.isFinite(split.ratio) or split.ratio < 0 or split.ratio > 1) {
-                break :blk error.InvalidSplitRatio;
-            }
-
-            const first_index: usize = split.first;
-            const second_index: usize = split.second;
-            if (first_index >= nodes.len or second_index >= nodes.len) {
-                break :blk error.InvalidNodeIndex;
-            }
-
-            const first_count = try visitNode(nodes, visited, first_index);
-            const second_count = try visitNode(nodes, visited, second_index);
-            break :blk first_count + second_count;
-        },
-    };
 }
 
 fn expectSessionStateEqual(expected: SessionState, actual: SessionState) !void {
@@ -305,6 +342,30 @@ test "win32 session state parse rejects unsupported schema version" {
     );
 }
 
+test "win32 session state parse rejects newer schema before unknown field errors" {
+    const raw =
+        \\{"schema_version":2,"windows":[],"future":{"layout_generation":1}}
+    ;
+
+    try std.testing.expectError(
+        error.UnsupportedVersion,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state parse keeps current schema strict about unknown fields" {
+    const raw =
+        \\{"schema_version":1,"windows":[],"future":{"layout_generation":1}}
+    ;
+
+    if (parseAlloc(std.testing.allocator, raw)) |parsed| {
+        parsed.deinit();
+        return error.TestUnexpectedResult;
+    } else |err| {
+        try std.testing.expect(err != error.UnsupportedVersion);
+    }
+}
+
 test "win32 session state encode rejects invalid split child index" {
     const nodes = [_]Node{
         .{ .split = .{
@@ -338,4 +399,54 @@ test "win32 session state encode rejects invalid split child index" {
         error.InvalidNodeIndex,
         encodeAlloc(std.testing.allocator, state),
     );
+}
+
+test "win32 session state validates deep split layout without recursion" {
+    const split_count: usize = 4096;
+    const total_nodes = split_count * 2 + 1;
+
+    const nodes = try std.testing.allocator.alloc(Node, total_nodes);
+    defer std.testing.allocator.free(nodes);
+
+    for (0..split_count) |i| {
+        const split: Split = if (i + 1 < split_count)
+            .{
+                .axis = .horizontal,
+                .ratio = 0.5,
+                .first = @intCast(i + 1),
+                .second = @intCast(split_count + i),
+            }
+        else
+            .{
+                .axis = .horizontal,
+                .ratio = 0.5,
+                .first = @intCast(split_count + i),
+                .second = @intCast(split_count + i + 1),
+            };
+        nodes[i] = .{ .split = split };
+    }
+
+    for (split_count..total_nodes) |i| {
+        nodes[i] = .{ .pane = .{ .cwd = "C:\\src\\winghostty" } };
+    }
+
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = split_count,
+            .layout = .{
+                .root = 0,
+                .nodes = nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+
+    try validateAlloc(std.testing.allocator, .{
+        .windows = &windows,
+    });
 }

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -39,17 +39,17 @@ pub const SessionState = struct {
 };
 
 pub const Window = struct {
-    selected_tab: usize = 0,
+    selected_tab: usize,
     tabs: []const Tab = &.{},
 };
 
 pub const Tab = struct {
-    selected_leaf: usize = 0,
+    selected_leaf: usize,
     layout: LayoutTree,
 };
 
 pub const LayoutTree = struct {
-    root: u16 = 0,
+    root: u16,
     nodes: []const Node = &.{},
 };
 
@@ -348,6 +348,39 @@ test "win32 session state parse rejects unsupported schema version" {
 test "win32 session state parse requires explicit schema version" {
     const raw =
         \\{"windows":[]}
+    ;
+
+    try std.testing.expectError(
+        error.MissingField,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state parse requires explicit selected_tab" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"pane":{"cwd":"C:\\src\\winghostty"}}]}}]}]}
+    ;
+
+    try std.testing.expectError(
+        error.MissingField,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state parse requires explicit selected_leaf" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"selected_tab":0,"tabs":[{"layout":{"root":0,"nodes":[{"pane":{"cwd":"C:\\src\\winghostty"}}]}}]}]}
+    ;
+
+    try std.testing.expectError(
+        error.MissingField,
+        parseAlloc(std.testing.allocator, raw),
+    );
+}
+
+test "win32 session state parse requires explicit layout root" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"nodes":[{"pane":{"cwd":"C:\\src\\winghostty"}}]}}]}]}
     ;
 
     try std.testing.expectError(


### PR DESCRIPTION
## Summary
- adds a versioned Win32 session-state schema helper
- stores windows, tabs, split layout metadata, selected tab/leaf, cwd/profile/title overrides
- intentionally omits commands, scrollback, and terminal contents

## Validation
- zig build test -Dtest-filter="win32 session state"
- zig fmt src/apprt/win32_session_state.zig src/apprt.zig AGENTS.md

## Summary by Sourcery

Introduce a versioned Win32 session state schema and validation helpers for future window/tab layout restore flows.

New Features:
- Add a Win32 session state data model capturing windows, tabs, split layouts, and pane metadata such as cwd, profile, and title overrides.
- Provide allocation-based encode and parse helpers for Win32 session state using a versioned JSON schema.

Enhancements:
- Add comprehensive validation for Win32 session layouts to ensure tree integrity, split ratios, and selection indices are consistent and non-recursive.
- Extend the apprt module exports and tests to include the new Win32 session state helper.
- Document recent workflow and testing pitfalls in the self-correction log.

Documentation:
- Update the AGENTS self-correction log with additional guidance on GitHub CLI repo targeting and Zig test invocation.

Tests:
- Add unit tests covering session state round-tripping, omission of unset optional fields, schema version handling, validation of large split trees, and rejection of malformed layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows session-state persistence: save/load window/tab layouts, pane metadata, profiles, and titles with schema versioning and strict validation.

* **Tests**
  * Added unit tests covering JSON round-trips, omission of unset optional fields, schema version rejection, strict unknown-field handling, layout validation, and edge cases (deep, shared, or malformed layouts).

* **Documentation**
  * Added operational notes with two workflow caveats and recommended commands to avoid common pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->