### PR TITLE
feat(win32): support all-screen quick terminal placement

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -14577,8 +14577,14 @@ fn primaryMonitor() ?*anyopaque {
 
 const AllMonitorsSearch = struct {
     found: bool = false,
+    failed: bool = false,
     info: win32_quick_terminal.MonitorInfo = undefined,
 };
+
+fn isVisibleMonitorInfo(info: win32_quick_terminal.MonitorInfo) bool {
+    return info.full_rect.width() > 0 and info.full_rect.height() > 0 and
+        info.work_area.width() > 0 and info.work_area.height() > 0;
+}
 
 fn allMonitorsEnumProc(
     monitor: ?*anyopaque,
@@ -14587,7 +14593,11 @@ fn allMonitorsEnumProc(
     data: LPARAM,
 ) callconv(.winapi) BOOL {
     const search: *AllMonitorsSearch = @ptrFromInt(@as(usize, @bitCast(data)));
-    const info = monitorInfo(monitor) orelse return 1;
+    const info = monitorInfo(monitor) orelse {
+        search.failed = true;
+        return 0;
+    };
+    if (!isVisibleMonitorInfo(info)) return 1;
     if (!search.found) {
         search.info = info;
         search.found = true;
@@ -14606,6 +14616,7 @@ fn allMonitorsInfo() ?win32_quick_terminal.MonitorInfo {
         allMonitorsEnumProc,
         @as(LPARAM, @bitCast(@intFromPtr(&search))),
     ) == 0) return null;
+    if (search.failed) return null;
     if (!search.found) return null;
     return search.info;
 }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -14594,6 +14594,7 @@ fn allMonitorsEnumProc(
 ) callconv(.winapi) BOOL {
     const search: *AllMonitorsSearch = @ptrFromInt(@as(usize, @bitCast(data)));
     const info = monitorInfo(monitor) orelse {
+        log.warn("quick-terminal-screen=all: failed to query monitor info", .{});
         search.failed = true;
         return 0;
     };

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -5763,6 +5763,7 @@ pub const App = struct {
                 // pick the monitor containing the current input focus /
                 // cursor. Matches the documented config intent.
                 .mouse => .focused,
+                .all => .all,
             },
             .animation_duration_s = self.config.@"quick-terminal-animation-duration",
             .autohide = self.config.@"quick-terminal-autohide",
@@ -5786,44 +5787,25 @@ pub const App = struct {
         //   * `.focused` (config's `mouse`) → the monitor under
         //                 the cursor via `GetCursorPos` +
         //                 `MonitorFromPoint(MONITOR_DEFAULTTONEAREST)`.
-        //   * `.all`    → caller's current monitor; the current path
-        //                 does not span the virtual desktop.
-        const monitor = switch (qt_cfg.screen) {
+        //   * `.all`    → the union of all connected monitors' work
+        //                 areas, matching the full virtual desktop.
+        const mi = switch (qt_cfg.screen) {
             .focused => blk: {
                 var pt: POINT = .{ .x = 0, .y = 0 };
                 if (GetCursorPos(&pt) == 0) {
-                    break :blk MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) orelse
+                    const monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) orelse
                         return error.MonitorLookupFailed;
+                    break :blk monitorInfo(monitor) orelse return error.MonitorInfoFailed;
                 }
-                break :blk MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST) orelse
+                const monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST) orelse
                     return error.MonitorLookupFailed;
+                break :blk monitorInfo(monitor) orelse return error.MonitorInfoFailed;
             },
-            .main => primaryMonitor() orelse
-                return error.MonitorLookupFailed,
-            .all => MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) orelse
-                return error.MonitorLookupFailed,
-        };
-        var info: MONITORINFO = .{
-            .cbSize = @sizeOf(MONITORINFO),
-            .rcMonitor = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
-            .rcWork = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
-            .dwFlags = 0,
-        };
-        if (GetMonitorInfoW(monitor, &info) == 0) return error.MonitorInfoFailed;
-
-        const mi = win32_quick_terminal.MonitorInfo{
-            .work_area = .{
-                .left = info.rcWork.left,
-                .top = info.rcWork.top,
-                .right = info.rcWork.right,
-                .bottom = info.rcWork.bottom,
+            .main => blk: {
+                const monitor = primaryMonitor() orelse return error.MonitorLookupFailed;
+                break :blk monitorInfo(monitor) orelse return error.MonitorInfoFailed;
             },
-            .full_rect = .{
-                .left = info.rcMonitor.left,
-                .top = info.rcMonitor.top,
-                .right = info.rcMonitor.right,
-                .bottom = info.rcMonitor.bottom,
-            },
+            .all => allMonitorsInfo() orelse return error.MonitorLookupFailed,
         };
         const dims: configpkg.Config.QuickTerminalSize.Dimensions = .{
             .width = @intCast(@max(1, mi.work_area.width())),
@@ -14534,6 +14516,31 @@ fn rectEqual(a: RECT, b: RECT) bool {
         a.bottom == b.bottom;
 }
 
+fn monitorInfo(monitor: ?*anyopaque) ?win32_quick_terminal.MonitorInfo {
+    var info: MONITORINFO = .{
+        .cbSize = @sizeOf(MONITORINFO),
+        .rcMonitor = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
+        .rcWork = .{ .left = 0, .top = 0, .right = 0, .bottom = 0 },
+        .dwFlags = 0,
+    };
+    if (GetMonitorInfoW(monitor, &info) == 0) return null;
+
+    return .{
+        .work_area = .{
+            .left = info.rcWork.left,
+            .top = info.rcWork.top,
+            .right = info.rcWork.right,
+            .bottom = info.rcWork.bottom,
+        },
+        .full_rect = .{
+            .left = info.rcMonitor.left,
+            .top = info.rcMonitor.top,
+            .right = info.rcMonitor.right,
+            .bottom = info.rcMonitor.bottom,
+        },
+    };
+}
+
 const PrimaryMonitorSearch = struct {
     found: ?*anyopaque = null,
 };
@@ -14566,6 +14573,41 @@ fn primaryMonitor() ?*anyopaque {
         @as(LPARAM, @bitCast(@intFromPtr(&search))),
     );
     return search.found orelse MonitorFromPoint(.{ .x = 0, .y = 0 }, MONITOR_DEFAULTTOPRIMARY);
+}
+
+const AllMonitorsSearch = struct {
+    found: bool = false,
+    info: win32_quick_terminal.MonitorInfo = undefined,
+};
+
+fn allMonitorsEnumProc(
+    monitor: ?*anyopaque,
+    _: HDC,
+    _: *RECT,
+    data: LPARAM,
+) callconv(.winapi) BOOL {
+    const search: *AllMonitorsSearch = @ptrFromInt(@as(usize, @bitCast(data)));
+    const info = monitorInfo(monitor) orelse return 1;
+    if (!search.found) {
+        search.info = info;
+        search.found = true;
+        return 1;
+    }
+    const monitors = [_]win32_quick_terminal.MonitorInfo{ search.info, info };
+    search.info = win32_quick_terminal.unionMonitors(&monitors);
+    return 1;
+}
+
+fn allMonitorsInfo() ?win32_quick_terminal.MonitorInfo {
+    var search: AllMonitorsSearch = .{};
+    if (EnumDisplayMonitors(
+        null,
+        null,
+        allMonitorsEnumProc,
+        @as(LPARAM, @bitCast(@intFromPtr(&search))),
+    ) == 0) return null;
+    if (!search.found) return null;
+    return search.info;
 }
 
 // Keep helper modules reachable from the exe's module graph. Zig prunes

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2617,7 +2617,7 @@ keybind: Keybinds = .{},
 ///
 ///  * `mouse` - The screen that the mouse is currently hovered over.
 ///
-///  * `all` - The full virtual desktop spanning all connected screens.
+///  * `all` - The combined work area spanning all connected screens.
 ///
 /// The default value is `main`.
 @"quick-terminal-screen": QuickTerminalScreen = .main,
@@ -9933,6 +9933,7 @@ test "quick-terminal-screen accepts all" {
         "--quick-terminal-screen=all",
     } };
     try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
 
     try testing.expectEqual(QuickTerminalScreen.all, cfg.@"quick-terminal-screen");
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2617,17 +2617,14 @@ keybind: Keybinds = .{},
 ///
 ///  * `mouse` - The screen that the mouse is currently hovered over.
 ///
