### PR TITLE
fix(win32): apply window-decoration at startup and reload

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -20862,7 +20862,9 @@ pub const Surface = struct {
     }
 
     fn applyRuntimeConfig(self: *Surface, config: *const configpkg.Config) !void {
-        try self.setDecorationsVisible(decorationsVisibleForConfig(config.@"window-decoration"));
+        self.setDecorationsVisible(decorationsVisibleForConfig(config.@"window-decoration")) catch |err| {
+            log.warn("win32 decoration update failed during config reload err={}", .{err});
+        };
         self.background_opacity_default = normalizedBackgroundOpacity(config.@"background-opacity");
         self.scrollbar_config = config.scrollbar;
         if (self.background_opacity_default >= 0.999) {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1246,6 +1246,10 @@ fn decorationsVisibleForConfig(value: configpkg.Config.WindowDecoration) bool {
     return value != .none;
 }
 
+fn decorationVisibilityForChromeValue(active_surface_visible: ?bool, cached_visible: bool) bool {
+    return active_surface_visible orelse cached_visible;
+}
+
 fn startupHostWindowStyle(decorations_visible: bool, fullscreen: bool) u32 {
     return effectiveHostWindowStyle(decorations_visible, fullscreen, true) & ~@as(u32, WS_VISIBLE);
 }
@@ -10207,8 +10211,10 @@ const Host = struct {
     }
 
     fn decorationVisibilityForChrome(self: *const Host) bool {
-        if (self.activeSurface()) |surface| return surface.decorations_visible;
-        return self.cached_decorations_visible;
+        return decorationVisibilityForChromeValue(
+            if (self.activeSurface()) |surface| surface.decorations_visible else null,
+            self.cached_decorations_visible,
+        );
     }
 
     /// Host-local view of the integrated-titlebar state. The app
@@ -25935,25 +25941,10 @@ test "win32 initialDecorationsVisible follows startup source" {
 test "win32 decorationVisibilityForChrome uses cached fallback until active surface" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
-    var host: Host = undefined;
-    host.tabs = .empty;
-    host.active_tab = 0;
-    host.cached_decorations_visible = false;
-    defer {
-        for (host.tabs.items) |*tab| tab.deinit();
-        host.tabs.deinit(std.testing.allocator);
-    }
-
-    try std.testing.expect(!host.decorationVisibilityForChrome());
-
-    host.cached_decorations_visible = true;
-    try std.testing.expect(host.decorationVisibilityForChrome());
-
-    var surface: Surface = undefined;
-    surface.decorations_visible = false;
-    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &surface));
-
-    try std.testing.expect(!host.decorationVisibilityForChrome());
+    try std.testing.expect(!decorationVisibilityForChromeValue(null, false));
+    try std.testing.expect(decorationVisibilityForChromeValue(null, true));
+    try std.testing.expect(!decorationVisibilityForChromeValue(false, true));
+    try std.testing.expect(decorationVisibilityForChromeValue(true, false));
 }
 
 test "win32 usesIntegratedTitlebar requires visible decorations" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -21034,35 +21034,43 @@ pub const Surface = struct {
 
         if (!should_refresh_host) return;
         self.applyWindowStyle() catch |err| {
-            self.rollbackDecorationsVisible(previous_visible, host);
+            self.rollbackDecorationsVisible(previous_visible, host, false);
             return err;
         };
 
         if (host) |value| {
-            if (used_integrated_titlebar_before != value.usingIntegratedTitlebar()) {
+            const integrated_titlebar_changed = used_integrated_titlebar_before != value.usingIntegratedTitlebar();
+            if (integrated_titlebar_changed) {
                 // Switching between stock and app-owned caption chrome can
                 // strand hover state until the next NC leave.
                 value.handleNcMouseLeave();
             }
             value.layout() catch |err| {
-                self.rollbackDecorationsVisible(previous_visible, host);
+                self.rollbackDecorationsVisible(previous_visible, host, integrated_titlebar_changed);
                 return err;
             };
             value.refreshChrome() catch |err| {
-                self.rollbackDecorationsVisible(previous_visible, host);
+                self.rollbackDecorationsVisible(previous_visible, host, integrated_titlebar_changed);
                 return err;
             };
+            value.cached_decorations_visible = visible;
         }
     }
 
-    fn rollbackDecorationsVisible(self: *Surface, previous_visible: bool, host: ?*Host) void {
+    fn rollbackDecorationsVisible(
+        self: *Surface,
+        previous_visible: bool,
+        host: ?*Host,
+        integrated_titlebar_changed: bool,
+    ) void {
         self.decorations_visible = previous_visible;
         self.applyWindowStyle() catch |err| {
             log.warn("win32 decoration rollback style update failed err={}", .{err});
         };
 
         if (host) |value| {
-            value.handleNcMouseLeave();
+            value.cached_decorations_visible = previous_visible;
+            if (integrated_titlebar_changed) value.handleNcMouseLeave();
             value.layout() catch |err| {
                 log.warn("win32 decoration rollback layout failed err={}", .{err});
             };

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1242,12 +1242,6 @@ const RegisteredGlobalHotkey = struct {
     binding: *const input.Binding.Set.Value,
 };
 
-fn hostWindowStyle() u32 {
-    // Keep the host hidden until child controls and initial layout are ready,
-    // then show it explicitly from createHost.
-    return WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
-}
-
 fn decorationsVisibleForConfig(value: configpkg.Config.WindowDecoration) bool {
     return value != .none;
 }
@@ -18651,6 +18645,12 @@ pub const Surface = struct {
         return self.search_bar_button_prev_procs[@intFromEnum(role)];
     }
 
+    fn initialDecorationsVisible(config: *const configpkg.Config, opts: SurfaceInitOptions) bool {
+        if (opts.clone_state_from) |source| return source.decorations_visible;
+        if (opts.host_id == null) return decorationsVisibleForConfig(config.@"window-decoration");
+        return true;
+    }
+
     pub fn init(
         self: *Surface,
         app: *App,
@@ -18670,6 +18670,7 @@ pub const Surface = struct {
             .host_id = host.id,
             .host_active = true,
             .window_visible = false,
+            .decorations_visible = initialDecorationsVisible(config, opts),
             .scrollbar_config = config.scrollbar,
             .render_trace = RenderTrace.init(app.core_app.alloc),
             .undo_stack = win32_undo.UndoStack.init(app.core_app.alloc),
@@ -21020,6 +21021,7 @@ pub const Surface = struct {
     fn setDecorationsVisible(self: *Surface, visible: bool) !void {
         if (self.decorations_visible == visible) return;
 
+        const previous_visible = self.decorations_visible;
         const host = self.host;
         const should_refresh_host = shouldPropagateSharedHostWindowState(self);
         const used_integrated_titlebar_before = if (should_refresh_host and host != null)
@@ -21030,7 +21032,10 @@ pub const Surface = struct {
         self.decorations_visible = visible;
 
         if (!should_refresh_host) return;
-        try self.applyWindowStyle();
+        self.applyWindowStyle() catch |err| {
+            self.rollbackDecorationsVisible(previous_visible, host);
+            return err;
+        };
 
         if (host) |value| {
             if (used_integrated_titlebar_before != value.usingIntegratedTitlebar()) {
@@ -21038,8 +21043,30 @@ pub const Surface = struct {
                 // strand hover state until the next NC leave.
                 value.handleNcMouseLeave();
             }
-            try value.layout();
-            try value.refreshChrome();
+            value.layout() catch |err| {
+                self.rollbackDecorationsVisible(previous_visible, host);
+                return err;
+            };
+            value.refreshChrome() catch |err| {
+                self.rollbackDecorationsVisible(previous_visible, host);
+                return err;
+            };
+        }
+    }
+
+    fn rollbackDecorationsVisible(self: *Surface, previous_visible: bool, host: ?*Host) void {
+        self.decorations_visible = previous_visible;
+        self.applyWindowStyle() catch |err| {
+            log.warn("win32 decoration rollback style update failed err={}", .{err});
+        };
+
+        if (host) |value| {
+            value.layout() catch |err| {
+                log.warn("win32 decoration rollback layout failed err={}", .{err});
+            };
+            value.refreshChrome() catch |err| {
+                log.warn("win32 decoration rollback chrome refresh failed err={}", .{err});
+            };
         }
     }
 
@@ -25827,14 +25854,6 @@ test "win32 normalizeForwardedStartupArg drops class and normalizes working dire
     try std.testing.expectEqualStrings("--title=Inbox", other);
 }
 
-test "win32 hostWindowStyle clips child repaints" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    const style = hostWindowStyle();
-    try std.testing.expect((style & WS_CLIPCHILDREN) != 0);
-    try std.testing.expect((style & WS_VISIBLE) == 0);
-}
-
 test "win32 decorationsVisibleForConfig only hides none" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -25859,6 +25878,42 @@ test "win32 startupHostWindowStyle respects decoration and fullscreen frame stat
         effectiveHostWindowStyle(false, true, true) & ~@as(u32, WS_VISIBLE),
         startupHostWindowStyle(false, true),
     );
+    try std.testing.expect((startupHostWindowStyle(true, false) & WS_CLIPCHILDREN) != 0);
+    try std.testing.expect((startupHostWindowStyle(true, false) & WS_VISIBLE) == 0);
+}
+
+test "win32 initialDecorationsVisible follows startup source" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var config: configpkg.Config = .{};
+
+    config.@"window-decoration" = .none;
+    try std.testing.expect(!Surface.initialDecorationsVisible(&config, .{}));
+
+    config.@"window-decoration" = .auto;
+    try std.testing.expect(Surface.initialDecorationsVisible(&config, .{}));
+
+    var source: Surface = undefined;
+    source.decorations_visible = false;
+    try std.testing.expect(!Surface.initialDecorationsVisible(
+        &config,
+        .{ .clone_state_from = &source },
+    ));
+
+    source.decorations_visible = true;
+    try std.testing.expect(Surface.initialDecorationsVisible(
+        &config,
+        .{
+            .host_id = 7,
+            .clone_state_from = &source,
+        },
+    ));
+
+    config.@"window-decoration" = .none;
+    try std.testing.expect(Surface.initialDecorationsVisible(
+        &config,
+        .{ .host_id = 7 },
+    ));
 }
 
 test "win32 usesIntegratedTitlebar requires visible decorations" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8660,9 +8660,9 @@ const Host = struct {
         if (payload_ud != ud) return;
         // `hideOverlay` deinits the payload (frees owned string
         // bytes and clears `confirm_payload = null`) without
-        // invoking on_accept/on_cancel. The Host itself stays live.
+        // invoking on_accept/on_cancel. layout/repaint/refocus are
+        // handled inside hideOverlay for the confirm case.
         self.hideOverlay();
-        self.layout() catch {};
     }
 
     fn overlayInitialText(self: *Host, mode: HostOverlayMode) ?[]const u8 {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1248,6 +1248,14 @@ fn hostWindowStyle() u32 {
     return WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
 }
 
+fn decorationsVisibleForConfig(value: configpkg.Config.WindowDecoration) bool {
+    return value != .none;
+}
+
+fn startupHostWindowStyle(decorations_visible: bool, fullscreen: bool) u32 {
+    return effectiveHostWindowStyle(decorations_visible, fullscreen, true) & ~@as(u32, WS_VISIBLE);
+}
+
 fn surfaceWindowStyle() u32 {
     // Keep the terminal child surface hidden until GL + core init complete,
     // then show it explicitly from Surface.init.
@@ -1331,6 +1339,14 @@ fn sharedHostWindowOpacityEquals(a: *const Surface, b: *const Surface) bool {
 fn shouldPropagateSharedHostWindowState(source: *const Surface) bool {
     const host = source.host orelse return true;
     return host.activeSurface() == source;
+}
+
+fn usesIntegratedTitlebar(
+    enabled: bool,
+    tab_bar_visible: bool,
+    decorations_visible: bool,
+) bool {
+    return enabled and tab_bar_visible and decorations_visible;
 }
 
 fn hostPresentShowCommand(
@@ -4181,12 +4197,17 @@ pub const App = struct {
         }
 
         const position = configuredHostWindowPosition(&self.config);
+        const startup_decorations_visible = if (clone_state_from) |source|
+            source.decorations_visible
+        else
+            decorationsVisibleForConfig(self.config.@"window-decoration");
+        const startup_fullscreen = if (clone_state_from) |source| source.fullscreen else false;
 
         const hwnd = CreateWindowExW(
             0,
             host_class_name,
             title,
-            hostWindowStyle(),
+            startupHostWindowStyle(startup_decorations_visible, startup_fullscreen),
             if (position) |v| v.x else CW_USEDEFAULT,
             if (position) |v| v.y else CW_USEDEFAULT,
             1280,
@@ -8006,7 +8027,7 @@ const Host = struct {
     }
 
     fn titlebarActionButtonRole(self: *Host, child: HWND) TitlebarButtonRole {
-        if (!self.app.use_integrated_titlebar) return .none;
+        if (!self.usingIntegratedTitlebar()) return .none;
         if (self.new_tab_hwnd != null and child == self.new_tab_hwnd.?) return .new_tab;
         if (self.overflow_hwnd != null and child == self.overflow_hwnd.?) return .dropdown;
         return .none;
@@ -10189,12 +10210,21 @@ const Host = struct {
         };
     }
 
+    fn decorationVisibilityForChrome(self: *const Host) bool {
+        if (self.activeSurface()) |surface| return surface.decorations_visible;
+        return decorationsVisibleForConfig(self.app.config.@"window-decoration");
+    }
+
     /// Host-local view of the integrated-titlebar state. The app
     /// carries the build/config floor, but host-side non-client
     /// handling must also respect whether this host is actually
     /// reserving a visible caption/tab row.
     fn usingIntegratedTitlebar(self: *const Host) bool {
-        return self.app.use_integrated_titlebar and self.shouldShowTabBar();
+        return usesIntegratedTitlebar(
+            self.app.use_integrated_titlebar,
+            self.shouldShowTabBar(),
+            self.decorationVisibilityForChrome(),
+        );
     }
 
     fn tabBarHeight(self: *Host) i32 {
@@ -10212,7 +10242,7 @@ const Host = struct {
     }
 
     fn rightButtonsWidth(self: *const Host) i32 {
-        if (self.app.use_integrated_titlebar) {
+        if (self.usingIntegratedTitlebar()) {
             return self.scaled(host_titlebar_action_button_size) * 2 + self.scaled(12);
         }
         return self.scaled(host_tab_small_button_width) + // new tab (+)
@@ -10922,7 +10952,7 @@ const Host = struct {
         // Right-side cluster: [+][▾] — new tab and dropdown chevron.
         // Shift left by the caption-buttons reservation (0 on Win10)
         // so the chevron doesn't land under the close button.
-        const titlebar_actions = self.app.use_integrated_titlebar;
+        const titlebar_actions = self.usingIntegratedTitlebar();
         const action_size = self.scaled(host_titlebar_action_button_size);
         const action_y = @max(0, @divTrunc(self.tabBarHeight() - action_size, 2));
         var button_x = width - self.scaled(if (titlebar_actions) 4 else 8) - caption_buttons_w;
@@ -11455,7 +11485,7 @@ const Host = struct {
                 else
                     adjustColor(theme.accent, 18, 18, 18),
             );
-            if (!self.app.use_integrated_titlebar) {
+            if (!self.usingIntegratedTitlebar()) {
                 const cluster_left = @max(self.scaled(8), client_rect.right - self.rightButtonsWidth() - self.scaled(4));
                 const cluster_rect = RECT{
                     .left = cluster_left,
@@ -20824,6 +20854,7 @@ pub const Surface = struct {
     }
 
     fn applyRuntimeConfig(self: *Surface, config: *const configpkg.Config) !void {
+        try self.setDecorationsVisible(decorationsVisibleForConfig(config.@"window-decoration"));
         self.background_opacity_default = normalizedBackgroundOpacity(config.@"background-opacity");
         self.scrollbar_config = config.scrollbar;
         if (self.background_opacity_default >= 0.999) {
@@ -20867,8 +20898,7 @@ pub const Surface = struct {
     }
 
     fn toggleDecorations(self: *Surface) !void {
-        self.decorations_visible = !self.decorations_visible;
-        try self.applyWindowStyle();
+        try self.setDecorationsVisible(!self.decorations_visible);
     }
 
     fn setInitialSize(self: *Surface, size: apprt.action.InitialSize) !void {
@@ -20984,6 +21014,32 @@ pub const Surface = struct {
         self.restore_maximized = IsZoomed(hwnd) != 0;
         if (GetWindowRect(hwnd, &self.restore_rect) == 0) {
             self.restore_rect = .{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
+        }
+    }
+
+    fn setDecorationsVisible(self: *Surface, visible: bool) !void {
+        if (self.decorations_visible == visible) return;
+
+        const host = self.host;
+        const should_refresh_host = shouldPropagateSharedHostWindowState(self);
+        const used_integrated_titlebar_before = if (should_refresh_host and host != null)
+            host.?.usingIntegratedTitlebar()
+        else
+            false;
+
+        self.decorations_visible = visible;
+
+        if (!should_refresh_host) return;
+        try self.applyWindowStyle();
+
+        if (host) |value| {
+            if (used_integrated_titlebar_before != value.usingIntegratedTitlebar()) {
+                // Switching between stock and app-owned caption chrome can
+                // strand hover state until the next NC leave.
+                value.handleNcMouseLeave();
+            }
+            try value.layout();
+            try value.refreshChrome();
         }
     }
 
@@ -25777,6 +25833,41 @@ test "win32 hostWindowStyle clips child repaints" {
     const style = hostWindowStyle();
     try std.testing.expect((style & WS_CLIPCHILDREN) != 0);
     try std.testing.expect((style & WS_VISIBLE) == 0);
+}
+
+test "win32 decorationsVisibleForConfig only hides none" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expect(decorationsVisibleForConfig(.auto));
+    try std.testing.expect(decorationsVisibleForConfig(.client));
+    try std.testing.expect(decorationsVisibleForConfig(.server));
+    try std.testing.expect(!decorationsVisibleForConfig(.none));
+}
+
+test "win32 startupHostWindowStyle respects decoration and fullscreen frame state" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqual(
+        effectiveHostWindowStyle(true, false, true) & ~@as(u32, WS_VISIBLE),
+        startupHostWindowStyle(true, false),
+    );
+    try std.testing.expectEqual(
+        effectiveHostWindowStyle(false, false, true) & ~@as(u32, WS_VISIBLE),
+        startupHostWindowStyle(false, false),
+    );
+    try std.testing.expectEqual(
+        effectiveHostWindowStyle(false, true, true) & ~@as(u32, WS_VISIBLE),
+        startupHostWindowStyle(false, true),
+    );
+}
+
+test "win32 usesIntegratedTitlebar requires visible decorations" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expect(usesIntegratedTitlebar(true, true, true));
+    try std.testing.expect(!usesIntegratedTitlebar(false, true, true));
+    try std.testing.expect(!usesIntegratedTitlebar(true, false, true));
+    try std.testing.expect(!usesIntegratedTitlebar(true, true, false));
 }
 
 test "win32 surfaceWindowStyle clips sibling repaints" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4195,6 +4195,7 @@ pub const App = struct {
             source.decorations_visible
         else
             decorationsVisibleForConfig(self.config.@"window-decoration");
+        host.cached_decorations_visible = startup_decorations_visible;
         const startup_fullscreen = if (clone_state_from) |source| source.fullscreen else false;
 
         const hwnd = CreateWindowExW(
@@ -6258,6 +6259,7 @@ const Host = struct {
     app: *App,
     id: u32,
     hwnd: ?HWND = null,
+    cached_decorations_visible: bool = true,
     tabs: std.ArrayListUnmanaged(Tab) = .empty,
     active_tab: usize = 0,
     next_tab_id: u32 = 1,
@@ -10206,7 +10208,7 @@ const Host = struct {
 
     fn decorationVisibilityForChrome(self: *const Host) bool {
         if (self.activeSurface()) |surface| return surface.decorations_visible;
-        return decorationsVisibleForConfig(self.app.config.@"window-decoration");
+        return self.cached_decorations_visible;
     }
 
     /// Host-local view of the integrated-titlebar state. The app
@@ -18647,8 +18649,7 @@ pub const Surface = struct {
 
     fn initialDecorationsVisible(config: *const configpkg.Config, opts: SurfaceInitOptions) bool {
         if (opts.clone_state_from) |source| return source.decorations_visible;
-        if (opts.host_id == null) return decorationsVisibleForConfig(config.@"window-decoration");
-        return true;
+        return decorationsVisibleForConfig(config.@"window-decoration");
     }
 
     pub fn init(
@@ -21061,6 +21062,7 @@ pub const Surface = struct {
         };
 
         if (host) |value| {
+            value.handleNcMouseLeave();
             value.layout() catch |err| {
                 log.warn("win32 decoration rollback layout failed err={}", .{err});
             };
@@ -25910,10 +25912,40 @@ test "win32 initialDecorationsVisible follows startup source" {
     ));
 
     config.@"window-decoration" = .none;
+    try std.testing.expect(!Surface.initialDecorationsVisible(
+        &config,
+        .{ .host_id = 7 },
+    ));
+
+    config.@"window-decoration" = .auto;
     try std.testing.expect(Surface.initialDecorationsVisible(
         &config,
         .{ .host_id = 7 },
     ));
+}
+
+test "win32 decorationVisibilityForChrome uses cached fallback until active surface" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var host: Host = undefined;
+    host.tabs = .empty;
+    host.active_tab = 0;
+    host.cached_decorations_visible = false;
+    defer {
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    try std.testing.expect(!host.decorationVisibilityForChrome());
+
+    host.cached_decorations_visible = true;
+    try std.testing.expect(host.decorationVisibilityForChrome());
+
+    var surface: Surface = undefined;
+    surface.decorations_visible = false;
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &surface));
+
+    try std.testing.expect(!host.decorationVisibilityForChrome());
 }
 
 test "win32 usesIntegratedTitlebar requires visible decorations" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1344,6 +1344,10 @@ fn shouldPropagateSharedHostWindowState(source: *const Surface) bool {
     return host.activeSurface() == source;
 }
 
+fn shouldApplyConfigDecorations(decorations_visible_overridden: bool) bool {
+    return !decorations_visible_overridden;
+}
+
 fn usesIntegratedTitlebar(
     enabled: bool,
     tab_bar_visible: bool,
@@ -8518,14 +8522,15 @@ const Host = struct {
     }
 
     fn hideOverlay(self: *Host) void {
+        const was_confirm = self.overlay_mode == .confirm;
         self.overlay_mode = .none;
         self.clearOverlayCompletion();
         self.setBanner(.none, null) catch {};
         // Drop any active confirm payload. Both accept and cancel
         // paths route through hideOverlay, so this is the one place
-        // the owned byte slices get freed. Callbacks were already
-        // dispatched in invokeConfirm{Accept,Cancel} before reaching
-        // this point.
+        // the owned byte slices get freed. Accept/cancel callbacks
+        // snapshot their callback data before reaching this point and
+        // dispatch only after hideOverlay returns.
         if (self.confirm_payload) |*p| {
             p.deinit(self.app.core_app.alloc);
             self.confirm_payload = null;
@@ -8540,6 +8545,11 @@ const Host = struct {
         self.palette_list_scroll = 0;
         self.invalidateOverlayTransitionPlacementCache();
         self.forceHostCompositionPaint();
+        if (was_confirm) {
+            self.layout() catch {};
+            self.forceVisibleSurfaceRepaintsNow();
+            refocusActiveSurface(self);
+        }
     }
 
     fn invalidateOverlayTransitionPlacementCache(self: *Host) void {
@@ -8613,36 +8623,27 @@ const Host = struct {
     fn invokeConfirmAccept(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
         const userdata = captured.userdata;
         // hideOverlay deinits the payload (frees the owned byte
         // slices) and clears `confirm_payload = null`. After this
-        // point, no Host-mutating call may touch fields the
-        // callback might also reach.
+        // point, do not touch Host state before the callback: confirm
+        // teardown repaint/focus restoration happens inside
+        // hideOverlay while the Host is still owned by this path.
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         cb(userdata);
     }
 
     fn invokeConfirmCancel(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 
@@ -18508,6 +18509,7 @@ pub const Surface = struct {
     window_focused: bool = false,
     quick_terminal: bool = false,
     decorations_visible: bool = true,
+    decorations_visible_overridden: bool = false,
     fullscreen: bool = false,
     topmost: bool = false,
     restore_rect: RECT = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
@@ -20869,9 +20871,11 @@ pub const Surface = struct {
     }
 
     fn applyRuntimeConfig(self: *Surface, config: *const configpkg.Config) !void {
-        self.setDecorationsVisible(decorationsVisibleForConfig(config.@"window-decoration")) catch |err| {
-            log.warn("win32 decoration update failed during config reload err={}", .{err});
-        };
+        if (shouldApplyConfigDecorations(self.decorations_visible_overridden)) {
+            self.setDecorationsVisible(decorationsVisibleForConfig(config.@"window-decoration")) catch |err| {
+                log.warn("win32 decoration update failed during config reload err={}", .{err});
+            };
+        }
         self.background_opacity_default = normalizedBackgroundOpacity(config.@"background-opacity");
         self.scrollbar_config = config.scrollbar;
         if (self.background_opacity_default >= 0.999) {
@@ -20916,6 +20920,7 @@ pub const Surface = struct {
 
     fn toggleDecorations(self: *Surface) !void {
         try self.setDecorationsVisible(!self.decorations_visible);
+        self.decorations_visible_overridden = true;
     }
 
     fn setInitialSize(self: *Surface, size: apprt.action.InitialSize) !void {
@@ -21128,6 +21133,7 @@ pub const Surface = struct {
 
     fn copySharedWindowStateFrom(self: *Surface, source: *const Surface) void {
         self.decorations_visible = source.decorations_visible;
+        self.decorations_visible_overridden = source.decorations_visible_overridden;
         if (self.host) |host| {
             if (host.activeSurface() == self) {
                 host.cached_decorations_visible = self.decorations_visible;
@@ -26012,6 +26018,7 @@ test "win32 copySharedWindowStateFrom clones host-scoped window fields" {
 
     var source: Surface = undefined;
     source.decorations_visible = false;
+    source.decorations_visible_overridden = true;
     source.fullscreen = true;
     source.topmost = true;
     source.restore_rect = .{ .left = 10, .top = 20, .right = 30, .bottom = 40 };
@@ -26032,6 +26039,7 @@ test "win32 copySharedWindowStateFrom clones host-scoped window fields" {
     dest.copySharedWindowStateFrom(&source);
 
     try std.testing.expectEqual(source.decorations_visible, dest.decorations_visible);
+    try std.testing.expectEqual(source.decorations_visible_overridden, dest.decorations_visible_overridden);
     try std.testing.expectEqual(source.fullscreen, dest.fullscreen);
     try std.testing.expectEqual(source.topmost, dest.topmost);
     try std.testing.expectEqualDeep(source.restore_rect, dest.restore_rect);
@@ -26089,6 +26097,13 @@ test "win32 shouldPropagateSharedHostWindowState only for active shared-host sur
     host.active_tab = 1;
     try std.testing.expect(!shouldPropagateSharedHostWindowState(&active_surface));
     try std.testing.expect(shouldPropagateSharedHostWindowState(&inactive_surface));
+}
+
+test "win32 config decoration reload respects runtime override" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expect(shouldApplyConfigDecorations(false));
+    try std.testing.expect(!shouldApplyConfigDecorations(true));
 }
 
 test "win32 shouldResizeHostForInitialSize only for single-surface hosts" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8614,6 +8614,7 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
@@ -8624,6 +8625,8 @@ const Host = struct {
         // callback might also reach.
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         cb(userdata);
     }
 
@@ -8631,12 +8634,15 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1246,6 +1246,11 @@ fn decorationsVisibleForConfig(value: configpkg.Config.WindowDecoration) bool {
     return value != .none;
 }
 
+fn initialDecorationsVisibleForSource(config: *const configpkg.Config, clone_state_from: ?*const Surface) bool {
+    if (clone_state_from) |source| return source.decorations_visible;
+    return decorationsVisibleForConfig(config.@"window-decoration");
+}
+
 fn decorationVisibilityForChromeValue(active_surface_visible: ?bool, cached_visible: bool) bool {
     return active_surface_visible orelse cached_visible;
 }
@@ -4195,10 +4200,7 @@ pub const App = struct {
         }
 
         const position = configuredHostWindowPosition(&self.config);
-        const startup_decorations_visible = if (clone_state_from) |source|
-            source.decorations_visible
-        else
-            decorationsVisibleForConfig(self.config.@"window-decoration");
+        const startup_decorations_visible = initialDecorationsVisibleForSource(&self.config, clone_state_from);
         host.cached_decorations_visible = startup_decorations_visible;
         const startup_fullscreen = if (clone_state_from) |source| source.fullscreen else false;
 
@@ -18654,8 +18656,7 @@ pub const Surface = struct {
     }
 
     fn initialDecorationsVisible(config: *const configpkg.Config, opts: SurfaceInitOptions) bool {
-        if (opts.clone_state_from) |source| return source.decorations_visible;
-        return decorationsVisibleForConfig(config.@"window-decoration");
+        return initialDecorationsVisibleForSource(config, opts.clone_state_from);
     }
 
     pub fn init(
@@ -21121,6 +21122,11 @@ pub const Surface = struct {
 
     fn copySharedWindowStateFrom(self: *Surface, source: *const Surface) void {
         self.decorations_visible = source.decorations_visible;
+        if (self.host) |host| {
+            if (host.activeSurface() == self) {
+                host.cached_decorations_visible = self.decorations_visible;
+            }
+        }
         self.fullscreen = source.fullscreen;
         self.topmost = source.topmost;
         self.restore_rect = source.restore_rect;
@@ -25912,6 +25918,7 @@ test "win32 initialDecorationsVisible follows startup source" {
     try std.testing.expect(Surface.initialDecorationsVisible(&config, .{}));
 
     var source: Surface = undefined;
+    source.host = null;
     source.decorations_visible = false;
     try std.testing.expect(!Surface.initialDecorationsVisible(
         &config,
@@ -26014,6 +26021,7 @@ test "win32 copySharedWindowStateFrom clones host-scoped window fields" {
         .max_height = 444,
     };
     var dest: Surface = undefined;
+    dest.host = null;
 
     dest.copySharedWindowStateFrom(&source);
 


### PR DESCRIPTION
Summary: derive initial Win32 host style from window-decoration config or cloned host state, apply decoration changes on config reload, and gate integrated titlebar chrome on visible decorations. Validation: focused Zig tests for decoration config, startup style, integrated titlebar gating, host styles, and Win11 titlebar floor passed; git diff --check passed. Note: no live HWND harness was run. Ready for review; not draft.

## Summary by Sourcery

Align Win32 window decoration visibility and integrated titlebar behavior with configuration and cloned state, and ensure host startup style and runtime updates respect decoration visibility and fullscreen state.

Bug Fixes:
- Derive initial Win32 host and surface decoration visibility from configuration or cloned surface state so startup chrome matches expected decorations.
- Gate the integrated titlebar chrome on both tab bar visibility and effective decoration visibility to avoid showing integrated controls when decorations are hidden.
- Apply window-decoration configuration changes at runtime by updating surface and host window styles, with rollback on failure to keep state consistent.

Enhancements:
- Hide the Win32 host window at startup by deriving its style from the effective host style while explicitly clearing WS_VISIBLE.
- Cache decoration visibility on the host and use it as a fallback for chrome decisions until an active surface is available.

Tests:
- Add focused Win32 tests covering decoration visibility derivation, startup host styles, chrome visibility fallback, and integrated titlebar gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter startup and runtime window styling that computes and respects decoration visibility, fullscreen state, and caches decoration state for consistent chrome and integrated-titlebar behavior.

* **Bug Fixes**
  * Integrated titlebar now requires visible decorations before activating; decoration toggles are idempotent, update layout/chrome immediately, and roll back safely on failure.

* **Tests**
  * Added tests covering decoration visibility rules, startup styling, caching behavior, and integrated-titlebar eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->