### PR TITLE
fix(win32): honor window-new-tab-position

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -6708,7 +6708,7 @@ const Host = struct {
 
     fn restoreClosedTabEntry(self: *Host, value: *CloseTabUndo) Allocator.Error!bool {
         const tab = value.tab orelse return false;
-        const insert_index = @min(value.index, self.tabs.items.len);
+        const insert_index = clampTabInsertIndex(value.index, self.tabs.items.len);
         try self.tabs.insert(self.app.core_app.alloc, insert_index, tab);
         value.tab = null;
         value.index = insert_index;
@@ -12463,7 +12463,9 @@ fn rollbackFailedSurfaceAttach(
         state.tab.focused = state.focused;
         split_rollback.* = null;
     } else if (tabs.items.len > prev_tab_count) {
-        const remove_index = @min(inserted_tab_index orelse tabs.items.len - 1, tabs.items.len - 1);
+        // Null inserted_tab_index means no caller-recorded tab insert index;
+        // remove the newest tab as a best-effort rollback for legacy callers.
+        const remove_index = clampTabInsertIndex(inserted_tab_index orelse tabs.items.len - 1, tabs.items.len - 1);
         var removed = tabs.orderedRemove(remove_index);
         removed.deinit();
     }
@@ -12483,12 +12485,17 @@ fn windowNewTabInsertIndex(
     position: configpkg.Config.WindowNewTabPosition,
 ) usize {
     return switch (position) {
-        .current => if (host.tabs.items.len == 0 or host.active_tab >= host.tabs.items.len)
-            host.tabs.items.len
-        else
-            host.active_tab + 1,
+        .current => clampTabInsertIndex(host.active_tab + 1, host.tabs.items.len),
         .end => host.tabs.items.len,
     };
+}
+
+fn requestedTabInsertIndex(requested: ?usize, tab_count: usize) usize {
+    return clampTabInsertIndex(requested orelse tab_count, tab_count);
+}
+
+fn clampTabInsertIndex(index: usize, tab_count: usize) usize {
+    return @min(index, tab_count);
 }
 
 const RestoredTerminalUndoState = struct {
@@ -18777,7 +18784,7 @@ pub const Surface = struct {
             } else return error.InvalidTab;
         } else {
             const tab_id = host.nextTabId();
-            inserted_tab_index = @min(opts.tab_insert_index orelse host.tabs.items.len, host.tabs.items.len);
+            inserted_tab_index = requestedTabInsertIndex(opts.tab_insert_index, host.tabs.items.len);
             try host.tabs.insert(
                 app.core_app.alloc,
                 inserted_tab_index.?,
@@ -22928,7 +22935,7 @@ test "win32 new_tab action inserts after the active tab by default, clears curre
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            const insert_index = @min(opts.tab_insert_index orelse host_ref.tabs.items.len, host_ref.tabs.items.len);
+            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
                 insert_index,
@@ -23062,7 +23069,7 @@ test "win32 new_tab action appends when window-new-tab-position is end" {
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            const insert_index = @min(opts.tab_insert_index orelse host_ref.tabs.items.len, host_ref.tabs.items.len);
+            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
                 insert_index,
@@ -23084,6 +23091,143 @@ test "win32 new_tab action appends when window-new-tab-position is end" {
     try std.testing.expectEqual(@as(u32, 2), host.tabs.items[1].id);
     try std.testing.expectEqual(@as(u32, 3), host.tabs.items[2].id);
     try std.testing.expect(host.tabs.items[2].focusedSurface() == &created);
+}
+
+test "win32 profile tab open appends when window-new-tab-position is end" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    try core_app.init(std.testing.allocator);
+    defer core_app.deinit();
+
+    var app: App = .{
+        .core_app = &core_app,
+        .config = try configpkg.Config.default(std.testing.allocator),
+        .hinstance = GetModuleHandleW(null),
+    };
+    defer {
+        app.config.deinit();
+        app.hosts.deinit(std.testing.allocator);
+        app.windows.deinit(std.testing.allocator);
+    }
+    app.config.@"window-new-tab-position" = .end;
+
+    var host: Host = .{
+        .app = &app,
+        .id = 1,
+        .tabs = .empty,
+        .structural_undo_entries = .empty,
+        .structural_redo_entries = .empty,
+    };
+    defer {
+        host.clearStructuralHistory(.normal);
+        host.structural_undo_entries.deinit(std.testing.allocator);
+        host.structural_redo_entries.deinit(std.testing.allocator);
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    var source: Surface = undefined;
+    source.app = &app;
+    source.host = &host;
+    source.host_id = host.id;
+    source.hwnd = null;
+    source.core_initialized = false;
+    source.window_visible = true;
+    source.host_active = true;
+    source.launch_profile_key = null;
+    source.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer source.undo_stack.deinit();
+
+    var other: Surface = undefined;
+    other.app = &app;
+    other.host = &host;
+    other.host_id = host.id;
+    other.hwnd = null;
+    other.core_initialized = false;
+    other.window_visible = true;
+    other.host_active = true;
+    other.launch_profile_key = null;
+    other.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer other.undo_stack.deinit();
+
+    var created: Surface = undefined;
+    created.app = &app;
+    created.host = &host;
+    created.host_id = host.id;
+    created.hwnd = null;
+    created.core_initialized = false;
+    created.window_visible = false;
+    created.host_active = false;
+    created.launch_profile_key = null;
+    created.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer {
+        if (created.launch_profile_key) |value| std.testing.allocator.free(value);
+        created.undo_stack.deinit();
+    }
+
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &source));
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &other));
+    host.active_tab = 0;
+    host.next_tab_id = 3;
+
+    try app.hosts.append(std.testing.allocator, &host);
+    try app.windows.append(std.testing.allocator, &source);
+    try app.windows.append(std.testing.allocator, &other);
+
+    const Hook = struct {
+        var host_ref: *Host = undefined;
+        var created_ref: *Surface = undefined;
+        var captured_host_id: ?u32 = null;
+        var captured_tab_insert_index: ?usize = 999;
+
+        fn createSurface(
+            hook_app: *App,
+            config: *const configpkg.Config,
+            title: LPCWSTR,
+            opts: SurfaceInitOptions,
+        ) anyerror!*Surface {
+            _ = config;
+            _ = title;
+            captured_host_id = opts.host_id;
+            captured_tab_insert_index = opts.tab_insert_index;
+
+            created_ref.app = hook_app;
+            created_ref.host = host_ref;
+            created_ref.host_id = host_ref.id;
+            try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
+            const tab_id = host_ref.nextTabId();
+            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                insert_index,
+                try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
+            );
+            return created_ref;
+        }
+    };
+
+    Hook.host_ref = &host;
+    Hook.created_ref = &created;
+    app.test_create_window_surface = &Hook.createSurface;
+
+    const profile: windows_shell.Profile = .{
+        .kind = .pwsh,
+        .key = "pwsh",
+        .label = "PowerShell",
+        .command = .{ .direct = &.{"pwsh.exe"} },
+    };
+
+    const surface = try app.createProfileSurface(.app, &profile, .tab);
+    try std.testing.expect(surface == &created);
+    try std.testing.expectEqual(@as(?u32, host.id), Hook.captured_host_id);
+    try std.testing.expectEqual(@as(?usize, 2), Hook.captured_tab_insert_index);
+    try std.testing.expectEqual(@as(usize, 3), host.tabs.items.len);
+    try std.testing.expectEqual(@as(u32, 1), host.tabs.items[0].id);
+    try std.testing.expectEqual(@as(u32, 2), host.tabs.items[1].id);
+    try std.testing.expectEqual(@as(u32, 3), host.tabs.items[2].id);
+    try std.testing.expect(host.tabs.items[2].focusedSurface() == &created);
+    try std.testing.expectEqualStrings("pwsh", created.launch_profile_key.?);
 }
 
 test "win32 moveTab invalidates current tab redo and structural history before reordering tabs" {
@@ -27636,6 +27780,15 @@ test "win32 windowNewTabInsertIndex respects current and end positions" {
         @as(usize, 2),
         windowNewTabInsertIndex(&host, .current),
     );
+}
+
+test "win32 requestedTabInsertIndex clamps requested insert positions" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqual(@as(usize, 0), requestedTabInsertIndex(null, 0));
+    try std.testing.expectEqual(@as(usize, 2), requestedTabInsertIndex(null, 2));
+    try std.testing.expectEqual(@as(usize, 1), requestedTabInsertIndex(1, 2));
+    try std.testing.expectEqual(@as(usize, 2), requestedTabInsertIndex(99, 2));
 }
 
 test "win32 rollbackFailedSurfaceAttach removes failed tab and restores active index" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23233,6 +23233,146 @@ test "win32 profile tab open appends when window-new-tab-position is end" {
     try std.testing.expectEqualStrings("pwsh", created.launch_profile_key.?);
 }
 
