### PR TITLE
feat(win32): expose shell integration diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-01: When invoking `scripts/dev-windows.cmd zig build test -Dtest-filter=...`, keep the filter value to one token (quote it or use a no-space substring) or `zig build` treats trailing words as step names.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -15306,8 +15306,8 @@ fn buildProfileChromeBadgeText(alloc: Allocator, kind: windows_shell.ProfileKind
     });
 }
 
-fn profileKindDetail(kind: windows_shell.ProfileKind) []const u8 {
-    return windows_shell.shellIntegrationDiagnostic(kind).summary;
+fn profileKindDetail(kind: windows_shell.ProfileKind) windows_shell.ShellIntegrationDiagnostic {
+    return windows_shell.shellIntegrationDiagnostic(kind);
 }
 
 fn profileOpenTargetActionText(target: ProfileOpenTarget) []const u8 {
@@ -15748,6 +15748,7 @@ fn buildProfileDetailText(
     defer alloc.free(overlay_suffix);
     const idle_suffix = try std.fmt.allocPrint(alloc, "{s}{s}", .{ quick_suffix, order_suffix });
     defer alloc.free(idle_suffix);
+    const detail = profileKindDetail(profile.kind);
     return if (overlay_open)
         std.fmt.allocPrint(
             alloc,
@@ -15764,13 +15765,15 @@ fn buildProfileDetailText(
     else
         std.fmt.allocPrint(
             alloc,
-            "Default profile: {s} {s}. Run {s}.{s} New hosts inherit this {s}. + opens a {s}, middle-click + splits here, and right-click + opens a new window. Alt+1-3 launches visible slots. Alt+Shift+1-3 pins the current profile. Alt+Shift+0 clears pinning.{s}",
+            "Default profile: {s} {s}. Run {s}.{s} New hosts inherit this {s}.{s}{s} + opens a {s}, middle-click + splits here, and right-click + opens a new window. Alt+1-3 launches visible slots. Alt+Shift+1-3 pins the current profile. Alt+Shift+0 clears pinning.{s}",
             .{
                 badge,
                 profile.label,
                 preview,
                 pinned_slot,
-                profileKindDetail(profile.kind),
+                detail.summary,
+                if (detail.next_step != null) " " else "",
+                detail.next_step orelse "",
                 profileOpenTargetActionText(default_target),
                 idle_suffix,
             },
@@ -26808,6 +26811,40 @@ test "win32 buildProfileDetailText reflects selected launcher state" {
     try std.testing.expect(std.mem.indexOf(u8, idle, "Order: git > pwsh > Ubuntu > cmd.") != null);
 }
 
+test "win32 buildProfileDetailText appends shell integration guidance when present" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const profile: windows_shell.Profile = .{
+        .kind = .cmd,
+        .key = "cmd.exe",
+        .label = "Command Prompt",
+        .command = .{ .direct = &.{"cmd.exe"} },
+    };
+
+    const detail = try buildProfileDetailText(
+        std.testing.allocator,
+        &profile,
+        &.{profile},
+        false,
+        .tab,
+        null,
+        .{ null, null, null },
+    );
+    defer std.testing.allocator.free(detail);
+
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        detail,
+        "New hosts inherit this Command Prompt profile; shell integration unavailable.",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        detail,
+        "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "+ opens a new tab") != null);
+}
+
 test "win32 buildProfileCommandPreviewText compacts shell command preview" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -27279,21 +27316,38 @@ test "win32 buildProfileChromeBadgeText adds profile glyph treatment" {
 test "win32 profileKindDetail exposes shell integration posture" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
+    const pwsh = profileKindDetail(.pwsh);
     try std.testing.expectEqualStrings(
         "PowerShell profile with automatic shell integration",
-        profileKindDetail(.pwsh),
+        pwsh.summary,
     );
+    try std.testing.expectEqual(@as(?[]const u8, null), pwsh.next_step);
+
+    const wsl = profileKindDetail(.wsl_distro);
     try std.testing.expectEqualStrings(
         "WSL distro profile; shell integration depends on the Linux shell",
-        profileKindDetail(.wsl_distro),
+        wsl.summary,
     );
+    try std.testing.expectEqualStrings(
+        "Enable shell integration inside the selected WSL shell startup.",
+        wsl.next_step.?,
+    );
+
+    const git_bash = profileKindDetail(.git_bash);
     try std.testing.expectEqualStrings(
         "Git Bash profile with automatic shell integration",
-        profileKindDetail(.git_bash),
+        git_bash.summary,
     );
+    try std.testing.expectEqual(@as(?[]const u8, null), git_bash.next_step);
+
+    const cmd = profileKindDetail(.cmd);
     try std.testing.expectEqualStrings(
         "Command Prompt profile; shell integration unavailable",
-        profileKindDetail(.cmd),
+        cmd.summary,
+    );
+    try std.testing.expectEqualStrings(
+        "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+        cmd.next_step.?,
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -15307,14 +15307,7 @@ fn buildProfileChromeBadgeText(alloc: Allocator, kind: windows_shell.ProfileKind
 }
 
 fn profileKindDetail(kind: windows_shell.ProfileKind) []const u8 {
-    return switch (kind) {
-        .wsl_default => "WSL default profile",
-        .wsl_distro => "WSL distro profile",
-        .pwsh => "PowerShell profile",
-        .powershell => "Windows PowerShell profile",
-        .git_bash => "Git Bash profile",
-        .cmd => "Command Prompt profile",
-    };
+    return windows_shell.shellIntegrationDiagnostic(kind).summary;
 }
 
 fn profileOpenTargetActionText(target: ProfileOpenTarget) []const u8 {
@@ -27281,6 +27274,27 @@ test "win32 buildProfileChromeBadgeText adds profile glyph treatment" {
     const wsl = try buildProfileChromeBadgeText(std.testing.allocator, .wsl_distro);
     defer std.testing.allocator.free(wsl);
     try std.testing.expectEqualStrings("WSL <>", wsl);
+}
+
+test "win32 profileKindDetail exposes shell integration posture" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqualStrings(
+        "PowerShell profile with automatic shell integration",
+        profileKindDetail(.pwsh),
+    );
+    try std.testing.expectEqualStrings(
+        "WSL distro profile; shell integration depends on the Linux shell",
+        profileKindDetail(.wsl_distro),
+    );
+    try std.testing.expectEqualStrings(
+        "Git Bash profile; manual shell integration setup required",
+        profileKindDetail(.git_bash),
+    );
+    try std.testing.expectEqualStrings(
+        "Command Prompt profile; shell integration unavailable",
+        profileKindDetail(.cmd),
+    );
 }
 
 test "win32 startupProfilePickerEnabled parses launcher env values" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -26798,7 +26798,7 @@ test "win32 buildProfileDetailText reflects selected launcher state" {
     try std.testing.expect(std.mem.indexOf(u8, idle, "Default profile: PWSH >> PowerShell") != null);
     try std.testing.expect(std.mem.indexOf(u8, idle, "Run pwsh.exe") != null);
     try std.testing.expect(std.mem.indexOf(u8, idle, "Pinned slot 1.") != null);
-    try std.testing.expect(std.mem.indexOf(u8, idle, "PowerShell profile") != null);
+    try std.testing.expect(std.mem.indexOf(u8, idle, "New hosts inherit this PowerShell profile with automatic shell integration.") != null);
     try std.testing.expect(std.mem.indexOf(u8, idle, "opens a new window") != null);
     try std.testing.expect(std.mem.indexOf(u8, idle, "Alt+1-3 launches visible slots") != null);
     try std.testing.expect(std.mem.indexOf(u8, idle, "Alt+Shift+1-3 pins the current profile") != null);
@@ -27288,7 +27288,7 @@ test "win32 profileKindDetail exposes shell integration posture" {
         profileKindDetail(.wsl_distro),
     );
     try std.testing.expectEqualStrings(
-        "Git Bash profile; manual shell integration setup required",
+        "Git Bash profile with automatic shell integration",
         profileKindDetail(.git_bash),
     );
     try std.testing.expectEqualStrings(

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -117,9 +117,8 @@ pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic 
             .summary = "Windows PowerShell profile with automatic shell integration",
         },
         .git_bash => .{
-            .support = .manual,
-            .summary = "Git Bash profile; manual shell integration setup required",
-            .next_step = "Source the shipped bash integration script from your Git Bash startup files.",
+            .support = .automatic,
+            .summary = "Git Bash profile with automatic shell integration",
         },
         .cmd => .{
             .support = .unavailable,
@@ -1466,7 +1465,7 @@ test "shellIntegrationDiagnostic reports automatic PowerShell support" {
     );
 }
 
-test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd posture" {
+test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd support" {
     const testing = std.testing;
 
     const wsl = shellIntegrationDiagnostic(.wsl_distro);
@@ -1478,13 +1477,12 @@ test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd posture" {
     try testing.expect(wsl.next_step != null);
 
     const git_bash = shellIntegrationDiagnostic(.git_bash);
-    try testing.expectEqual(ShellIntegrationSupport.manual, git_bash.support);
+    try testing.expectEqual(ShellIntegrationSupport.automatic, git_bash.support);
     try testing.expectEqualStrings(
-        "Git Bash profile; manual shell integration setup required",
+        "Git Bash profile with automatic shell integration",
         git_bash.summary,
     );
-    try testing.expect(git_bash.next_step != null);
-    try testing.expect(std.mem.indexOf(u8, git_bash.next_step.?, "Source") != null);
+    try testing.expectEqual(@as(?[]const u8, null), git_bash.next_step);
 
     const cmd = shellIntegrationDiagnostic(.cmd);
     try testing.expectEqual(ShellIntegrationSupport.unavailable, cmd.support);

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -10,6 +10,8 @@ const windows = std.os.windows;
 const wsl_probe_timeout_ms: windows.DWORD = 1500;
 var wsl_probe_mutex: std.Thread.Mutex = .{};
 var wsl_probe_cache: ?bool = null;
+const wsl_shell_integration_next_step =
+    "Enable shell integration inside the selected WSL shell startup.";
 
 pub const DefaultShell = enum {
     wsl,
@@ -98,15 +100,14 @@ pub fn deinitProfiles(alloc: Allocator, profiles: []Profile) void {
 
 pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic {
     return switch (kind) {
-        .wsl_default => .{
+        .wsl_default, .wsl_distro => .{
             .support = .shell_managed,
-            .summary = "WSL default profile; shell integration depends on the Linux shell",
-            .next_step = "Enable shell integration inside the selected WSL shell startup.",
-        },
-        .wsl_distro => .{
-            .support = .shell_managed,
-            .summary = "WSL distro profile; shell integration depends on the Linux shell",
-            .next_step = "Enable shell integration inside the selected WSL shell startup.",
+            .summary = switch (kind) {
+                .wsl_default => "WSL default profile; shell integration depends on the Linux shell",
+                .wsl_distro => "WSL distro profile; shell integration depends on the Linux shell",
+                else => unreachable,
+            },
+            .next_step = wsl_shell_integration_next_step,
         },
         .pwsh => .{
             .support = .automatic,
@@ -1468,13 +1469,24 @@ test "shellIntegrationDiagnostic reports automatic PowerShell support" {
 test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd support" {
     const testing = std.testing;
 
+    const wsl_default = shellIntegrationDiagnostic(.wsl_default);
+    try testing.expectEqual(ShellIntegrationSupport.shell_managed, wsl_default.support);
+    try testing.expectEqualStrings(
+        "WSL default profile; shell integration depends on the Linux shell",
+        wsl_default.summary,
+    );
+    try testing.expectEqualStrings(
+        wsl_shell_integration_next_step,
+        wsl_default.next_step.?,
+    );
+
     const wsl = shellIntegrationDiagnostic(.wsl_distro);
     try testing.expectEqual(ShellIntegrationSupport.shell_managed, wsl.support);
     try testing.expectEqualStrings(
         "WSL distro profile; shell integration depends on the Linux shell",
         wsl.summary,
     );
-    try testing.expect(wsl.next_step != null);
+    try testing.expectEqualStrings(wsl_shell_integration_next_step, wsl.next_step.?);
 
     const git_bash = shellIntegrationDiagnostic(.git_bash);
     try testing.expectEqual(ShellIntegrationSupport.automatic, git_bash.support);

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -20,6 +20,19 @@ pub const DefaultShell = enum {
 
 pub const ProfileKind = windows_shell_types.ProfileKind;
 
+pub const ShellIntegrationSupport = enum {
+    automatic,
+    shell_managed,
+    manual,
+    unavailable,
+};
+
+pub const ShellIntegrationDiagnostic = struct {
+    support: ShellIntegrationSupport,
+    summary: []const u8,
+    next_step: ?[]const u8 = null,
+};
+
 pub const Profile = struct {
     kind: ProfileKind,
     key: []const u8,
@@ -81,6 +94,39 @@ pub fn profileOrderHint(alloc: Allocator) ?[:0]const u8 {
 pub fn deinitProfiles(alloc: Allocator, profiles: []Profile) void {
     for (profiles) |*profile| profile.deinit(alloc);
     alloc.free(profiles);
+}
+
+pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic {
+    return switch (kind) {
+        .wsl_default => .{
+            .support = .shell_managed,
+            .summary = "WSL default profile; shell integration depends on the Linux shell",
+            .next_step = "Enable shell integration inside the selected WSL shell startup.",
+        },
+        .wsl_distro => .{
+            .support = .shell_managed,
+            .summary = "WSL distro profile; shell integration depends on the Linux shell",
+            .next_step = "Enable shell integration inside the selected WSL shell startup.",
+        },
+        .pwsh => .{
+            .support = .automatic,
+            .summary = "PowerShell profile with automatic shell integration",
+        },
+        .powershell => .{
+            .support = .automatic,
+            .summary = "Windows PowerShell profile with automatic shell integration",
+        },
+        .git_bash => .{
+            .support = .manual,
+            .summary = "Git Bash profile; manual shell integration setup required",
+            .next_step = "Source the shipped bash integration script from your Git Bash startup files.",
+        },
+        .cmd => .{
+            .support = .unavailable,
+            .summary = "Command Prompt profile; shell integration unavailable",
+            .next_step = "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+        },
+    };
 }
 
 /// Prepare a command for Windows spawning. Today this only special-cases WSL
@@ -1399,4 +1445,52 @@ test "spawnCwd uses home for non-absolute cwd" {
     if (builtin.os.tag == .windows) {
         try testing.expect(result != null);
     }
+}
+
+test "shellIntegrationDiagnostic reports automatic PowerShell support" {
+    const testing = std.testing;
+
+    const pwsh = shellIntegrationDiagnostic(.pwsh);
+    try testing.expectEqual(ShellIntegrationSupport.automatic, pwsh.support);
+    try testing.expectEqualStrings(
+        "PowerShell profile with automatic shell integration",
+        pwsh.summary,
+    );
+    try testing.expectEqual(@as(?[]const u8, null), pwsh.next_step);
+
+    const powershell = shellIntegrationDiagnostic(.powershell);
+    try testing.expectEqual(ShellIntegrationSupport.automatic, powershell.support);
+    try testing.expectEqualStrings(
+        "Windows PowerShell profile with automatic shell integration",
+        powershell.summary,
+    );
+}
+
+test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd posture" {
+    const testing = std.testing;
+
+    const wsl = shellIntegrationDiagnostic(.wsl_distro);
+    try testing.expectEqual(ShellIntegrationSupport.shell_managed, wsl.support);
+    try testing.expectEqualStrings(
+        "WSL distro profile; shell integration depends on the Linux shell",
+        wsl.summary,
+    );
+    try testing.expect(wsl.next_step != null);
+
+    const git_bash = shellIntegrationDiagnostic(.git_bash);
+    try testing.expectEqual(ShellIntegrationSupport.manual, git_bash.support);
+    try testing.expectEqualStrings(
+        "Git Bash profile; manual shell integration setup required",
+        git_bash.summary,
+    );
+    try testing.expect(git_bash.next_step != null);
+    try testing.expect(std.mem.indexOf(u8, git_bash.next_step.?, "Source") != null);
+
+    const cmd = shellIntegrationDiagnostic(.cmd);
+    try testing.expectEqual(ShellIntegrationSupport.unavailable, cmd.support);
+    try testing.expectEqualStrings(
+        "Command Prompt profile; shell integration unavailable",
+        cmd.summary,
+    );
+    try testing.expect(cmd.next_step != null);
 }

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -158,7 +158,7 @@ fn detectShell(alloc: Allocator, command: config.Command) !?Shell {
     const arg0 = arg_iter.next() orelse return null;
     const exe = std.fs.path.basename(arg0);
 
-    if (std.mem.eql(u8, "bash", exe) or std.ascii.eqlIgnoreCase(exe, "bash.exe")) {
+    if (std.ascii.eqlIgnoreCase(exe, "bash") or std.ascii.eqlIgnoreCase(exe, "bash.exe")) {
         // Apple distributes their own patched version of Bash 3.2
         // on macOS that disables the ENV-based POSIX startup path.
         // This means we're unable to perform our automatic shell
@@ -200,6 +200,7 @@ test detectShell {
 
     try testing.expect(try detectShell(alloc, .{ .shell = "sh" }) == null);
     try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "bash" }));
+    try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "BASH" }));
     try testing.expectEqual(.bash, try detectShell(alloc, .{
         .direct = &.{ "bash.exe", "--login", "-i" },
     }));

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -158,7 +158,7 @@ fn detectShell(alloc: Allocator, command: config.Command) !?Shell {
     const arg0 = arg_iter.next() orelse return null;
     const exe = std.fs.path.basename(arg0);
 
-    if (std.mem.eql(u8, "bash", exe)) {
+    if (std.mem.eql(u8, "bash", exe) or std.ascii.eqlIgnoreCase(exe, "bash.exe")) {
         // Apple distributes their own patched version of Bash 3.2
         // on macOS that disables the ENV-based POSIX startup path.
         // This means we're unable to perform our automatic shell
@@ -200,6 +200,9 @@ test detectShell {
 
     try testing.expect(try detectShell(alloc, .{ .shell = "sh" }) == null);
     try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "bash" }));
+    try testing.expectEqual(.bash, try detectShell(alloc, .{
+        .direct = &.{ "C:\\Program Files\\Git\\bin\\bash.exe", "--login", "-i" },
+    }));
     try testing.expectEqual(.elvish, try detectShell(alloc, .{ .shell = "elvish" }));
     try testing.expectEqual(.fish, try detectShell(alloc, .{ .shell = "fish" }));
     try testing.expectEqual(.nushell, try detectShell(alloc, .{ .shell = "nu" }));

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -201,8 +201,13 @@ test detectShell {
     try testing.expect(try detectShell(alloc, .{ .shell = "sh" }) == null);
     try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "bash" }));
     try testing.expectEqual(.bash, try detectShell(alloc, .{
-        .direct = &.{ "C:\\Program Files\\Git\\bin\\bash.exe", "--login", "-i" },
+        .direct = &.{ "bash.exe", "--login", "-i" },
     }));
+    if (builtin.target.os.tag == .windows) {
+        try testing.expectEqual(.bash, try detectShell(alloc, .{
+            .direct = &.{ "C:\\Program Files\\Git\\bin\\bash.exe", "--login", "-i" },
+        }));
+    }
     try testing.expectEqual(.elvish, try detectShell(alloc, .{ .shell = "elvish" }));
     try testing.expectEqual(.fish, try detectShell(alloc, .{ .shell = "fish" }));
     try testing.expectEqual(.nushell, try detectShell(alloc, .{ .shell = "nu" }));


### PR DESCRIPTION
## Summary
- adds Windows shell integration diagnostic metadata for PowerShell, WSL, Git Bash, and CMD
- surfaces shell integration posture in Win32 profile detail text

## Validation
- zig build test -Dtest-filter="shellIntegrationDiagnostic"
- zig build test -Dtest-filter="win32 profileKindDetail exposes shell integration posture"

## Summary by Sourcery

Expose Windows shell integration diagnostics and surface them in Win32 profile details.

New Features:
- Add a Windows shell integration diagnostic model that describes support level, summary, and next-step guidance per shell profile.
- Use shell integration diagnostics as the profile detail text in the Win32 UI to communicate integration posture for each shell.

Enhancements:
- Improve shell detection to recognize Git Bash on Windows via bash.exe paths and case-insensitive matching.

Documentation:
- Update AGENTS self-correction log with guidance on quoting Zig test filters on Windows.

Tests:
- Add unit tests for Windows shell integration diagnostics across WSL, PowerShell, Git Bash, and CMD profiles.
- Extend Win32 profile detail tests to verify shell integration posture messaging.
- Expand shell detection tests to cover bash.exe and Windows Git Bash paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Shell integration diagnostics now present posture-aware summaries and actionable next steps for WSL, Command Prompt, PowerShell, and Git Bash.
  * PowerShell and other profiles surface clearer integration status (automatic vs unavailable) and specific guidance when manual steps are required.
  * Improved Bash detection on Windows to recognize bash.exe and case-insensitive names.

* **Documentation**
  * Added Windows dev/test guidance clarifying how to pass test-filter tokens so they are interpreted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->