### PR TITLE
feat(update): stage signed Windows downloads

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,11 +124,11 @@ auto-update = check
 The updater hits GitHub's public releases API at most once every 24 hours,
 opens the release page if a newer stable version is available, and never
 replaces binaries silently. `auto-update = download` downloads only stable
-Windows installer releases that include `SHA256SUMS.txt` and
-`SHA256SUMS.txt.sig`, verifies the installer SHA-256, requires a valid
-Windows Authenticode signature, and stages the installer under the local
-winghostty state directory. Installing the staged update is still manual. No
-telemetry or analytics are sent.
+Windows installer releases that include `SHA256SUMS.txt`, verifies the
+installer SHA-256 against that manifest, requires a valid Windows Authenticode
+signature, and stages the installer under the local winghostty state directory.
+Installing the staged update is still manual. No telemetry or analytics are
+sent.
 
 ## 9. Crash reports
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,8 +123,12 @@ auto-update = check
 
 The updater hits GitHub's public releases API at most once every 24 hours,
 opens the release page if a newer stable version is available, and never
-replaces binaries silently. `auto-update = download` currently behaves the
-same as `check`. No telemetry or analytics are sent.
+replaces binaries silently. `auto-update = download` downloads only stable
+Windows installer releases that include `SHA256SUMS.txt` and
+`SHA256SUMS.txt.sig`, verifies the installer SHA-256, requires a valid
+Windows Authenticode signature, and stages the installer under the local
+winghostty state directory. Installing the staged update is still manual. No
+telemetry or analytics are sent.
 
 ## 9. Crash reports
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -61,8 +61,8 @@ For a row-by-row mapping against official Ghostty docs, see
 - **Manual install**: never replaces the binary silently
 - Gated to at most one check every 24 hours
 - `auto-update = download` stages only Windows installer releases that include
-  checksum metadata and pass SHA-256 plus Authenticode verification. Apply is
-  not automatic.
+  checksum metadata and pass SHA-256 plus Authenticode verification. Applying
+  updates is not automatic.
 
 ### Crash reports
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -58,11 +58,11 @@ For a row-by-row mapping against official Ghostty docs, see
 ### Updater
 
 - Checks `api.github.com/repos/amanthanvi/winghostty/releases/latest`
-- **Notify-only**: never replaces the binary silently
+- **Manual install**: never replaces the binary silently
 - Gated to at most one check every 24 hours
-- `auto-update = download` currently behaves the same as `check` (see
-  the `auto-update` docstring in `src/config/Config.zig`), pending signed
-  background installs
+- `auto-update = download` stages only Windows installer releases that include
+  checksum metadata and pass SHA-256 plus Authenticode verification. Apply is
+  not automatic.
 
 ### Crash reports
 

--- a/docs/superpowers/specs/2026-05-03-win32-update-install-design.md
+++ b/docs/superpowers/specs/2026-05-03-win32-update-install-design.md
@@ -37,8 +37,8 @@ The design intentionally extends current repo behavior instead of replacing it:
 - `src/update/github_releases.zig`
   - Owns update throttling, persisted dismissal state, release discovery, and
     GitHub API parsing.
-  - Already parses a signed Windows install candidate:
-    `setup.exe` + `SHA256SUMS.txt` + `SHA256SUMS.txt.sig`.
+  - Parses a Windows install candidate:
+    `setup.exe` + `SHA256SUMS.txt`.
   - Cached throttled state only preserves `last_seen_version`, so asset-scoped
     metadata is dropped between runs.
 - `src/apprt/win32.zig`
@@ -57,8 +57,7 @@ The design intentionally extends current repo behavior instead of replacing it:
   - Builds both the portable ZIP and the Inno Setup installer.
   - Can Authenticode-sign staged `.exe`/`.dll` artifacts and the final
     installer when secrets are present.
-  - Writes `SHA256SUMS.txt`, but does not currently emit
-    `SHA256SUMS.txt.sig`.
+  - Writes `SHA256SUMS.txt`.
 - `dist/windows/winghostty.iss`
   - Defines the current installer identity, default install root, shortcut
     AUMID wiring, and post-install launch behavior.
@@ -68,7 +67,6 @@ The design intentionally extends current repo behavior instead of replacing it:
     - `winghostty-<version>-windows-x64-portable.zip`
     - `SHA256SUMS.txt`
     - `winghostty-icon.svg`
-  - Does not currently publish `SHA256SUMS.txt.sig`.
 - `docs/getting-started.md`, `docs/status.md`, and
   `docs/windows-capability-matrix.md`
   - All currently describe the updater as notify-only and describe
@@ -141,7 +139,6 @@ For a release to be eligible for `auto-update = download`, it must publish:
 - `winghostty-<version>-windows-x64-setup.exe`
 - `winghostty-<version>-windows-x64-portable.zip`
 - `SHA256SUMS.txt`
-- `SHA256SUMS.txt.sig`
 
 The current filename conventions in `scripts/package-windows.ps1` and
 `src/update/github_releases.zig` stay authoritative.
@@ -151,30 +148,15 @@ The current filename conventions in `scripts/package-windows.ps1` and
 - `winghostty-<version>-windows-x64-setup.exe`
 - `winghostty-<version>-windows-x64-portable.zip`
 
-### Signature format
-
-Use a detached Minisign signature for `SHA256SUMS.txt`:
-
-- Release pipeline signs the raw bytes of `SHA256SUMS.txt`.
-- The Win32 updater embeds the trusted Minisign public key.
-- Verification of the checksum file is the primary authenticity gate for both
-  installer and portable assets.
-
-Rationale:
-
-- The repo already expects a detached `.sig` sidecar.
-- ZIP files do not have a native Windows trust story equivalent to
-  Authenticode.
-- A signed checksum manifest gives one trust anchor for both install modes.
-
 ### Authenticode requirements
 
-Detached checksum signing is necessary but not sufficient for auto-apply.
+The installer trust model is `SHA256SUMS.txt` for release-asset integrity plus
+Windows Authenticode for publisher and signing-chain trust.
 
 - Installer mode requires a valid Authenticode signature on the staged
   `setup.exe`.
 - Portable mode should verify:
