### PR TITLE
feat(cli): add vt capability probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This fork has removed the upstream `macos/` Xcode app and the
 
 ## Self-Correction Log
 
+- 2026-05-02: Lowercasing Zig type aliases to satisfy naming review can collide with same-named declarations or locals in Zig's shared declaration namespace; check for helper/local name conflicts before committing mechanical renames.
 - 2026-05-01: The Windows release workflow's explicit `zig build` and `scripts/package-windows.ps1` fallback build must both pass `-Doptimize=ReleaseFast`; otherwise a successful release can publish `.Debug` binaries even though tests and packaging pass.
 - 2026-05-01: A stale queued GitHub Actions run can get stuck in a backend state where `gh run cancel` returns HTTP 500 and `DELETE /actions/runs/{id}` returns HTTP 403; clean failed/cancelled runs normally, but treat that survivor as GitHub-side cleanup debt rather than a script bug.
 - 2026-05-01: WinGet release CI must skip `wingetcreate update --submit` when `WINGET_PACKAGE_IDENTIFIER` is not yet bootstrapped in `microsoft/winget-pkgs`; a greenfield fork with no existing manifest path will otherwise fail deployments after release, Scoop, and packaging already succeeded.

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -89,7 +89,7 @@ pub fn options(comptime self: Action) type {
             .@"list-themes" => list_themes.Options,
             .@"list-colors" => list_colors.Options,
             .@"list-actions" => list_actions.Options,
-            .@"vt-probe" => vt_probe.Options,
+            .@"vt-probe" => vt_probe.options,
             .@"ssh-cache" => ssh_cache.Options,
             .@"edit-config" => edit_config.Options,
             .@"show-config" => show_config.Options,

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -10,6 +10,7 @@ const list_keybinds = @import("list_keybinds.zig");
 const list_themes = @import("list_themes.zig");
 const list_colors = @import("list_colors.zig");
 const list_actions = @import("list_actions.zig");
+const vt_probe = @import("vt_probe.zig");
 const ssh_cache = @import("ssh_cache.zig");
 const edit_config = @import("edit_config.zig");
 const show_config = @import("show_config.zig");
@@ -62,6 +63,7 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .@"list-themes" => try list_themes.run(alloc),
         .@"list-colors" => try list_colors.run(alloc),
         .@"list-actions" => try list_actions.run(alloc),
+        .@"vt-probe" => try vt_probe.run(alloc),
         .@"ssh-cache" => try ssh_cache.run(alloc),
         .@"edit-config" => try edit_config.run(alloc),
         .@"show-config" => try show_config.run(alloc),
@@ -87,6 +89,7 @@ pub fn options(comptime self: Action) type {
             .@"list-themes" => list_themes.Options,
             .@"list-colors" => list_colors.Options,
             .@"list-actions" => list_actions.Options,
+            .@"vt-probe" => vt_probe.Options,
             .@"ssh-cache" => ssh_cache.Options,
             .@"edit-config" => edit_config.Options,
             .@"show-config" => show_config.Options,
@@ -222,4 +225,24 @@ test "terminal UI actions are classified separately" {
     try testing.expect(!requiresTerminalUi(.version));
     try testing.expect(!requiresTerminalUi(.@"show-config"));
     try testing.expect(!requiresTerminalUi(.@"crash-report"));
+}
+
+test "vt-probe action is registered" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const probe = std.meta.stringToEnum(Action, "vt-probe");
+    try testing.expect(probe != null);
+    try testing.expect(@hasDecl(help_strings.Action, "vt-probe"));
+
+    if (probe) |expected| {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(
+            alloc,
+            "+vt-probe",
+        );
+        defer iter.deinit();
+        const action = try actionpkg.detectIter(Action, &iter);
+        try testing.expect(action != null);
+        try testing.expectEqual(expected, action.?);
+    }
 }

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -27,6 +27,9 @@ pub const Action = enum {
     /// List keybind actions
     @"list-actions",
 
+    /// Print a deterministic VT capability summary for diagnostics
+    @"vt-probe",
+
     /// Manage SSH terminfo cache for automatic remote host setup
     @"ssh-cache",
 

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const actionpkg = @import("action.zig");
 const args = @import("args.zig");
+const ghostty_terminfo = @import("../terminfo/ghostty.zig").ghostty;
 
 pub const Category = enum {
     terminfo,
@@ -32,10 +33,11 @@ pub const Report = struct {
     capabilities: []const Capability,
 };
 
-const default_term = "xterm-ghostty";
+const default_term = ghostty_terminfo.names[0];
+const terminfo_capability_id = "terminfo-" ++ default_term;
 const capabilities = [_]Capability{
     .{
-        .id = "terminfo-xterm-ghostty",
+        .id = terminfo_capability_id,
         .category = .terminfo,
         .direction = .advertise,
         .status = .supported,
@@ -166,16 +168,24 @@ test "vt-probe report includes core capabilities" {
     if (comptime @hasDecl(@This(), "report")) {
         const probe = @field(@This(), "report")();
         try testing.expectEqualStrings("static", probe.source);
-        try testing.expectEqualStrings("xterm-ghostty", probe.term);
+        try testing.expectEqualStrings(default_term, probe.term);
         try testing.expectEqual(@as(usize, 6), probe.capabilities.len);
 
-        try testing.expectEqualStrings("terminfo-xterm-ghostty", probe.capabilities[0].id);
+        try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
         try testing.expectEqualStrings("osc-8-hyperlink", probe.capabilities[1].id);
         try testing.expectEqualStrings("osc-4-palette", probe.capabilities[2].id);
         try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[3].id);
         try testing.expectEqualStrings("osc-21-kitty-color-stack", probe.capabilities[4].id);
         try testing.expectEqualStrings("csi-2026-synchronized-output", probe.capabilities[5].id);
     }
+}
+
+test "vt-probe terminfo claim tracks compiled terminfo" {
+    const testing = std.testing;
+    const probe = report();
+
+    try testing.expectEqualStrings(ghostty_terminfo.names[0], probe.term);
+    try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
 }
 
 test "vt-probe plain output is deterministic" {

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -4,35 +4,35 @@ const actionpkg = @import("action.zig");
 const args = @import("args.zig");
 const ghostty_terminfo = @import("../terminfo/ghostty.zig").ghostty;
 
-pub const Category = enum {
+pub const category = enum {
     terminfo,
     osc,
     csi,
 };
 
-pub const Direction = enum {
+pub const direction = enum {
     advertise,
     parse,
     parse_emit,
 };
 
-pub const Capability = struct {
+pub const capability = struct {
     id: []const u8,
-    category: Category,
-    direction: Direction,
+    category: category,
+    direction: direction,
 };
 
-pub const Report = struct {
+pub const report = struct {
     source: []const u8,
     term: []const u8,
-    capabilities: []const Capability,
+    capabilities: []const capability,
 };
 
-const default_term = ghostty_terminfo.names[0];
-const terminfo_capability_id = "terminfo-" ++ default_term;
-const capabilities = [_]Capability{
+const defaultTerm = ghostty_terminfo.names[0];
+const terminfoCapabilityId = "terminfo-" ++ defaultTerm;
+const capabilities = [_]capability{
     .{
-        .id = terminfo_capability_id,
+        .id = terminfoCapabilityId,
         .category = .terminfo,
         .direction = .advertise,
     },
@@ -63,13 +63,13 @@ const capabilities = [_]Capability{
     },
 };
 
-pub const Options = struct {
-    pub fn deinit(self: Options) void {
+pub const options = struct {
+    pub fn deinit(self: options) void {
         _ = self;
     }
 
     /// Enables `-h` and `--help` to work.
-    pub fn help(self: Options) !void {
+    pub fn help(self: options) !void {
         _ = self;
         return actionpkg.help_error;
     }
@@ -81,50 +81,50 @@ pub const Options = struct {
 /// This is a static probe of compiled winghostty support. It does not query a
 /// live terminal, start the GUI, or depend on ConPTY runtime state.
 pub fn run(alloc: Allocator) !u8 {
-    var opts: Options = .{};
+    var opts: options = .{};
     defer opts.deinit();
 
     {
         var iter = try args.argsIterator(alloc);
         defer iter.deinit();
-        try args.parse(Options, alloc, &opts, &iter);
+        try args.parse(options, alloc, &opts, &iter);
     }
 
     var buffer: [2048]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&buffer);
-    try writePlain(&stdout_writer.interface, report());
+    try writePlain(&stdout_writer.interface, probeReport());
     try stdout_writer.interface.flush();
 
     return 0;
 }
 
-pub fn report() Report {
+pub fn probeReport() report {
     return .{
         .source = "static",
-        .term = default_term,
+        .term = defaultTerm,
         .capabilities = &capabilities,
     };
 }
 
-pub fn writePlain(writer: *std.Io.Writer, probe: Report) std.Io.Writer.Error!void {
+pub fn writePlain(writer: *std.Io.Writer, probe: report) std.Io.Writer.Error!void {
     try writer.print(
         "probe={s}\nterm={s}\n",
         .{ probe.source, probe.term },
     );
 
-    for (probe.capabilities) |capability| {
+    for (probe.capabilities) |entry| {
         try writer.print(
             "capability={s} category={s} direction={s}\n",
             .{
-                capability.id,
-                categoryString(capability.category),
-                directionString(capability.direction),
+                entry.id,
+                categoryString(entry.category),
+                directionString(entry.direction),
             },
         );
     }
 }
 
-fn categoryString(value: Category) []const u8 {
+fn categoryString(value: category) []const u8 {
     return switch (value) {
         .terminfo => "terminfo",
         .osc => "osc",
@@ -132,7 +132,7 @@ fn categoryString(value: Category) []const u8 {
     };
 }
 
-fn directionString(value: Direction) []const u8 {
+fn directionString(value: direction) []const u8 {
     return switch (value) {
         .advertise => "advertise",
         .parse => "parse",
@@ -142,13 +142,13 @@ fn directionString(value: Direction) []const u8 {
 
 test "vt-probe report includes core capabilities" {
     const testing = std.testing;
-    const probe = report();
+    const probe = probeReport();
 
     try testing.expectEqualStrings("static", probe.source);
-    try testing.expectEqualStrings(default_term, probe.term);
+    try testing.expectEqualStrings(defaultTerm, probe.term);
     try testing.expectEqual(@as(usize, 6), probe.capabilities.len);
 
-    try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
+    try testing.expectEqualStrings(terminfoCapabilityId, probe.capabilities[0].id);
     try testing.expectEqualStrings("osc-8-hyperlink", probe.capabilities[1].id);
     try testing.expectEqualStrings("osc-4-palette", probe.capabilities[2].id);
     try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[3].id);
@@ -158,17 +158,17 @@ test "vt-probe report includes core capabilities" {
 
 test "vt-probe terminfo claim tracks compiled terminfo" {
     const testing = std.testing;
-    const probe = report();
+    const probe = probeReport();
 
     try testing.expectEqualStrings(ghostty_terminfo.names[0], probe.term);
-    try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
+    try testing.expectEqualStrings(terminfoCapabilityId, probe.capabilities[0].id);
 }
 
 test "vt-probe plain output is deterministic" {
     const testing = std.testing;
     var buf: [1024]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
-    try writePlain(&writer, report());
+    try writePlain(&writer, probeReport());
 
     try testing.expectEqualStrings(
         \\probe=static

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const actionpkg = @import("action.zig");
+const args = @import("args.zig");
+
+pub const Category = enum {
+    terminfo,
+    osc,
+    csi,
+};
+
+pub const Direction = enum {
+    advertise,
+    parse,
+    parse_emit,
+};
+
+pub const Status = enum {
+    supported,
+};
+
+pub const Capability = struct {
+    id: []const u8,
+    category: Category,
+    direction: Direction,
+    status: Status,
+};
+
+pub const Report = struct {
+    source: []const u8,
+    term: []const u8,
+    capabilities: []const Capability,
+};
+
+const default_term = "xterm-ghostty";
+const capabilities = [_]Capability{
+    .{
+        .id = "terminfo-xterm-ghostty",
+        .category = .terminfo,
+        .direction = .advertise,
+        .status = .supported,
+    },
+    .{
+        .id = "osc-8-hyperlink",
+        .category = .osc,
+        .direction = .parse_emit,
+        .status = .supported,
+    },
+    .{
+        .id = "osc-4-palette",
+        .category = .osc,
+        .direction = .parse_emit,
+        .status = .supported,
+    },
+    .{
+        .id = "osc-10-11-colors",
+        .category = .osc,
+        .direction = .parse_emit,
+        .status = .supported,
+    },
+    .{
+        .id = "osc-21-kitty-color-stack",
+        .category = .osc,
+        .direction = .parse,
+        .status = .supported,
+    },
+    .{
+        .id = "csi-2026-synchronized-output",
+        .category = .csi,
+        .direction = .parse,
+        .status = .supported,
+    },
+};
+
+pub const Options = struct {
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return actionpkg.help_error;
+    }
+};
+
+/// The `vt-probe` command prints a deterministic VT capability summary for
+/// developer diagnostics.
+///
+/// This is a static probe of compiled winghostty support. It does not query a
+/// live terminal, start the GUI, or depend on ConPTY runtime state.
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try args.argsIterator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    var buffer: [2048]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&buffer);
+    try writePlain(&stdout_writer.interface, report());
+    try stdout_writer.interface.flush();
+
+    return 0;
+}
+
+pub fn report() Report {
+    return .{
+        .source = "static",
+        .term = default_term,
+        .capabilities = &capabilities,
+    };
+}
+
+pub fn writePlain(writer: *std.Io.Writer, probe: Report) std.Io.Writer.Error!void {
+    try writer.print(
+        "probe={s}\nterm={s}\n",
+        .{ probe.source, probe.term },
+    );
+
+    for (probe.capabilities) |capability| {
+        try writer.print(
+            "capability={s} category={s} direction={s} status={s}\n",
+            .{
+                capability.id,
+                categoryString(capability.category),
+                directionString(capability.direction),
+                statusString(capability.status),
+            },
+        );
+    }
+}
+
+fn categoryString(value: Category) []const u8 {
+    return switch (value) {
+        .terminfo => "terminfo",
+        .osc => "osc",
+        .csi => "csi",
+    };
+}
+
+fn directionString(value: Direction) []const u8 {
+    return switch (value) {
+        .advertise => "advertise",
+        .parse => "parse",
+        .parse_emit => "parse+emit",
+    };
+}
+
+fn statusString(value: Status) []const u8 {
+    return switch (value) {
+        .supported => "supported",
+    };
+}
+
+test "vt-probe report includes core capabilities" {
+    const testing = std.testing;
+
+    try testing.expect(@hasDecl(@This(), "Capability"));
+    try testing.expect(@hasDecl(@This(), "Report"));
+    try testing.expect(@hasDecl(@This(), "report"));
+
+    if (comptime @hasDecl(@This(), "report")) {
+        const probe = @field(@This(), "report")();
+        try testing.expectEqualStrings("static", probe.source);
+        try testing.expectEqualStrings("xterm-ghostty", probe.term);
+        try testing.expectEqual(@as(usize, 6), probe.capabilities.len);
+
+        try testing.expectEqualStrings("terminfo-xterm-ghostty", probe.capabilities[0].id);
+        try testing.expectEqualStrings("osc-8-hyperlink", probe.capabilities[1].id);
+        try testing.expectEqualStrings("osc-4-palette", probe.capabilities[2].id);
+        try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[3].id);
+        try testing.expectEqualStrings("osc-21-kitty-color-stack", probe.capabilities[4].id);
+        try testing.expectEqualStrings("csi-2026-synchronized-output", probe.capabilities[5].id);
+    }
+}
+
+test "vt-probe plain output is deterministic" {
+    const testing = std.testing;
+
+    try testing.expect(@hasDecl(@This(), "report"));
+    try testing.expect(@hasDecl(@This(), "writePlain"));
+
+    if (comptime @hasDecl(@This(), "report") and @hasDecl(@This(), "writePlain")) {
+        var buf: [1024]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        try @field(@This(), "writePlain")(&writer, @field(@This(), "report")());
+
+        try testing.expectEqualStrings(
+            \\probe=static
+            \\term=xterm-ghostty
+            \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise status=supported
+            \\capability=osc-8-hyperlink category=osc direction=parse+emit status=supported
+            \\capability=osc-4-palette category=osc direction=parse+emit status=supported
+            \\capability=osc-10-11-colors category=osc direction=parse+emit status=supported
+            \\capability=osc-21-kitty-color-stack category=osc direction=parse status=supported
+            \\capability=csi-2026-synchronized-output category=csi direction=parse status=supported
+            \\
+        ,
+            writer.buffered(),
+        );
+    }
+}

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -16,15 +16,10 @@ pub const Direction = enum {
     parse_emit,
 };
 
-pub const Status = enum {
-    supported,
-};
-
 pub const Capability = struct {
     id: []const u8,
     category: Category,
     direction: Direction,
-    status: Status,
 };
 
 pub const Report = struct {
@@ -40,37 +35,31 @@ const capabilities = [_]Capability{
         .id = terminfo_capability_id,
         .category = .terminfo,
         .direction = .advertise,
-        .status = .supported,
     },
     .{
         .id = "osc-8-hyperlink",
         .category = .osc,
         .direction = .parse_emit,
-        .status = .supported,
     },
     .{
         .id = "osc-4-palette",
         .category = .osc,
         .direction = .parse_emit,
-        .status = .supported,
     },
     .{
         .id = "osc-10-11-colors",
         .category = .osc,
         .direction = .parse_emit,
-        .status = .supported,
     },
     .{
         .id = "osc-21-kitty-color-stack",
         .category = .osc,
         .direction = .parse,
-        .status = .supported,
     },
     .{
         .id = "csi-2026-synchronized-output",
         .category = .csi,
         .direction = .parse,
-        .status = .supported,
     },
 };
 
@@ -125,12 +114,11 @@ pub fn writePlain(writer: *std.Io.Writer, probe: Report) std.Io.Writer.Error!voi
 
     for (probe.capabilities) |capability| {
         try writer.print(
-            "capability={s} category={s} direction={s} status={s}\n",
+            "capability={s} category={s} direction={s}\n",
             .{
                 capability.id,
                 categoryString(capability.category),
                 directionString(capability.direction),
-                statusString(capability.status),
             },
         );
     }
@@ -152,32 +140,20 @@ fn directionString(value: Direction) []const u8 {
     };
 }
 
-fn statusString(value: Status) []const u8 {
-    return switch (value) {
-        .supported => "supported",
-    };
-}
-
 test "vt-probe report includes core capabilities" {
     const testing = std.testing;
+    const probe = report();
 
-    try testing.expect(@hasDecl(@This(), "Capability"));
-    try testing.expect(@hasDecl(@This(), "Report"));
-    try testing.expect(@hasDecl(@This(), "report"));
+    try testing.expectEqualStrings("static", probe.source);
+    try testing.expectEqualStrings(default_term, probe.term);
+    try testing.expectEqual(@as(usize, 6), probe.capabilities.len);
 
-    if (comptime @hasDecl(@This(), "report")) {
-        const probe = @field(@This(), "report")();
-        try testing.expectEqualStrings("static", probe.source);
-        try testing.expectEqualStrings(default_term, probe.term);
-        try testing.expectEqual(@as(usize, 6), probe.capabilities.len);
-
-        try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
-        try testing.expectEqualStrings("osc-8-hyperlink", probe.capabilities[1].id);
-        try testing.expectEqualStrings("osc-4-palette", probe.capabilities[2].id);
-        try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[3].id);
-        try testing.expectEqualStrings("osc-21-kitty-color-stack", probe.capabilities[4].id);
-        try testing.expectEqualStrings("csi-2026-synchronized-output", probe.capabilities[5].id);
-    }
+    try testing.expectEqualStrings(terminfo_capability_id, probe.capabilities[0].id);
+    try testing.expectEqualStrings("osc-8-hyperlink", probe.capabilities[1].id);
+    try testing.expectEqualStrings("osc-4-palette", probe.capabilities[2].id);
+    try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[3].id);
+    try testing.expectEqualStrings("osc-21-kitty-color-stack", probe.capabilities[4].id);
+    try testing.expectEqualStrings("csi-2026-synchronized-output", probe.capabilities[5].id);
 }
 
 test "vt-probe terminfo claim tracks compiled terminfo" {
@@ -190,27 +166,21 @@ test "vt-probe terminfo claim tracks compiled terminfo" {
 
 test "vt-probe plain output is deterministic" {
     const testing = std.testing;
+    var buf: [1024]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writePlain(&writer, report());
 
-    try testing.expect(@hasDecl(@This(), "report"));
-    try testing.expect(@hasDecl(@This(), "writePlain"));
-
-    if (comptime @hasDecl(@This(), "report") and @hasDecl(@This(), "writePlain")) {
-        var buf: [1024]u8 = undefined;
-        var writer: std.Io.Writer = .fixed(&buf);
-        try @field(@This(), "writePlain")(&writer, @field(@This(), "report")());
-
-        try testing.expectEqualStrings(
-            \\probe=static
-            \\term=xterm-ghostty
-            \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise status=supported
-            \\capability=osc-8-hyperlink category=osc direction=parse+emit status=supported
-            \\capability=osc-4-palette category=osc direction=parse+emit status=supported
-            \\capability=osc-10-11-colors category=osc direction=parse+emit status=supported
-            \\capability=osc-21-kitty-color-stack category=osc direction=parse status=supported
-            \\capability=csi-2026-synchronized-output category=csi direction=parse status=supported
-            \\
-        ,
-            writer.buffered(),
-        );
-    }
+    try testing.expectEqualStrings(
+        \\probe=static
+        \\term=xterm-ghostty
+        \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise
+        \\capability=osc-8-hyperlink category=osc direction=parse+emit
+        \\capability=osc-4-palette category=osc direction=parse+emit
+        \\capability=osc-10-11-colors category=osc direction=parse+emit
+        \\capability=osc-21-kitty-color-stack category=osc direction=parse
+        \\capability=csi-2026-synchronized-output category=csi direction=parse
+        \\
+    ,
+        writer.buffered(),
+    );
 }


### PR DESCRIPTION
## Summary
- adds winghostty +vt-probe for a deterministic static terminal capability report
- registers CLI action and tests output stability

## Validation
- zig build test -Dtest-filter="vt-probe"
- zig build test -Dtest-filter="vt-probe action is registered"

## Summary by Sourcery

Add a new CLI action for printing a static VT capability diagnostic report and wire it into the Ghostty CLI.

New Features:
- Introduce a `vt-probe` CLI command that outputs a deterministic summary of supported VT capabilities for the compiled terminal profile.

Tests:
- Add tests to verify the `vt-probe` action is registered, reports expected capabilities, and produces deterministic plain-text output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vt‑probe CLI command that prints a deterministic VT capability report (source, terminal name, and one line per capability).

* **Tests**
  * Added tests to verify the command is exposed, has help text, and produces stable, deterministic output.

* **Documentation**
  * Added a self-correction note about tooling-induced naming pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->