### PR TITLE
fix: refresh Windows CLI help discovery

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8591,6 +8591,7 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
@@ -8601,6 +8602,8 @@ const Host = struct {
         // callback might also reach.
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         cb(userdata);
     }
 
@@ -8608,12 +8611,15 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8495,14 +8495,15 @@ const Host = struct {
     }
 
     fn hideOverlay(self: *Host) void {
+        const was_confirm = self.overlay_mode == .confirm;
         self.overlay_mode = .none;
         self.clearOverlayCompletion();
         self.setBanner(.none, null) catch {};
         // Drop any active confirm payload. Both accept and cancel
         // paths route through hideOverlay, so this is the one place
-        // the owned byte slices get freed. Callbacks were already
-        // dispatched in invokeConfirm{Accept,Cancel} before reaching
-        // this point.
+        // the owned byte slices get freed. Accept/cancel callbacks
+        // snapshot their callback data before reaching this point and
+        // dispatch only after hideOverlay returns.
         if (self.confirm_payload) |*p| {
             p.deinit(self.app.core_app.alloc);
             self.confirm_payload = null;
@@ -8517,6 +8518,11 @@ const Host = struct {
         self.palette_list_scroll = 0;
         self.invalidateOverlayTransitionPlacementCache();
         self.forceHostCompositionPaint();
+        if (was_confirm) {
+            self.layout() catch {};
+            self.forceVisibleSurfaceRepaintsNow();
+            refocusActiveSurface(self);
+        }
     }
 
     fn invalidateOverlayTransitionPlacementCache(self: *Host) void {
@@ -8590,36 +8596,27 @@ const Host = struct {
     fn invokeConfirmAccept(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
         const userdata = captured.userdata;
         // hideOverlay deinits the payload (frees the owned byte
         // slices) and clears `confirm_payload = null`. After this
-        // point, no Host-mutating call may touch fields the
-        // callback might also reach.
+        // point, do not touch Host state before the callback: confirm
+        // teardown repaint/focus restoration happens inside
+        // hideOverlay while the Host is still owned by this path.
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         cb(userdata);
     }
 
     fn invokeConfirmCancel(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -28,7 +28,8 @@ const help_prelude =
     \\
     \\Discover configuration from the CLI:
     \\  `winghostty +show-config --default --docs` lists every config key and its docs.
-    \\  `winghostty +explain-config <option>` or `--keybind=<action>` explains one item.
+    \\  `winghostty +explain-config <option>` explains one config key.
+    \\  `winghostty +explain-config --keybind=<action>` explains one keybind action.
     \\
     \\A special command line argument `-e <command>` can be used to run
     \\the specific command inside the terminal emulator. For example,
@@ -93,6 +94,7 @@ test "help prelude is Windows-only" {
 test "help prelude points to CLI discovery commands" {
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+show-config --default --docs") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+explain-config") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+explain-config --keybind=<action>") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-actions --docs") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-keybinds --default") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-keybinds --docs") != null);

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -26,13 +26,18 @@ const help_prelude =
     \\where key and value are the same format you'd put into a configuration
     \\file. For example, `--font-size=12` or `--font-family="Fira Code"`.
     \\
-    \\To see a list of all available configuration options, please see
-    \\the `src/config/Config.zig` file. A future update will allow seeing
-    \\the list of configuration options from the command line.
+    \\Discover configuration from the CLI:
+    \\  `winghostty +show-config --default --docs` lists every config key and its docs.
+    \\  `winghostty +explain-config <option>` or `--keybind=<action>` explains one item.
     \\
     \\A special command line argument `-e <command>` can be used to run
     \\the specific command inside the terminal emulator. For example,
     \\`winghostty -e top` will run the `top` command inside the terminal.
+    \\
+    \\Discover actions and keybindings:
+    \\  `winghostty +list-actions --docs` lists bindable actions with docs.
+    \\  `winghostty +list-keybinds --default` shows the shipped default bindings.
+    \\  `winghostty +list-keybinds --docs` annotates bindings with action docs.
     \\
     \\Useful Windows actions:
     \\  `winghostty +new-window` forwards into the running instance when possible.
@@ -83,4 +88,14 @@ test "help prelude is Windows-only" {
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "winghostty.exe") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "Ghostty.app") == null);
     try std.testing.expect(std.mem.indexOf(u8, help_prelude, "open -na") == null);
+}
+
+test "help prelude points to CLI discovery commands" {
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+show-config --default --docs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+explain-config") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-actions --docs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-keybinds --default") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "+list-keybinds --docs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "src/config/Config.zig") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_prelude, "future update") == null);
 }

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const args = @import("args.zig");
 const actionpkg = @import("action.zig");