+test "win32 profile tab open inserts after active tab when window-new-tab-position is current" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    try core_app.init(std.testing.allocator);
+    defer core_app.deinit();
+
+    var app: App = .{
+        .core_app = &core_app,
+        .config = try configpkg.Config.default(std.testing.allocator),
+        .hinstance = GetModuleHandleW(null),
+    };
+    defer {
+        app.config.deinit();
+        app.hosts.deinit(std.testing.allocator);
+        app.windows.deinit(std.testing.allocator);
+    }
+    // default is .current — explicitly set for clarity
+    app.config.@"window-new-tab-position" = .current;
+
+    var host: Host = .{
+        .app = &app,
+        .id = 1,
+        .tabs = .empty,
+        .structural_undo_entries = .empty,
+        .structural_redo_entries = .empty,
+    };
+    defer {
+        host.clearStructuralHistory(.normal);
+        host.structural_undo_entries.deinit(std.testing.allocator);
+        host.structural_redo_entries.deinit(std.testing.allocator);
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    var source: Surface = undefined;
+    source.app = &app;
+    source.host = &host;
+    source.host_id = host.id;
+    source.hwnd = null;
+    source.core_initialized = false;
+    source.window_visible = true;
+    source.host_active = true;
+    source.launch_profile_key = null;
+    source.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer source.undo_stack.deinit();
+
+    var other: Surface = undefined;
+    other.app = &app;
+    other.host = &host;
+    other.host_id = host.id;
+    other.hwnd = null;
+    other.core_initialized = false;
+    other.window_visible = true;
+    other.host_active = true;
+    other.launch_profile_key = null;
+    other.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer other.undo_stack.deinit();
+
+    var created: Surface = undefined;
+    created.app = &app;
+    created.host = &host;
+    created.host_id = host.id;
+    created.hwnd = null;
+    created.core_initialized = false;
+    created.window_visible = false;
+    created.host_active = false;
+    created.launch_profile_key = null;
+    created.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer {
+        if (created.launch_profile_key) |value| std.testing.allocator.free(value);
+        created.undo_stack.deinit();
+    }
+
+    // active_tab = 0; new tab should be inserted at index 1 (between tab1 and tab2)
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &source));
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &other));
+    host.active_tab = 0;
+    host.next_tab_id = 3;
+
+    try app.hosts.append(std.testing.allocator, &host);
+    try app.windows.append(std.testing.allocator, &source);
+    try app.windows.append(std.testing.allocator, &other);
+
+    const Hook = struct {
+        var host_ref: *Host = undefined;
+        var created_ref: *Surface = undefined;
+        var captured_host_id: ?u32 = null;
+        var captured_tab_insert_index: ?usize = 999;
+
+        fn createSurface(
+            hook_app: *App,
+            config: *const configpkg.Config,
+            title: LPCWSTR,
+            opts: SurfaceInitOptions,
+        ) anyerror!*Surface {
+            _ = config;
+            _ = title;
+            captured_host_id = opts.host_id;
+            captured_tab_insert_index = opts.tab_insert_index;
+
+            created_ref.app = hook_app;
+            created_ref.host = host_ref;
+            created_ref.host_id = host_ref.id;
+            try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
+            const tab_id = host_ref.nextTabId();
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                opts.tab_insert_index.?,
+                try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
+            );
+            return created_ref;
+        }
+    };
+
+    Hook.host_ref = &host;
+    Hook.created_ref = &created;
+    app.test_create_window_surface = &Hook.createSurface;
+
+    const profile: windows_shell.Profile = .{
+        .kind = .pwsh,
+        .key = "pwsh",
+        .label = "PowerShell",
+        .command = .{ .direct = &.{"pwsh.exe"} },
+    };
+
+    const surface = try app.createProfileSurface(.app, &profile, .tab);
+    try std.testing.expect(surface == &created);
+    try std.testing.expectEqual(@as(?u32, host.id), Hook.captured_host_id);
+    // .current: insert after active_tab (0), so index = 1
+    try std.testing.expectEqual(@as(?usize, 1), Hook.captured_tab_insert_index);
+    try std.testing.expectEqual(@as(usize, 3), host.tabs.items.len);
+    // tab order: [source(1), created(3), other(2)]
+    try std.testing.expectEqual(@as(u32, 1), host.tabs.items[0].id);
+    try std.testing.expectEqual(@as(u32, 3), host.tabs.items[1].id);
+    try std.testing.expectEqual(@as(u32, 2), host.tabs.items[2].id);
+    try std.testing.expect(host.tabs.items[1].focusedSurface() == &created);
+    try std.testing.expectEqualStrings("pwsh", created.launch_profile_key.?);
+}
+
 test "win32 moveTab invalidates current tab redo and structural history before reordering tabs" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -3069,6 +3069,10 @@ pub const App = struct {
                 const source = self.findSurfaceForTarget(target);
                 const surface = try self.createWindowSurface(&config, default_title, .{
                     .host_id = if (source) |v| v.host_id else null,
+                    .tab_insert_index = if (source) |v| if (v.host) |host|
+                        windowNewTabInsertIndex(host, self.config.@"window-new-tab-position")
+                    else
+                        null else null,
                     .clone_state_from = source,
                 });
                 if (source) |v| {
@@ -4033,6 +4037,10 @@ pub const App = struct {
         defer self.core_app.alloc.free(title_w);
         const surface = try self.createWindowSurface(&config, title_w.ptr, .{
             .host_id = if (open_target == .window) null else if (source) |v| v.host_id else null,
+            .tab_insert_index = if (open_target == .tab and source != null and source.?.host != null)
+                windowNewTabInsertIndex(source.?.host.?, self.config.@"window-new-tab-position")
+            else
+                null,
             .tab_id = tab_id,
             .clone_state_from = source,
         });
@@ -12423,6 +12431,7 @@ const SurfaceInitOptions = struct {
     quick_terminal: bool = false,
     host_id: ?u32 = null,
     tab_id: ?u32 = null,
+    tab_insert_index: ?usize = null,
     clone_state_from: ?*const Surface = null,
     split_direction: SplitTreeSurface.Split.Direction = .right,
     /// Passive first-show: the newly-created host HWND is shown via
@@ -12445,6 +12454,7 @@ fn rollbackFailedSurfaceAttach(
     active_tab: *usize,
     prev_active_tab: usize,
     prev_tab_count: usize,
+    inserted_tab_index: ?usize,
     split_rollback: *?SplitSurfaceAttachRollback,
 ) void {
     if (split_rollback.*) |state| {
@@ -12453,7 +12463,8 @@ fn rollbackFailedSurfaceAttach(
         state.tab.focused = state.focused;
         split_rollback.* = null;
     } else if (tabs.items.len > prev_tab_count) {
-        var removed = tabs.orderedRemove(tabs.items.len - 1);
+        const remove_index = @min(inserted_tab_index orelse tabs.items.len - 1, tabs.items.len - 1);
+        var removed = tabs.orderedRemove(remove_index);
         removed.deinit();
     }
 
@@ -12465,6 +12476,19 @@ fn commitSplitSurfaceAttach(split_rollback: *?SplitSurfaceAttachRollback) void {
         state.tree.deinit();
         split_rollback.* = null;
     }
+}
+
+fn windowNewTabInsertIndex(
+    host: *const Host,
+    position: configpkg.Config.WindowNewTabPosition,
+) usize {
+    return switch (position) {
+        .current => if (host.tabs.items.len == 0 or host.active_tab >= host.tabs.items.len)
+            host.tabs.items.len
+        else
+            host.active_tab + 1,
+        .end => host.tabs.items.len,
+    };
 }
 
 const RestoredTerminalUndoState = struct {
@@ -18720,6 +18744,7 @@ pub const Surface = struct {
 
         const prev_active_tab = host.active_tab;
         const prev_tab_count = host.tabs.items.len;
+        var inserted_tab_index: ?usize = null;
         var split_rollback: ?SplitSurfaceAttachRollback = null;
         defer commitSplitSurfaceAttach(&split_rollback);
         if (opts.tab_id) |tab_id| {
@@ -18752,7 +18777,12 @@ pub const Surface = struct {
             } else return error.InvalidTab;
         } else {
             const tab_id = host.nextTabId();
-            try host.tabs.append(app.core_app.alloc, try Tab.init(app.core_app.alloc, tab_id, self));
+            inserted_tab_index = @min(opts.tab_insert_index orelse host.tabs.items.len, host.tabs.items.len);
+            try host.tabs.insert(
+                app.core_app.alloc,
+                inserted_tab_index.?,
+                try Tab.init(app.core_app.alloc, tab_id, self),
+            );
         }
         // Rollback the tab entry if core_surface.init or later init steps fail.
         // Without this, a zombie tab with a dangling surface pointer would remain
@@ -18763,6 +18793,7 @@ pub const Surface = struct {
                 &host.active_tab,
                 prev_active_tab,
                 prev_tab_count,
+                inserted_tab_index,
                 &split_rollback,
             );
         }
@@ -22747,7 +22778,7 @@ test "win32 structural redo invalidation clears affected tab redo only" {
     try std.testing.expectEqual(@as(usize, 1), surface_c.undo_stack.redoDepth());
 }
 
-test "win32 new_tab action clears current tab redo and activates the created tab" {
+test "win32 new_tab action inserts after the active tab by default, clears current tab redo, and activates the created tab" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     var core_app: CoreApp = undefined;
@@ -22841,6 +22872,7 @@ test "win32 new_tab action clears current tab redo and activates the created tab
     host.tabs.items[0].tree = next_tree;
     host.tabs.items[0].focused = host.tabs.items[0].findHandle(&source) orelse host.tabs.items[0].focused;
     try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &other));
+    host.active_tab = 0;
     host.next_tab_id = 3;
 
     try app.hosts.append(std.testing.allocator, &host);
@@ -22875,6 +22907,7 @@ test "win32 new_tab action clears current tab redo and activates the created tab
         var created_ref: *Surface = undefined;
         var captured_host_id: ?u32 = null;
         var captured_tab_id: ?u32 = 999;
+        var captured_tab_insert_index: ?usize = 999;
         var captured_clone_state_from: ?*const Surface = null;
 
         fn createSurface(
@@ -22887,6 +22920,7 @@ test "win32 new_tab action clears current tab redo and activates the created tab
             _ = title;
             captured_host_id = opts.host_id;
             captured_tab_id = opts.tab_id;
+            captured_tab_insert_index = opts.tab_insert_index;
             captured_clone_state_from = opts.clone_state_from;
 
             created_ref.app = hook_app;
@@ -22894,7 +22928,12 @@ test "win32 new_tab action clears current tab redo and activates the created tab
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            try host_ref.tabs.append(hook_app.core_app.alloc, try Tab.init(hook_app.core_app.alloc, tab_id, created_ref));
+            const insert_index = @min(opts.tab_insert_index orelse host_ref.tabs.items.len, host_ref.tabs.items.len);
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                insert_index,
+                try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
+            );
             return created_ref;
         }
     };
@@ -22906,11 +22945,15 @@ test "win32 new_tab action clears current tab redo and activates the created tab
     try std.testing.expect(try app.performAction(.app, .new_tab, {}));
     try std.testing.expectEqual(@as(?u32, host.id), Hook.captured_host_id);
     try std.testing.expectEqual(@as(?u32, null), Hook.captured_tab_id);
+    try std.testing.expectEqual(@as(?usize, 1), Hook.captured_tab_insert_index);
     try std.testing.expect(Hook.captured_clone_state_from == &source);
     try std.testing.expectEqual(@as(usize, 3), host.tabs.items.len);
-    try std.testing.expectEqual(@as(usize, 2), host.active_tab);
+    try std.testing.expectEqual(@as(usize, 1), host.active_tab);
     try std.testing.expectEqual(@as(usize, 4), app.windows.items.len);
-    try std.testing.expect(host.tabs.items[2].focusedSurface() == &created);
+    try std.testing.expectEqual(@as(u32, 1), host.tabs.items[0].id);
+    try std.testing.expectEqual(@as(u32, 3), host.tabs.items[1].id);
+    try std.testing.expectEqual(@as(u32, 2), host.tabs.items[2].id);
+    try std.testing.expect(host.tabs.items[1].focusedSurface() == &created);
     try std.testing.expect(created.host_active);
     try std.testing.expect(created.window_visible);
     try std.testing.expectEqual(@as(usize, 1), source.undo_stack.undoDepth());
@@ -22921,6 +22964,126 @@ test "win32 new_tab action clears current tab redo and activates the created tab
     try std.testing.expectEqual(@as(usize, 1), other.undo_stack.redoDepth());
     try std.testing.expectEqual(@as(usize, 1), host.structural_undo_entries.items.len);
     try std.testing.expectEqual(@as(usize, 0), host.structural_redo_entries.items.len);
+}
+
+test "win32 new_tab action appends when window-new-tab-position is end" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    try core_app.init(std.testing.allocator);
+    defer core_app.deinit();
+
+    var app: App = .{
+        .core_app = &core_app,
+        .config = try configpkg.Config.default(std.testing.allocator),
+        .hinstance = GetModuleHandleW(null),
+    };
+    defer {
+        app.config.deinit();
+        app.hosts.deinit(std.testing.allocator);
+        app.windows.deinit(std.testing.allocator);
+    }
+    app.config.@"window-new-tab-position" = .end;
+
+    var host: Host = .{
+        .app = &app,
+        .id = 1,
+        .tabs = .empty,
+        .structural_undo_entries = .empty,
+        .structural_redo_entries = .empty,
+    };
+    defer {
+        host.clearStructuralHistory(.normal);
+        host.structural_undo_entries.deinit(std.testing.allocator);
+        host.structural_redo_entries.deinit(std.testing.allocator);
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    var source: Surface = undefined;
+    source.app = &app;
+    source.host = &host;
+    source.host_id = host.id;
+    source.hwnd = null;
+    source.core_initialized = false;
+    source.window_visible = true;
+    source.host_active = true;
+    source.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer source.undo_stack.deinit();
+
+    var other: Surface = undefined;
+    other.app = &app;
+    other.host = &host;
+    other.host_id = host.id;
+    other.hwnd = null;
+    other.core_initialized = false;
+    other.window_visible = true;
+    other.host_active = true;
+    other.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer other.undo_stack.deinit();
+
+    var created: Surface = undefined;
+    created.app = &app;
+    created.host = &host;
+    created.host_id = host.id;
+    created.hwnd = null;
+    created.core_initialized = false;
+    created.window_visible = false;
+    created.host_active = false;
+    created.undo_stack = win32_undo.UndoStack.init(std.testing.allocator);
+    defer created.undo_stack.deinit();
+
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &source));
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &other));
+    host.active_tab = 0;
+    host.next_tab_id = 3;
+
+    try app.hosts.append(std.testing.allocator, &host);
+    try app.windows.append(std.testing.allocator, &source);
+    try app.windows.append(std.testing.allocator, &other);
+
+    const Hook = struct {
+        var host_ref: *Host = undefined;
+        var created_ref: *Surface = undefined;
+        var captured_tab_insert_index: ?usize = 999;
+
+        fn createSurface(
+            hook_app: *App,
+            config: *const configpkg.Config,
+            title: LPCWSTR,
+            opts: SurfaceInitOptions,
+        ) anyerror!*Surface {
+            _ = config;
+            _ = title;
+            captured_tab_insert_index = opts.tab_insert_index;
+
+            created_ref.app = hook_app;
+            created_ref.host = host_ref;
+            created_ref.host_id = host_ref.id;
+            try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
+            const tab_id = host_ref.nextTabId();
+            const insert_index = @min(opts.tab_insert_index orelse host_ref.tabs.items.len, host_ref.tabs.items.len);
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                insert_index,
+                try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
+            );
+            return created_ref;
+        }
+    };
+
+    Hook.host_ref = &host;
+    Hook.created_ref = &created;
+    app.test_create_window_surface = &Hook.createSurface;
+
+    try std.testing.expect(try app.performAction(.app, .new_tab, {}));
+    try std.testing.expectEqual(@as(usize, 3), host.tabs.items.len);
+    try std.testing.expectEqual(@as(usize, 2), host.active_tab);
+    try std.testing.expectEqual(@as(?usize, 2), Hook.captured_tab_insert_index);
+    try std.testing.expectEqual(@as(u32, 1), host.tabs.items[0].id);
+    try std.testing.expectEqual(@as(u32, 2), host.tabs.items[1].id);
+    try std.testing.expectEqual(@as(u32, 3), host.tabs.items[2].id);
+    try std.testing.expect(host.tabs.items[2].focusedSurface() == &created);
 }
 
 test "win32 moveTab invalidates current tab redo and structural history before reordering tabs" {
@@ -27440,6 +27603,41 @@ test "win32 profileStatusBadgeTextLen matches built text" {
     try std.testing.expectEqual(badge.len, profileStatusBadgeTextLen(&profile, 0, 0));
 }
 
+test "win32 windowNewTabInsertIndex respects current and end positions" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var surface_a: Surface = undefined;
+    var surface_b: Surface = undefined;
+    var host: Host = .{
+        .app = undefined,
+        .id = 1,
+        .tabs = .empty,
+    };
+    defer {
+        for (host.tabs.items) |*tab| tab.deinit();
+        host.tabs.deinit(std.testing.allocator);
+    }
+
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &surface_a));
+    try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &surface_b));
+
+    host.active_tab = 0;
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        windowNewTabInsertIndex(&host, .current),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        windowNewTabInsertIndex(&host, .end),
+    );
+
+    host.active_tab = 9;
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        windowNewTabInsertIndex(&host, .current),
+    );
+}
+
 test "win32 rollbackFailedSurfaceAttach removes failed tab and restores active index" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -27457,11 +27655,38 @@ test "win32 rollbackFailedSurfaceAttach removes failed tab and restores active i
 
     var active_tab: usize = 1;
     var split_rollback: ?SplitSurfaceAttachRollback = null;
