### PR TITLE
docs: refresh Windows capability parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ winghostty is a young, single-maintainer fork. First fork commit: 2026-04-06.
 First public releases: 2026-04-16.
 
 - **Supported platform:** Windows 10 and Windows 11 on x64.
-- **Releases:** unsigned installer + portable ZIP. Windows SmartScreen will
+- **Releases:** unsigned installer + portable ZIP. Windows SmartScreen may
   warn on first run; that is expected until code signing lands.
 - **Feedback:** use
   [Discussions](https://github.com/amanthanvi/winghostty/discussions) for
@@ -80,7 +80,10 @@ First public releases: 2026-04-16.
   available as a plain fallback shell without automatic shell integration.
 - Windows-aware shell selection: PowerShell, `cmd`, Git Bash, opt-in WSL.
 - In-app profile picker that auto-detects installed shells.
-- GitHub Releases updater, notify-only, gated to one check per 24 hours.
+- Session restore for practical window shape: windows, tabs, splits, profiles,
+  working directories, and explicit titles.
+- GitHub Releases updater with check and verified-download modes, gated to one
+  check per 24 hours. Update installation remains manual.
 - High-contrast (HC) mode detection and palette switching.
 - `libghostty-vt` as a retained Zig / C library deliverable.
 
@@ -92,16 +95,16 @@ official Ghostty docs, see
 ## Install
 
 Latest stable release:
-**[winghostty 1.3.109](https://github.com/amanthanvi/winghostty/releases/tag/v1.3.109)**,
-published 2026-05-01.
+**[winghostty 1.3.110](https://github.com/amanthanvi/winghostty/releases/tag/v1.3.110)**,
+published 2026-05-09.
 
 Download directly from **[Releases](https://github.com/amanthanvi/winghostty/releases)**:
 
 | File | Use when |
 | --- | --- |
-| [`winghostty-1.3.109-windows-x64-setup.exe`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/winghostty-1.3.109-windows-x64-setup.exe) | You want a normal install with a Start menu entry. |
-| [`winghostty-1.3.109-windows-x64-portable.zip`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/winghostty-1.3.109-windows-x64-portable.zip) | You want to run without installing. |
-| [`SHA256SUMS.txt`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.109/SHA256SUMS.txt) | Verifying downloads. |
+| [`winghostty-1.3.110-windows-x64-setup.exe`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.110/winghostty-1.3.110-windows-x64-setup.exe) | You want a normal install with a Start menu entry. |
+| [`winghostty-1.3.110-windows-x64-portable.zip`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.110/winghostty-1.3.110-windows-x64-portable.zip) | You want to run without installing. |
+| [`SHA256SUMS.txt`](https://github.com/amanthanvi/winghostty/releases/download/v1.3.110/SHA256SUMS.txt) | Verifying downloads. |
 
 Scoop users can install from the fork-owned bucket:
 
@@ -186,9 +189,11 @@ auto-update = check
 ```
 
 The updater checks `api.github.com/repos/amanthanvi/winghostty/releases/latest`
-at most once every 24 hours. It is **notify-only**: it opens the release
-page if a newer stable version exists and never replaces binaries silently.
-`auto-update = download` currently behaves the same as `check`.
+at most once every 24 hours. `auto-update = check` opens the release page if a
+newer stable version exists and never replaces binaries silently.
+`auto-update = download` downloads only eligible stable Windows installer
+releases, verifies `SHA256SUMS.txt` plus Authenticode, and stages the installer
+locally. Applying the staged installer is still manual.
 
 ## Crash reports
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ First public releases: 2026-04-16.
 - **Supported platform:** Windows 10 and Windows 11 on x64.
 - **Releases:** unsigned installer + portable ZIP. Windows SmartScreen may
   warn on first run; that is expected until code signing lands.
+  Unsigned installers are not eligible for `auto-update = download` staging
+  because staging requires a valid Authenticode signature.
 - **Feedback:** use
   [Discussions](https://github.com/amanthanvi/winghostty/discussions) for
   questions. GitHub Issues are reserved for reproducible bugs.
@@ -193,7 +195,8 @@ at most once every 24 hours. `auto-update = check` opens the release page if a
 newer stable version exists and never replaces binaries silently.
 `auto-update = download` downloads only eligible stable Windows installer
 releases, verifies `SHA256SUMS.txt` plus Authenticode, and stages the installer
-locally. Applying the staged installer is still manual.
+locally. Unsigned installers fail that verification and are not staged.
+Applying the staged installer is still manual.
 
 ## Crash reports
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -3,7 +3,7 @@
 What currently works in winghostty, what is experimental, and what is out of
 scope. When this page disagrees with a commit message, trust this page.
 
-Last updated: 2026-05-01, against current fork HEAD.
+Last updated: 2026-05-09, against current fork HEAD.
 
 For a row-by-row mapping against official Ghostty docs, see
 [windows-capability-matrix.md](windows-capability-matrix.md).
@@ -47,6 +47,10 @@ For a row-by-row mapping against official Ghostty docs, see
 - IME for CJK and other composed input (`ImmGetContext`)
 - Drag-and-drop of files into the terminal (`WM_DROPFILES` +
   `DragAcceptFiles`)
+- Window/session shape restore via `window-save-state`: host windows, tabs,
+  splits, selected profiles, working directories, and explicit titles are
+  persisted under `%LOCALAPPDATA%\winghostty\session-state.json`. Terminal
+  contents and child process state are not restored.
 - Windows-convention default keybindings (see
   `src/config/Config.zig` for the full set)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -98,7 +98,7 @@ extractions will land as they stabilize.
 
 ## Known caveats
 
-- **Unsigned installer.** Windows SmartScreen warns on first install.
+- **Unsigned installer.** Windows SmartScreen may warn on first install.
   Click *More info* → *Run anyway*. Code signing is a planned packaging
   step; no ETA.
 - **Issues disabled for usage questions.** GitHub Issues on this repo

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -4,7 +4,7 @@ Maps current official Ghostty docs surfaces to winghostty behavior on
 Windows. Keep this short. Update rows when Windows behavior changes or when
 upstream docs add or remove a surface that this fork cares about.
 
-Last reviewed: 2026-05-01.
+Last reviewed: 2026-05-09.
 
 ## Status legend
 
@@ -34,6 +34,7 @@ Last reviewed: 2026-05-01.
 | [Shell integration](https://ghostty.org/docs/features/shell-integration) | Upstream docs for automatic `bash` / `elvish` / `fish` / `nushell` / `zsh` injection still apply when those shells are launched on Windows. winghostty additionally supports automatic PowerShell injection (`powershell.exe`, `pwsh.exe`) plus a manual fallback under `%LOCALAPPDATA%\winghostty\shell-integration\powershell\integration.ps1`. PowerShell emits OSC 7 cwd URIs, OSC 133 prompt marks, command-finish status, and PSReadLine command metadata when available. `cmd.exe` remains a plain fallback shell without automatic shell integration. |
 | [Action reference](https://ghostty.org/docs/config/keybind/reference) | Shared action grammar is intact, but upstream docs still mix shared actions with macOS/Linux-specific behavior. For Windows-specific truth on a disputed action, prefer `winghostty +show-config --default --docs` plus the current defaults from `+list-keybinds`. |
 | [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and update prompts backed by GitHub Releases. `download` can stage signed, checksum-matching installer releases, but install/apply remains manual. |
+| [Configuration: `window-save-state`](https://ghostty.org/docs/config/reference) | Windows persists practical session shape under `%LOCALAPPDATA%\winghostty\session-state.json`: host windows, tabs, splits, selected profiles, working directories, and explicit titles. Terminal contents and child process state are not restored. |
 | [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |
 
 ## No-op Compatibility


### PR DESCRIPTION
Summary:
- Refreshes Windows docs for v1.3.110, verified update staging, and session restore parity.
- Updates capability matrix/status docs from current origin/main behavior.

Validation:
- git diff --check passed
- stale-string rg checks passed
- prettier unavailable on PATH

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Refresh Windows documentation to reflect v1.3.110 behavior and updated auto-update/session restore capabilities.

New Features:
- Document Windows session restore support for window, tab, split, profile, working-directory, and title shape persistence.

Enhancements:
- Clarify Windows SmartScreen behavior and updater modes in the README and config docs.
- Update versioned download links and dates in the README to point to the v1.3.110 release.
- Extend the Windows capability matrix and status docs with the new `window-save-state` behavior and latest review date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to latest stable release (v1.3.110)
  * Documented window/session state restoration capability, detailing persistence of windows, tabs, splits, profile selections, and working directories
  * Clarified SmartScreen warning behavior and verified-download mode
  * Distinguished auto-update configuration options (notification vs. staged download)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amanthanvi/winghostty/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->