### PR TITLE
feat(win32): restore saved window sessions

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -44,6 +44,7 @@ const win32_status_bar = @import("win32_status_bar.zig");
 const win32_tab_visual = @import("win32_tab_visual.zig");
 const win32_focus_ring = @import("win32_focus_ring.zig");
 const win32_types = @import("win32_types.zig");
+const win32_session_state = @import("win32_session_state.zig");
 
 // Re-export types from theme module
 const ThemeColors = win32_theme.ThemeColors;
@@ -835,6 +836,15 @@ const WINDOWPOS = extern struct {
     flags: UINT,
 };
 
+const WINDOWPLACEMENT = extern struct {
+    length: UINT,
+    flags: UINT,
+    showCmd: UINT,
+    ptMinPosition: POINT,
+    ptMaxPosition: POINT,
+    rcNormalPosition: RECT,
+};
+
 const NCCALCSIZE_PARAMS = extern struct {
     rgrc: [3]RECT,
     lppos: *WINDOWPOS,
@@ -921,6 +931,7 @@ extern "user32" fn GetKeyState(nVirtKey: i32) callconv(.winapi) SHORT;
 extern "user32" fn GetKeyboardState(lpKeyState: *[256]u8) callconv(.winapi) BOOL;
 extern "user32" fn GetMonitorInfoW(hMonitor: ?*anyopaque, lpmi: *MONITORINFO) callconv(.winapi) BOOL;
 extern "user32" fn GetWindowRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
+extern "user32" fn GetWindowPlacement(hWnd: HWND, lpwndpl: *WINDOWPLACEMENT) callconv(.winapi) BOOL;
 extern "user32" fn GetWindowTextLengthW(hWnd: HWND) callconv(.winapi) i32;
 extern "user32" fn GetWindowTextW(hWnd: HWND, lpString: [*]u16, nMaxCount: i32) callconv(.winapi) i32;
 extern "user32" fn IsWindow(hWnd: HWND) callconv(.winapi) BOOL;
@@ -2347,11 +2358,14 @@ pub const App = struct {
         try self.startIpcServer();
 
         if (self.config.@"initial-window") {
-            try self.createWindow(default_title);
-            if (self.startup_profile_picker) {
+            const restored = try self.restoreSessionState();
+            if (!restored) try self.createWindow(default_title);
+            if (!restored and self.startup_profile_picker) {
                 if (self.primarySurface()) |surface| {
                     if (surface.host) |host| _ = host.toggleProfileOverlay();
                 }
+                self.startup_profile_picker = false;
+            } else if (restored) {
                 self.startup_profile_picker = false;
             }
         } else {
@@ -2460,6 +2474,7 @@ pub const App = struct {
         }
         self.unregisterGlobalHotkeys();
         self.stopIpcServer();
+        self.saveSessionState();
         self.destroyAllWindows();
         self.hosts.deinit(self.core_app.alloc);
         self.windows.deinit(self.core_app.alloc);
@@ -2517,6 +2532,29 @@ pub const App = struct {
             dir,
             "palette-mru.txt",
         }) catch null;
+    }
+
+    /// Resolve `%LOCALAPPDATA%\winghostty\session-state.json`. Caller
+    /// frees with `core_app.alloc`.
+    fn sessionStatePath(self: *const App) ?[]u8 {
+        const local = std.process.getEnvVarOwned(
+            self.core_app.alloc,
+            "LOCALAPPDATA",
+        ) catch return null;
+        defer self.core_app.alloc.free(local);
+        const dir = std.fs.path.join(self.core_app.alloc, &.{
+            local,
+            "winghostty",
+        }) catch return null;
+        defer self.core_app.alloc.free(dir);
+        return std.fs.path.join(self.core_app.alloc, &.{
+            dir,
+            "session-state.json",
+        }) catch null;
+    }
+
+    fn sessionStateEnabled(self: *const App) bool {
+        return self.config.@"window-save-state" != .never;
     }
 
     /// Populate `palette_mru` from the on-disk file, one action per line
@@ -2581,6 +2619,365 @@ pub const App = struct {
             }
         }
         fw.interface.flush() catch {};
+    }
+
+    fn loadSessionState(self: *App) !?std.json.Parsed(win32_session_state.SessionState) {
+        if (!self.sessionStateEnabled()) return null;
+        const path = self.sessionStatePath() orelse return null;
+        defer self.core_app.alloc.free(path);
+
+        const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer file.close();
+
+        const raw = try file.readToEndAlloc(self.core_app.alloc, 1024 * 1024);
+        defer self.core_app.alloc.free(raw);
+        return try win32_session_state.parseAlloc(self.core_app.alloc, raw);
+    }
+
+    fn restoreSessionState(self: *App) !bool {
+        var parsed = self.loadSessionState() catch |err| {
+            log.warn("win32 session restore: ignored unreadable session state err={}", .{err});
+            return false;
+        } orelse return false;
+        defer parsed.deinit();
+
+        var restored = false;
+        for (parsed.value.windows) |window| {
+            if (self.restoreSessionWindow(window)) |surface| {
+                restored = true;
+                self.activateSurface(surface);
+            } else |err| {
+                log.warn("win32 session restore: skipped window err={}", .{err});
+            }
+        }
+
+        return restored;
+    }
+
+    fn restoreSessionWindow(
+        self: *App,
+        window: win32_session_state.Window,
+    ) !*Surface {
+        var host: ?*Host = null;
+        var window_surface: ?*Surface = null;
+
+        for (window.tabs, 0..) |saved_tab, tab_index| {
+            const tab_surface = try self.restoreSessionTab(
+                saved_tab,
+                host,
+                tab_index,
+            );
+            if (host == null) {
+                host = tab_surface.host;
+                if (host) |created_host| {
+                    self.applyRestoredWindowPlacement(created_host, window) catch |err| {
+                        log.warn("win32 session restore: window placement failed err={}", .{err});
+                    };
+                }
+            }
+            if (window_surface == null or tab_index == window.selected_tab) {
+                window_surface = tab_surface;
+            }
+        }
+
+        const restored_host = host orelse return error.EmptyTabs;
+        if (restored_host.tabs.items.len == 0) return error.EmptyTabs;
+        restored_host.active_tab = @min(window.selected_tab, restored_host.tabs.items.len - 1);
+        const active_tab = &restored_host.tabs.items[restored_host.active_tab];
+        return active_tab.focusedSurface() orelse window_surface orelse return error.EmptyTabs;
+    }
+
+    fn restoreSessionTab(
+        self: *App,
+        saved_tab: win32_session_state.Tab,
+        existing_host: ?*Host,
+        tab_index: usize,
+    ) !*Surface {
+        var tab_surface: ?*Surface = null;
+        var created: usize = 0;
+        var selected_surface: ?*Surface = null;
+
+        for (saved_tab.layout.nodes) |node| {
+            const pane = switch (node) {
+                .pane => |value| value,
+                .split => continue,
+            };
+            const surface = try self.restoreSessionPane(
+                pane,
+                existing_host,
+                tab_surface,
+                tab_index,
+                preferredSplitDirection(saved_tab.layout),
+            );
+            if (tab_surface == null) tab_surface = surface;
+            if (created == saved_tab.selected_leaf) selected_surface = surface;
+            created += 1;
+        }
+
+        const first = tab_surface orelse return error.EmptyLayout;
+        const selected = selected_surface orelse first;
+        if (self.findTabForSurface(selected)) |found| {
+            if (found.tab.findHandle(selected)) |handle| found.tab.focused = handle;
+        }
+        return selected;
+    }
+
+    fn restoreSessionPane(
+        self: *App,
+        pane: win32_session_state.Pane,
+        existing_host: ?*Host,
+        tab_surface: ?*Surface,
+        tab_index: usize,
+        split_direction: SplitTreeSurface.Split.Direction,
+    ) !*Surface {
+        const host = existing_host orelse if (tab_surface) |source| source.host else null;
+        const open_kind: apprt.surface.NewSurfaceContext = if (host == null)
+            .window
+        else if (tab_surface == null)
+            .tab
+        else
+            .split;
+        var config = try apprt.surface.newConfig(self.core_app, &self.config, open_kind);
+        defer config.deinit();
+
+        if (pane.profile) |key| {
+            if (host) |existing| {
+                if ((try existing.profileForKey(key))) |profile| {
+                    try applyProfileSurfaceConfig(&config, profile);
+                }
+            }
+        }
+        if (pane.cwd) |cwd| {
+            const alloc = config._arena.?.allocator();
+            config.@"working-directory" = .{ .path = try alloc.dupe(u8, cwd) };
+        }
+
+        const tab_id = if (tab_surface) |source|
+            (self.findTabForSurface(source) orelse return error.NoActiveSurface).tab.id
+        else
+            null;
+        const surface = try self.createWindowSurface(&config, default_title, .{
+            .host_id = if (host) |existing| existing.id else null,
+            .tab_id = tab_id,
+            .tab_insert_index = if (host != null and tab_surface == null) tab_index else null,
+            .clone_state_from = tab_surface,
+            .split_direction = split_direction,
+        });
+
+        if (pane.profile) |key| try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, key);
+        if (pane.title_override) |title| try surface.setTitleOverride(title);
+        if (pane.tab_title_override) |title| try surface.setTabTitleOverride(title);
+        if (pane.cwd) |cwd| try surface.setPwd(cwd);
+        return surface;
+    }
+
+    fn applyRestoredWindowPlacement(
+        self: *App,
+        host: *Host,
+        window: win32_session_state.Window,
+    ) !void {
+        _ = self;
+        const hwnd = host.hwnd orelse return;
+        if (window.x != null) {
+            if (SetWindowPos(
+                hwnd,
+                null,
+                window.x.?,
+                window.y.?,
+                window.width.?,
+                window.height.?,
+                SWP_NOZORDER | SWP_NOACTIVATE,
+            ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        if ((window.state orelse .normal) == .maximized) {
+            _ = ShowWindow(hwnd, SW_MAXIMIZE);
+        }
+    }
+
+    fn saveSessionState(self: *const App) void {
+        if (!self.sessionStateEnabled()) return;
+        const path = self.sessionStatePath() orelse return;
+        defer self.core_app.alloc.free(path);
+
+        var arena = std.heap.ArenaAllocator.init(self.core_app.alloc);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        const state = self.buildSessionState(alloc) catch |err| {
+            log.warn("win32 session save: snapshot failed err={}", .{err});
+            return;
+        };
+        if (state.windows.len == 0) return;
+
+        const encoded = win32_session_state.encodeAlloc(self.core_app.alloc, state) catch |err| {
+            log.warn("win32 session save: encode failed err={}", .{err});
+            return;
+        };
+        defer self.core_app.alloc.free(encoded);
+
+        if (std.fs.path.dirname(path)) |dir| {
+            std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => {
+                    log.warn("win32 session save: mkdir failed path={s} err={}", .{ dir, err });
+                    return;
+                },
+            };
+        }
+
+        const file = std.fs.createFileAbsolute(path, .{ .truncate = true }) catch |err| {
+            log.warn("win32 session save: create failed path={s} err={}", .{ path, err });
+            return;
+        };
+        defer file.close();
+        var buf: [4096]u8 = undefined;
+        var writer = file.writer(&buf);
+        writer.interface.writeAll(encoded) catch |err| {
+            log.warn("win32 session save: write failed path={s} err={}", .{ path, err });
+            return;
+        };
+        writer.interface.flush() catch |err| {
+            log.warn("win32 session save: flush failed path={s} err={}", .{ path, err });
+        };
+    }
+
+    fn buildSessionState(
+        self: *const App,
+        alloc: Allocator,
+    ) !win32_session_state.SessionState {
+        var count: usize = 0;
+        for (self.hosts.items) |host| {
+            if (host.tabs.items.len > 0) count += 1;
+        }
+
+        const windows_state = try alloc.alloc(win32_session_state.Window, count);
+        var built: usize = 0;
+        for (self.hosts.items) |host| {
+            if (host.tabs.items.len == 0) continue;
+            windows_state[built] = try self.buildSessionWindow(alloc, host);
+            built += 1;
+        }
+
+        return .{ .windows = windows_state };
+    }
+
+    fn buildSessionWindow(
+        self: *const App,
+        alloc: Allocator,
+        host: *Host,
+    ) !win32_session_state.Window {
+        const tabs = try alloc.alloc(win32_session_state.Tab, host.tabs.items.len);
+        for (host.tabs.items, 0..) |*tab, i| {
+            tabs[i] = try buildSessionTab(alloc, tab);
+        }
+
+        var window: win32_session_state.Window = .{
+            .selected_tab = @min(host.active_tab, if (host.tabs.items.len > 0) host.tabs.items.len - 1 else 0),
+            .tabs = tabs,
+        };
+        if (sessionWindowRect(host)) |rect| {
+            window.x = rect.left;
+            window.y = rect.top;
+            window.width = rect.right - rect.left;
+            window.height = rect.bottom - rect.top;
+        }
+        if (host.hwnd) |hwnd| {
+            window.state = if (IsZoomed(hwnd) != 0) .maximized else .normal;
+        }
+        _ = self;
+        return window;
+    }
+
+    fn buildSessionTab(
+        alloc: Allocator,
+        tab: *const Tab,
+    ) !win32_session_state.Tab {
+        var selected_leaf: usize = 0;
+        var leaf_index: usize = 0;
+        for (tab.tree.nodes, 0..) |node, node_index| {
+            switch (node) {
+                .leaf => {},
+                .split => continue,
+            }
+            if (tab.focused.idx() == node_index) selected_leaf = leaf_index;
+            leaf_index += 1;
+        }
+
+        return .{
+            .selected_leaf = selected_leaf,
+            .layout = try buildSessionLayout(alloc, tab),
+        };
+    }
+
+    fn buildSessionLayout(
+        alloc: Allocator,
+        tab: *const Tab,
+    ) !win32_session_state.LayoutTree {
+        if (tab.tree.nodes.len > std.math.maxInt(u16)) return error.OutOfMemory;
+        const nodes = try alloc.alloc(win32_session_state.Node, tab.tree.nodes.len);
+        for (tab.tree.nodes, 0..) |node, i| {
+            nodes[i] = switch (node) {
+                .leaf => |surface| .{ .pane = .{
+                    .cwd = surface.pwd,
+                    .profile = surface.launch_profile_key,
+                    .title_override = surface.title_override,
+                    .tab_title_override = surface.tab_title_override,
+                } },
+                .split => |split| .{ .split = .{
+                    .axis = switch (split.layout) {
+                        .horizontal => .horizontal,
+                        .vertical => .vertical,
+                    },
+                    .ratio = @floatCast(split.ratio),
+                    .first = @intFromEnum(split.left),
+                    .second = @intFromEnum(split.right),
+                } },
+            };
+        }
+        return .{ .root = 0, .nodes = nodes };
+    }
+
+    fn preferredSplitDirection(
+        layout: win32_session_state.LayoutTree,
+    ) SplitTreeSurface.Split.Direction {
+        if (layout.root < layout.nodes.len) {
+            switch (layout.nodes[layout.root]) {
+                .split => |split| return switch (split.axis) {
+                    .horizontal => .right,
+                    .vertical => .down,
+                },
+                .pane => {},
+            }
+        }
+        return .right;
+    }
+
+    fn sessionWindowRect(host: *Host) ?RECT {
+        const hwnd = host.hwnd orelse return null;
+        var rect: RECT = undefined;
+        if (IsZoomed(hwnd) != 0 or IsIconic(hwnd) != 0) {
+            var placement: WINDOWPLACEMENT = .{
+                .length = @sizeOf(WINDOWPLACEMENT),
+                .flags = 0,
+                .showCmd = 0,
+                .ptMinPosition = .{ .x = 0, .y = 0 },
+                .ptMaxPosition = .{ .x = 0, .y = 0 },
+                .rcNormalPosition = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
+            };
+            if (GetWindowPlacement(hwnd, &placement) != 0) {
+                rect = placement.rcNormalPosition;
+            } else if (GetWindowRect(hwnd, &rect) == 0) {
+                return null;
+            }
+        } else if (GetWindowRect(hwnd, &rect) == 0) {
+            return null;
+        }
+
+        if (rect.right <= rect.left or rect.bottom <= rect.top) return null;
+        return rect;
     }
 
     /// Push an action string onto the palette MRU list, dedup'd by

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2514,10 +2514,10 @@ pub const App = struct {
         }
     }
 
-    /// Resolve `%LOCALAPPDATA%\winghostty\palette-mru.txt`. Caller frees
-    /// with `core_app.alloc`. Returns null if `LOCALAPPDATA` is
-    /// unreadable or allocation fails.
-    fn paletteMruPath(self: *const App) ?[]u8 {
+    /// Resolve `%LOCALAPPDATA%\winghostty\<name>`. Caller frees with
+    /// `core_app.alloc`. Returns null if `LOCALAPPDATA` is unreadable
+    /// or allocation fails.
+    fn localAppDataPath(self: *const App, name: []const u8) ?[]u8 {
         const local = std.process.getEnvVarOwned(
             self.core_app.alloc,
             "LOCALAPPDATA",
@@ -2528,29 +2528,19 @@ pub const App = struct {
             "winghostty",
         }) catch return null;
         defer self.core_app.alloc.free(dir);
-        return std.fs.path.join(self.core_app.alloc, &.{
-            dir,
-            "palette-mru.txt",
-        }) catch null;
+        return std.fs.path.join(self.core_app.alloc, &.{ dir, name }) catch null;
+    }
+
+    /// Resolve `%LOCALAPPDATA%\winghostty\palette-mru.txt`. Caller frees
+    /// with `core_app.alloc`.
+    fn paletteMruPath(self: *const App) ?[]u8 {
+        return self.localAppDataPath("palette-mru.txt");
     }
 
     /// Resolve `%LOCALAPPDATA%\winghostty\session-state.json`. Caller
     /// frees with `core_app.alloc`.
     fn sessionStatePath(self: *const App) ?[]u8 {
-        const local = std.process.getEnvVarOwned(
-            self.core_app.alloc,
-            "LOCALAPPDATA",
-        ) catch return null;
-        defer self.core_app.alloc.free(local);
-        const dir = std.fs.path.join(self.core_app.alloc, &.{
-            local,
-            "winghostty",
-        }) catch return null;
-        defer self.core_app.alloc.free(dir);
-        return std.fs.path.join(self.core_app.alloc, &.{
-            dir,
-            "session-state.json",
-        }) catch null;
+        return self.localAppDataPath("session-state.json");
     }
 
     fn sessionStateEnabled(self: *const App) bool {
@@ -2757,13 +2747,7 @@ pub const App = struct {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, open_kind);
         defer config.deinit();
 
-        if (pane.profile) |key| {
-            if (host) |existing| {
-                if ((try existing.profileForKey(key))) |profile| {
-                    try applyProfileSurfaceConfig(&config, profile);
-                }
-            }
-        }
+        if (pane.profile) |key| try self.applyRestoredProfileConfig(&config, host, key);
         if (pane.cwd) |cwd| {
             const alloc = config._arena.?.allocator();
             config.@"working-directory" = .{ .path = try alloc.dupe(u8, cwd) };
@@ -2788,6 +2772,24 @@ pub const App = struct {
         return surface;
     }
 
+    fn applyRestoredProfileConfig(
+        self: *App,
+        config: *configpkg.Config,
+        host: ?*Host,
+        key: []const u8,
+    ) !void {
+        if (host) |existing| {
+            if ((try existing.profileForKey(key))) |profile| {
+                try applyProfileSurfaceConfig(config, profile);
+            }
+            return;
+        }
+
+        const profiles = try windows_shell.listProfiles(self.core_app.alloc);
+        defer windows_shell.deinitProfiles(self.core_app.alloc, profiles);
+        try applyProfileConfigByKey(config, profiles, key);
+    }
+
     fn applyRestoredWindowPlacement(
         self: *App,
         host: *Host,
@@ -2795,14 +2797,14 @@ pub const App = struct {
     ) !void {
         _ = self;
         const hwnd = host.hwnd orelse return;
-        if (window.x != null) {
+        if (try sessionStateWindowRect(window)) |rect| {
             if (SetWindowPos(
                 hwnd,
                 null,
-                window.x.?,
-                window.y.?,
-                window.width.?,
-                window.height.?,
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top,
                 SWP_NOZORDER | SWP_NOACTIVATE,
             ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
         }
@@ -2835,29 +2837,8 @@ pub const App = struct {
         };
         defer self.core_app.alloc.free(encoded);
 
-        if (std.fs.path.dirname(path)) |dir| {
-            std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
-                error.PathAlreadyExists => {},
-                else => {
-                    log.warn("win32 session save: mkdir failed path={s} err={}", .{ dir, err });
-                    return;
-                },
-            };
-        }
-
-        const file = std.fs.createFileAbsolute(path, .{ .truncate = true }) catch |err| {
-            log.warn("win32 session save: create failed path={s} err={}", .{ path, err });
-            return;
-        };
-        defer file.close();
-        var buf: [4096]u8 = undefined;
-        var writer = file.writer(&buf);
-        writer.interface.writeAll(encoded) catch |err| {
+        writeSessionStateFile(self.core_app.alloc, path, encoded) catch |err| {
             log.warn("win32 session save: write failed path={s} err={}", .{ path, err });
-            return;
-        };
-        writer.interface.flush() catch |err| {
-            log.warn("win32 session save: flush failed path={s} err={}", .{ path, err });
         };
     }
 
@@ -2933,7 +2914,7 @@ pub const App = struct {
         alloc: Allocator,
         tab: *const Tab,
     ) !win32_session_state.LayoutTree {
-        if (tab.tree.nodes.len > std.math.maxInt(u16)) return error.OutOfMemory;
+        if (tab.tree.nodes.len > std.math.maxInt(u16)) return error.TooManySessionLayoutNodes;
         const nodes = try alloc.alloc(win32_session_state.Node, tab.tree.nodes.len);
         for (tab.tree.nodes, 0..) |node, i| {
             nodes[i] = switch (node) {
@@ -2976,13 +2957,13 @@ pub const App = struct {
         alloc: Allocator,
         layout: win32_session_state.LayoutTree,
         node_surfaces: []const ?*Surface,
-    ) (Allocator.Error || error{InvalidTreeShape})!SplitTreeSurface {
+    ) (Allocator.Error || error{ InvalidTreeShape, TooManySessionLayoutNodes })!SplitTreeSurface {
         if (layout.nodes.len == 0 or layout.nodes.len != node_surfaces.len) {
             return error.InvalidTreeShape;
         }
         if (layout.root >= layout.nodes.len) return error.InvalidTreeShape;
         if (layout.nodes.len > std.math.maxInt(SplitTreeSurface.Node.Handle.Backing)) {
-            return error.OutOfMemory;
+            return error.TooManySessionLayoutNodes;
         }
 
         const invalid_index = std.math.maxInt(usize);
@@ -3049,6 +3030,59 @@ pub const App = struct {
             .nodes = tree_nodes,
             .zoomed = null,
         };
+    }
+
+    fn sessionStateWindowRect(window: win32_session_state.Window) !?RECT {
+        const x = window.x orelse {
+            if (window.y == null and window.width == null and window.height == null) return null;
+            return error.InvalidWindowRect;
+        };
+        const y = window.y orelse return error.InvalidWindowRect;
+        const width = window.width orelse return error.InvalidWindowRect;
+        const height = window.height orelse return error.InvalidWindowRect;
+        if (width <= 0 or height <= 0) return error.InvalidWindowRect;
+        const right = std.math.add(i32, x, width) catch return error.InvalidWindowRect;
+        const bottom = std.math.add(i32, y, height) catch return error.InvalidWindowRect;
+        return .{
+            .left = x,
+            .top = y,
+            .right = right,
+            .bottom = bottom,
+        };
+    }
+
+    fn writeSessionStateFile(alloc: Allocator, path: []const u8, data: []const u8) !void {
+        if (std.fs.path.dirname(path)) |dir| {
+            std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+        }
+
+        const tmp_path = try std.fmt.allocPrint(alloc, "{s}.tmp", .{path});
+        defer alloc.free(tmp_path);
+        errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+
+        {
+            const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+            defer file.close();
+            var buf: [4096]u8 = undefined;
+            var writer = file.writer(&buf);
+            try writer.interface.writeAll(data);
+            try writer.interface.flush();
+            try file.sync();
+        }
+
+        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, path);
+        defer alloc.free(path_w);
+        const tmp_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, tmp_path);
+        defer alloc.free(tmp_w);
+
+        if (ReplaceFileW(path_w, tmp_w, null, 0, null, null) == 0) {
+            if (MoveFileExW(tmp_w, path_w, MOVEFILE_REPLACE_EXISTING) == 0) {
+                return windows.unexpectedError(windows.kernel32.GetLastError());
+            }
+        }
     }
 
     fn deleteSessionStateFile(path: []const u8) void {
@@ -15057,6 +15091,15 @@ fn profileIndexByKey(profiles: []const windows_shell.Profile, key: []const u8) ?
         if (std.ascii.eqlIgnoreCase(profile.key, key)) return index;
     }
     return null;
+}
+
+fn applyProfileConfigByKey(
+    config: *configpkg.Config,
+    profiles: []const windows_shell.Profile,
+    key: []const u8,
+) !void {
+    const index = profileIndexByKey(profiles, key) orelse return;
+    try applyProfileSurfaceConfig(config, &profiles[index]);
 }
 
 fn preferredProfileIndex(
@@ -27459,6 +27502,32 @@ test "win32 applyProfileCommandConfig preserves inherited working directory" {
     try std.testing.expectEqualStrings("C:\\work", clone.@"working-directory".?.path);
 }
 
+test "win32 applyProfileConfigByKey applies saved first-pane profile before host exists" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var base = try configpkg.Config.default(std.testing.allocator);
+    defer base.deinit();
+    const base_alloc = base._arena.?.allocator();
+    base.command = .{ .shell = try base_alloc.dupeZ(u8, "pwsh.exe") };
+
+    var clone = base.shallowClone(std.testing.allocator);
+    defer clone.deinit();
+
+    var profile: windows_shell.Profile = .{
+        .kind = .cmd,
+        .key = try std.testing.allocator.dupe(u8, "cmd.exe"),
+        .label = try std.testing.allocator.dupe(u8, "Command Prompt"),
+        .command = .{ .shell = try std.testing.allocator.dupeZ(u8, "cmd.exe") },
+    };
+    defer profile.deinit(std.testing.allocator);
+    const profiles = [_]windows_shell.Profile{profile};
+
+    try applyProfileConfigByKey(&clone, &profiles, "cmd.exe");
+
+    try std.testing.expect(clone.command != null);
+    try std.testing.expectEqualStrings("cmd.exe", clone.command.?.shell);
+}
+
 test "win32 splitWorkingDirectoryCandidate prefers live cwd over cached wrapper cwd" {
     try std.testing.expectEqualStrings(
         "/home/user/live",
@@ -27656,6 +27725,54 @@ test "win32 session save deletes stale state file for empty snapshot" {
     try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("session-state.json", .{}));
 
     App.deleteSessionStateFile(path);
+}
+
+test "win32 session state window rect requires complete geometry" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqual(@as(?RECT, null), try App.sessionStateWindowRect(.{
+        .selected_tab = 0,
+        .tabs = &.{},
+    }));
+    try std.testing.expectError(error.InvalidWindowRect, App.sessionStateWindowRect(.{
+        .x = 10,
+        .selected_tab = 0,
+        .tabs = &.{},
+    }));
+
+    const rect = (try App.sessionStateWindowRect(.{
+        .x = 10,
+        .y = 20,
+        .width = 300,
+        .height = 200,
+        .selected_tab = 0,
+        .tabs = &.{},
+    })).?;
+    try std.testing.expectEqual(@as(i32, 10), rect.left);
+    try std.testing.expectEqual(@as(i32, 20), rect.top);
+    try std.testing.expectEqual(@as(i32, 310), rect.right);
+    try std.testing.expectEqual(@as(i32, 220), rect.bottom);
+}
+
+test "win32 session state file write replaces through temp file" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{
+        .sub_path = "session-state.json",
+        .data = "old",
+    });
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "session-state.json");
+    defer std.testing.allocator.free(path);
+
+    try App.writeSessionStateFile(std.testing.allocator, path, "new");
+
+    const contents = try tmp.dir.readFileAlloc(std.testing.allocator, "session-state.json", 1024);
+    defer std.testing.allocator.free(contents);
+    try std.testing.expectEqualStrings("new", contents);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("session-state.json.tmp", .{}));
 }
 
 test "win32 session restore rebuilds saved split tree shape" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2699,8 +2699,11 @@ pub const App = struct {
         var tab_surface: ?*Surface = null;
         var created: usize = 0;
         var selected_surface: ?*Surface = null;
+        const node_surfaces = try self.core_app.alloc.alloc(?*Surface, saved_tab.layout.nodes.len);
+        defer self.core_app.alloc.free(node_surfaces);
+        @memset(node_surfaces, null);
 
-        for (saved_tab.layout.nodes) |node| {
+        for (saved_tab.layout.nodes, 0..) |node, node_index| {
             const pane = switch (node) {
                 .pane => |value| value,
                 .split => continue,
@@ -2712,6 +2715,7 @@ pub const App = struct {
                 tab_index,
                 preferredSplitDirection(saved_tab.layout),
             );
+            node_surfaces[node_index] = surface;
             if (tab_surface == null) tab_surface = surface;
             if (created == saved_tab.selected_leaf) selected_surface = surface;
             created += 1;
@@ -2720,7 +2724,17 @@ pub const App = struct {
         const first = tab_surface orelse return error.EmptyLayout;
         const selected = selected_surface orelse first;
         if (self.findTabForSurface(selected)) |found| {
+            var restored_tree = try buildRestoredSessionSplitTree(
+                self.core_app.alloc,
+                saved_tab.layout,
+                node_surfaces,
+            );
+            errdefer restored_tree.deinit();
+
+            found.tab.tree.deinit();
+            found.tab.tree = restored_tree;
             if (found.tab.findHandle(selected)) |handle| found.tab.focused = handle;
+            try found.host.layout();
         }
         return selected;
     }
@@ -2810,7 +2824,10 @@ pub const App = struct {
             log.warn("win32 session save: snapshot failed err={}", .{err});
             return;
         };
-        if (state.windows.len == 0) return;
+        if (state.windows.len == 0) {
+            deleteSessionStateFile(path);
+            return;
+        }
 
         const encoded = win32_session_state.encodeAlloc(self.core_app.alloc, state) catch |err| {
             log.warn("win32 session save: encode failed err={}", .{err});
@@ -2953,6 +2970,92 @@ pub const App = struct {
             }
         }
         return .right;
+    }
+
+    fn buildRestoredSessionSplitTree(
+        alloc: Allocator,
+        layout: win32_session_state.LayoutTree,
+        node_surfaces: []const ?*Surface,
+    ) (Allocator.Error || error{InvalidTreeShape})!SplitTreeSurface {
+        if (layout.nodes.len == 0 or layout.nodes.len != node_surfaces.len) {
+            return error.InvalidTreeShape;
+        }
+        if (layout.root >= layout.nodes.len) return error.InvalidTreeShape;
+        if (layout.nodes.len > std.math.maxInt(SplitTreeSurface.Node.Handle.Backing)) {
+            return error.OutOfMemory;
+        }
+
+        const invalid_index = std.math.maxInt(usize);
+        const remap = try alloc.alloc(usize, layout.nodes.len);
+        defer alloc.free(remap);
+        @memset(remap, invalid_index);
+
+        if (layout.root == 0) {
+            for (remap, 0..) |*slot, i| slot.* = i;
+        } else {
+            const stack = try alloc.alloc(usize, layout.nodes.len);
+            defer alloc.free(stack);
+
+            remap[layout.root] = 0;
+            stack[0] = layout.root;
+            var stack_len: usize = 1;
+            var next_index: usize = 1;
+            while (stack_len > 0) {
+                stack_len -= 1;
+                const saved_index = stack[stack_len];
+                switch (layout.nodes[saved_index]) {
+                    .pane => {},
+                    .split => |split| {
+                        const children = [_]u16{ split.first, split.second };
+                        for (children) |child| {
+                            const child_index: usize = child;
+                            if (child_index >= layout.nodes.len) return error.InvalidTreeShape;
+                            if (remap[child_index] == invalid_index) {
+                                remap[child_index] = next_index;
+                                next_index += 1;
+                                stack[stack_len] = child_index;
+                                stack_len += 1;
+                            }
+                        }
+                    },
+                }
+            }
+            if (next_index != layout.nodes.len) return error.InvalidTreeShape;
+        }
+
+        var arena = std.heap.ArenaAllocator.init(alloc);
+        errdefer arena.deinit();
+        const tree_nodes = try arena.allocator().alloc(SplitTreeSurface.Node, layout.nodes.len);
+
+        for (layout.nodes, 0..) |node, saved_index| {
+            const restored_index = remap[saved_index];
+            if (restored_index == invalid_index) return error.InvalidTreeShape;
+            tree_nodes[restored_index] = switch (node) {
+                .pane => .{ .leaf = node_surfaces[saved_index] orelse return error.InvalidTreeShape },
+                .split => |split| .{ .split = .{
+                    .layout = switch (split.axis) {
+                        .horizontal => .horizontal,
+                        .vertical => .vertical,
+                    },
+                    .ratio = @floatCast(split.ratio),
+                    .left = @enumFromInt(remap[split.first]),
+                    .right = @enumFromInt(remap[split.second]),
+                } },
+            };
+        }
+
+        return .{
+            .arena = arena,
+            .nodes = tree_nodes,
+            .zoomed = null,
+        };
+    }
+
+    fn deleteSessionStateFile(path: []const u8) void {
+        std.fs.deleteFileAbsolute(path) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => log.warn("win32 session save: delete stale state failed path={s} err={}", .{ path, err }),
+        };
     }
 
     fn sessionWindowRect(host: *Host) ?RECT {
@@ -27534,6 +27637,96 @@ test "win32 splitDirectionFromAction preserves requested split direction" {
     try std.testing.expectEqual(SplitTreeSurface.Split.Direction.right, splitDirectionFromAction(.right));
     try std.testing.expectEqual(SplitTreeSurface.Split.Direction.up, splitDirectionFromAction(.up));
     try std.testing.expectEqual(SplitTreeSurface.Split.Direction.down, splitDirectionFromAction(.down));
+}
+
+test "win32 session save deletes stale state file for empty snapshot" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{
+        .sub_path = "session-state.json",
+        .data = "stale",
+    });
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "session-state.json");
+    defer std.testing.allocator.free(path);
+
+    App.deleteSessionStateFile(path);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.openFile("session-state.json", .{}));
+
+    App.deleteSessionStateFile(path);
+}
+
+test "win32 session restore rebuilds saved split tree shape" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var surface_a: Surface = undefined;
+    var surface_b: Surface = undefined;
+    var surface_c: Surface = undefined;
+
+    const layout_nodes = [_]win32_session_state.Node{
+        .{ .split = .{
+            .axis = .horizontal,
+            .ratio = 0.25,
+            .first = 1,
+            .second = 2,
+        } },
+        .{ .pane = .{ .cwd = "C:\\left" } },
+        .{ .split = .{
+            .axis = .vertical,
+            .ratio = 0.75,
+            .first = 3,
+            .second = 4,
+        } },
+        .{ .pane = .{ .cwd = "C:\\top-right" } },
+        .{ .pane = .{ .cwd = "C:\\bottom-right" } },
+    };
+    const node_surfaces = [_]?*Surface{
+        null,
+        &surface_a,
+        null,
+        &surface_b,
+        &surface_c,
+    };
+
+    var tree = try App.buildRestoredSessionSplitTree(
+        std.testing.allocator,
+        .{ .root = 0, .nodes = &layout_nodes },
+        &node_surfaces,
+    );
+    defer tree.deinit();
+
+    try std.testing.expectEqual(@as(usize, 5), tree.nodes.len);
+    try std.testing.expectEqual(SplitTreeSurface.Split.Layout.horizontal, tree.nodes[0].split.layout);
+    try std.testing.expectEqual(@as(f16, 0.25), tree.nodes[0].split.ratio);
+    try std.testing.expectEqual(@as(SplitTreeSurface.Node.Handle, @enumFromInt(1)), tree.nodes[0].split.left);
+    try std.testing.expectEqual(@as(SplitTreeSurface.Node.Handle, @enumFromInt(2)), tree.nodes[0].split.right);
+    try std.testing.expectEqual(&surface_a, tree.nodes[1].leaf);
+    try std.testing.expectEqual(SplitTreeSurface.Split.Layout.vertical, tree.nodes[2].split.layout);
+    try std.testing.expectEqual(@as(f16, 0.75), tree.nodes[2].split.ratio);
+    try std.testing.expectEqual(@as(SplitTreeSurface.Node.Handle, @enumFromInt(3)), tree.nodes[2].split.left);
+    try std.testing.expectEqual(@as(SplitTreeSurface.Node.Handle, @enumFromInt(4)), tree.nodes[2].split.right);
+    try std.testing.expectEqual(&surface_b, tree.nodes[3].leaf);
+    try std.testing.expectEqual(&surface_c, tree.nodes[4].leaf);
+}
+
+test "win32 session restore rejects split tree with missing pane surface" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const layout_nodes = [_]win32_session_state.Node{
+        .{ .pane = .{ .cwd = "C:\\left" } },
+    };
+    const node_surfaces = [_]?*Surface{null};
+
+    try std.testing.expectError(
+        error.InvalidTreeShape,
+        App.buildRestoredSessionSplitTree(
+            std.testing.allocator,
+            .{ .root = 0, .nodes = &layout_nodes },
+            &node_surfaces,
+        ),
+    );
 }
 
 test "win32 nextInspectorVisible follows requested mode" {

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -19,6 +19,7 @@ pub const ValidationError = error{
     InvalidNodeIndex,
     InvalidTreeShape,
     InvalidSplitRatio,
+    InvalidWindowRect,
     UnreachableNode,
 };
 
@@ -39,8 +40,18 @@ pub const SessionState = struct {
 };
 
 pub const Window = struct {
+    x: ?i32 = null,
+    y: ?i32 = null,
+    width: ?i32 = null,
+    height: ?i32 = null,
+    state: ?WindowState = null,
     selected_tab: usize,
     tabs: []const Tab = &.{},
+};
+
+pub const WindowState = enum {
+    normal,
+    maximized,
 };
 
 pub const Tab = struct {
@@ -116,6 +127,7 @@ pub fn validateAlloc(alloc: Allocator, state: SessionState) ValidateError!void {
     }
 
     for (state.windows) |window| {
+        try validateWindowRect(window);
         if (window.tabs.len == 0) return error.EmptyTabs;
         if (window.selected_tab >= window.tabs.len) return error.InvalidSelectedTab;
 
@@ -123,6 +135,21 @@ pub fn validateAlloc(alloc: Allocator, state: SessionState) ValidateError!void {
             const leaf_count = try validateLayoutTree(alloc, tab.layout);
             if (tab.selected_leaf >= leaf_count) return error.InvalidSelectedLeaf;
         }
+    }
+}
+
+fn validateWindowRect(window: Window) ValidationError!void {
+    const present_count =
+        @as(usize, @intFromBool(window.x != null)) +
+        @as(usize, @intFromBool(window.y != null)) +
+        @as(usize, @intFromBool(window.width != null)) +
+        @as(usize, @intFromBool(window.height != null));
+    if (present_count != 0 and present_count != 4) return error.InvalidWindowRect;
+    if (window.width) |width| {
+        if (width <= 0) return error.InvalidWindowRect;
+    }
+    if (window.height) |height| {
+        if (height <= 0) return error.InvalidWindowRect;
     }
 }
 
@@ -199,6 +226,11 @@ fn expectSessionStateEqual(expected: SessionState, actual: SessionState) !void {
     try std.testing.expectEqual(expected.windows.len, actual.windows.len);
 
     for (expected.windows, actual.windows) |expected_window, actual_window| {
+        try std.testing.expectEqual(expected_window.x, actual_window.x);
+        try std.testing.expectEqual(expected_window.y, actual_window.y);
+        try std.testing.expectEqual(expected_window.width, actual_window.width);
+        try std.testing.expectEqual(expected_window.height, actual_window.height);
+        try std.testing.expectEqual(expected_window.state, actual_window.state);
         try std.testing.expectEqual(expected_window.selected_tab, actual_window.selected_tab);
         try std.testing.expectEqual(expected_window.tabs.len, actual_window.tabs.len);
 
@@ -332,6 +364,56 @@ test "win32 session state omits unset optional pane metadata" {
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"scrollback\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"contents\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "null") == null);
+}
+
+test "win32 session state round-trips window geometry" {
+    const nodes = [_]Node{
+        .{ .pane = .{} },
+    };
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = 0,
+            .layout = .{
+                .root = 0,
+                .nodes = &nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .x = 10,
+            .y = 20,
+            .width = 1280,
+            .height = 720,
+            .state = .maximized,
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+    const state: SessionState = .{
+        .windows = &windows,
+    };
+
+    const encoded = try encodeAlloc(std.testing.allocator, state);
+    defer std.testing.allocator.free(encoded);
+
+    try std.testing.expectEqualStrings(
+        "{\"schema_version\":1,\"windows\":[{\"x\":10,\"y\":20,\"width\":1280,\"height\":720,\"state\":\"maximized\",\"selected_tab\":0,\"tabs\":[{\"selected_leaf\":0,\"layout\":{\"root\":0,\"nodes\":[{\"pane\":{}}]}}]}]}",
+        encoded,
+    );
+
+    var parsed = try parseAlloc(std.testing.allocator, encoded);
+    defer parsed.deinit();
+
+    try expectSessionStateEqual(state, parsed.value);
+}
+
+test "win32 session state rejects incomplete window geometry" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"x":10,"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"pane":{}}]}}]}]}
+    ;
+
+    try std.testing.expectError(error.InvalidWindowRect, parseAlloc(std.testing.allocator, raw));
 }
 
 test "win32 session state parse rejects unsupported schema version" {

--- a/src/apprt/win32_session_state.zig
+++ b/src/apprt/win32_session_state.zig
@@ -21,6 +21,7 @@ pub const ValidationError = error{
     InvalidSplitRatio,
     InvalidWindowRect,
     UnreachableNode,
+    TooManySessionLayoutNodes,
 };
 
 pub const ValidateError = ValidationError || Allocator.Error;
@@ -155,6 +156,7 @@ fn validateWindowRect(window: Window) ValidationError!void {
 
 fn validateLayoutTree(alloc: Allocator, layout: LayoutTree) ValidateError!usize {
     if (layout.nodes.len == 0) return error.EmptyLayout;
+    if (layout.nodes.len > std.math.maxInt(u16)) return error.TooManySessionLayoutNodes;
 
     const root_index: usize = layout.root;
     if (root_index >= layout.nodes.len) return error.InvalidRootNode;
@@ -416,6 +418,14 @@ test "win32 session state rejects incomplete window geometry" {
     try std.testing.expectError(error.InvalidWindowRect, parseAlloc(std.testing.allocator, raw));
 }
 
+test "win32 session state rejects non-positive window geometry" {
+    const raw =
+        \\{"schema_version":1,"windows":[{"x":10,"y":20,"width":0,"height":720,"selected_tab":0,"tabs":[{"selected_leaf":0,"layout":{"root":0,"nodes":[{"pane":{}}]}}]}]}
+    ;
+
+    try std.testing.expectError(error.InvalidWindowRect, parseAlloc(std.testing.allocator, raw));
+}
+
 test "win32 session state parse rejects unsupported schema version" {
     const raw =
         \\{"schema_version":9,"windows":[]}
@@ -576,6 +586,32 @@ test "win32 session state validates deep split layout without recursion" {
     try validateAlloc(std.testing.allocator, .{
         .windows = &windows,
     });
+}
+
+test "win32 session state rejects layout node count above handle range" {
+    const nodes = try std.testing.allocator.alloc(Node, std.math.maxInt(u16) + 1);
+    defer std.testing.allocator.free(nodes);
+    @memset(nodes, .{ .pane = .{} });
+
+    const tabs = [_]Tab{
+        .{
+            .selected_leaf = 0,
+            .layout = .{
+                .root = 0,
+                .nodes = nodes,
+            },
+        },
+    };
+    const windows = [_]Window{
+        .{
+            .selected_tab = 0,
+            .tabs = &tabs,
+        },
+    };
+
+    try std.testing.expectError(error.TooManySessionLayoutNodes, validateAlloc(std.testing.allocator, .{
+        .windows = &windows,
+    }));
 }
 
 test "win32 session state parse rejects shared-node layout before DFS stack overflow" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2166,8 +2166,10 @@ keybind: Keybinds = .{},
 ///
 /// The default value is `default`.
 ///
-/// This is retained as a compatibility setting in the Windows-only fork and
-/// currently has no effect.
+/// On Windows this persists the practical window/session shape on app exit:
+/// host window rectangle/state plus tab, split, profile, working-directory,
+/// and explicit title metadata. Terminal contents and child process state are
+/// not restored.
 @"window-save-state": WindowSaveState = .default,
 
 /// Resize the window in discrete increments of the focused surface's cell size.


### PR DESCRIPTION
## Summary
- saves practical Windows session state under `%LOCALAPPDATA%\winghostty\session-state.json`
- restores saved window geometry/state at startup when `window-save-state != never`
- persists tabs, panes, profile key, cwd, title metadata, and window rect/maximized state
- updates `window-save-state` docs for Windows behavior

## Validation
- `zig build test -Dtest-filter="win32 session state"`
- `zig build -Demit-exe=true`
- `git diff --check`

Review loop: @codex @coderabbitai @greptileai @Copilot please review. I will iterate on findings until this is clean to squash and merge.

## Summary by Sourcery

Persist and restore practical window session state on Windows, including window geometry and tab/pane layout, when window-save-state is enabled.

New Features:
- Add Windows session persistence that saves window geometry, tab and split layout, profiles, working directories, and title metadata to a JSON file under LOCALAPPDATA.
- Restore saved Windows sessions on startup, recreating windows, tabs, panes, and their focus/selection when an initial window is requested.

Enhancements:
- Track and validate per-window geometry and state in the session schema, including normal vs maximized state, and derive window placement from WINDOWPLACEMENT when needed.
- Guard session restore/save with configuration, error logging, and validation to safely ignore unreadable or invalid session files.

Documentation:
- Update window-save-state configuration docs to describe the Windows behavior and clarify that terminal contents and processes are not restored.

Tests:
- Extend win32 session state tests to cover window geometry/state round-tripping and rejection of invalid window rectangles.