-    rollbackFailedSurfaceAttach(&tabs, &active_tab, 0, prev_tab_count, &split_rollback);
+    rollbackFailedSurfaceAttach(&tabs, &active_tab, 0, prev_tab_count, 1, &split_rollback);
 
     try std.testing.expectEqual(@as(usize, 1), tabs.items.len);
     try std.testing.expectEqual(@as(usize, 0), active_tab);
     try std.testing.expectEqual(@as(?*Surface, &surface_a), tabs.items[0].focusedSurface());
+}
+
+test "win32 rollbackFailedSurfaceAttach removes a failed middle tab insertion" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var surface_a: Surface = undefined;
+    var inserted_surface: Surface = undefined;
+    var surface_b: Surface = undefined;
+    var tabs: std.ArrayListUnmanaged(Tab) = .empty;
+    defer {
+        for (tabs.items) |*tab| tab.deinit();
+        tabs.deinit(std.testing.allocator);
+    }
+
+    try tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 1, &surface_a));
+    try tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 2, &surface_b));
+    const prev_tab_count = tabs.items.len;
+    try tabs.insert(std.testing.allocator, 1, try Tab.init(std.testing.allocator, 3, &inserted_surface));
+
+    var active_tab: usize = 1;
+    var split_rollback: ?SplitSurfaceAttachRollback = null;
+    rollbackFailedSurfaceAttach(&tabs, &active_tab, 0, prev_tab_count, 1, &split_rollback);
+
+    try std.testing.expectEqual(@as(usize, 2), tabs.items.len);
+    try std.testing.expectEqual(@as(usize, 0), active_tab);
+    try std.testing.expectEqual(@as(u32, 1), tabs.items[0].id);
+    try std.testing.expectEqual(@as(u32, 2), tabs.items[1].id);
 }
 
 test "win32 rollbackFailedSurfaceAttach restores split tree after failed attach" {
@@ -27502,7 +27727,7 @@ test "win32 rollbackFailedSurfaceAttach restores split tree after failed attach"
         .tree = prev_tree,
         .focused = prev_focused,
     };
