### PR TITLE
feat(win32): expose native inspector in command palette

### DIFF
--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -549,7 +549,11 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Toggle the inspector.",
         }},
 
-        .show_gtk_inspector => comptime &.{},
+        .show_gtk_inspector => comptime &.{.{
+            .action = .show_gtk_inspector,
+            .title = "Show Native Inspector",
+            .description = "Open the native Win32 terminal inspector.",
+        }},
 
         .show_on_screen_keyboard => comptime &.{.{
             .action = .show_on_screen_keyboard,
@@ -732,4 +736,14 @@ test "command defaults" {
     const testing = std.testing;
     try testing.expect(defaults.len > 0);
     try testing.expectEqual(defaults.len, defaultsC.len);
+}
+
+test "command defaults expose Win32 inspector alias" {
+    for (defaults) |cmd| {
+        if (cmd.action == .show_gtk_inspector) {
+            try std.testing.expectEqualStrings("Show Native Inspector", cmd.title);
+            return;
+        }
+    }
+    return error.MissingWin32InspectorCommand;
 }


### PR DESCRIPTION
Summary:
- Adds the existing Win32 inspector action to the default command catalog as Show Native Inspector.
- Adds catalog coverage so it remains discoverable.

Validation:
- zig build test -Dtest-filter='Win32 inspector alias' passed
- zig build test -Dtest-filter=rankedForQuery passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Expose the existing Win32/native inspector action through the default command catalog and ensure it is discoverable via the command palette.

New Features:
- Add a default command catalog entry for the native inspector action under the title "Show Native Inspector".

Tests:
- Add a test verifying that the command defaults include the Win32 inspector alias with the expected title.