### PR TITLE
feat(win32): add UIA terminal text snapshot helper

### DIFF
--- a/src/apprt/win32_uia/mod.zig
+++ b/src/apprt/win32_uia/mod.zig
@@ -19,6 +19,7 @@ pub const events = @import("events.zig");
 pub const widgets = @import("widgets.zig");
 
 pub const RootProvider = root.RootProvider;
+pub const OffsetRange = text.OffsetRange;
 pub const TerminalTextSnapshot = text.TerminalTextSnapshot;
 pub const PaletteListProvider = widgets.PaletteListProvider;
 pub const PaletteListState = widgets.PaletteListState;

--- a/src/apprt/win32_uia/mod.zig
+++ b/src/apprt/win32_uia/mod.zig
@@ -14,16 +14,19 @@ const std = @import("std");
 const com = @import("com.zig");
 const constants = @import("constants.zig");
 const root = @import("root.zig");
+const text = @import("text.zig");
 pub const events = @import("events.zig");
 pub const widgets = @import("widgets.zig");
 
 pub const RootProvider = root.RootProvider;
+pub const TerminalTextSnapshot = text.TerminalTextSnapshot;
 pub const PaletteListProvider = widgets.PaletteListProvider;
 pub const PaletteListState = widgets.PaletteListState;
 pub const handlePaletteListGetObject = widgets.handlePaletteListGetObject;
 pub const HRESULT = com.HRESULT;
 pub const UiaRootObjectId = com.UiaRootObjectId;
 pub const IRawElementProviderSimple = com.IRawElementProviderSimple;
+pub const snapshotTerminalPlainText = text.snapshotTerminalPlainText;
 
 /// Handle `WM_GETOBJECT` for the main host HWND. Returns `null` if the
 /// caller should fall through to `DefWindowProcW`; otherwise returns
@@ -62,6 +65,7 @@ test {
     std.testing.refAllDecls(com);
     std.testing.refAllDecls(constants);
     std.testing.refAllDecls(root);
+    std.testing.refAllDecls(text);
     std.testing.refAllDecls(events);
     std.testing.refAllDecls(widgets);
 }

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -6,9 +6,6 @@
 
 const std = @import("std");
 const terminal = @import("../../terminal/main.zig");
