### PR TITLE
feat(win32): document keybinding discovery in settings

### DIFF
--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -21,6 +21,7 @@
 const std = @import("std");
 const windows = std.os.windows;
 const Config = @import("../config/Config.zig");
+const cli_help = @import("../cli/help.zig");
 const win32_types = @import("win32_types.zig");
 
 /// Minimal set of Win32 aliases + externs we need here. Shared ABI structs
@@ -187,10 +188,8 @@ const AppNotificationField = enum { clipboard, config };
 
 fn keybindingsHelpText() []const u8 {
     return "Useful commands:\n" ++
-        "  winghostty +list-keybinds --default\n" ++
-        "  winghostty +list-keybinds --docs\n" ++
-        "  winghostty +list-actions --docs\n" ++
-        "  winghostty +explain-config --keybind=<action>\n\n" ++
+        cli_help.keybinding_discovery_hint ++
+        "\n" ++
         "Config syntax:\n" ++
         "  keybind = ctrl+shift+c=copy_to_clipboard\n" ++
         "  keybind = ctrl+a>n=new_window\n" ++
@@ -1839,6 +1838,7 @@ fn recoverOwner(hwnd: HWND) ?*SettingsWindow {
 const DT_LEFT: UINT = 0x0;
 const DT_WORDBREAK: UINT = 0x10;
 const DT_TOP: UINT = 0x0;
+const DT_CALCRECT: UINT = 0x400;
 
 fn paint(hwnd: HWND, owner: *SettingsWindow) void {
     var ps: PAINTSTRUCT = undefined;
@@ -1978,9 +1978,11 @@ fn drawLabel(hdc: ?*anyopaque, x: i32, y: i32, right: i32, text: []const u8) voi
 }
 
 fn drawHelpBlock(hdc: ?*anyopaque, x: i32, y: i32, right: i32, text: []const u8) void {
-    var buf: [512]u16 = undefined;
+    var buf: [1024]u16 = undefined;
     const w = utf8ToW(&buf, text);
-    var rect: RECT = .{ .left = x, .top = y, .right = right, .bottom = y + 220 };
+    const flags = DT_LEFT | DT_TOP | DT_WORDBREAK | DT_NOPREFIX;
+    var rect: RECT = .{ .left = x, .top = y, .right = right, .bottom = y };
+    _ = DrawTextW(hdc, w, -1, &rect, flags | DT_CALCRECT);
     _ = DrawTextW(hdc, w, -1, &rect, DT_LEFT | DT_TOP | DT_WORDBREAK | DT_NOPREFIX);
 }
 

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -164,7 +164,7 @@ pub const Section = enum(u32) {
             .appearance => "Font family, size, theme, opacity, cursor, padding, and background blur.",
             .terminal => "Scrollback, copy-on-select, clipboard trimming, close confirmation, and notifications.",
             .shell => "Default shell command and shell integration detection mode.",
-            .keybindings => "Open the config file for keybind edits; action names are available from winghostty +list-actions.",
+            .keybindings => "Open the config file for keybind edits; list defaults, actions, and docs from the CLI.",
             .advanced => "Updater defaults plus the text editor escape hatch for config keys that do not yet have native controls.",
         };
     }
@@ -184,6 +184,18 @@ fn backgroundBlurFromCheckbox(
 
 const PaddingAxis = enum { x, y };
 const AppNotificationField = enum { clipboard, config };
+
+fn keybindingsHelpText() []const u8 {
+    return "Useful commands:\n" ++
+        "  winghostty +list-keybinds --default\n" ++
+        "  winghostty +list-keybinds --docs\n" ++
+        "  winghostty +list-actions --docs\n" ++
+        "  winghostty +explain-config --keybind=<action>\n\n" ++
+        "Config syntax:\n" ++
+        "  keybind = ctrl+shift+c=copy_to_clipboard\n" ++
+        "  keybind = ctrl+a>n=new_window\n" ++
+        "  keybind = chain=goto_split:left";
+}
 
 extern "user32" fn RegisterClassExW(lpwcx: *const WNDCLASSEXW) callconv(.winapi) ATOM;
 extern "user32" fn CreateWindowExW(
@@ -1942,6 +1954,13 @@ fn paint(hwnd: HWND, owner: *SettingsWindow) void {
         },
         .keybindings => {
             drawLabel(hdc, pane_left, pane_top + 72 - label_pad, pane_right, "Keybind configuration");
+            drawHelpBlock(
+                hdc,
+                pane_left,
+                pane_top + 72 + row_gap,
+                pane_right,
+                keybindingsHelpText(),
+            );
         },
         .advanced => {
             drawLabel(hdc, pane_left, pane_top + 72 - label_pad, pane_right, "Auto-update mode");
@@ -1956,6 +1975,13 @@ fn drawLabel(hdc: ?*anyopaque, x: i32, y: i32, right: i32, text: []const u8) voi
     const w = utf8ToW(&buf, text);
     var rect: RECT = .{ .left = x, .top = y, .right = right, .bottom = y + 16 };
     _ = DrawTextW(hdc, w, -1, &rect, DT_LEFT | DT_TOP | DT_SINGLELINE | DT_NOPREFIX);
+}
+
+fn drawHelpBlock(hdc: ?*anyopaque, x: i32, y: i32, right: i32, text: []const u8) void {
+    var buf: [512]u16 = undefined;
+    const w = utf8ToW(&buf, text);
+    var rect: RECT = .{ .left = x, .top = y, .right = right, .bottom = y + 220 };
+    _ = DrawTextW(hdc, w, -1, &rect, DT_LEFT | DT_TOP | DT_WORDBREAK | DT_NOPREFIX);
 }
 
 fn readEditUtf8(edit: HWND, buf: []u8) ?[]const u8 {
@@ -2097,4 +2123,15 @@ test "win32_settings: direct command edit text quotes argv boundaries" {
     try testing.expectEqual(@as(usize, 4), round_trip.direct.len);
     try testing.expectEqualStrings("echo hello", round_trip.direct[2]);
     try testing.expectEqualStrings("C:\\Program Files\\winghostty", round_trip.direct[3]);
+}
+
+test "win32_settings: keybinding help points to discoverability commands" {
+    const text = keybindingsHelpText();
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "+list-keybinds --default") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+list-keybinds --docs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+list-actions --docs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "+explain-config --keybind=<action>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "keybind = ctrl+a>n=new_window") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "keybind = chain=goto_split:left") != null);
 }

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -2130,6 +2130,8 @@ test "win32_settings: direct command edit text quotes argv boundaries" {
 test "win32_settings: keybinding help points to discoverability commands" {
     const text = keybindingsHelpText();
 
+    try std.testing.expect(text.len < 1024);
+    try std.testing.expect(std.mem.indexOfScalar(u8, text, 0) == null);
     try std.testing.expect(std.mem.indexOf(u8, text, "+list-keybinds --default") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "+list-keybinds --docs") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "+list-actions --docs") != null);

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -15,6 +15,13 @@ pub const Options = struct {
     }
 };
 
+pub const keybinding_discovery_hint =
+    \\  `winghostty +explain-config --keybind=<action>` explains one keybind action.
+    \\  `winghostty +list-actions --docs` lists bindable actions with docs.
+    \\  `winghostty +list-keybinds --default` shows the shipped default bindings.
+    \\  `winghostty +list-keybinds --docs` annotates bindings with action docs.
+;
+
 const help_prelude =
     \\Usage: winghostty [+action] [options]
     \\
@@ -29,16 +36,14 @@ const help_prelude =
     \\Discover configuration from the CLI:
     \\  `winghostty +show-config --default --docs` lists every config key and its docs.
     \\  `winghostty +explain-config <option>` explains one config key.
-    \\  `winghostty +explain-config --keybind=<action>` explains one keybind action.
     \\
     \\A special command line argument `-e <command>` can be used to run
     \\the specific command inside the terminal emulator. For example,
     \\`winghostty -e top` will run the `top` command inside the terminal.
     \\
     \\Discover actions and keybindings:
-    \\  `winghostty +list-actions --docs` lists bindable actions with docs.
-    \\  `winghostty +list-keybinds --default` shows the shipped default bindings.
-    \\  `winghostty +list-keybinds --docs` annotates bindings with action docs.
+    \\
+++ keybinding_discovery_hint ++
     \\
     \\Useful Windows actions:
     \\  `winghostty +new-window` forwards into the running instance when possible.


### PR DESCRIPTION
Summary:
- Adds native settings keybinding help text for +list-keybinds, +list-actions, +explain-config, and chained keybind syntax.
- Adds a focused settings test for these hints.

Validation:
- zig build test -Dtest-filter=win32_settings passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Document and surface keybinding discovery commands and examples in the Win32 settings UI, and cover them with a focused test.

New Features:
- Add inline keybinding help text in the Win32 settings keybindings section, including discovery commands and sample config syntax.

Tests:
- Add a unit test ensuring the keybinding help text references the expected discovery commands and chained keybind examples.