### PR TITLE
feat(win32): add local automation action IPC

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,9 +165,11 @@ Invoke an action on a specific pane from `+list-windows`:
 winghostty +perform-action --surface-id=<surface_id> toggle_fullscreen
 ```
 
-Actions use the same names as `keybind` values. Terminal-input and arbitrary
-file helper actions such as `text`, `csi`, `esc`, `paste_from_clipboard`,
-`write_screen_file`, and `crash` are rejected by the running instance.
+Actions use the same names as `keybind` values. `--surface-id` is only valid
+for surface-scoped actions; app-scoped actions such as `quit` always target the
+app. Terminal-input and arbitrary file helper actions such as `text`, `csi`,
+`esc`, `paste_from_clipboard`, `write_screen_file`, and `crash` are rejected by
+the running instance.
 
 ## 11. Uninstall
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,7 +142,34 @@ what is there with:
 winghostty +crash-report
 ```
 
-## 10. Uninstall
+## 10. Local automation
+
+winghostty exposes a local Windows automation surface over the same
+single-instance IPC path used by `+new-window`.
+
+List windows, tabs, and panes:
+
+```powershell
+winghostty +list-windows
+```
+
+Invoke a keybinding action on the focused surface:
+
+```powershell
+winghostty +perform-action new_tab
+```
+
+Invoke an action on a specific pane from `+list-windows`:
+
+```powershell
+winghostty +perform-action --surface-id=<surface_id> toggle_fullscreen
+```
+
+Actions use the same names as `keybind` values. Terminal-input and arbitrary
+file helper actions such as `text`, `csi`, `esc`, `paste_from_clipboard`,
+`write_screen_file`, and `crash` are rejected by the running instance.
+
+## 11. Uninstall
 
 - **Installer builds:** *Settings → Apps → Installed apps → winghostty →
   Uninstall*.
@@ -156,6 +183,8 @@ slate.
 
 - [docs/status.md](status.md) — what works, what's experimental, known
   caveats
+- [docs/windows-capability-matrix.md](windows-capability-matrix.md) —
+  Windows-specific behavior and docs truth
 - [HACKING.md](../HACKING.md) — build, test, runtime notes (for
   developers)
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — how to submit changes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,7 +169,8 @@ Actions use the same names as `keybind` values. `--surface-id` is only valid
 for surface-scoped actions; app-scoped actions such as `quit` always target the
 app. Terminal-input and arbitrary file helper actions such as `text`, `csi`,
 `esc`, `paste_from_clipboard`, `write_screen_file`, and `crash` are rejected by