-const terminal_c = @import("../../terminal/c/terminal.zig");
-const terminal_lib = @import("../../terminal/lib.zig");
-const Result = @import("../../terminal/c/result.zig").Result;
 
 pub const OffsetRange = struct {
     start: usize,
@@ -146,23 +143,18 @@ fn buildUtf16OffsetMap(
 }
 
 test "snapshotTerminalPlainText captures terminal rows" {
-    var t: terminal_c.Terminal = null;
-    try std.testing.expectEqual(Result.success, terminal_c.new(
-        &terminal_lib.alloc.test_allocator,
-        &t,
-        .{
-            .cols = 80,
-            .rows = 24,
-            .max_scrollback = 10_000,
-        },
-    ));
-    defer terminal_c.free(t);
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
 
-    terminal_c.vt_write(t, "Hello\r\nWorld", 12);
+    try t.printString("Hello\nWorld");
 
     var snapshot = try snapshotTerminalPlainText(
         std.testing.allocator,
-        (t orelse unreachable).terminal,
+        &t,
     );
     defer snapshot.deinit();
 
@@ -185,23 +177,18 @@ test "snapshotTerminalPlainText captures terminal rows" {
 }
 
 test "snapshotTerminalPlainText includes scrollback rows" {
-    var t: terminal_c.Terminal = null;
-    try std.testing.expectEqual(Result.success, terminal_c.new(
-        &terminal_lib.alloc.test_allocator,
-        &t,
-        .{
-            .cols = 80,
-            .rows = 3,
-            .max_scrollback = 10_000,
-        },
-    ));
-    defer terminal_c.free(t);
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
 
-    terminal_c.vt_write(t, "line1\r\nline2\r\nline3\r\nline4\r\nline5\r\n", 35);
+    try t.printString("line1\nline2\nline3\nline4\nline5\n");
 
     var snapshot = try snapshotTerminalPlainText(
         std.testing.allocator,
-        (t orelse unreachable).terminal,
+        &t,
     );
     defer snapshot.deinit();
 
@@ -217,23 +204,18 @@ test "snapshotTerminalPlainText includes scrollback rows" {
 }
 
 test "snapshotTerminalPlainText preserves blank rows in line map" {
-    var t: terminal_c.Terminal = null;
-    try std.testing.expectEqual(Result.success, terminal_c.new(
-        &terminal_lib.alloc.test_allocator,
-        &t,
-        .{
-            .cols = 80,
-            .rows = 24,
-            .max_scrollback = 10_000,
-        },
-    ));
-    defer terminal_c.free(t);
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
 
-    terminal_c.vt_write(t, "top\r\n\r\nbottom", 13);
+    try t.printString("top\n\nbottom");
 
     var snapshot = try snapshotTerminalPlainText(
         std.testing.allocator,
-        (t orelse unreachable).terminal,
+        &t,
     );
     defer snapshot.deinit();
 
@@ -277,23 +259,18 @@ test "snapshotTerminalPlainText line map ignores trailing newline terminator" {
 }
 
 test "snapshotTerminalPlainText tracks multibyte text for UIA offsets" {
-    var t: terminal_c.Terminal = null;
-    try std.testing.expectEqual(Result.success, terminal_c.new(
-        &terminal_lib.alloc.test_allocator,
-        &t,
-        .{
-            .cols = 80,
-            .rows = 24,
-            .max_scrollback = 10_000,
-        },
-    ));
-    defer terminal_c.free(t);
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
 
-    terminal_c.vt_write(t, "A\xf0\x9f\x94\xa5B", 6);
+    try t.printString("A\xf0\x9f\x94\xa5B");
 
     var snapshot = try snapshotTerminalPlainText(
         std.testing.allocator,
-        (t orelse unreachable).terminal,
+        &t,
     );
     defer snapshot.deinit();
 

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -1,0 +1,161 @@
+//! Pure terminal-text helpers for future UIA text-pattern providers.
+//!
+//! This first slice deliberately stops before COM registration. It
+//! snapshots the terminal's plain-text document and line boundaries so
+//! later `ITextProvider` / `ITextRangeProvider` wiring can stay thin.
+
+const std = @import("std");
+const terminal = @import("../../terminal/main.zig");
+const terminal_c = @import("../../terminal/c/terminal.zig");
+const terminal_lib = @import("../../terminal/lib.zig");
+const Result = @import("../../terminal/c/result.zig").Result;
+
+pub const ByteRange = struct {
+    start: usize,
+    end: usize,
+};
+
+pub const TerminalTextSnapshot = struct {
+    alloc: std.mem.Allocator,
+    text: []u8,
+    line_start_offsets: []usize,
+
+    pub fn deinit(self: *TerminalTextSnapshot) void {
+        self.alloc.free(self.line_start_offsets);
+        self.alloc.free(self.text);
+        self.* = undefined;
+    }
+
+    pub fn lineCount(self: *const TerminalTextSnapshot) usize {
+        return self.line_start_offsets.len;
+    }
+
+    pub fn lineByteRange(self: *const TerminalTextSnapshot, line_index: usize) ?ByteRange {
+        if (line_index >= self.line_start_offsets.len) return null;
+
+        const start = self.line_start_offsets[line_index];
+        const end = if (line_index + 1 < self.line_start_offsets.len)
+            self.line_start_offsets[line_index + 1] - 1
+        else
+            self.text.len;
+        return .{ .start = start, .end = end };
+    }
+};
+
+pub fn snapshotTerminalPlainText(
+    alloc: std.mem.Allocator,
+    terminal_state: *const terminal.Terminal,
+) !TerminalTextSnapshot {
+    var text_writer: std.Io.Writer.Allocating = .init(alloc);
+    defer text_writer.deinit();
+
+    var formatter = terminal.formatter.TerminalFormatter.init(
+        terminal_state,
+        .plain,
+    );
+    formatter.extra = .none;
+    try formatter.format(&text_writer.writer);
+
+    const text = try text_writer.toOwnedSlice();
+    errdefer alloc.free(text);
+
+    var line_start_offsets: std.ArrayList(usize) = .empty;
+    defer line_start_offsets.deinit(alloc);
+    try line_start_offsets.append(alloc, 0);
+    for (text, 0..) |c, i| {
+        if (c == '\n') try line_start_offsets.append(alloc, i + 1);
+    }
+
+    return .{
+        .alloc = alloc,
+        .text = text,
+        .line_start_offsets = try line_start_offsets.toOwnedSlice(alloc),
+    };
+}
+
+test "snapshotTerminalPlainText captures terminal rows" {
+    var t: terminal_c.Terminal = null;
+    try std.testing.expectEqual(Result.success, terminal_c.new(
+        &terminal_lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer terminal_c.free(t);
+
+    terminal_c.vt_write(t, "Hello\r\nWorld", 12);
+
+    var snapshot = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        (t orelse unreachable).terminal,
+    );
+    defer snapshot.deinit();
+
+    try std.testing.expectEqualStrings("Hello\nWorld", snapshot.text);
+    try std.testing.expectEqual(@as(usize, 2), snapshot.lineCount());
+
+    const first = snapshot.lineByteRange(0).?;
+    try std.testing.expectEqualStrings("Hello", snapshot.text[first.start..first.end]);
+
+    const second = snapshot.lineByteRange(1).?;
+    try std.testing.expectEqualStrings("World", snapshot.text[second.start..second.end]);
+}
+
+test "snapshotTerminalPlainText includes scrollback rows" {
+    var t: terminal_c.Terminal = null;
+    try std.testing.expectEqual(Result.success, terminal_c.new(
+        &terminal_lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 3,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer terminal_c.free(t);
+
+    terminal_c.vt_write(t, "line1\r\nline2\r\nline3\r\nline4\r\nline5\r\n", 35);
+
+    var snapshot = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        (t orelse unreachable).terminal,
+    );
+    defer snapshot.deinit();
+
+    try std.testing.expectEqualStrings(
+        "line1\nline2\nline3\nline4\nline5",
+        snapshot.text,
+    );
+    try std.testing.expectEqual(@as(usize, 5), snapshot.lineCount());
+}
+
+test "snapshotTerminalPlainText preserves blank rows in line map" {
+    var t: terminal_c.Terminal = null;
+    try std.testing.expectEqual(Result.success, terminal_c.new(
+        &terminal_lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer terminal_c.free(t);
+
+    terminal_c.vt_write(t, "top\r\n\r\nbottom", 13);
+
+    var snapshot = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        (t orelse unreachable).terminal,
+    );
+    defer snapshot.deinit();
+
+    try std.testing.expectEqualStrings("top\n\nbottom", snapshot.text);
+    try std.testing.expectEqual(@as(usize, 3), snapshot.lineCount());
+
+    const blank = snapshot.lineByteRange(1).?;
+    try std.testing.expectEqual(@as(usize, blank.start), blank.end);
+}

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -46,8 +46,11 @@ pub const TerminalTextSnapshot = struct {
         const start = self.line_start_byte_offsets[line_index];
         const end = if (line_index + 1 < self.line_start_byte_offsets.len)
             self.line_start_byte_offsets[line_index + 1] - 1
-        else
-            self.text.len;
+        else blk: {
+            var line_end = self.text.len;
+            if (line_end > start and self.text[line_end - 1] == '\n') line_end -= 1;
+            break :blk line_end;
+        };
         return .{ .start = start, .end = end };
     }
 
@@ -89,20 +92,34 @@ pub fn snapshotTerminalPlainText(
     const utf16_offset_for_byte = try buildUtf16OffsetMap(alloc, text);
     errdefer alloc.free(utf16_offset_for_byte);
 
-    var line_start_byte_offsets: std.ArrayList(usize) = .empty;
-    defer line_start_byte_offsets.deinit(alloc);
-    try line_start_byte_offsets.append(alloc, 0);
-    for (text, 0..) |c, i| {
-        if (c == '\n') try line_start_byte_offsets.append(alloc, i + 1);
-    }
+    const line_start_byte_offsets = try buildLineStartByteOffsets(alloc, text);
+    errdefer alloc.free(line_start_byte_offsets);
 
     return .{
         .alloc = alloc,
         .text = text,
         .pin_map = owned_pin_map,
         .utf16_offset_for_byte = utf16_offset_for_byte,
-        .line_start_byte_offsets = try line_start_byte_offsets.toOwnedSlice(alloc),
+        .line_start_byte_offsets = line_start_byte_offsets,
     };
+}
+
+fn buildLineStartByteOffsets(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+) ![]usize {
+    var line_start_byte_offsets: std.ArrayList(usize) = .empty;
+    defer line_start_byte_offsets.deinit(alloc);
+
+    try line_start_byte_offsets.append(alloc, 0);
+
+    // Preserve interior blank lines, but treat a terminal trailing '\n' as the
+    // last line terminator instead of the start of a phantom empty line.
+    for (text, 0..) |c, i| {
+        if (c == '\n' and i + 1 < text.len) try line_start_byte_offsets.append(alloc, i + 1);
+    }
+
+    return try line_start_byte_offsets.toOwnedSlice(alloc);
 }
 
 fn buildUtf16OffsetMap(
@@ -227,6 +244,34 @@ test "snapshotTerminalPlainText preserves blank rows in line map" {
         OffsetRange{ .start = 4, .end = 4 },
         snapshot.lineUtf16Range(1).?,
     );
+}
+
+test "snapshotTerminalPlainText line map ignores trailing newline terminator" {
+    const alloc = std.testing.allocator;
+    const text = "top\n\n";
+
+    var snapshot = TerminalTextSnapshot{
+        .alloc = alloc,
+        .text = try alloc.dupe(u8, text),
+        .pin_map = try alloc.alloc(terminal.Pin, text.len),
+        .utf16_offset_for_byte = try buildUtf16OffsetMap(alloc, text),
+        .line_start_byte_offsets = try buildLineStartByteOffsets(alloc, text),
+    };
+    defer snapshot.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), snapshot.lineCount());
+    try std.testing.expectEqualSlices(usize, &.{ 0, 4 }, snapshot.line_start_byte_offsets);
+
+    const first = snapshot.lineByteRange(0).?;
+    try std.testing.expectEqualStrings("top", snapshot.text[first.start..first.end]);
+
+    const second = snapshot.lineByteRange(1).?;
+    try std.testing.expectEqual(@as(usize, second.start), second.end);
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 4, .end = 4 },
+        snapshot.lineUtf16Range(1).?,
+    );
+    try std.testing.expect(snapshot.lineByteRange(2) == null);
 }
 
 test "snapshotTerminalPlainText tracks multibyte text for UIA offsets" {

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -19,7 +19,8 @@ pub const TerminalTextSnapshot = struct {
     alloc: std.mem.Allocator,
     /// UTF-8 plain text with `\n` separators for hard and soft line breaks.
     text: []u8,
-    /// Source terminal cell for each byte in `text`.
+    /// Terminal pin for each byte in `text`; `\n` bytes reuse the pin from
+    /// the row they terminate rather than naming a distinct source cell.
     pin_map: []terminal.Pin,
     /// UTF-16 code-unit offset for each byte in `text`, plus a sentinel for
     /// `text.len`. Multibyte scalars therefore repeat the same start offset.
@@ -133,6 +134,7 @@ fn buildUtf16OffsetMap(
     var utf16_offset: usize = 0;
     while (byte_index < text.len) {
         const utf8_len = try std.unicode.utf8ByteSequenceLength(text[byte_index]);
+        if (byte_index + utf8_len > text.len) return error.TruncatedUtf8;
         const codepoint = try std.unicode.utf8Decode(text[byte_index .. byte_index + utf8_len]);
         @memset(utf16_offset_for_byte[byte_index .. byte_index + utf8_len], utf16_offset);
         byte_index += utf8_len;
@@ -310,5 +312,14 @@ test "snapshotTerminalPlainText tracks multibyte text for UIA offsets" {
     try std.testing.expectEqual(
         OffsetRange{ .start = 0, .end = 4 },
         snapshot.lineUtf16Range(0).?,
+    );
+}
+
+test "snapshotTerminalPlainText utf16 map rejects truncated utf8" {
+    const alloc = std.testing.allocator;
+
+    try std.testing.expectError(
+        error.TruncatedUtf8,
+        buildUtf16OffsetMap(alloc, &.{ 0xF0, 0x9F }),
     );
 }

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -10,35 +10,54 @@ const terminal_c = @import("../../terminal/c/terminal.zig");
 const terminal_lib = @import("../../terminal/lib.zig");
 const Result = @import("../../terminal/c/result.zig").Result;
 
-pub const ByteRange = struct {
+pub const OffsetRange = struct {
     start: usize,
     end: usize,
 };
 
 pub const TerminalTextSnapshot = struct {
     alloc: std.mem.Allocator,
+    /// UTF-8 plain text with `\n` separators for hard and soft line breaks.
     text: []u8,
-    line_start_offsets: []usize,
+    /// Source terminal cell for each byte in `text`.
+    pin_map: []terminal.Pin,
+    /// UTF-16 code-unit offset for each byte in `text`, plus a sentinel for
+    /// `text.len`. Multibyte scalars therefore repeat the same start offset.
+    utf16_offset_for_byte: []usize,
+    /// Byte offsets into `text` for each line start.
+    line_start_byte_offsets: []usize,
 
     pub fn deinit(self: *TerminalTextSnapshot) void {
-        self.alloc.free(self.line_start_offsets);
+        self.alloc.free(self.line_start_byte_offsets);
+        self.alloc.free(self.utf16_offset_for_byte);
+        self.alloc.free(self.pin_map);
         self.alloc.free(self.text);
         self.* = undefined;
     }
 
     pub fn lineCount(self: *const TerminalTextSnapshot) usize {
-        return self.line_start_offsets.len;
+        return self.line_start_byte_offsets.len;
     }
 
-    pub fn lineByteRange(self: *const TerminalTextSnapshot, line_index: usize) ?ByteRange {
-        if (line_index >= self.line_start_offsets.len) return null;
+    /// Return a half-open UTF-8 byte range for the requested line.
+    pub fn lineByteRange(self: *const TerminalTextSnapshot, line_index: usize) ?OffsetRange {
+        if (line_index >= self.line_start_byte_offsets.len) return null;
 
-        const start = self.line_start_offsets[line_index];
-        const end = if (line_index + 1 < self.line_start_offsets.len)
-            self.line_start_offsets[line_index + 1] - 1
+        const start = self.line_start_byte_offsets[line_index];
+        const end = if (line_index + 1 < self.line_start_byte_offsets.len)
+            self.line_start_byte_offsets[line_index + 1] - 1
         else
             self.text.len;
         return .{ .start = start, .end = end };
+    }
+
+    /// Return a half-open UTF-16 code-unit range for the requested line.
+    pub fn lineUtf16Range(self: *const TerminalTextSnapshot, line_index: usize) ?OffsetRange {
+        const byte_range = self.lineByteRange(line_index) orelse return null;
+        return .{
+            .start = self.utf16_offset_for_byte[byte_range.start],
+            .end = self.utf16_offset_for_byte[byte_range.end],
+        };
     }
 };
 
@@ -49,28 +68,62 @@ pub fn snapshotTerminalPlainText(
     var text_writer: std.Io.Writer.Allocating = .init(alloc);
     defer text_writer.deinit();
 
+    var pin_map: std.ArrayList(terminal.Pin) = .empty;
+    defer pin_map.deinit(alloc);
+
     var formatter = terminal.formatter.TerminalFormatter.init(
         terminal_state,
         .plain,
     );
     formatter.extra = .none;
+    formatter.pin_map = .{ .alloc = alloc, .map = &pin_map };
     try formatter.format(&text_writer.writer);
 
     const text = try text_writer.toOwnedSlice();
     errdefer alloc.free(text);
 
-    var line_start_offsets: std.ArrayList(usize) = .empty;
-    defer line_start_offsets.deinit(alloc);
-    try line_start_offsets.append(alloc, 0);
+    if (pin_map.items.len != text.len) return error.PinMapLengthMismatch;
+    const owned_pin_map = try pin_map.toOwnedSlice(alloc);
+    errdefer alloc.free(owned_pin_map);
+
+    const utf16_offset_for_byte = try buildUtf16OffsetMap(alloc, text);
+    errdefer alloc.free(utf16_offset_for_byte);
+
+    var line_start_byte_offsets: std.ArrayList(usize) = .empty;
+    defer line_start_byte_offsets.deinit(alloc);
+    try line_start_byte_offsets.append(alloc, 0);
     for (text, 0..) |c, i| {
-        if (c == '\n') try line_start_offsets.append(alloc, i + 1);
+        if (c == '\n') try line_start_byte_offsets.append(alloc, i + 1);
     }
 
     return .{
         .alloc = alloc,
         .text = text,
-        .line_start_offsets = try line_start_offsets.toOwnedSlice(alloc),
+        .pin_map = owned_pin_map,
+        .utf16_offset_for_byte = utf16_offset_for_byte,
+        .line_start_byte_offsets = try line_start_byte_offsets.toOwnedSlice(alloc),
     };
+}
+
+fn buildUtf16OffsetMap(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+) ![]usize {
+    const utf16_offset_for_byte = try alloc.alloc(usize, text.len + 1);
+    errdefer alloc.free(utf16_offset_for_byte);
+
+    var byte_index: usize = 0;
+    var utf16_offset: usize = 0;
+    while (byte_index < text.len) {
+        const utf8_len = try std.unicode.utf8ByteSequenceLength(text[byte_index]);
+        const codepoint = try std.unicode.utf8Decode(text[byte_index .. byte_index + utf8_len]);
+        @memset(utf16_offset_for_byte[byte_index .. byte_index + utf8_len], utf16_offset);
+        byte_index += utf8_len;
+        utf16_offset += if (codepoint <= 0xFFFF) 1 else 2;
+    }
+    utf16_offset_for_byte[text.len] = utf16_offset;
+
+    return utf16_offset_for_byte;
 }
 
 test "snapshotTerminalPlainText captures terminal rows" {
@@ -99,9 +152,17 @@ test "snapshotTerminalPlainText captures terminal rows" {
 
     const first = snapshot.lineByteRange(0).?;
     try std.testing.expectEqualStrings("Hello", snapshot.text[first.start..first.end]);
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 0, .end = 5 },
+        snapshot.lineUtf16Range(0).?,
+    );
 
     const second = snapshot.lineByteRange(1).?;
     try std.testing.expectEqualStrings("World", snapshot.text[second.start..second.end]);
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 6, .end = 11 },
+        snapshot.lineUtf16Range(1).?,
+    );
 }
 
 test "snapshotTerminalPlainText includes scrollback rows" {
@@ -130,6 +191,10 @@ test "snapshotTerminalPlainText includes scrollback rows" {
         snapshot.text,
     );
     try std.testing.expectEqual(@as(usize, 5), snapshot.lineCount());
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 24, .end = 29 },
+        snapshot.lineUtf16Range(4).?,
+    );
 }
 
 test "snapshotTerminalPlainText preserves blank rows in line map" {
@@ -158,4 +223,47 @@ test "snapshotTerminalPlainText preserves blank rows in line map" {
 
     const blank = snapshot.lineByteRange(1).?;
     try std.testing.expectEqual(@as(usize, blank.start), blank.end);
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 4, .end = 4 },
+        snapshot.lineUtf16Range(1).?,
+    );
+}
+
+test "snapshotTerminalPlainText tracks multibyte text for UIA offsets" {
+    var t: terminal_c.Terminal = null;
+    try std.testing.expectEqual(Result.success, terminal_c.new(
+        &terminal_lib.alloc.test_allocator,
+        &t,
+        .{
+            .cols = 80,
+            .rows = 24,
+            .max_scrollback = 10_000,
+        },
+    ));
+    defer terminal_c.free(t);
+
+    terminal_c.vt_write(t, "A\xf0\x9f\x94\xa5B", 6);
+
+    var snapshot = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        (t orelse unreachable).terminal,
+    );
+    defer snapshot.deinit();
+
+    try std.testing.expectEqualStrings("A🔥B", snapshot.text);
+    try std.testing.expectEqual(@as(usize, snapshot.text.len), snapshot.pin_map.len);
+    try std.testing.expectEqual(@as(usize, snapshot.text.len + 1), snapshot.utf16_offset_for_byte.len);
+    try std.testing.expectEqualSlices(
+        usize,
+        &.{ 0, 1, 1, 1, 1, 3, 4 },
+        snapshot.utf16_offset_for_byte,
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pin_map[0].x);
+    for (1..5) |i| try std.testing.expectEqual(@as(usize, 1), snapshot.pin_map[i].x);
+    try std.testing.expectEqual(@as(usize, 3), snapshot.pin_map[5].x);
+    try std.testing.expectEqual(
+        OffsetRange{ .start = 0, .end = 4 },
+        snapshot.lineUtf16Range(0).?,
+    );
 }


### PR DESCRIPTION
## Summary
- adds a terminal plain-text snapshot helper for future UIA TextPattern support
- includes line byte ranges and covers viewport/scrollback rows

## Validation
- zig build test -Dtest-filter="snapshotTerminalPlainText"
- zig build test -Dtest-filter="apprt.win32_uia"

## Summary by Sourcery

Add a Win32 UIA helper to snapshot the terminal’s plain-text contents, including line and UTF-16 offset metadata, for future TextPattern support.

New Features:
- Expose a TerminalTextSnapshot type with line and UTF-16 offset accessors for terminal content.
- Provide a snapshotTerminalPlainText helper to capture viewport and scrollback text along with pin and offset maps.

Tests:
- Add unit tests covering terminal text snapshotting, scrollback handling, blank and trailing newline behavior, multibyte character offset tracking, and UTF-8 truncation errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal text snapshot capability with plain-text conversion, UTF-8→UTF-16 offset mapping, per-byte pin mapping, and accurate line boundary detection.
  * Exposed snapshot types and helpers through the accessibility/UIA layer so assistive tools can access terminal plain-text snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->