-  - ZIP hash against the signed checksum manifest.
+  - ZIP hash against the checksum manifest.
   - Basic extracted-tree shape after unzip.
   - Valid Authenticode signatures on shipped PE files where present
     (`winghostty.exe`, `ghostty-vt.dll`, and any future dedicated update
@@ -188,7 +170,7 @@ allowances are harness-only behavior, not production behavior.
 - Reject versions `<= current_version` for automatic staging/apply.
 - Reject releases whose filename version, tag version, and parsed semantic
   version disagree.
-- If the signed checksum manifest omits the expected asset, treat that release
+- If the checksum manifest omits the expected asset, treat that release
   as ineligible for `download`.
 
 ## Install Mode Detection
@@ -239,7 +221,6 @@ Suggested layout:
   updates\
     1.3.110\
       SHA256SUMS.txt
-      SHA256SUMS.txt.sig
       asset\
         winghostty-1.3.110-windows-x64-setup.exe
         winghostty-1.3.110-windows-x64-portable.zip
@@ -309,7 +290,7 @@ Selection rules:
 
 - Stable channel:
   - prefer the newest semver-greater candidate from `releases/latest`
-  - require checksum file + checksum signature + install-mode-matching asset
+  - require checksum file + install-mode-matching asset
 - Tip channel, future:
   - newest prerelease semver-greater candidate with the same trust contract
 
@@ -317,7 +298,6 @@ Candidate rejection reasons must be explicit in logs:
 
 - missing asset
 - missing checksum line
-- missing checksum signature
 - unsupported channel
 - version not newer
 - install mode unknown
@@ -328,26 +308,23 @@ For `auto-update = download`, verification happens in this order:
 
 1. Resolve release candidate from GitHub API.
 2. Download `SHA256SUMS.txt`.
-3. Download `SHA256SUMS.txt.sig`.
-4. Verify the detached signature against the pinned Minisign public key.
-5. Parse the checksum line for the selected asset.
-6. Download the selected asset to `*.partial` inside the stage dir.
-7. Stream SHA-256 while downloading.
-8. Compare the final hash to the signed checksum line.
-9. Rename `*.partial` -> final asset name only after hash match.
-10. Perform mode-specific verification:
+3. Parse the checksum line for the selected asset.
+4. Download the selected asset to `*.partial` inside the stage dir.
+5. Stream SHA-256 while downloading.
+6. Compare the final hash to the checksum line.
+7. Rename `*.partial` -> final asset name only after hash match.
+8. Perform mode-specific verification:
     - installer mode:
       - verify Authenticode on the staged `setup.exe`
     - portable mode:
       - unzip into `extracted\`
       - verify expected packaged tree shape
       - verify Authenticode on extracted PE files where present
-11. Mark the stage `ready`.
+9. Mark the stage `ready`.
 
 Re-verify immediately before apply:
 
-- Re-hash the staged asset against the saved signed checksum.
-- Re-check detached checksum signature bytes if the sidecar or manifest changed.
+- Re-hash the staged asset against the saved checksum.
 - Re-run Authenticode verification before execute/swap.
 
 This avoids a stale "verified once, trusted forever" assumption.
@@ -553,10 +530,8 @@ On app startup:
 
 Required future changes:
 
-- emit `SHA256SUMS.txt.sig`
 - sign every production PE that will be auto-applied or executed
 - continue writing `SHA256SUMS.txt`
-- fail closed if checksum signing is required but unavailable
 
 ### `dist/windows/winghostty.iss`
 
@@ -571,8 +546,6 @@ Required review points for silent updater compatibility:
 
 Required future changes:
 
-- publish `SHA256SUMS.txt.sig`
-- verify the detached signature before release upload
 - fail the release if any required asset is missing
 - keep publishing both installer and portable assets
 
@@ -580,25 +553,23 @@ Required future changes:
 
 Required future changes:
 
-- include signature asset metadata in generated `metadata.json`
-- keep installer and portable hashes aligned with the signed checksum manifest
+- keep installer and portable hashes aligned with the checksum manifest
 
 ### `scripts/release-preflight.ps1`
 
 Required future changes:
 
-- validate the presence of checksum-signing secrets/config
-- validate that release signing and checksum signing are both configured when
-  `download` mode is intended to be trustworthy in production
+- validate that release signing is configured when `download` mode is intended
+  to be trustworthy in production
 
 ## Security And Threat Model
 
 ### Threats addressed
 
 - GitHub API or release-page tampering in transit
-  - mitigated by TLS plus detached checksum signature verification
+  - mitigated by TLS plus Authenticode verification on the installer
 - Corrupt or replaced downloaded artifact
-  - mitigated by signed checksum validation and re-hash before apply
+  - mitigated by checksum validation and re-hash before apply
 - Unsigned or differently signed installer
   - mitigated by Authenticode verification before execute
 - Stale or replayed older release
@@ -610,13 +581,11 @@ Required future changes:
 
 - Full compromise of the local user account
 - Malicious code already running with the same user rights
-- Offline theft of the updater signing private key
+- Offline theft of the Authenticode signing private key
 - Session continuity or user-shell command replay after restart
 
 ### Operational trust assumptions
 
-- The detached checksum-signing key is protected more tightly than normal repo
-  content edits.
 - The Authenticode certificate used for production releases is stable and
   valid.
 - Release workflow environment protections are enforced before public release.
@@ -641,20 +610,15 @@ Win32 updater modules for:
 Add test fixtures for:
 
 - valid `SHA256SUMS.txt`
-- valid detached `.sig`
 - hash mismatch
 - missing asset line
-- invalid signature
-
-The signature fixtures should be deterministic and repo-local so targeted tests
-do not require live keys.
+- invalid Authenticode signature
 
 ### Packaging script validation
 
 Add narrow script-level checks that validate:
 
-- `scripts/package-windows.ps1` emits `SHA256SUMS.txt` and `.sig`
-- release metadata includes the signature asset
+- `scripts/package-windows.ps1` emits `SHA256SUMS.txt`
 - missing signing inputs fail closed
 
 ### Interactive/manual Win11 harness
@@ -675,7 +639,6 @@ Before publishing a release, CI should verify:
 - setup exe present
 - portable ZIP present
 - `SHA256SUMS.txt` present
-- `SHA256SUMS.txt.sig` present
 - Authenticode valid where required
 - hashes in the checksum file match the uploaded assets exactly
 
@@ -690,9 +653,8 @@ Before publishing a release, CI should verify:
 
 ### Milestone 2: Trust pipeline and release packaging
 
-- Make `scripts/package-windows.ps1` emit `SHA256SUMS.txt.sig`.
-- Publish the signature asset from `.github/workflows/release.yml`.
-- Add runtime checksum-signature verification.
+- Keep `scripts/package-windows.ps1` emitting `SHA256SUMS.txt`.
+- Verify runtime checksum and Authenticode checks.
 - Keep apply disabled; stage only in test/dev harnesses.
 
 ### Milestone 3: Installer-mode download and ready-to-apply UX

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -40,7 +40,7 @@ Last reviewed: 2026-05-01.
 
 | Ghostty docs surface | winghostty note |
 | --- | --- |
-| [Configuration: `auto-update = download`](https://ghostty.org/docs/config/reference) | Stages only stable Windows installer releases with `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, a matching installer SHA-256, and a valid Authenticode signature. It does not install automatically. |
+| [Configuration: `auto-update = download`](https://ghostty.org/docs/config/reference) | Stages only stable Windows installer releases with `SHA256SUMS.txt`, a matching installer SHA-256, and a valid Authenticode signature. It does not install automatically. |
 
 ## Windows-Specific
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -33,14 +33,14 @@ Last reviewed: 2026-05-01.
 | --- | --- |
 | [Shell integration](https://ghostty.org/docs/features/shell-integration) | Upstream docs for automatic `bash` / `elvish` / `fish` / `nushell` / `zsh` injection still apply when those shells are launched on Windows. winghostty additionally supports automatic PowerShell injection (`powershell.exe`, `pwsh.exe`) plus a manual fallback under `%LOCALAPPDATA%\winghostty\shell-integration\powershell\integration.ps1`, which upstream docs do not cover. |
 | [Action reference](https://ghostty.org/docs/config/keybind/reference) | Shared action grammar is intact, but upstream docs still mix shared actions with macOS/Linux-specific behavior. For Windows-specific truth on a disputed action, prefer `winghostty +show-config --default --docs` plus the current defaults from `+list-keybinds`. |
-| [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and notify-only update prompts backed by GitHub Releases. Background download/install behavior is not implemented. |
+| [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and update prompts backed by GitHub Releases. `download` can stage signed, checksum-matching installer releases, but install/apply remains manual. |
 | [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |
 
 ## No-op Compatibility
 
 | Ghostty docs surface | winghostty note |
 | --- | --- |
-| [Configuration: `auto-update = download`](https://ghostty.org/docs/config/reference) | Accepted on Windows, but today behaves the same as `auto-update = check`; no background download or install path runs. |
+| [Configuration: `auto-update = download`](https://ghostty.org/docs/config/reference) | Stages only stable Windows installer releases with `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, a matching installer SHA-256, and a valid Authenticode signature. It does not install automatically. |
 
 ## Windows-Specific
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -5810,13 +5810,9 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
             stage_download: {
                 if (request.download) {
                     var staged = updatepkg.stageWindowsInstall(alloc, request.state_path, &release) catch |err| {
-                        log.warn("failed to stage signed updater download err={}", .{err});
+                        log.warn("failed to stage verified updater download err={}", .{err});
                         if (request.manual) {
-                            completion.manual_message = std.fmt.allocPrint(
-                                alloc,
-                                "Update found, but the signed download could not be staged ({s}).",
-                                .{@errorName(err)},
-                            ) catch null;
+                            completion.manual_message = updateStageFailureMessage(alloc, err) catch null;
                         }
                         break :stage_download;
                     };
@@ -5868,6 +5864,40 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
 
 fn tryOrNull(alloc: Allocator, text: []const u8) ?[]u8 {
     return alloc.dupe(u8, text) catch null;
+}
+
+fn updateStageFailureMessage(alloc: Allocator, err: anyerror) ![]u8 {
+    const detail = switch (err) {
+        error.WindowsInstallNotEligible => "the release is missing a Windows installer or SHA256SUMS.txt",
+        error.InstallerChecksumMissing => "SHA256SUMS.txt does not include the Windows installer",
+        error.InvalidChecksum => "SHA256SUMS.txt contains an invalid checksum",
+        error.InstallerChecksumMismatch => "the downloaded installer did not match SHA256SUMS.txt",
+        error.InvalidAuthenticodeSignature => "the installer Authenticode signature could not be trusted",
+        error.AuthenticodeRequiresWindows => "Authenticode verification is only available on Windows",
+        error.SignatureVerifierUnavailable => "Windows signature verification is unavailable",
+        error.InvalidStatePath => "the updater state directory could not be resolved",
+        error.InvalidDownloadPath => "the staging download path was invalid",
+        error.UpdateHttpUnauthorized => "GitHub rejected the download request as unauthorized",
+        error.UpdateHttpForbidden => "GitHub blocked the download request",
+        error.UpdateHttpNotFound => "a required release asset was not found",
+        error.UpdateHttpRateLimited => "GitHub rate limited the update download",
+        error.UnexpectedHttpStatus => "GitHub returned an unexpected HTTP status",
+        else => null,
+    };
+
+    if (detail) |text| {
+        return std.fmt.allocPrint(
+            alloc,
+            "Update found, but it could not be verified or staged: {s} ({s}).",
+            .{ text, @errorName(err) },
+        );
+    }
+
+    return std.fmt.allocPrint(
+        alloc,
+        "Update found, but it could not be verified or staged ({s}).",
+        .{@errorName(err)},
+    );
 }
 
 fn postUpdateCheckCompletion(ui_thread_id: DWORD, completion: *UpdateCheckCompletion) void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2033,16 +2033,25 @@ const UpdateNotice = struct {
     version_text: ?[]u8 = null,
     release_url: ?[]u8 = null,
     message_text: ?[]u8 = null,
+    staged: bool = false,
 
-    fn init(alloc: Allocator, version_text: []const u8, release_url: []const u8) !UpdateNotice {
+    fn init(alloc: Allocator, version_text: []const u8, release_url: []const u8, staged: bool) !UpdateNotice {
         return .{
             .version_text = try alloc.dupe(u8, version_text),
             .release_url = try alloc.dupe(u8, release_url),
-            .message_text = try std.fmt.allocPrint(
-                alloc,
-                "Update available: winghostty {s} is ready on GitHub Releases.",
-                .{version_text},
-            ),
+            .message_text = if (staged)
+                try std.fmt.allocPrint(
+                    alloc,
+                    "Update downloaded and verified: winghostty {s} is staged. Open Release to install.",
+                    .{version_text},
+                )
+            else
+                try std.fmt.allocPrint(
+                    alloc,
+                    "Update available: winghostty {s} is ready on GitHub Releases.",
+                    .{version_text},
+                ),
+            .staged = staged,
         };
     }
 
@@ -2063,6 +2072,7 @@ const UpdateCheckRequest = struct {
     force: bool,
     manual: bool,
     respect_dismissal: bool,
+    download: bool,
 
     fn deinit(self: *UpdateCheckRequest) void {
         self.alloc.free(self.state_path);
@@ -2075,6 +2085,7 @@ const UpdateCheckCompletion = struct {
     alloc: Allocator,
     release: ?updatepkg.Release = null,
     manual_message: ?[]u8 = null,
+    staged: bool = false,
 
     fn deinit(self: *UpdateCheckCompletion) void {
         if (self.release) |*value| value.deinit(self.alloc);
@@ -2804,6 +2815,7 @@ pub const App = struct {
             .force = opts.force,
             .manual = opts.manual,
             .respect_dismissal = opts.respect_dismissal,
+            .download = self.config.@"auto-update" == .download,
         };
 
         const thread = try std.Thread.spawn(.{}, updateCheckThreadMain, .{request});
@@ -2814,10 +2826,14 @@ pub const App = struct {
         self.update_check_running.store(false, .release);
 
         if (completion.release) |release| {
-            self.setUpdateNotice(release.version_text, release.release_url) catch |err| {
+            self.setUpdateNotice(release.version_text, release.release_url, completion.staged) catch |err| {
                 log.warn("failed to surface update notice err={}", .{err});
             };
-            if (completion.manual_message) |_| {}
+            if (completion.manual_message) |message| {
+                self.showUpdateInfo(message) catch |err| {
+                    log.warn("failed to show updater status message err={}", .{err});
+                };
+            }
             return;
         }
 
@@ -2828,10 +2844,11 @@ pub const App = struct {
         }
     }
 
-    fn setUpdateNotice(self: *App, version_text: []const u8, release_url: []const u8) !void {
+    fn setUpdateNotice(self: *App, version_text: []const u8, release_url: []const u8, staged: bool) !void {
         if (self.update_notice) |*notice| {
             if (ownedBytesEquals(notice.version_text, version_text) and
-                ownedBytesEquals(notice.release_url, release_url))
+                ownedBytesEquals(notice.release_url, release_url) and
+                notice.staged == staged)
             {
                 return;
             }
@@ -2839,7 +2856,7 @@ pub const App = struct {
             self.update_notice = null;
         }
 
-        self.update_notice = try UpdateNotice.init(self.core_app.alloc, version_text, release_url);
+        self.update_notice = try UpdateNotice.init(self.core_app.alloc, version_text, release_url, staged);
         for (self.hosts.items) |host| host.invalidateBannerText();
     }
 
@@ -5790,6 +5807,31 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
 
     switch (result) {
         .update_available => |release| {
+            stage_download: {
+                if (request.download) {
+                    var staged = updatepkg.stageWindowsInstall(alloc, request.state_path, &release) catch |err| {
+                        log.warn("failed to stage signed updater download err={}", .{err});
+                        if (request.manual) {
+                            completion.manual_message = std.fmt.allocPrint(
+                                alloc,
+                                "Update found, but the signed download could not be staged ({s}).",
+                                .{@errorName(err)},
+                            ) catch null;
+                        }
+                        break :stage_download;
+                    };
+                    staged.deinit(alloc);
+                    completion.staged = true;
+                    if (request.manual) {
+                        completion.manual_message = std.fmt.allocPrint(
+                            alloc,
+                            "winghostty {s} was downloaded, verified, and staged.",
+                            .{release.version_text},
+                        ) catch null;
+                    }
+                }
+            }
+
             const version_text = tryOrNull(alloc, release.version_text);
             const release_url = tryOrNull(alloc, release.release_url);
             if (version_text != null and release_url != null) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3202,8 +3202,9 @@ term: []const u8 = "xterm-ghostty",
 
 /// Control the auto-update functionality of winghostty.
 ///
-/// The Windows runtime currently supports notify-only stable update checks
-/// backed by GitHub Releases.
+/// The Windows runtime supports stable update checks backed by GitHub
+/// Releases. Downloads are staged only after checksum verification and a
+/// valid Windows Authenticode signature check on the installer.
 ///
 /// Valid values are:
 ///
@@ -3212,7 +3213,8 @@ term: []const u8 = "xterm-ghostty",
 ///    available, but do not automatically install the update.
 ///  * `download` - Check for updates, automatically download the update,
 ///    notify the user, but do not automatically install the update.
-///    In v1 of the Windows updater this behaves the same as `check`.
+///    Windows stages only signed, checksum-matching installer releases and
+///    still requires the user to install manually.
 @"auto-update": ?AutoUpdate = null,
 
 /// The release channel to use for auto-updates.
@@ -3231,8 +3233,8 @@ term: []const u8 = "xterm-ghostty",
 ///    beta testing by thousands of people. It is generally stable but
 ///    will likely have more bugs than the stable channel.
 ///
-/// The v1 Windows updater only checks the `stable` channel. `tip` remains a
-/// manual prerelease channel until signed download/install support exists.
+/// The Windows updater only checks the `stable` channel. `tip` remains a
+/// manual prerelease channel.
 @"auto-update-channel": ?build_config.ReleaseChannel = null,
 
 /// This is set by the CLI parser for deinit.

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const internal_os = @import("../os/main.zig");
 
 const Allocator = std.mem.Allocator;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 
 pub const repo_owner = "amanthanvi";
 pub const repo_name = "winghostty";
@@ -17,10 +19,17 @@ pub const State = struct {
     last_checked_at: i64 = 0,
     last_seen_version: ?[]u8 = null,
     dismissed_version: ?[]u8 = null,
+    staged_version: ?[]u8 = null,
+    staged_installer_path: ?[]u8 = null,
+    staged_sha256: ?[]u8 = null,
+    staged_at: i64 = 0,
 
     pub fn deinit(self: *State, alloc: Allocator) void {
         if (self.last_seen_version) |value| alloc.free(value);
         if (self.dismissed_version) |value| alloc.free(value);
+        if (self.staged_version) |value| alloc.free(value);
+        if (self.staged_installer_path) |value| alloc.free(value);
+        if (self.staged_sha256) |value| alloc.free(value);
         self.* = undefined;
     }
 };
@@ -49,6 +58,19 @@ pub const WindowsInstallCandidate = struct {
         alloc.free(self.installer_url);
         alloc.free(self.checksums_url);
         alloc.free(self.checksums_signature_url);
+        self.* = undefined;
+    }
+};
+
+pub const StagedWindowsInstall = struct {
+    version_text: []u8,
+    installer_path: []u8,
+    sha256_hex: []u8,
+
+    pub fn deinit(self: *StagedWindowsInstall, alloc: Allocator) void {
+        alloc.free(self.version_text);
+        alloc.free(self.installer_path);
+        alloc.free(self.sha256_hex);
         self.* = undefined;
     }
 };
@@ -120,6 +142,30 @@ pub fn loadState(alloc: Allocator, path: []const u8) !State {
             else => {},
         }
     }
+    if (root.get("staged_version")) |value| {
+        switch (value) {
+            .string => |text| state.staged_version = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
+    if (root.get("staged_installer_path")) |value| {
+        switch (value) {
+            .string => |text| state.staged_installer_path = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
+    if (root.get("staged_sha256")) |value| {
+        switch (value) {
+            .string => |text| state.staged_sha256 = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
+    if (root.get("staged_at")) |value| {
+        switch (value) {
+            .integer => |integer| state.staged_at = @intCast(integer),
+            else => {},
+        }
+    }
 
     return state;
 }
@@ -142,6 +188,14 @@ pub fn saveState(path: []const u8, state: *const State) !void {
     try writeOptionalJsonString(writer, state.last_seen_version);
     try writer.writeAll(",\"dismissed_version\":");
     try writeOptionalJsonString(writer, state.dismissed_version);
+    try writer.writeAll(",\"staged_version\":");
+    try writeOptionalJsonString(writer, state.staged_version);
+    try writer.writeAll(",\"staged_installer_path\":");
+    try writeOptionalJsonString(writer, state.staged_installer_path);
+    try writer.writeAll(",\"staged_sha256\":");
+    try writeOptionalJsonString(writer, state.staged_sha256);
+    try writer.writeAll(",\"staged_at\":");
+    try writer.print("{d}", .{state.staged_at});
     try writer.writeAll("}");
     try writer.flush();
 }
@@ -214,16 +268,255 @@ pub fn releaseUrlForVersion(alloc: Allocator, version_text: []const u8) ![]u8 {
     );
 }
 
+pub fn stageWindowsInstall(
+    alloc: Allocator,
+    state_path: []const u8,
+    release: *const Release,
+) !StagedWindowsInstall {
+    const candidate = release.windows_install orelse return error.WindowsInstallNotEligible;
+
+    const state_dir = std.fs.path.dirname(state_path) orelse return error.InvalidStatePath;
+    const stage_dir = try std.fs.path.join(alloc, &.{ state_dir, "updates", release.version_text });
+    defer alloc.free(stage_dir);
+    try std.fs.cwd().makePath(stage_dir);
+
+    const installer_path = try std.fs.path.join(alloc, &.{ stage_dir, candidate.installer_name });
+    errdefer alloc.free(installer_path);
+    const checksums_path = try std.fs.path.join(alloc, &.{ stage_dir, windows_checksums_asset_name });
+    defer alloc.free(checksums_path);
+    const signature_path = try std.fs.path.join(alloc, &.{ stage_dir, windows_checksums_signature_asset_name });
+    defer alloc.free(signature_path);
+
+    try downloadUrlToFile(alloc, candidate.checksums_url, checksums_path);
+    try downloadUrlToFile(alloc, candidate.checksums_signature_url, signature_path);
+    try downloadUrlToFile(alloc, candidate.installer_url, installer_path);
+
+    const checksums = try std.fs.cwd().readFileAlloc(alloc, checksums_path, 1024 * 1024);
+    defer alloc.free(checksums);
+    const expected_digest = try parseExpectedSha256(checksums, candidate.installer_name);
+
+    const actual_digest = try sha256File(installer_path);
+    if (!std.mem.eql(u8, &expected_digest, &actual_digest)) return error.InstallerChecksumMismatch;
+
+    if (builtin.os.tag == .windows) {
+        try verifyAuthenticodeSignature(installer_path);
+    } else {
+        return error.AuthenticodeRequiresWindows;
+    }
+
+    const sha256_hex = try alloc.dupe(u8, &std.fmt.bytesToHex(actual_digest, .lower));
+    errdefer alloc.free(sha256_hex);
+
+    var state = try loadState(alloc, state_path);
+    defer state.deinit(alloc);
+    replaceOptionalOwned(alloc, &state.staged_version, try alloc.dupe(u8, release.version_text));
+    replaceOptionalOwned(alloc, &state.staged_installer_path, try alloc.dupe(u8, installer_path));
+    replaceOptionalOwned(alloc, &state.staged_sha256, try alloc.dupe(u8, sha256_hex));
+    state.staged_at = std.time.timestamp();
+    try saveState(state_path, &state);
+
+    return .{
+        .version_text = try alloc.dupe(u8, release.version_text),
+        .installer_path = installer_path,
+        .sha256_hex = sha256_hex,
+    };
+}
+
 fn writeOptionalJsonString(writer: *std.Io.Writer, value: ?[]const u8) !void {
     if (value) |text| {
         try writer.writeByte('"');
-        try writer.writeAll(text);
+        for (text) |c| {
+            switch (c) {
+                '\\', '"' => {
+                    try writer.writeByte('\\');
+                    try writer.writeByte(c);
+                },
+                '\n' => try writer.writeAll("\\n"),
+                '\r' => try writer.writeAll("\\r"),
+                '\t' => try writer.writeAll("\\t"),
+                else => try writer.writeByte(c),
+            }
+        }
         try writer.writeByte('"');
         return;
     }
 
     try writer.writeAll("null");
 }
+
+fn replaceOptionalOwned(alloc: Allocator, slot: *?[]u8, value: []u8) void {
+    if (slot.*) |old| alloc.free(old);
+    slot.* = value;
+}
+
+fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !void {
+    const temp_path = try std.fmt.allocPrint(alloc, "{s}.part", .{dest_path});
+    defer alloc.free(temp_path);
+    var committed = false;
+    defer if (!committed) {
+        std.fs.deleteFileAbsolute(temp_path) catch {};
+    };
+    std.fs.deleteFileAbsolute(temp_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+
+    if (std.fs.path.dirname(dest_path)) |dir_path| {
+        try std.fs.cwd().makePath(dir_path);
+    }
+
+    var file = try std.fs.createFileAbsolute(temp_path, .{ .truncate = true });
+    var file_open = true;
+    errdefer if (file_open) file.close();
+
+    var client: std.http.Client = .{ .allocator = alloc };
+    defer client.deinit();
+
+    var file_buf: [64 * 1024]u8 = undefined;
+    var file_writer = file.writer(&file_buf);
+    const result = try client.fetch(.{
+        .location = .{ .url = url },
+        .extra_headers = &.{
+            .{ .name = "accept", .value = "application/octet-stream" },
+            .{ .name = "user-agent", .value = "winghostty-updater" },
+        },
+        .response_writer = &file_writer.interface,
+    });
+    try file_writer.interface.flush();
+    file.close();
+    file_open = false;
+
+    if (result.status != .ok) return error.BadGateway;
+
+    std.fs.deleteFileAbsolute(dest_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+    try std.fs.renameAbsolute(temp_path, dest_path);
+    committed = true;
+}
+
+fn parseExpectedSha256(checksums: []const u8, installer_name: []const u8) ![Sha256.digest_length]u8 {
+    var lines = std.mem.splitScalar(u8, checksums, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+
+        var parts = std.mem.tokenizeAny(u8, line, " \t");
+        const hex = parts.next() orelse continue;
+        const filename_raw = parts.next() orelse continue;
+        const filename = if (filename_raw.len > 0 and filename_raw[0] == '*')
+            filename_raw[1..]
+        else
+            filename_raw;
+
+        if (!std.mem.eql(u8, filename, installer_name)) continue;
+        return parseSha256Hex(hex);
+    }
+
+    return error.InstallerChecksumMissing;
+}
+
+fn parseSha256Hex(hex: []const u8) ![Sha256.digest_length]u8 {
+    if (hex.len != Sha256.digest_length * 2) return error.InvalidChecksum;
+    var digest: [Sha256.digest_length]u8 = undefined;
+    for (&digest, 0..) |*byte, i| {
+        byte.* = (try hexNibble(hex[i * 2]) << 4) | try hexNibble(hex[i * 2 + 1]);
+    }
+    return digest;
+}
+
+fn hexNibble(c: u8) !u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => error.InvalidChecksum,
+    };
+}
+
+fn sha256File(path: []const u8) ![Sha256.digest_length]u8 {
+    var file = try std.fs.openFileAbsolute(path, .{});
+    defer file.close();
+
+    var hasher = Sha256.init(.{});
+    var buf: [64 * 1024]u8 = undefined;
+    while (true) {
+        const len = try file.read(&buf);
+        if (len == 0) break;
+        hasher.update(buf[0..len]);
+    }
+
+    var digest: [Sha256.digest_length]u8 = undefined;
+    hasher.final(&digest);
+    return digest;
+}
+
+fn verifyAuthenticodeSignature(path: []const u8) !void {
+    if (builtin.os.tag != .windows) return error.AuthenticodeRequiresWindows;
+
+    const windows = std.os.windows;
+    const WinVerifyTrustFn = *const fn (?windows.HWND, *windows.GUID, *WinTrustData) callconv(.winapi) i32;
+    const module = try windows.LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("wintrust.dll"));
+    const proc = windows.kernel32.GetProcAddress(module, "WinVerifyTrust") orelse return error.SignatureVerifierUnavailable;
+    const winVerifyTrust: WinVerifyTrustFn = @ptrCast(proc);
+
+    const path_w = try std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, path);
+    defer std.heap.page_allocator.free(path_w);
+
+    var action = windows.GUID.parse("{00AAC56B-CD44-11D0-8CC2-00C04FC295EE}");
+    var file_info: WinTrustFileInfo = .{
+        .cbStruct = @sizeOf(WinTrustFileInfo),
+        .pcwszFilePath = path_w.ptr,
+        .hFile = null,
+        .pgKnownSubject = null,
+    };
+    var data: WinTrustData = .{
+        .cbStruct = @sizeOf(WinTrustData),
+        .pPolicyCallbackData = null,
+        .pSIPClientData = null,
+        .dwUIChoice = WTD_UI_NONE,
+        .fdwRevocationChecks = WTD_REVOKE_NONE,
+        .dwUnionChoice = WTD_CHOICE_FILE,
+        .pFile = &file_info,
+        .dwStateAction = WTD_STATEACTION_IGNORE,
+        .hWVTStateData = null,
+        .pwszURLReference = null,
+        .dwProvFlags = 0,
+        .dwUIContext = 0,
+        .pSignatureSettings = null,
+    };
+
+    if (winVerifyTrust(null, &action, &data) != 0) return error.InvalidAuthenticodeSignature;
+}
+
+const WTD_UI_NONE: u32 = 2;
+const WTD_REVOKE_NONE: u32 = 0;
+const WTD_CHOICE_FILE: u32 = 1;
+const WTD_STATEACTION_IGNORE: u32 = 0;
+
+const WinTrustFileInfo = extern struct {
+    cbStruct: u32,
+    pcwszFilePath: [*:0]const u16,
+    hFile: ?std.os.windows.HANDLE,
+    pgKnownSubject: ?*std.os.windows.GUID,
+};
+
+const WinTrustData = extern struct {
+    cbStruct: u32,
+    pPolicyCallbackData: ?*anyopaque,
+    pSIPClientData: ?*anyopaque,
+    dwUIChoice: u32,
+    fdwRevocationChecks: u32,
+    dwUnionChoice: u32,
+    pFile: *WinTrustFileInfo,
+    dwStateAction: u32,
+    hWVTStateData: ?std.os.windows.HANDLE,
+    pwszURLReference: ?[*:0]const u16,
+    dwProvFlags: u32,
+    dwUIContext: u32,
+    pSignatureSettings: ?*anyopaque,
+};
 
 fn shouldCheckNetwork(last_checked_at: i64, now: i64) bool {
     if (last_checked_at <= 0) return true;
@@ -409,6 +702,60 @@ test "cached update respects dismissal" {
 
     const current = try std.SemanticVersion.parse("1.2.2");
     try std.testing.expect((try cachedAvailableRelease(alloc, &state, current, true)) == null);
+}
+
+test "state persists staged windows install metadata with escaped path" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    const state_path = try std.fs.path.join(alloc, &.{ tmp_path, "winghostty-test", "update-state.json" });
+    defer alloc.free(state_path);
+
+    var state: State = .{
+        .last_checked_at = 123,
+        .last_seen_version = try alloc.dupe(u8, "1.3.100"),
+        .staged_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_installer_path = try alloc.dupe(u8, "C:\\Users\\Aman\\updates\\winghostty-1.3.101-windows-x64-setup.exe"),
+        .staged_sha256 = try alloc.dupe(u8, "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+        .staged_at = 456,
+    };
+    defer state.deinit(alloc);
+
+    try saveState(state_path, &state);
+    var loaded = try loadState(alloc, state_path);
+    defer loaded.deinit(alloc);
+
+    try std.testing.expectEqual(@as(i64, 123), loaded.last_checked_at);
+    try std.testing.expectEqual(@as(i64, 456), loaded.staged_at);
+    try std.testing.expectEqualStrings("1.3.101", loaded.staged_version.?);
+    try std.testing.expectEqualStrings(state.staged_installer_path.?, loaded.staged_installer_path.?);
+    try std.testing.expectEqualStrings(state.staged_sha256.?, loaded.staged_sha256.?);
+}
+
+test "checksum parser accepts sha256 star filename lines" {
+    const digest = try parseExpectedSha256(
+        \\d00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00d *winghostty-1.3.100-windows-x64-setup.exe
+        \\00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff *other.exe
+    ,
+        "winghostty-1.3.100-windows-x64-setup.exe",
+    );
+    try std.testing.expectEqualStrings(
+        "d00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00d",
+        &std.fmt.bytesToHex(digest, .lower),
+    );
+}
+
+test "checksum parser rejects missing installer entry" {
+    try std.testing.expectError(
+        error.InstallerChecksumMissing,
+        parseExpectedSha256(
+            "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff *other.exe",
+            "winghostty-1.3.100-windows-x64-setup.exe",
+        ),
+    );
 }
 
 test "release parser requires signed checksum metadata for windows install candidate" {

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -12,7 +12,6 @@ pub const repo_name = "winghostty";
 pub const latest_stable_api_url = "https://api.github.com/repos/amanthanvi/winghostty/releases/latest";
 pub const releases_url = "https://github.com/amanthanvi/winghostty/releases";
 pub const windows_checksums_asset_name = "SHA256SUMS.txt";
-pub const windows_checksums_signature_asset_name = "SHA256SUMS.txt.sig";
 
 pub const throttle_seconds: i64 = 24 * 60 * 60;
 
@@ -52,13 +51,11 @@ pub const WindowsInstallCandidate = struct {
     installer_name: []u8,
     installer_url: []u8,
     checksums_url: []u8,
-    checksums_signature_url: []u8,
 
     pub fn deinit(self: *WindowsInstallCandidate, alloc: Allocator) void {
         alloc.free(self.installer_name);
         alloc.free(self.installer_url);
         alloc.free(self.checksums_url);
-        alloc.free(self.checksums_signature_url);
         self.* = undefined;
     }
 };
@@ -286,11 +283,8 @@ pub fn stageWindowsInstall(
     errdefer alloc.free(installer_path);
     const checksums_path = try std.fs.path.join(alloc, &.{ stage_dir, windows_checksums_asset_name });
     defer alloc.free(checksums_path);
-    const signature_path = try std.fs.path.join(alloc, &.{ stage_dir, windows_checksums_signature_asset_name });
-    defer alloc.free(signature_path);
 
     try downloadUrlToFile(alloc, candidate.checksums_url, checksums_path);
-    try downloadUrlToFile(alloc, candidate.checksums_signature_url, signature_path);
     try downloadUrlToFile(alloc, candidate.installer_url, installer_path);
 
     const checksums = try std.fs.cwd().readFileAlloc(alloc, checksums_path, 1024 * 1024);
@@ -336,6 +330,9 @@ fn writeOptionalJsonString(writer: *std.Io.Writer, value: ?[]const u8) !void {
                 '\n' => try writer.writeAll("\\n"),
                 '\r' => try writer.writeAll("\\r"),
                 '\t' => try writer.writeAll("\\t"),
+                0x08 => try writer.writeAll("\\b"),
+                0x0C => try writer.writeAll("\\f"),
+                0x00...0x07, 0x0B, 0x0E...0x1F => try writer.print("\\u{x:0>4}", .{c}),
                 else => try writer.writeByte(c),
             }
         }
@@ -415,10 +412,7 @@ fn requireOkHttpStatus(context: []const u8, url: []const u8, status: std.http.St
         .forbidden => error.UpdateHttpForbidden,
         .not_found => error.UpdateHttpNotFound,
         .too_many_requests => error.UpdateHttpRateLimited,
-        else => switch (status.class()) {
-            .server_error => error.BadGateway,
-            else => error.UnexpectedHttpStatus,
-        },
+        else => error.UnexpectedHttpStatus,
     };
 }
 
@@ -504,7 +498,7 @@ fn verifyAuthenticodeSignature(path: []const u8) !void {
         .pPolicyCallbackData = null,
         .pSIPClientData = null,
         .dwUIChoice = WTD_UI_NONE,
-        .fdwRevocationChecks = WTD_REVOKE_NONE,
+        .fdwRevocationChecks = WTD_REVOKE_WHOLECHAIN,
         .dwUnionChoice = WTD_CHOICE_FILE,
         .pFile = &file_info,
         .dwStateAction = WTD_STATEACTION_VERIFY,
@@ -515,17 +509,15 @@ fn verifyAuthenticodeSignature(path: []const u8) !void {
         .pSignatureSettings = null,
     };
     defer {
-        if (data.hWVTStateData != null) {
-            data.dwStateAction = WTD_STATEACTION_CLOSE;
-            _ = winVerifyTrust(null, &action, &data);
-        }
+        data.dwStateAction = WTD_STATEACTION_CLOSE;
+        _ = winVerifyTrust(null, &action, &data);
     }
 
     if (winVerifyTrust(null, &action, &data) != 0) return error.InvalidAuthenticodeSignature;
 }
 
 const WTD_UI_NONE: u32 = 2;
-const WTD_REVOKE_NONE: u32 = 0;
+const WTD_REVOKE_WHOLECHAIN: u32 = 1;
 const WTD_CHOICE_FILE: u32 = 1;
 const WTD_STATEACTION_VERIFY: u32 = 1;
 const WTD_STATEACTION_CLOSE: u32 = 2;
@@ -658,7 +650,6 @@ fn parseWindowsInstallCandidate(
 
     var installer_url: ?[]const u8 = null;
     var checksums_url: ?[]const u8 = null;
-    var checksums_signature_url: ?[]const u8 = null;
 
     for (assets.items) |asset_value| {
         const asset = switch (asset_value) {
@@ -683,12 +674,9 @@ fn parseWindowsInstallCandidate(
             checksums_url = browser_download_url;
             continue;
         }
-        if (std.mem.eql(u8, name, windows_checksums_signature_asset_name)) {
-            checksums_signature_url = browser_download_url;
-        }
     }
 
-    if (installer_url == null or checksums_url == null or checksums_signature_url == null) {
+    if (installer_url == null or checksums_url == null) {
         alloc.free(expected_installer_name);
         return null;
     }
@@ -697,14 +685,11 @@ fn parseWindowsInstallCandidate(
     errdefer alloc.free(owned_installer_url);
     const owned_checksums_url = try alloc.dupe(u8, checksums_url.?);
     errdefer alloc.free(owned_checksums_url);
-    const owned_checksums_signature_url = try alloc.dupe(u8, checksums_signature_url.?);
-    errdefer alloc.free(owned_checksums_signature_url);
 
     return .{
         .installer_name = expected_installer_name,
         .installer_url = owned_installer_url,
         .checksums_url = owned_checksums_url,
-        .checksums_signature_url = owned_checksums_signature_url,
     };
 }
 
@@ -770,6 +755,36 @@ test "state persists staged windows install metadata with escaped path" {
     try std.testing.expectEqualStrings(state.staged_sha256.?, loaded.staged_sha256.?);
 }
 
+test "state JSON writer escapes ASCII control characters" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    const state_path = try std.fs.path.join(alloc, &.{ tmp_path, "winghostty-test", "update-state.json" });
+    defer alloc.free(state_path);
+
+    var state: State = .{
+        .last_seen_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_installer_path = try alloc.dupe(u8, "a\x00b\x08c\x0Bd\x0Ce\x1Ff"),
+    };
+    defer state.deinit(alloc);
+
+    try saveState(state_path, &state);
+    const contents = try std.fs.cwd().readFileAlloc(alloc, state_path, 16 * 1024);
+    defer alloc.free(contents);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\\u0000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\\b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\\u000b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\\f") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\\u001f") != null);
+
+    var loaded = try loadState(alloc, state_path);
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings(state.staged_installer_path.?, loaded.staged_installer_path.?);
+}
+
 test "checksum parser accepts sha256 star filename lines" {
     const digest = try parseExpectedSha256(
         \\d00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00dd00df00d *winghostty-1.3.100-windows-x64-setup.exe
@@ -812,7 +827,7 @@ test "http status mapping distinguishes update response failures" {
         requireOkHttpStatus("test", "https://example.invalid/rate-limit", .too_many_requests),
     );
     try std.testing.expectError(
-        error.BadGateway,
+        error.UnexpectedHttpStatus,
         requireOkHttpStatus("test", "https://example.invalid/server-error", .service_unavailable),
     );
     try std.testing.expectError(
@@ -830,7 +845,6 @@ test "windows install staging rejects relative state path before download" {
             .installer_name = try alloc.dupe(u8, "winghostty-1.3.100-windows-x64-setup.exe"),
             .installer_url = try alloc.dupe(u8, "https://example.invalid/winghostty-1.3.100-windows-x64-setup.exe"),
             .checksums_url = try alloc.dupe(u8, "https://example.invalid/SHA256SUMS.txt"),
-            .checksums_signature_url = try alloc.dupe(u8, "https://example.invalid/SHA256SUMS.txt.sig"),
         },
     };
     defer release.deinit(alloc);
@@ -841,7 +855,7 @@ test "windows install staging rejects relative state path before download" {
     );
 }
 
-test "release parser requires signed checksum metadata for windows install candidate" {
+test "release parser accepts checksum metadata without detached signature" {
     const alloc = std.testing.allocator;
     const body =
         \\{
@@ -863,10 +877,10 @@ test "release parser requires signed checksum metadata for windows install candi
     var release = try parseLatestStableReleaseResponse(alloc, body);
     defer release.deinit(alloc);
 
-    try std.testing.expect(release.windows_install == null);
+    try std.testing.expect(release.windows_install != null);
 }
 
-test "release parser selects windows install candidate when signed checksum metadata is present" {
+test "release parser selects windows install candidate when checksum metadata is present" {
     const alloc = std.testing.allocator;
     const body =
         \\{
@@ -880,10 +894,6 @@ test "release parser selects windows install candidate when signed checksum meta
         \\    {
         \\      "name": "SHA256SUMS.txt",
         \\      "browser_download_url": "https://example.invalid/SHA256SUMS.txt"
-        \\    },
-        \\    {
-        \\      "name": "SHA256SUMS.txt.sig",
-        \\      "browser_download_url": "https://example.invalid/SHA256SUMS.txt.sig"
         \\    }
         \\  ]
         \\}
@@ -905,10 +915,6 @@ test "release parser selects windows install candidate when signed checksum meta
     try std.testing.expectEqualStrings(
         "https://example.invalid/SHA256SUMS.txt",
         windows_install.checksums_url,
-    );
-    try std.testing.expectEqualStrings(
-        "https://example.invalid/SHA256SUMS.txt.sig",
-        windows_install.checksums_signature_url,
     );
 }
 
@@ -942,10 +948,6 @@ test "release parser accepts long semver tags for windows install candidate" {
         \\    {{
         \\      "name": "SHA256SUMS.txt",
         \\      "browser_download_url": "https://example.invalid/SHA256SUMS.txt"
-        \\    }},
-        \\    {{
-        \\      "name": "SHA256SUMS.txt.sig",
-        \\      "browser_download_url": "https://example.invalid/SHA256SUMS.txt.sig"
         \\    }}
         \\  ]
         \\}}

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -5,6 +5,7 @@ const internal_os = @import("../os/main.zig");
 
 const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
+const log = std.log.scoped(.update_github_releases);
 
 pub const repo_owner = "amanthanvi";
 pub const repo_name = "winghostty";
@@ -274,6 +275,7 @@ pub fn stageWindowsInstall(
     release: *const Release,
 ) !StagedWindowsInstall {
     const candidate = release.windows_install orelse return error.WindowsInstallNotEligible;
+    if (!std.fs.path.isAbsolute(state_path)) return error.InvalidStatePath;
 
     const state_dir = std.fs.path.dirname(state_path) orelse return error.InvalidStatePath;
     const stage_dir = try std.fs.path.join(alloc, &.{ state_dir, "updates", release.version_text });
@@ -350,6 +352,8 @@ fn replaceOptionalOwned(alloc: Allocator, slot: *?[]u8, value: []u8) void {
 }
 
 fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !void {
+    if (!std.fs.path.isAbsolute(dest_path)) return error.InvalidDownloadPath;
+
     const temp_path = try std.fmt.allocPrint(alloc, "{s}.part", .{dest_path});
     defer alloc.free(temp_path);
     var committed = false;
@@ -386,7 +390,7 @@ fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !
     file.close();
     file_open = false;
 
-    if (result.status != .ok) return error.BadGateway;
+    try requireOkHttpStatus("download", url, result.status);
 
     std.fs.deleteFileAbsolute(dest_path) catch |err| switch (err) {
         error.FileNotFound => {},
@@ -394,6 +398,28 @@ fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !
     };
     try std.fs.renameAbsolute(temp_path, dest_path);
     committed = true;
+}
+
+fn requireOkHttpStatus(context: []const u8, url: []const u8, status: std.http.Status) !void {
+    if (status == .ok) return;
+
+    log.warn("{s} HTTP request failed status={} phrase={s} url={s}", .{
+        context,
+        @intFromEnum(status),
+        status.phrase() orelse "unknown",
+        url,
+    });
+
+    return switch (status) {
+        .unauthorized => error.UpdateHttpUnauthorized,
+        .forbidden => error.UpdateHttpForbidden,
+        .not_found => error.UpdateHttpNotFound,
+        .too_many_requests => error.UpdateHttpRateLimited,
+        else => switch (status.class()) {
+            .server_error => error.BadGateway,
+            else => error.UnexpectedHttpStatus,
+        },
+    };
 }
 
 fn parseExpectedSha256(checksums: []const u8, installer_name: []const u8) ![Sha256.digest_length]u8 {
@@ -458,6 +484,8 @@ fn verifyAuthenticodeSignature(path: []const u8) !void {
     const windows = std.os.windows;
     const WinVerifyTrustFn = *const fn (?windows.HWND, *windows.GUID, *WinTrustData) callconv(.winapi) i32;
     const module = try windows.LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("wintrust.dll"));
+    defer windows.FreeLibrary(module);
+
     const proc = windows.kernel32.GetProcAddress(module, "WinVerifyTrust") orelse return error.SignatureVerifierUnavailable;
     const winVerifyTrust: WinVerifyTrustFn = @ptrCast(proc);
 
@@ -479,13 +507,19 @@ fn verifyAuthenticodeSignature(path: []const u8) !void {
         .fdwRevocationChecks = WTD_REVOKE_NONE,
         .dwUnionChoice = WTD_CHOICE_FILE,
         .pFile = &file_info,
-        .dwStateAction = WTD_STATEACTION_IGNORE,
+        .dwStateAction = WTD_STATEACTION_VERIFY,
         .hWVTStateData = null,
         .pwszURLReference = null,
         .dwProvFlags = 0,
         .dwUIContext = 0,
         .pSignatureSettings = null,
     };
+    defer {
+        if (data.hWVTStateData != null) {
+            data.dwStateAction = WTD_STATEACTION_CLOSE;
+            _ = winVerifyTrust(null, &action, &data);
+        }
+    }
 
     if (winVerifyTrust(null, &action, &data) != 0) return error.InvalidAuthenticodeSignature;
 }
@@ -493,7 +527,8 @@ fn verifyAuthenticodeSignature(path: []const u8) !void {
 const WTD_UI_NONE: u32 = 2;
 const WTD_REVOKE_NONE: u32 = 0;
 const WTD_CHOICE_FILE: u32 = 1;
-const WTD_STATEACTION_IGNORE: u32 = 0;
+const WTD_STATEACTION_VERIFY: u32 = 1;
+const WTD_STATEACTION_CLOSE: u32 = 2;
 
 const WinTrustFileInfo = extern struct {
     cbStruct: u32,
@@ -564,7 +599,7 @@ fn fetchLatestStableRelease(alloc: Allocator) !Release {
         .response_writer = &response_buf.writer,
     });
 
-    if (result.status != .ok) return error.BadGateway;
+    try requireOkHttpStatus("release metadata", latest_stable_api_url, result.status);
 
     const body = try response_buf.toOwnedSlice();
     defer alloc.free(body);
@@ -755,6 +790,54 @@ test "checksum parser rejects missing installer entry" {
             "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff *other.exe",
             "winghostty-1.3.100-windows-x64-setup.exe",
         ),
+    );
+}
+
+test "http status mapping distinguishes update response failures" {
+    try requireOkHttpStatus("test", "https://example.invalid/ok", .ok);
+    try std.testing.expectError(
+        error.UpdateHttpUnauthorized,
+        requireOkHttpStatus("test", "https://example.invalid/unauthorized", .unauthorized),
+    );
+    try std.testing.expectError(
+        error.UpdateHttpForbidden,
+        requireOkHttpStatus("test", "https://example.invalid/forbidden", .forbidden),
+    );
+    try std.testing.expectError(
+        error.UpdateHttpNotFound,
+        requireOkHttpStatus("test", "https://example.invalid/not-found", .not_found),
+    );
+    try std.testing.expectError(
+        error.UpdateHttpRateLimited,
+        requireOkHttpStatus("test", "https://example.invalid/rate-limit", .too_many_requests),
+    );
+    try std.testing.expectError(
+        error.BadGateway,
+        requireOkHttpStatus("test", "https://example.invalid/server-error", .service_unavailable),
+    );
+    try std.testing.expectError(
+        error.UnexpectedHttpStatus,
+        requireOkHttpStatus("test", "https://example.invalid/client-error", .bad_request),
+    );
+}
+
+test "windows install staging rejects relative state path before download" {
+    const alloc = std.testing.allocator;
+    var release: Release = .{
+        .version_text = try alloc.dupe(u8, "1.3.100"),
+        .release_url = try alloc.dupe(u8, "https://example.invalid/release"),
+        .windows_install = .{
+            .installer_name = try alloc.dupe(u8, "winghostty-1.3.100-windows-x64-setup.exe"),
+            .installer_url = try alloc.dupe(u8, "https://example.invalid/winghostty-1.3.100-windows-x64-setup.exe"),
+            .checksums_url = try alloc.dupe(u8, "https://example.invalid/SHA256SUMS.txt"),
+            .checksums_signature_url = try alloc.dupe(u8, "https://example.invalid/SHA256SUMS.txt.sig"),
+        },
+    };
+    defer release.deinit(alloc);
+
+    try std.testing.expectError(
+        error.InvalidStatePath,
+        stageWindowsInstall(alloc, "relative-update-state.json", &release),
     );
 }
 


### PR DESCRIPTION
## Summary
- implements staged `auto-update = download` for Windows installer releases
- requires installer, `SHA256SUMS.txt`, and `SHA256SUMS.txt.sig` assets
- verifies installer SHA-256 and requires trusted Authenticode via `WinVerifyTrust`
- records staged update metadata without silent install/apply
- updates docs/status/capability matrix

## Validation
- `zig build test -Dtest-filter=updater`
- `zig build test -Dtest-filter=checksum`
- `zig build test -Dtest-filter=staged`
- `zig build`
- `git diff --check`

Review loop: @codex @coderabbitai @greptileai @Copilot please review. I will iterate on findings until this is clean to squash and merge.

## Summary by Sourcery

Add support for staging signed Windows installer updates when auto-update is set to download, including checksum and Authenticode verification and persisted metadata, and update UI messaging and docs to reflect the new behavior.

New Features:
- Introduce staged Windows installer downloads that verify SHA-256 checksums and Authenticode signatures before recording them for later manual installation.
- Expose staged update status in the Windows UI, including distinct messaging when an update has been downloaded and verified.

Enhancements:
- Extend updater state persistence to track staged installer metadata and ensure JSON string fields are safely escaped.
- Improve HTTP download robustness for updater assets with temporary file handling and explicit error reporting.
- Clarify configuration, status, and Windows capability documentation to describe the staged download behavior and limitations of auto-update on Windows.

Tests:
- Add tests for persisting and reloading staged update metadata, including Windows-style paths with escape characters.
- Add tests for parsing SHA256SUMS entries, including star-prefixed filenames and missing installer entries.