+///  * `all` - The full virtual desktop spanning all connected screens.
+///
 /// The default value is `main`.
 @"quick-terminal-screen": QuickTerminalScreen = .main,
 
 /// Duration (in seconds) of the quick terminal enter and exit animation.
 /// Set it to 0 to disable animation completely. This can be changed at
 /// runtime.
-///
-/// Retained compatibility setting from platform-specific quick terminal
-/// behavior.
-///
-/// This currently has no effect in the Windows-only fork.
 @"quick-terminal-animation-duration": f64 = 0.2,
 
 /// Automatically hide the quick terminal when focus shifts to another window.
@@ -2682,7 +2679,9 @@ keybind: Keybinds = .{},
 /// Retained compatibility setting from platform-specific quick terminal
 /// behavior.
 ///
-/// This currently has no effect in the Windows-only fork.
+/// On Windows, `none` shows the quick terminal without activating it,
+/// `on-demand` activates it, and `exclusive` falls back to activated
+/// focused input because global keyboard capture is unsupported.
 @"quick-terminal-keyboard-interactivity": QuickTerminalKeyboardInteractivity = .@"on-demand",
 
 /// Whether to enable shell integration auto-injection or not. Shell integration
@@ -8998,6 +8997,7 @@ pub const QuickTerminalSize = struct {
 pub const QuickTerminalScreen = enum {
     main,
     mouse,
+    all,
 };
 
 // See quick-terminal-space-behavior
@@ -9921,6 +9921,20 @@ test "clone preserves conditional set" {
     defer clone1.deinit();
 
     try testing.expect(clone1._conditional_set.contains(.theme));
+}
+
+test "quick-terminal-screen accepts all" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    var it: TestIterator = .{ .data = &.{
+        "--quick-terminal-screen=all",
+    } };
+    try cfg.loadIter(alloc, &it);
+
+    try testing.expectEqual(QuickTerminalScreen.all, cfg.@"quick-terminal-screen");
 }
 
 test "working-directory expands tilde" {


### PR DESCRIPTION
Summary:
- Adds Win32 support for quick-terminal-screen=all using the union of connected monitor areas.
- Documents current Windows quick-terminal screen/animation behavior.

Validation:
- zig build test -Dtest-filter=quick passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Add Windows support for placing the quick terminal across the full virtual desktop spanning all monitors and centralize monitor info handling.

New Features:
- Allow the quick terminal screen setting to target the full virtual desktop across all connected monitors on Windows.

Enhancements:
- Refactor Windows monitor selection to share a common monitor info helper and aggregate info across multiple monitors when needed.
- Clarify configuration documentation for quick terminal screen options and keyboard interactivity semantics on Windows.

Tests:
- Add a configuration test ensuring the quick-terminal-screen option correctly accepts the all value.