-the running instance.
+the running instance. New keybinding action variants are not automation-enabled
+until explicitly reviewed and added to the allowlist.
 
 ## 11. Uninstall
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -49,6 +49,7 @@ Last reviewed: 2026-05-01.
 | [Features overview](https://ghostty.org/docs/features) | Upstream Ghostty docs still say Windows support is planned. winghostty ships a native Win32 app on Windows 10/11 x64. |
 | [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Upstream highlights Metal on macOS and OpenGL on Linux. winghostty renders on Windows with OpenGL 4.3+ via WGL; no D3D/DirectX backend ships. |
 | [Configuration](https://ghostty.org/docs/config) | Windows state/config paths live under `%LOCALAPPDATA%\winghostty\...`, not the macOS/Linux paths documented upstream. |
+| Local automation | `winghostty +list-windows` reports local window/tab/pane IDs as JSON, and `winghostty +perform-action <action>` forwards safe keybinding actions over Win32 single-instance IPC. Terminal-input, arbitrary file helper, and crash actions are rejected by the running instance. |
 | [Features overview](https://ghostty.org/docs/features) | Win32-specific UX includes DWM dark title bar integration, high-contrast palette switching, IME, drag-and-drop, and native context menus. |
 
 ## Maintenance Anchors

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -49,7 +49,7 @@ Last reviewed: 2026-05-01.
 | [Features overview](https://ghostty.org/docs/features) | Upstream Ghostty docs still say Windows support is planned. winghostty ships a native Win32 app on Windows 10/11 x64. |
 | [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Upstream highlights Metal on macOS and OpenGL on Linux. winghostty renders on Windows with OpenGL 4.3+ via WGL; no D3D/DirectX backend ships. |
 | [Configuration](https://ghostty.org/docs/config) | Windows state/config paths live under `%LOCALAPPDATA%\winghostty\...`, not the macOS/Linux paths documented upstream. |
-| Local automation | `winghostty +list-windows` reports local window/tab/pane IDs as JSON, and `winghostty +perform-action <action>` forwards safe keybinding actions over Win32 single-instance IPC. Terminal-input, arbitrary file helper, and crash actions are rejected by the running instance. |
+| Local automation | `winghostty +list-windows` reports local window/tab/pane IDs as JSON, and `winghostty +perform-action <action>` forwards safe keybinding actions over Win32 single-instance IPC. `--surface-id` targets only surface-scoped actions; app-scoped actions target the app. Terminal-input, arbitrary file helper, and crash actions are rejected by the running instance. |
 | [Features overview](https://ghostty.org/docs/features) | Win32-specific UX includes DWM dark title bar integration, high-contrast palette switching, IME, drag-and-drop, and native context menus. |
 
 ## Maintenance Anchors

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -49,7 +49,7 @@ Last reviewed: 2026-05-01.
 | [Features overview](https://ghostty.org/docs/features) | Upstream Ghostty docs still say Windows support is planned. winghostty ships a native Win32 app on Windows 10/11 x64. |
 | [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Upstream highlights Metal on macOS and OpenGL on Linux. winghostty renders on Windows with OpenGL 4.3+ via WGL; no D3D/DirectX backend ships. |
 | [Configuration](https://ghostty.org/docs/config) | Windows state/config paths live under `%LOCALAPPDATA%\winghostty\...`, not the macOS/Linux paths documented upstream. |
-| Local automation | `winghostty +list-windows` reports local window/tab/pane IDs as JSON, and `winghostty +perform-action <action>` forwards safe keybinding actions over Win32 single-instance IPC. `--surface-id` targets only surface-scoped actions; app-scoped actions target the app. Terminal-input, arbitrary file helper, and crash actions are rejected by the running instance. |
+| Local automation | `winghostty +list-windows` reports local window/tab/pane IDs as JSON, and `winghostty +perform-action <action>` forwards allowlisted keybinding actions over Win32 single-instance IPC. `--surface-id` targets only surface-scoped actions; app-scoped actions target the app. Terminal-input, arbitrary file helper, and crash actions are rejected by the running instance, and new action variants remain disabled until reviewed. |
 | [Features overview](https://ghostty.org/docs/features) | Win32-specific UX includes DWM dark title bar integration, high-contrast palette switching, IME, drag-and-drop, and native context menus. |
 
 ## Maintenance Anchors

--- a/src/App.zig
+++ b/src/App.zig
@@ -233,6 +233,23 @@ test "automation-action safety rejects terminal input and crash actions" {
     try std.testing.expect(!isSafeAutomationAction(.{ .crash = .main }));
 }
 
+test "automation-action surface id targets reject app scoped actions" {
+    const action = try input.Binding.Action.parse("quit");
+    try std.testing.expectEqual(input.Binding.Action.Scope.app, action.scope());
+    try std.testing.expectEqual(
+        error.InvalidAutomationTarget,
+        automationActionTargetError(.{ .surface_id = 42 }, action).?,
+    );
+    try std.testing.expectEqual(
+        null,
+        automationActionTargetError(.focused, action),
+    );
+    try std.testing.expectEqual(
+        null,
+        automationActionTargetError(.{ .surface_id = 42 }, .new_tab),
+    );
+}
+
 /// Returns true if confirmation is needed to quit the app. It is up to
 /// the apprt to call this.
 pub fn needsConfirmQuit(self: *const App) bool {
@@ -543,6 +560,7 @@ fn performAutomationAction(
         else => return err,
     };
     if (!isSafeAutomationAction(action)) return error.UnsafeAutomationAction;
+    if (automationActionTargetError(target, action)) |err| return err;
 
     switch (target) {
         .focused => {
@@ -555,6 +573,16 @@ fn performAutomationAction(
             _ = try surface.performBindingAction(action);
         },
     }
+}
+
+fn automationActionTargetError(
+    target: apprt.ipc.AutomationActionTarget,
+    action: input.Binding.Action,
+) ?anyerror {
+    return switch (target) {
+        .focused => null,
+        .surface_id => if (action.scope() == .app) error.InvalidAutomationTarget else null,
+    };
 }
 
 fn isSafeAutomationAction(action: input.Binding.Action) bool {

--- a/src/App.zig
+++ b/src/App.zig
@@ -224,6 +224,15 @@ pub fn focusedSurface(self: *const App) ?*Surface {
     return surface;
 }
 
+test "automation-action safety rejects terminal input and crash actions" {
+    try std.testing.expect(isSafeAutomationAction(.new_tab));
+    try std.testing.expect(!isSafeAutomationAction(.{ .text = "hello" }));
+    try std.testing.expect(!isSafeAutomationAction(.{ .csi = "0m" }));
+    try std.testing.expect(!isSafeAutomationAction(.paste_from_clipboard));
+    try std.testing.expect(!isSafeAutomationAction(.{ .write_screen_file = .copy }));
+    try std.testing.expect(!isSafeAutomationAction(.{ .crash = .main }));
+}
+
 /// Returns true if confirmation is needed to quit the app. It is up to
 /// the apprt to call this.
 pub fn needsConfirmQuit(self: *const App) bool {
@@ -255,6 +264,16 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
                 request.result = rt_app.buildAutomationWindowListJson(request.alloc) catch |err| blk: {
                     request.err = err;
                     break :blk null;
+                };
+            },
+            .automation_action => |request| {
+                defer request.done.set();
+                self.performAutomationAction(
+                    rt_app,
+                    request.target,
+                    request.action_text,
+                ) catch |err| {
+                    request.err = err;
                 };
             },
             .close => |surface| self.closeSurface(surface),
@@ -513,6 +532,48 @@ pub fn performAllAction(
     }
 }
 
+fn performAutomationAction(
+    self: *App,
+    rt_app: *apprt.App,
+    target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) !void {
+    const action = input.Binding.Action.parse(action_text) catch |err| switch (err) {
+        error.InvalidAction, error.InvalidFormat => return error.InvalidAutomationAction,
+        else => return err,
+    };
+    if (!isSafeAutomationAction(action)) return error.UnsafeAutomationAction;
+
+    switch (target) {
+        .focused => {
+            if (action.scope() == .app) return try self.performAllAction(rt_app, action);
+            const surface = self.focusedSurface() orelse return error.NoAutomationTarget;
+            _ = try surface.performBindingAction(action);
+        },
+        .surface_id => |id| {
+            const surface = self.findSurfaceByID(id) orelse return error.NoAutomationTarget;
+            _ = try surface.performBindingAction(action);
+        },
+    }
+}
+
+fn isSafeAutomationAction(action: input.Binding.Action) bool {
+    return switch (action) {
+        .csi,
+        .esc,
+        .text,
+        .cursor_key,
+        .paste_from_clipboard,
+        .paste_from_selection,
+        .write_scrollback_file,
+        .write_screen_file,
+        .write_selection_file,
+        .crash,
+        => false,
+        else => true,
+    };
+}
+
 /// Handle a window message
 fn surfaceMessage(self: *App, surface: *Surface, msg: apprt.surface.Message) !void {
     // We want to ensure our window is still active. Window messages
@@ -566,6 +627,9 @@ pub const Message = union(enum) {
     /// Produce a read-only automation window snapshot on the app thread.
     automation_window_list: *AutomationWindowListRequest,
 
+    /// Perform a safe parsed keybinding action on the app thread.
+    automation_action: *AutomationActionRequest,
+
     /// Close a surface. This notifies the runtime that a surface
     /// should close.
     close: *Surface,
@@ -589,6 +653,13 @@ pub const Message = union(enum) {
         alloc: Allocator,
         done: std.Thread.ResetEvent = .{},
         result: ?[]u8 = null,
+        err: ?anyerror = null,
+    };
+
+    pub const AutomationActionRequest = struct {
+        target: apprt.ipc.AutomationActionTarget,
+        action_text: []const u8,
+        done: std.Thread.ResetEvent = .{},
         err: ?anyerror = null,
     };
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -226,6 +226,8 @@ pub fn focusedSurface(self: *const App) ?*Surface {
 
 test "automation-action safety rejects terminal input and crash actions" {
     try std.testing.expect(isSafeAutomationAction(.new_tab));
+    try std.testing.expect(isSafeAutomationAction(.toggle_fullscreen));
+    try std.testing.expect(isSafeAutomationAction(.quit));
     try std.testing.expect(!isSafeAutomationAction(.{ .text = "hello" }));
     try std.testing.expect(!isSafeAutomationAction(.{ .csi = "0m" }));
     try std.testing.expect(!isSafeAutomationAction(.paste_from_clipboard));
@@ -564,9 +566,12 @@ fn performAutomationAction(
 
     switch (target) {
         .focused => {
-            if (action.scope() == .app) return try self.performAllAction(rt_app, action);
-            const surface = self.focusedSurface() orelse return error.NoAutomationTarget;
-            _ = try surface.performBindingAction(action);
+            if (self.focusedSurface()) |surface| {
+                _ = try surface.performBindingAction(action);
+            } else {
+                if (action.scope() != .app) return error.NoAutomationTarget;
+                try self.performAction(rt_app, action.scoped(.app).?);
+            }
         },
         .surface_id => |id| {
             const surface = self.findSurfaceByID(id) orelse return error.NoAutomationTarget;
@@ -587,18 +592,84 @@ fn automationActionTargetError(
 
 fn isSafeAutomationAction(action: input.Binding.Action) bool {
     return switch (action) {
-        .csi,
-        .esc,
-        .text,
-        .cursor_key,
-        .paste_from_clipboard,
-        .paste_from_selection,
-        .write_scrollback_file,
-        .write_screen_file,
-        .write_selection_file,
-        .crash,
-        => false,
-        else => true,
+        .ignore,
+        .unbind,
+        .search,
+        .navigate_search,
+        .search_selection,
+        .start_search,
+        .end_search,
+        .reset,
+        .copy_to_clipboard,
+        .copy_url_to_clipboard,
+        .copy_title_to_clipboard,
+        .increase_font_size,
+        .decrease_font_size,
+        .reset_font_size,
+        .set_font_size,
+        .prompt_surface_title,
+        .prompt_tab_title,
+        .set_surface_title,
+        .set_tab_title,
+        .clear_screen,
+        .select_all,
+        .scroll_to_top,
+        .scroll_to_bottom,
+        .scroll_to_selection,
+        .scroll_to_row,
+        .scroll_page_up,
+        .scroll_page_down,
+        .scroll_page_fractional,
+        .scroll_page_lines,
+        .adjust_selection,
+        .jump_to_prompt,
+        .new_window,
+        .new_tab,
+        .previous_tab,
+        .next_tab,
+        .last_tab,
+        .goto_tab,
+        .move_tab,
+        .toggle_tab_overview,
+        .new_split,
+        .goto_split,
+        .goto_window,
+        .toggle_split_zoom,
+        .toggle_readonly,
+        .resize_split,
+        .equalize_splits,
+        .reset_window_size,
+        .inspector,
+        .show_gtk_inspector,
+        .show_on_screen_keyboard,
+        .open_config,
+        .reload_config,
+        .close_surface,
+        .close_tab,
+        .close_window,
+        .close_all_windows,
+        .toggle_maximize,
+        .toggle_fullscreen,
+        .toggle_window_decorations,
+        .toggle_window_float_on_top,
+        .toggle_secure_input,
+        .toggle_mouse_reporting,
+        .toggle_command_palette,
+        .toggle_quick_terminal,
+        .toggle_visibility,
+        .toggle_background_opacity,
+        .check_for_updates,
+        .undo,
+        .redo,
+        .end_key_sequence,
+        .activate_key_table,
+        .activate_key_table_once,
+        .deactivate_key_table,
+        .deactivate_all_key_tables,
+        .quit,
+        => true,
+
+        else => false,
     };
 }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -228,6 +228,7 @@ test "automation-action safety rejects terminal input and crash actions" {
     try std.testing.expect(isSafeAutomationAction(.new_tab));
     try std.testing.expect(isSafeAutomationAction(.toggle_fullscreen));
     try std.testing.expect(isSafeAutomationAction(.quit));
+    try std.testing.expect(!isSafeAutomationAction(.unbind));
     try std.testing.expect(!isSafeAutomationAction(.{ .text = "hello" }));
     try std.testing.expect(!isSafeAutomationAction(.{ .csi = "0m" }));
     try std.testing.expect(!isSafeAutomationAction(.paste_from_clipboard));
@@ -593,7 +594,6 @@ fn automationActionTargetError(
 fn isSafeAutomationAction(action: input.Binding.Action) bool {
     return switch (action) {
         .ignore,
-        .unbind,
         .search,
         .navigate_search,
         .search_selection,

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -96,6 +96,11 @@ pub const AutomationPane = struct {
     focused: bool,
 };
 
+pub const AutomationActionTarget = union(enum) {
+    focused,
+    surface_id: u64,
+};
+
 pub const Action = union(enum) {
     // A GUIDE TO ADDING NEW ACTIONS:
     //

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -23,6 +23,15 @@ pub const App = struct {
         return null;
     }
 
+    pub fn performAutomationAction(
+        _: Allocator,
+        _: apprt.ipc.Target,
+        _: apprt.ipc.AutomationActionTarget,
+        _: []const u8,
+    ) !bool {
+        return false;
+    }
+
     pub fn buildAutomationWindowListJson(
         _: *App,
         _: Allocator,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -761,6 +761,7 @@ const ipc_max_new_window_argc: u32 = 4096;
 const IpcRequestKind = enum(u8) {
     new_window = 1,
     list_windows = 2,
+    perform_action = 3,
 };
 
 const POINT = win32_types.POINT;
@@ -1553,8 +1554,18 @@ fn appendU32(dst: *std.ArrayList(u8), alloc: Allocator, value: u32) !void {
     try dst.appendSlice(alloc, &buf);
 }
 
+fn appendU64(dst: *std.ArrayList(u8), alloc: Allocator, value: u64) !void {
+    var buf: [8]u8 = undefined;
+    std.mem.writeInt(u64, &buf, value, .little);
+    try dst.appendSlice(alloc, &buf);
+}
+
 fn readU32(src: []const u8) u32 {
     return std.mem.readInt(u32, src[0..4], .little);
+}
+
+fn readU64(src: []const u8) u64 {
+    return std.mem.readInt(u64, src[0..8], .little);
 }
 
 fn freeOwnedArguments(alloc: Allocator, arguments: ?[]const [:0]const u8) void {
@@ -1601,6 +1612,30 @@ fn encodeListWindowsIpcRequest(alloc: Allocator) ![]u8 {
     return try encoded.toOwnedSlice(alloc);
 }
 
+fn encodePerformActionIpcRequest(
+    alloc: Allocator,
+    target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) ![]u8 {
+    var encoded: std.ArrayList(u8) = .empty;
+    errdefer encoded.deinit(alloc);
+
+    try appendU32(&encoded, alloc, ipc_wire_version);
+    try encoded.append(alloc, @intFromEnum(IpcRequestKind.perform_action));
+    try encoded.append(alloc, switch (target) {
+        .focused => 0,
+        .surface_id => 1,
+    });
+    try appendU64(&encoded, alloc, switch (target) {
+        .focused => 0,
+        .surface_id => |id| id,
+    });
+    try appendU32(&encoded, alloc, @intCast(action_text.len));
+    try encoded.appendSlice(alloc, action_text);
+
+    return try encoded.toOwnedSlice(alloc);
+}
+
 fn decodeIpcRequestKind(
     pipe: windows.HANDLE,
 ) !IpcRequestKind {
@@ -1637,6 +1672,33 @@ fn decodeNewWindowIpcPayload(
     }
 
     return argv;
+}
+
+fn decodePerformActionIpcPayload(
+    alloc: Allocator,
+    pipe: windows.HANDLE,
+) !struct {
+    target: apprt.ipc.AutomationActionTarget,
+    action_text: []u8,
+} {
+    var header: [13]u8 = undefined;
+    try readExactHandle(pipe, &header);
+
+    const target: apprt.ipc.AutomationActionTarget = switch (header[0]) {
+        0 => .focused,
+        1 => .{ .surface_id = readU64(header[1..9]) },
+        else => return error.InvalidIpcRequest,
+    };
+    const len = readU32(header[9..13]);
+    if (len == 0 or len > ipc_max_data_response_len) return error.InvalidIpcRequest;
+
+    const action_text = try alloc.alloc(u8, len);
+    errdefer alloc.free(action_text);
+    try readExactHandle(pipe, action_text);
+    return .{
+        .target = target,
+        .action_text = action_text,
+    };
 }
 
 fn writeIpcAck(pipe: windows.HANDLE, success: bool) !void {
@@ -1824,6 +1886,26 @@ fn sendListWindowsIpc(
     return try readIpcDataResponse(alloc, pipe);
 }
 
+fn sendPerformActionIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+    target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) !bool {
+    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        error.PipeBusy => return error.IPCFailed,
+        else => return err,
+    };
+    defer _ = windows.CloseHandle(pipe);
+
+    const request = try encodePerformActionIpcRequest(alloc, target, action_text);
+    defer alloc.free(request);
+
+    try writeAllHandle(pipe, request);
+    return try readIpcAck(pipe);
+}
+
 fn applyNewWindowArguments(
     alloc_gpa: Allocator,
     config: *configpkg.Config,
@@ -1974,6 +2056,10 @@ fn handleIpcClient(app: *App, pipe: windows.HANDLE) !void {
             log.warn("failed to process win32 automation list IPC request err={}", .{err});
             try writeIpcDataResponse(pipe, false, "");
         },
+        .perform_action => handlePerformActionIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation action IPC request err={}", .{err});
+            try writeIpcAck(pipe, false);
+        },
     }
 }
 
@@ -1998,6 +2084,14 @@ fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try writeIpcDataResponse(pipe, true, json);
 }
 
+fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    const payload = try decodePerformActionIpcPayload(app.core_app.alloc, pipe);
+    defer app.core_app.alloc.free(payload.action_text);
+
+    try requestAutomationAction(app, payload.target, payload.action_text);
+    try writeIpcAck(pipe, true);
+}
+
 fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
     var request: CoreApp.Message.AutomationWindowListRequest = .{
         .alloc = alloc,
@@ -2013,6 +2107,27 @@ fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
     request.done.wait();
     if (request.err) |err| return err;
     return request.result orelse error.IPCFailed;
+}
+
+fn requestAutomationAction(
+    app: *App,
+    target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) !void {
+    var request: CoreApp.Message.AutomationActionRequest = .{
+        .target = target,
+        .action_text = action_text,
+    };
+    const mailbox: CoreApp.Mailbox = .{
+        .rt_app = app,
+        .mailbox = &app.core_app.mailbox,
+    };
+    if (mailbox.push(.{ .automation_action = &request }, .{ .forever = {} }) == 0) {
+        return error.IPCFailed;
+    }
+
+    request.done.wait();
+    if (request.err) |err| return err;
 }
 
 pub fn getProcAddress(name: [*:0]const u8) callconv(.c) ?*const anyopaque {
@@ -3777,6 +3892,17 @@ pub const App = struct {
         const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
         defer alloc.free(pipe_name);
         return try sendListWindowsIpc(alloc, pipe_name);
+    }
+
+    pub fn performAutomationAction(
+        alloc: Allocator,
+        target: apprt.ipc.Target,
+        action_target: apprt.ipc.AutomationActionTarget,
+        action_text: []const u8,
+    ) !bool {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
+        defer alloc.free(pipe_name);
+        return try sendPerformActionIpc(alloc, pipe_name, action_target, action_text);
     }
 
     pub fn buildAutomationWindowListJson(
@@ -26773,6 +26899,42 @@ test "win32 encodeListWindowsIpcRequest preserves legacy zero-argc trailer" {
     try std.testing.expectEqual(ipc_wire_version, readU32(request[0..4]));
     try std.testing.expectEqual(@intFromEnum(IpcRequestKind.list_windows), request[4]);
     try std.testing.expectEqual(@as(u32, 0), readU32(request[5..9]));
+}
+
+test "automation-action win32 ipc encodes focused action request" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const request = try encodePerformActionIpcRequest(
+        std.testing.allocator,
+        .focused,
+        "new_tab",
+    );
+    defer std.testing.allocator.free(request);
+
+    try std.testing.expectEqual(ipc_wire_version, readU32(request[0..4]));
+    try std.testing.expectEqual(@intFromEnum(IpcRequestKind.perform_action), request[4]);
+    try std.testing.expectEqual(@as(u8, 0), request[5]);
+    try std.testing.expectEqual(@as(u64, 0), readU64(request[6..14]));
+    try std.testing.expectEqual(@as(u32, 7), readU32(request[14..18]));
+    try std.testing.expectEqualStrings("new_tab", request[18..]);
+}
+
+test "automation-action win32 ipc encodes surface action request" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const request = try encodePerformActionIpcRequest(
+        std.testing.allocator,
+        .{ .surface_id = 42 },
+        "toggle_fullscreen",
+    );
+    defer std.testing.allocator.free(request);
+
+    try std.testing.expectEqual(ipc_wire_version, readU32(request[0..4]));
+    try std.testing.expectEqual(@intFromEnum(IpcRequestKind.perform_action), request[4]);
+    try std.testing.expectEqual(@as(u8, 1), request[5]);
+    try std.testing.expectEqual(@as(u64, 42), readU64(request[6..14]));
+    try std.testing.expectEqual(@as(u32, 17), readU32(request[14..18]));
+    try std.testing.expectEqualStrings("toggle_fullscreen", request[18..]);
 }
 
 test "win32 readIpcDataResponse treats legacy failure ack as IPCFailed" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -760,6 +760,7 @@ const ipc_ack_unsafe_automation_action: u8 = 3;
 const ipc_ack_invalid_automation_target: u8 = 4;
 const ipc_ack_no_automation_target: u8 = 5;
 const ipc_max_data_response_len: u32 = 16 * 1024 * 1024;
+const ipc_max_action_text_len: u32 = 16 * 1024;
 const ipc_max_new_window_argc: u32 = 4096;
 
 const IpcRequestKind = enum(u8) {
@@ -1621,6 +1622,10 @@ fn encodePerformActionIpcRequest(
     target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
 ) ![]u8 {
+    if (action_text.len == 0 or action_text.len > ipc_max_action_text_len) {
+        return error.InvalidAutomationAction;
+    }
+
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
 
@@ -1694,7 +1699,9 @@ fn decodePerformActionIpcPayload(
         else => return error.InvalidIpcRequest,
     };
     const len = readU32(header[9..13]);
-    if (len == 0 or len > ipc_max_data_response_len) return error.InvalidIpcRequest;
+    if (len == 0 or len > ipc_max_action_text_len) {
+        return error.InvalidAutomationAction;
+    }
 
     const action_text = try alloc.alloc(u8, len);
     errdefer alloc.free(action_text);
@@ -2100,7 +2107,13 @@ fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
 }
 
 fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const payload = try decodePerformActionIpcPayload(app.core_app.alloc, pipe);
+    const payload = decodePerformActionIpcPayload(app.core_app.alloc, pipe) catch |err| switch (err) {
+        error.InvalidAutomationAction => {
+            try writeIpcAckStatus(pipe, ipc_ack_invalid_automation_action);
+            return;
+        },
+        else => return err,
+    };
     defer app.core_app.alloc.free(payload.action_text);
 
     requestAutomationAction(app, payload.target, payload.action_text) catch |err| {
@@ -2139,6 +2152,10 @@ fn requestAutomationAction(
     target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
 ) !void {
+    if (action_text.len == 0 or action_text.len > ipc_max_action_text_len) {
+        return error.InvalidAutomationAction;
+    }
+
     var request: CoreApp.Message.AutomationActionRequest = .{
         .target = target,
         .action_text = action_text,
@@ -26960,6 +26977,44 @@ test "automation-action win32 ipc encodes surface action request" {
     try std.testing.expectEqual(@as(u64, 42), readU64(request[6..14]));
     try std.testing.expectEqual(@as(u32, 17), readU32(request[14..18]));
     try std.testing.expectEqualStrings("toggle_fullscreen", request[18..]);
+}
+
+test "automation-action win32 ipc rejects oversized action before encode" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const action_text = try std.testing.allocator.alloc(u8, ipc_max_action_text_len + 1);
+    defer std.testing.allocator.free(action_text);
+    @memset(action_text, 'x');
+
+    try std.testing.expectError(
+        error.InvalidAutomationAction,
+        encodePerformActionIpcRequest(std.testing.allocator, .focused, action_text),
+    );
+}
+
+test "automation-action win32 ipc rejects oversized decoded action" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-action-too-large.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var header: [13]u8 = undefined;
+    header[0] = 0;
+    std.mem.writeInt(u64, header[1..9], 0, .little);
+    std.mem.writeInt(u32, header[9..13], ipc_max_action_text_len + 1, .little);
+    try file.writeAll(&header);
+    try file.seekTo(0);
+
+    try std.testing.expectError(
+        error.InvalidAutomationAction,
+        decodePerformActionIpcPayload(std.testing.allocator, file.handle),
+    );
 }
 
 test "automation-action win32 ipc maps specific failure ack" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -755,6 +755,10 @@ const ipc_pipe_prefix = "\\\\.\\pipe\\winghostty.";
 const ipc_wire_version: u32 = 1;
 const ipc_ack_success: u8 = 0;
 const ipc_ack_failure: u8 = 1;
+const ipc_ack_invalid_automation_action: u8 = 2;
+const ipc_ack_unsafe_automation_action: u8 = 3;
+const ipc_ack_invalid_automation_target: u8 = 4;
+const ipc_ack_no_automation_target: u8 = 5;
 const ipc_max_data_response_len: u32 = 16 * 1024 * 1024;
 const ipc_max_new_window_argc: u32 = 4096;
 
@@ -1702,9 +1706,16 @@ fn decodePerformActionIpcPayload(
 }
 
 fn writeIpcAck(pipe: windows.HANDLE, success: bool) !void {
+    return writeIpcAckStatus(
+        pipe,
+        if (success) ipc_ack_success else ipc_ack_failure,
+    );
+}
+
+fn writeIpcAckStatus(pipe: windows.HANDLE, status: u8) !void {
     var response: [5]u8 = undefined;
     std.mem.writeInt(u32, response[0..4], ipc_wire_version, .little);
-    response[4] = if (success) ipc_ack_success else ipc_ack_failure;
+    response[4] = status;
     try writeAllHandle(pipe, &response);
 }
 
@@ -1715,6 +1726,10 @@ fn readIpcAck(pipe: windows.HANDLE) !bool {
     return switch (response[4]) {
         ipc_ack_success => true,
         ipc_ack_failure => error.IPCFailed,
+        ipc_ack_invalid_automation_action => error.InvalidAutomationAction,
+        ipc_ack_unsafe_automation_action => error.UnsafeAutomationAction,
+        ipc_ack_invalid_automation_target => error.InvalidAutomationTarget,
+        ipc_ack_no_automation_target => error.NoAutomationTarget,
         else => error.InvalidIpcResponse,
     };
 }
@@ -2088,7 +2103,17 @@ fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
     const payload = try decodePerformActionIpcPayload(app.core_app.alloc, pipe);
     defer app.core_app.alloc.free(payload.action_text);
 
-    try requestAutomationAction(app, payload.target, payload.action_text);
+    requestAutomationAction(app, payload.target, payload.action_text) catch |err| {
+        const status: u8 = switch (err) {
+            error.InvalidAutomationAction => ipc_ack_invalid_automation_action,
+            error.UnsafeAutomationAction => ipc_ack_unsafe_automation_action,
+            error.InvalidAutomationTarget => ipc_ack_invalid_automation_target,
+            error.NoAutomationTarget => ipc_ack_no_automation_target,
+            else => return err,
+        };
+        try writeIpcAckStatus(pipe, status);
+        return;
+    };
     try writeIpcAck(pipe, true);
 }
 
@@ -26935,6 +26960,27 @@ test "automation-action win32 ipc encodes surface action request" {
     try std.testing.expectEqual(@as(u64, 42), readU64(request[6..14]));
     try std.testing.expectEqual(@as(u32, 17), readU32(request[14..18]));
     try std.testing.expectEqualStrings("toggle_fullscreen", request[18..]);
+}
+
+test "automation-action win32 ipc maps specific failure ack" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("ipc-action-ack.bin", .{
+        .read = true,
+        .truncate = true,
+    });
+    defer file.close();
+
+    try writeIpcAckStatus(file.handle, ipc_ack_invalid_automation_target);
+    try file.seekTo(0);
+
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        readIpcAck(file.handle),
+    );
 }
 
 test "win32 readIpcDataResponse treats legacy failure ack as IPCFailed" {

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -21,6 +21,7 @@ const show_face = @import("show_face.zig");
 const boo = @import("boo.zig");
 const new_window = @import("new_window.zig");
 const list_windows = @import("list_windows.zig");
+const perform_action = @import("perform_action.zig");
 
 pub const Action = @import("ghostty_action.zig").Action;
 
@@ -75,6 +76,7 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .boo => try boo.run(alloc),
         .@"new-window" => try new_window.run(alloc),
         .@"list-windows" => try list_windows.run(alloc),
+        .@"perform-action" => try perform_action.run(alloc),
     };
 }
 
@@ -102,6 +104,7 @@ pub fn options(comptime self: Action) type {
             .boo => boo.Options,
             .@"new-window" => new_window.Options,
             .@"list-windows" => list_windows.Options,
+            .@"perform-action" => perform_action.Options,
         };
     }
 }

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -60,6 +60,9 @@ pub const Action = enum {
     // List read-only automation state for the running winghostty instance.
     @"list-windows",
 
+    // Forward a safe keybinding action to the running winghostty instance.
+    @"perform-action",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -42,6 +42,8 @@ const help_prelude =
     \\
     \\Useful Windows actions:
     \\  `winghostty +new-window` forwards into the running instance when possible.
+    \\  `winghostty +list-windows` prints local automation window IDs as JSON.
+    \\  `winghostty +perform-action new_tab` forwards a safe UI action.
     \\  `winghostty +edit-config` opens the config file in your default editor.
     \\
     \\Available actions:

--- a/src/cli/perform_action.zig
+++ b/src/cli/perform_action.zig
@@ -1,0 +1,258 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+const input = @import("../input.zig");
+const lib = @import("../lib/main.zig");
+
+pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
+    _arena: ?ArenaAllocator = null,
+
+    /// If set, query a custom single-instance namespace instead of the
+    /// default local winghostty instance.
+    class: ?[:0]const u8 = null,
+
+    /// If set, perform the action against a specific surface from
+    /// `+list-windows` instead of the focused surface.
+    @"surface-id": ?u64 = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return actionpkg.help_error;
+    }
+};
+
+/// The `perform-action` command forwards one safe keybinding action to a
+/// running local winghostty instance.
+///
+/// The action uses the same syntax as `keybind` values, for example:
+///
+///   * `winghostty +perform-action new_tab`
+///   * `winghostty +perform-action --surface-id=42 toggle_fullscreen`
+///
+/// The default target is the focused surface for surface-scoped actions and the
+/// app for app-scoped actions. `--surface-id` accepts pane IDs from
+/// `winghostty +list-windows`.
+///
+/// To keep this automation surface bounded, terminal-input and arbitrary file
+/// helper actions such as `text`, `csi`, `esc`, `paste_from_clipboard`,
+/// `write_screen_file`, and `crash` are rejected by the running instance.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+
+    var stderr_buf: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buf);
+    const stderr = &stderr_writer.interface;
+
+    const result = runArgs(alloc, &iter, stderr);
+    try stderr.flush();
+    return result;
+}
+
+fn runArgs(
+    alloc: Allocator,
+    args_iter: anytype,
+    stderr: *std.Io.Writer,
+) !u8 {
+    return runArgsWithPerform(
+        alloc,
+        args_iter,
+        stderr,
+        performAutomationAction,
+    );
+}
+
+const PerformAutomationActionFn = *const fn (
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+    action_target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) anyerror!bool;
+
+fn runArgsWithPerform(
+    alloc: Allocator,
+    args_iter: anytype,
+    stderr: *std.Io.Writer,
+    performAutomationActionFn: PerformAutomationActionFn,
+) !u8 {
+    var opts: Options = .{};
+    opts._arena = ArenaAllocator.init(alloc);
+    defer opts.deinit();
+    const opts_alloc = opts._arena.?.allocator();
+
+    var action_text: ?[]const u8 = null;
+    while (args_iter.next()) |arg| {
+        if (std.mem.eql(u8, arg, "+perform-action") or
+            std.mem.eql(u8, arg, "perform-action"))
+        {
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            return actionpkg.help_error;
+        }
+        if (lib.cutPrefix(u8, arg, "--class=")) |class| {
+            opts.class = try opts_alloc.dupeZ(u8, std.mem.trim(u8, class, &std.ascii.whitespace));
+            continue;
+        }
+        if (lib.cutPrefix(u8, arg, "--surface-id=")) |raw| {
+            opts.@"surface-id" = std.fmt.parseInt(u64, raw, 10) catch {
+                try stderr.print("Invalid --surface-id value: {s}\n", .{raw});
+                return 1;
+            };
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "-")) {
+            try stderr.print("Unknown option for +perform-action: {s}\n", .{arg});
+            return 1;
+        }
+        if (action_text != null) {
+            try stderr.print("+perform-action accepts exactly one action.\n", .{});
+            return 1;
+        }
+        action_text = arg;
+    }
+
+    const action = action_text orelse {
+        try stderr.print("+perform-action requires an action, for example: new_tab\n", .{});
+        return 1;
+    };
+
+    _ = input.Binding.Action.parse(action) catch |err| switch (err) {
+        error.InvalidAction, error.InvalidFormat => {
+            try stderr.print("Invalid action for +perform-action: {s}\n", .{action});
+            return 1;
+        },
+        else => return err,
+    };
+
+    const ok = performAutomationActionFn(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+        if (opts.@"surface-id") |id| .{ .surface_id = id } else .focused,
+        action,
+    ) catch |err| switch (err) {
+        error.IPCFailed => {
+            try stderr.print("Performing automation action via IPC failed.\n", .{});
+            return 1;
+        },
+        else => return err,
+    };
+
+    if (ok) return 0;
+
+    try stderr.print("No matching winghostty instance is listening for automation actions.\n", .{});
+    return 1;
+}
+
+fn performAutomationAction(
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+    action_target: apprt.ipc.AutomationActionTarget,
+    action_text: []const u8,
+) !bool {
+    return try apprt.App.performAutomationAction(
+        alloc,
+        target,
+        action_target,
+        action_text,
+    );
+}
+
+test "automation-action cli forwards class surface and action" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var seen_class: ?[]u8 = null;
+        var seen_surface_id: ?u64 = null;
+        var seen_action: ?[]u8 = null;
+
+        fn perform(
+            _: Allocator,
+            target: apprt.ipc.Target,
+            action_target: apprt.ipc.AutomationActionTarget,
+            action_text: []const u8,
+        ) !bool {
+            seen_class = switch (target) {
+                .class => |class| try testing.allocator.dupe(u8, class),
+                .detect => return error.UnexpectedTarget,
+            };
+            seen_surface_id = switch (action_target) {
+                .surface_id => |id| id,
+                .focused => return error.UnexpectedTarget,
+            };
+            seen_action = try testing.allocator.dupe(u8, action_text);
+            return true;
+        }
+    };
+    defer if (Hook.seen_class) |value| testing.allocator.free(value);
+    defer if (Hook.seen_action) |value| testing.allocator.free(value);
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "--class=lane9 --surface-id=42 new_tab",
+    );
+    defer iter.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithPerform(
+        testing.allocator,
+        &iter,
+        &stderr_buf.writer,
+        &Hook.perform,
+    );
+
+    try testing.expectEqual(@as(u8, 0), exit_code);
+    try testing.expectEqualStrings("", stderr_buf.written());
+    try testing.expectEqualStrings("lane9", Hook.seen_class.?);
+    try testing.expectEqual(@as(u64, 42), Hook.seen_surface_id.?);
+    try testing.expectEqualStrings("new_tab", Hook.seen_action.?);
+}
+
+test "automation-action cli rejects invalid action before ipc" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn perform(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationActionTarget,
+            _: []const u8,
+        ) !bool {
+            return error.UnexpectedIpc;
+        }
+    };
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "definitely_not_an_action",
+    );
+    defer iter.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithPerform(
+        testing.allocator,
+        &iter,
+        &stderr_buf.writer,
+        &Hook.perform,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings(
+        "Invalid action for +perform-action: definitely_not_an_action\n",
+        stderr_buf.written(),
+    );
+}

--- a/src/cli/perform_action.zig
+++ b/src/cli/perform_action.zig
@@ -41,7 +41,7 @@ pub const Options = struct {
 ///
 /// The default target is the focused surface for surface-scoped actions and the
 /// app for app-scoped actions. `--surface-id` accepts pane IDs from
-/// `winghostty +list-windows`.
+/// `winghostty +list-windows` and is only valid for surface-scoped actions.
 ///
 /// To keep this automation surface bounded, terminal-input and arbitrary file
 /// helper actions such as `text`, `csi`, `esc`, `paste_from_clipboard`,
@@ -127,7 +127,7 @@ fn runArgsWithPerform(
         return 1;
     };
 
-    _ = input.Binding.Action.parse(action) catch |err| switch (err) {
+    const parsed_action = input.Binding.Action.parse(action) catch |err| switch (err) {
         error.InvalidAction, error.InvalidFormat => {
             try stderr.print("Invalid action for +perform-action: {s}\n", .{action});
             return 1;
@@ -135,12 +135,36 @@ fn runArgsWithPerform(
         else => return err,
     };
 
+    if (opts.@"surface-id" != null and parsed_action.scope() == .app) {
+        try stderr.print(
+            "--surface-id is only valid for surface-scoped actions; '{s}' is app-scoped.\n",
+            .{action},
+        );
+        return 1;
+    }
+
     const ok = performAutomationActionFn(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
         if (opts.@"surface-id") |id| .{ .surface_id = id } else .focused,
         action,
     ) catch |err| switch (err) {
+        error.InvalidAutomationTarget => {
+            try stderr.print("Invalid automation target for action: {s}\n", .{action});
+            return 1;
+        },
+        error.NoAutomationTarget => {
+            try stderr.print("No matching automation target for action: {s}\n", .{action});
+            return 1;
+        },
+        error.InvalidAutomationAction => {
+            try stderr.print("Invalid action for +perform-action: {s}\n", .{action});
+            return 1;
+        },
+        error.UnsafeAutomationAction => {
+            try stderr.print("Unsafe action rejected for +perform-action: {s}\n", .{action});
+            return 1;
+        },
         error.IPCFailed => {
             try stderr.print("Performing automation action via IPC failed.\n", .{});
             return 1;
@@ -253,6 +277,43 @@ test "automation-action cli rejects invalid action before ipc" {
     try testing.expectEqual(@as(u8, 1), exit_code);
     try testing.expectEqualStrings(
         "Invalid action for +perform-action: definitely_not_an_action\n",
+        stderr_buf.written(),
+    );
+}
+
+test "automation-action cli rejects app action with surface id before ipc" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn perform(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationActionTarget,
+            _: []const u8,
+        ) !bool {
+            return error.UnexpectedIpc;
+        }
+    };
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "--surface-id=42 quit",
+    );
+    defer iter.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithPerform(
+        testing.allocator,
+        &iter,
+        &stderr_buf.writer,
+        &Hook.perform,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings(
+        "--surface-id is only valid for surface-scoped actions; 'quit' is app-scoped.\n",
         stderr_buf.written(),
     );
 }

--- a/src/cli/perform_action.zig
+++ b/src/cli/perform_action.zig
@@ -45,7 +45,9 @@ pub const Options = struct {
 ///
 /// To keep this automation surface bounded, terminal-input and arbitrary file
 /// helper actions such as `text`, `csi`, `esc`, `paste_from_clipboard`,
-/// `write_screen_file`, and `crash` are rejected by the running instance.
+/// `write_screen_file`, and `crash` are rejected by the running instance. New
+/// action variants are denied until explicitly added to the automation
+/// allowlist.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
@@ -167,6 +169,10 @@ fn runArgsWithPerform(
         },
         error.IPCFailed => {
             try stderr.print("Performing automation action via IPC failed.\n", .{});
+            return 1;
+        },
+        error.InvalidIpcResponse => {
+            try stderr.print("Performing automation action via IPC failed: invalid response from the target instance.\n", .{});
             return 1;
         },
         else => return err,
@@ -314,6 +320,43 @@ test "automation-action cli rejects app action with surface id before ipc" {
     try testing.expectEqual(@as(u8, 1), exit_code);
     try testing.expectEqualStrings(
         "--surface-id is only valid for surface-scoped actions; 'quit' is app-scoped.\n",
+        stderr_buf.written(),
+    );
+}
+
+test "automation-action cli reports invalid ipc response" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        fn perform(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationActionTarget,
+            _: []const u8,
+        ) !bool {
+            return error.InvalidIpcResponse;
+        }
+    };
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "new_tab",
+    );
+    defer iter.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    const exit_code = try runArgsWithPerform(
+        testing.allocator,
+        &iter,
+        &stderr_buf.writer,
+        &Hook.perform,
+    );
+
+    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqualStrings(
+        "Performing automation action via IPC failed: invalid response from the target instance.\n",
         stderr_buf.written(),
     );
 }


### PR DESCRIPTION
## Summary
- adds `winghostty +perform-action <action>` over existing Win32 single-instance IPC
- supports focused surface by default plus `--surface-id=<id>` from `+list-windows`
- parses existing keybinding action syntax
- rejects unsafe automation actions server-side
- adds CLI help/docs and parsing/safety/IPC tests

## Validation
- `zig build test -Dtest-filter=automation-action`
- `zig build test -Dtest-filter=automation-window-list`
- `zig build`
- `git diff --check`

Review loop: @codex @coderabbitai @greptileai @Copilot please review. I will iterate on findings until this is clean to squash and merge.

## Summary by Sourcery

Add a Windows local automation IPC pathway to forward safe keybinding actions from the CLI to a running winghostty instance, including focused or surface-targeted actions, and validate them on the app thread.

New Features:
- Expose a `+perform-action` CLI command that forwards a single parsed keybinding action to a running winghostty instance over existing Win32 single-instance IPC.
- Support targeting automation actions at either the currently focused surface or a specific pane by surface ID from `+list-windows`.

Enhancements:
- Introduce server-side safety filtering for automation actions to reject terminal-input, arbitrary file helper, and crash actions before execution.
- Extend the core app mailbox and message handling to support automation action requests executed on the app thread.
- Add a no-op automation action hook for non-Windows runtimes to keep the interface consistent.

Documentation:
- Document Windows local automation usage, including `+perform-action` and `--surface-id`, in the getting-started guide and Windows capability matrix.

Tests:
- Add unit tests for Win32 IPC encoding of automation action requests and for CLI argument parsing and validation of the new `+perform-action` command.
- Add tests to verify server-side automation action safety rules and mailbox handling results.