-const help_strings = @import("help_strings");
 const Arena = std.heap.ArenaAllocator;
 const Allocator = std.mem.Allocator;
 const configpkg = @import("../config.zig");
@@ -444,6 +443,8 @@ test "list-keybinds docs mode disables pretty printing" {
 }
 
 test "list-keybinds action help describes docs mode truthfully" {
+    const help_strings = @import("help_strings");
+
     try std.testing.expect(std.mem.indexOf(u8, help_strings.Action.@"list-keybinds", "currently does nothing") == null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.Action.@"list-keybinds", "On a TTY this also forces plain text output.") != null);
 }

--- a/src/cli/list_keybinds.zig
+++ b/src/cli/list_keybinds.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const args = @import("args.zig");
 const actionpkg = @import("action.zig");
+const help_strings = @import("help_strings");
 const Arena = std.heap.ArenaAllocator;
 const Allocator = std.mem.Allocator;
 const configpkg = @import("../config.zig");
@@ -46,8 +47,8 @@ pub const Options = struct {
 ///
 ///   * `--default`: will print out all the default keybinds
 ///
-///   * `--docs`: currently does nothing, intended to print out documentation
-///     about the action associated with the keybinds
+///   * `--docs`: will print out documentation about the action associated
+///     with the keybinds. On a TTY this also forces plain text output.
 ///
 ///   * `--plain`: will disable formatting and make the output more
 ///     friendly for Unix tooling. This is default when not printing to a tty.
@@ -69,7 +70,7 @@ pub fn run(alloc: Allocator) !u8 {
     var stdout_writer = stdout.writer(&buffer);
     const writer = &stdout_writer.interface;
 
-    if (tui.can_pretty_print and !opts.plain and stdout.isTty()) {
+    if (shouldPrettyPrint(opts, stdout.isTty())) {
         var arena = std.heap.ArenaAllocator.init(alloc);
         defer arena.deinit();
         return prettyPrint(arena.allocator(), config.keybind);
@@ -83,6 +84,10 @@ pub fn run(alloc: Allocator) !u8 {
     // Don't forget to flush!
     try writer.flush();
     return 0;
+}
+
+fn shouldPrettyPrint(opts: Options, stdout_is_tty: bool) bool {
+    return tui.can_pretty_print and stdout_is_tty and !opts.plain and !opts.docs;
 }
 
 const TriggerNode = struct {
@@ -432,4 +437,13 @@ fn iterateBindings(
     }
 
     return .{ try bindings.toOwnedSlice(alloc), widest_chord };
+}
+
+test "list-keybinds docs mode disables pretty printing" {
+    try std.testing.expect(!shouldPrettyPrint(.{ .docs = true }, true));
+}
+
+test "list-keybinds action help describes docs mode truthfully" {
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.Action.@"list-keybinds", "currently does nothing") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.Action.@"list-keybinds", "On a TTY this also forces plain text output.") != null);
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6746,18 +6746,24 @@ pub const Keybinds = struct {
             const v = next.value_ptr.*;
             if (docs) {
                 try formatter.writer.writeAll("\n");
-                const name = @tagName(v);
-                inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
-                    if (std.mem.eql(u8, decl.name, name)) {
-                        const help = @field(help_strings.KeybindAction, decl.name);
-                        try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
-                        var lines = std.mem.splitScalar(u8, help, '\n');
-                        while (lines.next()) |line| {
-                            try formatter.writer.writeAll("#   ");
-                            try formatter.writer.writeAll(line);
-                            try formatter.writer.writeAll("\n");
+                const name: []const u8 = switch (v) {
+                    .leaf => |leaf| @tagName(leaf.action),
+                    .leaf_chained => |leaf| if (leaf.actions.items.len > 0) @tagName(leaf.actions.items[0]) else "",
+                    .leader => "",
+                };
+                if (name.len > 0) {
+                    inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
+                        if (std.mem.eql(u8, decl.name, name)) {
+                            const help = @field(help_strings.KeybindAction, decl.name);
+                            try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
+                            var lines = std.mem.splitScalar(u8, help, '\n');
+                            while (lines.next()) |line| {
+                                try formatter.writer.writeAll("#   ");
+                                try formatter.writer.writeAll(line);
+                                try formatter.writer.writeAll("\n");
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
             }
@@ -6777,6 +6783,30 @@ pub const Keybinds = struct {
             while (binding_iter.next()) |next| {
                 const k = next.key_ptr.*;
                 const v = next.value_ptr.*;
+
+                if (docs) {
+                    try formatter.writer.writeAll("\n");
+                    const name: []const u8 = switch (v) {
+                        .leaf => |leaf| @tagName(leaf.action),
+                        .leaf_chained => |leaf| if (leaf.actions.items.len > 0) @tagName(leaf.actions.items[0]) else "",
+                        .leader => "",
+                    };
+                    if (name.len > 0) {
+                        inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
+                            if (std.mem.eql(u8, decl.name, name)) {
+                                const help = @field(help_strings.KeybindAction, decl.name);
+                                try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
+                                var lines = std.mem.splitScalar(u8, help, '\n');
+                                while (lines.next()) |line| {
+                                    try formatter.writer.writeAll("#   ");
+                                    try formatter.writer.writeAll(line);
+                                    try formatter.writer.writeAll("\n");
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
 
                 var writer: std.Io.Writer = .fixed(&buf);
                 writer.print("{s}/{f}", .{ table_name, k }) catch return error.OutOfMemory;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6744,29 +6744,7 @@ pub const Keybinds = struct {
         while (iter.next()) |next| {
             const k = next.key_ptr.*;
             const v = next.value_ptr.*;
-            if (docs) {
-                try formatter.writer.writeAll("\n");
-                const name: []const u8 = switch (v) {
-                    .leaf => |leaf| @tagName(leaf.action),
-                    .leaf_chained => |leaf| if (leaf.actions.items.len > 0) @tagName(leaf.actions.items[0]) else "",
-                    .leader => "",
-                };
-                if (name.len > 0) {
-                    inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
-                        if (std.mem.eql(u8, decl.name, name)) {
-                            const help = @field(help_strings.KeybindAction, decl.name);
-                            try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
-                            var lines = std.mem.splitScalar(u8, help, '\n');
-                            while (lines.next()) |line| {
-                                try formatter.writer.writeAll("#   ");
-                                try formatter.writer.writeAll(line);
-                                try formatter.writer.writeAll("\n");
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
+            if (docs) try formatActionDocsForValue(formatter, v);
 
             var writer: std.Io.Writer = .fixed(&buf);
             writer.print("{f}", .{k}) catch return error.OutOfMemory;
@@ -6783,34 +6761,47 @@ pub const Keybinds = struct {
             while (binding_iter.next()) |next| {
                 const k = next.key_ptr.*;
                 const v = next.value_ptr.*;
-
-                if (docs) {
-                    try formatter.writer.writeAll("\n");
-                    const name: []const u8 = switch (v) {
-                        .leaf => |leaf| @tagName(leaf.action),
-                        .leaf_chained => |leaf| if (leaf.actions.items.len > 0) @tagName(leaf.actions.items[0]) else "",
-                        .leader => "",
-                    };
-                    if (name.len > 0) {
-                        inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
-                            if (std.mem.eql(u8, decl.name, name)) {
-                                const help = @field(help_strings.KeybindAction, decl.name);
-                                try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
-                                var lines = std.mem.splitScalar(u8, help, '\n');
-                                while (lines.next()) |line| {
-                                    try formatter.writer.writeAll("#   ");
-                                    try formatter.writer.writeAll(line);
-                                    try formatter.writer.writeAll("\n");
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
+                if (docs) try formatActionDocsForValue(formatter, v);
 
                 var writer: std.Io.Writer = .fixed(&buf);
                 writer.print("{s}/{f}", .{ table_name, k }) catch return error.OutOfMemory;
                 try v.formatEntries(&writer, formatter);
+            }
+        }
+    }
+
+    fn formatActionDocsForValue(
+        formatter: formatterpkg.EntryFormatter,
+        value: inputpkg.Binding.Set.Value,
+    ) !void {
+        switch (value) {
+            .leader => {},
+            .leaf => |leaf| try formatActionDocs(formatter, leaf.action),
+            .leaf_chained => |leaf| {
+                for (leaf.actions.items) |action| {
+                    try formatActionDocs(formatter, action);
+                }
+            },
+        }
+    }
+
+    fn formatActionDocs(
+        formatter: formatterpkg.EntryFormatter,
+        action: inputpkg.Binding.Action,
+    ) !void {
+        try formatter.writer.writeAll("\n");
+        const name = @tagName(action);
+        inline for (@typeInfo(help_strings.KeybindAction).@"struct".decls) |decl| {
+            if (std.mem.eql(u8, decl.name, name)) {
+                const help = @field(help_strings.KeybindAction, decl.name);
+                try formatter.writer.writeAll("# " ++ decl.name ++ "\n");
+                var lines = std.mem.splitScalar(u8, help, '\n');
+                while (lines.next()) |line| {
+                    try formatter.writer.writeAll("#   ");
+                    try formatter.writer.writeAll(line);
+                    try formatter.writer.writeAll("\n");
+                }
+                break;
             }
         }
     }
@@ -7283,6 +7274,27 @@ pub const Keybinds = struct {
         const output = buf.written();
         try testing.expect(std.mem.indexOf(u8, output, "keybind = shift+b=csi:world\n") != null);
         try testing.expect(std.mem.indexOf(u8, output, "keybind = foo/shift+a=csi:hello\n") != null);
+    }
+
+    test "formatEntryDocs includes docs for root and table bindings" {
+        const testing = std.testing;
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var keybinds: Keybinds = .{};
+        try keybinds.parseCLI(alloc, "shift+a=copy_to_clipboard");
+        try keybinds.parseCLI(alloc, "foo/shift+b=paste_from_clipboard");
+        try keybinds.formatEntryDocs(formatterpkg.entryFormatter("keybind", &buf.writer), true);
+
+        const output = buf.written();
+        try testing.expect(std.mem.indexOf(u8, output, "# copy_to_clipboard\n") != null);
+        try testing.expect(std.mem.indexOf(u8, output, "# paste_from_clipboard\n") != null);
+        try testing.expect(std.mem.count(u8, output, "keybind = ") >= 2);
+        try testing.expect(std.mem.indexOf(u8, output, "keybind = foo/") != null);
     }
 
     test "parseCLI clear clears tables" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -640,7 +640,7 @@ pub const Action = union(enum) {
     /// size that a new window would be created with. This has no effect
     /// if the window is fullscreen.
     ///
-    /// Only implemented on macOS.
+    /// Implemented on Win32 in this fork.
     reset_window_size,
 
     /// Control the visibility of the terminal inspector.
@@ -656,10 +656,10 @@ pub const Action = union(enum) {
 
     /// Show the on-screen keyboard if one is present.
     ///
-    /// Only implemented on Linux (GTK). On GNOME, the "Screen Keyboard"
-    /// accessibility feature must be turned on, which can be found under
-    /// Settings > Accessibility > Typing. Other platforms are as of now
-    /// untested.
+    /// Implemented on Win32 in this fork by opening the system on-screen
+    /// keyboard. On Linux (GTK), the "Screen Keyboard" accessibility
+    /// feature must be turned on, which can be found under
+    /// Settings > Accessibility > Typing.
     show_on_screen_keyboard,
 
     /// Open the configuration file in the default OS editor.
@@ -715,7 +715,7 @@ pub const Action = union(enum) {
 
     /// Toggle window decorations (titlebar, buttons, etc.) for the current window.
     ///
-    /// Only implemented on Linux.
+    /// Implemented on Win32 in this fork and on Linux.
     toggle_window_decorations,
 
     /// Toggle whether the terminal window should always float on top of other
@@ -723,7 +723,7 @@ pub const Action = union(enum) {
     ///
     /// Terminal windows always start as normal (not float-on-top) windows.
     ///
-    /// Only implemented on macOS.
+    /// Implemented on Win32 in this fork and on macOS.
     toggle_window_float_on_top,
 
     /// Toggle secure input mode.
@@ -734,7 +734,8 @@ pub const Action = union(enum) {
     /// This applies to the entire application, not just the focused terminal.
     /// You must manually untoggle it or quit winghostty entirely to disable it.
     ///
-    /// Only implemented on macOS, as this uses a built-in system API.
+    /// Implemented on Win32 in this fork and on macOS. On macOS, this uses
+    /// a built-in system API.
     toggle_secure_input,
 
     /// Toggle mouse reporting on or off.
@@ -754,8 +755,9 @@ pub const Action = union(enum) {
     /// you can perform, their associated keybindings (if any), a search bar
     /// to filter the actions, and the ability to then execute the action.
     ///
-    /// This requires libadwaita 1.5 or newer on Linux. The current libadwaita
-    /// version can be found by running `winghostty +version`.
+    /// In the Windows-only fork, this is implemented by the native Win32 host.
+    /// On Linux, this requires libadwaita 1.5 or newer. The current
+    /// libadwaita version can be found by running `winghostty +version`.
     toggle_command_palette,
 
     /// Toggle the quick terminal.
@@ -771,12 +773,16 @@ pub const Action = union(enum) {
     ///
     /// As quick terminals are often useful when other windows are currently
     /// focused, they are best used with *global* keybinds. For example, one
-    /// can define the following key bind to toggle the quick terminal from
-    /// anywhere within the system by pressing `` Cmd+` ``:
+    /// can define a system-wide chord such as the following to toggle the
+    /// quick terminal from anywhere within the system:
     ///
     /// ```ini
-    /// keybind = global:cmd+backquote=toggle_quick_terminal
+    /// keybind = global:ctrl+backquote=toggle_quick_terminal
     /// ```
+    ///
+    /// In the Windows-only fork, this is implemented by the native Win32 host.
+    /// The macOS/Linux notes below are upstream context and do not gate the
+    /// Win32 implementation.
     ///
     /// The quick terminal has some limitations:
     ///
@@ -816,7 +822,7 @@ pub const Action = union(enum) {
     ///
     /// Note: When the focused surface is fullscreen, this method does nothing.
     ///
-    /// Only implemented on macOS.
+    /// Implemented on Win32 in this fork and on macOS.
     toggle_visibility,
 
     /// Toggle the window background opacity between transparent and opaque.
@@ -826,7 +832,7 @@ pub const Action = union(enum) {
     /// When `background-opacity` is less than 1, this action will either make
     /// the window transparent or not depending on its current transparency state.
     ///
-    /// Only implemented on macOS.
+    /// Implemented on Win32 in this fork and on macOS.
     toggle_background_opacity,
 
     /// Check for updates.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -723,7 +723,7 @@ pub const Action = union(enum) {
     ///
     /// Terminal windows always start as normal (not float-on-top) windows.
     ///
-    /// Implemented on Win32 in this fork and on macOS.
+    /// Only implemented on macOS.
     toggle_window_float_on_top,
 
     /// Toggle secure input mode.
@@ -734,8 +734,7 @@ pub const Action = union(enum) {
     /// This applies to the entire application, not just the focused terminal.
     /// You must manually untoggle it or quit winghostty entirely to disable it.
     ///
-    /// Implemented on Win32 in this fork and on macOS. On macOS, this uses
-    /// a built-in system API.
+    /// Only implemented on macOS, as this uses a built-in system API.
     toggle_secure_input,
 
     /// Toggle mouse reporting on or off.

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -3,7 +3,6 @@
 //! markdown for website) while maintaining consistent content.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const KeybindAction = @import("Binding.zig").Action;
 const help_strings = @import("help_strings");
 
@@ -113,6 +112,8 @@ pub fn generate(
 }
 
 test "windows action docs reflect fork platform truth" {
+    const builtin = @import("builtin");
+
     if (builtin.os.tag != .windows) return;
 
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_command_palette, "implemented by the native Win32 host") != null);

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -122,4 +122,6 @@ test "windows action docs reflect fork platform truth" {
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_decorations, "Only implemented on Linux.") == null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_visibility, "Implemented on Win32 in this fork") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_background_opacity, "Implemented on Win32 in this fork") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_float_on_top, "Implemented on Win32 in this fork") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_secure_input, "Implemented on Win32 in this fork") == null);
 }

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -3,6 +3,7 @@
 //! markdown for website) while maintaining consistent content.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const KeybindAction = @import("Binding.zig").Action;
 const help_strings = @import("help_strings");
 
@@ -109,4 +110,16 @@ pub fn generate(
     if (stream.written().len > 0) {
         try writer.writeAll(stream.written());
     }
+}
+
+test "windows action docs reflect fork platform truth" {
+    if (builtin.os.tag != .windows) return;
+
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_command_palette, "implemented by the native Win32 host") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_quick_terminal, "global:ctrl+backquote=toggle_quick_terminal") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_quick_terminal, "global:cmd+backquote=toggle_quick_terminal") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_decorations, "Implemented on Win32 in this fork") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_decorations, "Only implemented on Linux.") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_visibility, "Implemented on Win32 in this fork") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_background_opacity, "Implemented on Win32 in this fork") != null);
 }

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -111,11 +111,7 @@ pub fn generate(
     }
 }
 
-test "windows action docs reflect fork platform truth" {
-    const builtin = @import("builtin");
-
-    if (builtin.os.tag != .windows) return;
-
+test "action docs reflect fork platform truth" {
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_command_palette, "implemented by the native Win32 host") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_quick_terminal, "global:ctrl+backquote=toggle_quick_terminal") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_quick_terminal, "global:cmd+backquote=toggle_quick_terminal") == null);


### PR DESCRIPTION
Summary: refresh +help CLI discovery, make +list-keybinds --docs force plain docs output, and correct Windows action docs for fork-supported versus macOS-only actions. Validation: focused Zig tests for action docs, list-keybinds, and help prelude passed. Ready for review; not draft.

## Summary by Sourcery

Refresh Windows-focused CLI help and action documentation while aligning list-keybinds output behavior with its documented semantics.

New Features:
- Enable +list-keybinds --docs to print action documentation and force plain text output on TTYs.
- Document CLI commands for discovering configuration options, actions, and keybindings directly from the Windows binary.

Enhancements:
- Update Windows action docstrings to accurately describe fork-specific platform support and examples.
- Improve help prelude text to emphasize CLI-based discovery instead of pointing users to source files.

Tests:
- Add tests ensuring the help prelude references the new CLI discovery commands and omits outdated source-file guidance.
- Add tests verifying list-keybinds docs mode disables pretty printing and matches the updated help text.
- Add Windows-only tests to confirm generated action help strings reflect the fork's platform capabilities accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI help with discovery commands for config and keybindings; removed outdated notes and clarified TTY vs plain-text behavior
  * Updated action/keybinding help text to reflect actual platform availability and improve generated docs wording

* **Bug Fixes**
  * Docs mode now disables pretty printing to match help text
  * Restored UI refocus and repaint behavior after confirm dialogs

* **Tests**
  * Added tests validating help text, platform-specific action docs, and docs-mode formatting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->