-    rollbackFailedSurfaceAttach(&tabs, &active_tab, 0, prev_tab_count, &split_rollback);
+    rollbackFailedSurfaceAttach(&tabs, &active_tab, 0, prev_tab_count, null, &split_rollback);
 
     try std.testing.expectEqual(@as(usize, 1), tabs.items.len);
     try std.testing.expectEqual(@as(usize, 0), active_tab);

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8503,14 +8503,15 @@ const Host = struct {
     }
 
     fn hideOverlay(self: *Host) void {
+        const was_confirm = self.overlay_mode == .confirm;
         self.overlay_mode = .none;
         self.clearOverlayCompletion();
         self.setBanner(.none, null) catch {};
         // Drop any active confirm payload. Both accept and cancel
         // paths route through hideOverlay, so this is the one place
-        // the owned byte slices get freed. Callbacks were already
-        // dispatched in invokeConfirm{Accept,Cancel} before reaching
-        // this point.
+        // the owned byte slices get freed. Accept/cancel callbacks
+        // snapshot their callback data before reaching this point and
+        // dispatch only after hideOverlay returns.
         if (self.confirm_payload) |*p| {
             p.deinit(self.app.core_app.alloc);
             self.confirm_payload = null;
@@ -8525,6 +8526,11 @@ const Host = struct {
         self.palette_list_scroll = 0;
         self.invalidateOverlayTransitionPlacementCache();
         self.forceHostCompositionPaint();
+        if (was_confirm) {
+            self.layout() catch {};
+            self.forceVisibleSurfaceRepaintsNow();
+            refocusActiveSurface(self);
+        }
     }
 
     fn invalidateOverlayTransitionPlacementCache(self: *Host) void {
@@ -8598,36 +8604,27 @@ const Host = struct {
     fn invokeConfirmAccept(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
         const userdata = captured.userdata;
         // hideOverlay deinits the payload (frees the owned byte
         // slices) and clears `confirm_payload = null`. After this
-        // point, no Host-mutating call may touch fields the
-        // callback might also reach.
+        // point, do not touch Host state before the callback: confirm
+        // teardown repaint/focus restoration happens inside
+        // hideOverlay while the Host is still owned by this path.
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         cb(userdata);
     }
 
     fn invokeConfirmCancel(self: *Host) void {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
-            self.layout() catch {};
-            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
-        self.layout() catch {};
-        self.forceVisibleSurfaceRepaintsNow();
-        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -8599,6 +8599,7 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_accept;
@@ -8609,6 +8610,8 @@ const Host = struct {
         // callback might also reach.
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         cb(userdata);
     }
 
@@ -8616,12 +8619,15 @@ const Host = struct {
         const captured = self.confirm_payload orelse {
             self.hideOverlay();
             self.layout() catch {};
+            refocusActiveSurface(self);
             return;
         };
         const cb = captured.on_cancel;
         const userdata = captured.userdata;
         self.hideOverlay();
         self.layout() catch {};
+        self.forceVisibleSurfaceRepaintsNow();
+        refocusActiveSurface(self);
         if (cb) |f| f(userdata);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -18785,11 +18785,11 @@ pub const Surface = struct {
         } else {
             const tab_id = host.nextTabId();
             inserted_tab_index = requestedTabInsertIndex(opts.tab_insert_index, host.tabs.items.len);
-            try host.tabs.insert(
-                app.core_app.alloc,
-                inserted_tab_index.?,
-                try Tab.init(app.core_app.alloc, tab_id, self),
-            );
+            {
+                var tab = try Tab.init(app.core_app.alloc, tab_id, self);
+                errdefer tab.deinit();
+                try host.tabs.insert(app.core_app.alloc, inserted_tab_index.?, tab);
+            }
         }
         // Rollback the tab entry if core_surface.init or later init steps fail.
         // Without this, a zombie tab with a dangling surface pointer would remain
@@ -22935,10 +22935,9 @@ test "win32 new_tab action inserts after the active tab by default, clears curre
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
-                insert_index,
+                opts.tab_insert_index.?,
                 try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
             );
             return created_ref;
@@ -23069,10 +23068,9 @@ test "win32 new_tab action appends when window-new-tab-position is end" {
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
-                insert_index,
+                opts.tab_insert_index.?,
                 try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
             );
             return created_ref;
@@ -23197,10 +23195,9 @@ test "win32 profile tab open appends when window-new-tab-position is end" {
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             const tab_id = host_ref.nextTabId();
-            const insert_index = requestedTabInsertIndex(opts.tab_insert_index, host_ref.tabs.items.len);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
-                insert_index,
+                opts.tab_insert_index.?,
                 try Tab.init(hook_app.core_app.alloc, tab_id, created_ref),
             );
             return created_ref;


### PR DESCRIPTION
Summary: insert new Win32 tabs after the active tab for current mode, append for end mode, and preserve rollback correctness for failed middle insertion. Validation: focused Zig tests for new_tab action, rollbackFailedSurfaceAttach, and windowNewTabInsertIndex passed; git diff --check passed. Ready for review; not draft.

## Summary by Sourcery

Honor the window-new-tab-position setting for Win32 tabs by controlling where new tabs are inserted and ensuring rollback correctness when insertion fails.

New Features:
- Support configurable insertion index for new Win32 tabs based on window-new-tab-position (current vs end).

Bug Fixes:
- Ensure rollback of failed surface attaches correctly removes a newly inserted tab even when it was inserted in the middle of the tab list.

Tests:
- Extend and add Win32 tests to cover new_tab behavior for both tab insertion modes, the windowNewTabInsertIndex helper, and rollbackFailedSurfaceAttach with middle insertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to specify a tab insertion index when creating a new tab, including support for end insertion.

* **Bug Fixes**
  * Rollback now removes the specific inserted tab on failure instead of always removing the last tab.
  * Tab creation, ordering, and focus now honor requested and clamped insertion positions, with a legacy fallback when needed.
  * Confirm-overlay flows refocus the active surface after accept/cancel; cancel forces visible repaints before callback.

* **Tests**
  * Updated and added tests for insertion index handling, clamping, tab ordering, and focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->