### PR TITLE
feat(win32): write local crash minidumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,10 @@ winghostty does not upload crash reports. The app keeps a local directory:
 %LOCALAPPDATA%\winghostty\crash
 ```
 
-On Windows the Sentry initialization path is a no-op today, so some builds
-may produce nothing in this directory in practice. The `+crash-report` CLI
-reads anything that is there:
+On Windows the Sentry initialization path is a no-op, but winghostty installs a
+local unhandled-exception filter that writes `.dmp` minidumps for process-level
+crash exceptions. Some hard-abort paths may still terminate before Windows can
+produce a dump. The `+crash-report` CLI reads anything that is there:
 
 ```powershell
 winghostty +crash-report

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,9 +138,9 @@ winghostty keeps a local crash directory at:
 %LOCALAPPDATA%\winghostty\crash
 ```
 
-Nothing in this directory is ever uploaded. On current Windows builds the
-crash-capture path is a no-op, so the directory may stay empty. Inspect
-what is there with:
+Nothing in this directory is ever uploaded. On Windows, winghostty writes local
+`.dmp` minidumps for process-level unhandled exceptions when Windows can
+deliver one. Inspect what is there with:
 
 ```powershell
 winghostty +crash-report

--- a/docs/status.md
+++ b/docs/status.md
@@ -70,7 +70,9 @@ For a row-by-row mapping against official Ghostty docs, see
 - Local directory: `%LOCALAPPDATA%\winghostty\crash`
 - **No automatic upload.** No code path to upload exists in this repo.
 - On Windows the Sentry initialization path is a no-op
-  (`src/crash/sentry.zig`); the directory may stay empty in practice.
+  (`src/crash/sentry.zig`), but winghostty installs a local
+  unhandled-exception filter that writes `.dmp` minidumps through `DbgHelp`
+  when Windows delivers a process-level crash exception.
 - The `+crash-report` CLI reads anything that is there.
 
 ## Experimental / partial
@@ -109,9 +111,10 @@ extractions will land as they stabilize.
 - **Generated help links.** A few generated help strings still link to
   `github.com/ghostty-org/ghostty` rather than this fork. Tracked as a
   doc-generation fix.
-- **Crash capture on Windows is a no-op today.** The Sentry path is
-  gated off on Windows in `src/crash/sentry.zig`. The crash directory
-  exists but may stay empty until local capture is wired in.
+- **Crash capture on Windows is local-only.** The Sentry path is gated off on
+  Windows in `src/crash/sentry.zig`; local minidumps are written by
+  `src/crash/minidump_windows.zig` for process-level unhandled exceptions. Some
+  hard-abort paths may still terminate before Windows can produce a dump.
 
 ## Out of scope
 
@@ -129,7 +132,7 @@ No formal roadmap. Indicative next areas:
 - Continuing the `src/apprt/win32.zig` extraction begun in commit
   `a759eb6`
 - Code signing for Windows releases
-- Local-only crash capture on Windows
+- Broader local crash metadata and report packaging on Windows
 - ARB-context OpenGL migration paired with atlas rebuild
 
 Contributions that advance any of the above are welcome.

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -472,6 +472,7 @@ pub fn add(
                 step.linkSystemLibrary2("user32", dynamic_link_opts);
                 step.linkSystemLibrary2("gdi32", dynamic_link_opts);
                 step.linkSystemLibrary2("opengl32", dynamic_link_opts);
+                step.linkSystemLibrary2("dbghelp", dynamic_link_opts);
             },
         }
     }

--- a/src/crash/main.zig
+++ b/src/crash/main.zig
@@ -2,6 +2,7 @@
 //! whether that's setting up the system to catch crashes (Sentry client),
 //! introspecting crash reports, writing crash reports to disk, etc.
 
+const std = @import("std");
 const dir = @import("dir.zig");
 const sentry_envelope = @import("sentry_envelope.zig");
 const builtin = @import("builtin");
@@ -19,9 +20,12 @@ pub const ReportIterator = dir.ReportIterator;
 pub const Report = dir.Report;
 
 // The main init/deinit functions for global state.
-pub fn init(alloc: anytype) !void {
+pub fn init(alloc: std.mem.Allocator) !void {
     try minidump_windows.init(alloc);
-    try sentry.init(alloc);
+    sentry.init(alloc) catch |err| {
+        minidump_windows.deinit();
+        return err;
+    };
 }
 
 pub fn deinit() void {

--- a/src/crash/main.zig
+++ b/src/crash/main.zig
@@ -4,8 +4,13 @@
 
 const dir = @import("dir.zig");
 const sentry_envelope = @import("sentry_envelope.zig");
+const builtin = @import("builtin");
 
 pub const sentry = @import("sentry.zig");
+const minidump_windows = if (builtin.os.tag == .windows) @import("minidump_windows.zig") else struct {
+    pub fn init(_: anytype) !void {}
+    pub fn deinit() void {}
+};
 pub const Envelope = sentry_envelope.Envelope;
 pub const defaultDir = dir.defaultDir;
 pub const legacyGhosttyDir = dir.legacyGhosttyDir;
@@ -14,8 +19,15 @@ pub const ReportIterator = dir.ReportIterator;
 pub const Report = dir.Report;
 
 // The main init/deinit functions for global state.
-pub const init = sentry.init;
-pub const deinit = sentry.deinit;
+pub fn init(alloc: anytype) !void {
+    try minidump_windows.init(alloc);
+    try sentry.init(alloc);
+}
+
+pub fn deinit() void {
+    sentry.deinit();
+    minidump_windows.deinit();
+}
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/crash/minidump_windows.zig
+++ b/src/crash/minidump_windows.zig
@@ -12,6 +12,14 @@ const log = std.log.scoped(.crash_minidump);
 
 const EXCEPTION_EXECUTE_HANDLER: c_long = 1;
 const MiniDumpNormal: u32 = 0x00000000;
+const MiniDumpWithDataSegs: u32 = 0x00000001;
+const MiniDumpWithHandleData: u32 = 0x00000004;
+const MiniDumpWithUnloadedModules: u32 = 0x00000020;
+const MiniDumpType =
+    MiniDumpNormal |
+    MiniDumpWithDataSegs |
+    MiniDumpWithHandleData |
+    MiniDumpWithUnloadedModules;
 
 const MINIDUMP_EXCEPTION_INFORMATION = extern struct {
     ThreadId: windows.DWORD,
@@ -110,7 +118,7 @@ fn writeMinidump(info: *windows.EXCEPTION_POINTERS) !void {
         windows.GetCurrentProcess(),
         windows.GetCurrentProcessId(),
         file.handle,
-        MiniDumpNormal,
+        MiniDumpType,
         &exception_info,
         null,
         null,

--- a/src/crash/minidump_windows.zig
+++ b/src/crash/minidump_windows.zig
@@ -11,12 +11,10 @@ const dir = @import("dir.zig");
 const log = std.log.scoped(.crash_minidump);
 
 const EXCEPTION_EXECUTE_HANDLER: c_long = 1;
-const MiniDumpNormal: u32 = 0x00000000;
 const MiniDumpWithDataSegs: u32 = 0x00000001;
 const MiniDumpWithHandleData: u32 = 0x00000004;
 const MiniDumpWithUnloadedModules: u32 = 0x00000020;
 const MiniDumpType =
-    MiniDumpNormal |
     MiniDumpWithDataSegs |
     MiniDumpWithHandleData |
     MiniDumpWithUnloadedModules;
@@ -50,6 +48,7 @@ var crash_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
 var crash_dir: []const u8 = "";
 
 pub fn init(alloc: std.mem.Allocator) !void {
+    // Preserve the original exception filter across repeated crash init calls.
     if (installed) return;
 
     const crash = try dir.defaultDir(alloc);
@@ -78,8 +77,7 @@ pub fn deinit() void {
 
 fn unhandledExceptionFilter(info: *windows.EXCEPTION_POINTERS) callconv(.winapi) c_long {
     if (writing.swap(true, .seq_cst)) {
-        if (previous_filter) |filter| return filter(info);
-        return EXCEPTION_EXECUTE_HANDLER;
+        return callPreviousFilter(info);
     }
     defer writing.store(false, .seq_cst);
 
@@ -87,6 +85,10 @@ fn unhandledExceptionFilter(info: *windows.EXCEPTION_POINTERS) callconv(.winapi)
         log.warn("failed to write windows minidump err={}", .{err});
     };
 
+    return callPreviousFilter(info);
+}
+
+fn callPreviousFilter(info: *windows.EXCEPTION_POINTERS) c_long {
     if (previous_filter) |filter| return filter(info);
     return EXCEPTION_EXECUTE_HANDLER;
 }
@@ -106,6 +108,9 @@ fn writeMinidump(info: *windows.EXCEPTION_POINTERS) !void {
         .read = false,
         .truncate = true,
     });
+    errdefer std.fs.deleteFileAbsolute(path) catch |err| {
+        log.warn("failed to delete incomplete windows minidump path={s} err={}", .{ path, err });
+    };
     defer file.close();
 
     var exception_info: MINIDUMP_EXCEPTION_INFORMATION = .{

--- a/src/crash/minidump_windows.zig
+++ b/src/crash/minidump_windows.zig
@@ -1,0 +1,142 @@
+//! Local Windows minidump capture.
+//!
+//! This intentionally stays independent from Sentry. Windows builds in this
+//! fork keep crash capture local-only, so the unhandled-exception filter writes
+//! a small `.dmp` next to any other local crash artifacts.
+
+const std = @import("std");
+const windows = std.os.windows;
+const dir = @import("dir.zig");
+
+const log = std.log.scoped(.crash_minidump);
+
+const EXCEPTION_EXECUTE_HANDLER: c_long = 1;
+const MiniDumpNormal: u32 = 0x00000000;
+
+const MINIDUMP_EXCEPTION_INFORMATION = extern struct {
+    ThreadId: windows.DWORD,
+    ExceptionPointers: *windows.EXCEPTION_POINTERS,
+    ClientPointers: windows.BOOL,
+};
+
+const ExceptionFilter = ?*const fn (*windows.EXCEPTION_POINTERS) callconv(.winapi) c_long;
+
+extern "kernel32" fn SetUnhandledExceptionFilter(
+    lpTopLevelExceptionFilter: ExceptionFilter,
+) callconv(.winapi) ExceptionFilter;
+
+extern "dbghelp" fn MiniDumpWriteDump(
+    hProcess: windows.HANDLE,
+    ProcessId: windows.DWORD,
+    hFile: windows.HANDLE,
+    DumpType: u32,
+    ExceptionParam: ?*MINIDUMP_EXCEPTION_INFORMATION,
+    UserStreamParam: ?*anyopaque,
+    CallbackParam: ?*anyopaque,
+) callconv(.winapi) windows.BOOL;
+
+var installed = false;
+var previous_filter: ExceptionFilter = null;
+var writing = std.atomic.Value(bool).init(false);
+var crash_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+var crash_dir: []const u8 = "";
+
+pub fn init(alloc: std.mem.Allocator) !void {
+    const crash = try dir.defaultDir(alloc);
+    defer alloc.free(crash.path);
+
+    std.fs.makeDirAbsolute(crash.path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    if (crash.path.len > crash_dir_buf.len) return error.NameTooLong;
+
+    @memcpy(crash_dir_buf[0..crash.path.len], crash.path);
+    crash_dir = crash_dir_buf[0..crash.path.len];
+
+    previous_filter = SetUnhandledExceptionFilter(unhandledExceptionFilter);
+    installed = true;
+    log.debug("windows minidump handler initialized path={s}", .{crash_dir});
+}
+
+pub fn deinit() void {
+    if (!installed) return;
+    _ = SetUnhandledExceptionFilter(previous_filter);
+    installed = false;
+    previous_filter = null;
+}
+
+fn unhandledExceptionFilter(info: *windows.EXCEPTION_POINTERS) callconv(.winapi) c_long {
+    if (writing.swap(true, .seq_cst)) return EXCEPTION_EXECUTE_HANDLER;
+    writeMinidump(info) catch |err| {
+        log.warn("failed to write windows minidump err={}", .{err});
+    };
+
+    if (previous_filter) |filter| return filter(info);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+fn writeMinidump(info: *windows.EXCEPTION_POINTERS) !void {
+    if (crash_dir.len == 0) return error.NotInitialized;
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try formatDumpPath(
+        &path_buf,
+        crash_dir,
+        windows.GetCurrentProcessId(),
+        std.time.milliTimestamp(),
+    );
+
+    var file = try std.fs.createFileAbsolute(path, .{
+        .read = false,
+        .truncate = true,
+    });
+    defer file.close();
+
+    var exception_info: MINIDUMP_EXCEPTION_INFORMATION = .{
+        .ThreadId = windows.GetCurrentThreadId(),
+        .ExceptionPointers = info,
+        .ClientPointers = 0,
+    };
+
+    if (MiniDumpWriteDump(
+        windows.GetCurrentProcess(),
+        windows.GetCurrentProcessId(),
+        file.handle,
+        MiniDumpNormal,
+        &exception_info,
+        null,
+        null,
+    ) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+
+    log.warn("windows minidump written path={s}", .{path});
+}
+
+fn formatDumpPath(
+    buf: []u8,
+    base_dir: []const u8,
+    pid: windows.DWORD,
+    timestamp_ms: i64,
+) ![]const u8 {
+    if (base_dir.len == 0) return error.InvalidDirectory;
+    const sep: []const u8 = if (std.fs.path.isSep(base_dir[base_dir.len - 1])) "" else &.{std.fs.path.sep};
+    return try std.fmt.bufPrint(
+        buf,
+        "{s}{s}winghostty-{d}-{d}.dmp",
+        .{ base_dir, sep, pid, timestamp_ms },
+    );
+}
+
+test "formatDumpPath appends separator and dmp extension" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try formatDumpPath(&buf, "C:\\Users\\a\\winghostty\\crash", 42, 1234);
+    try std.testing.expectEqualStrings("C:\\Users\\a\\winghostty\\crash\\winghostty-42-1234.dmp", path);
+}
+
+test "formatDumpPath keeps existing separator" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try formatDumpPath(&buf, "C:\\crash\\", 7, 9);
+    try std.testing.expectEqualStrings("C:\\crash\\winghostty-7-9.dmp", path);
+}

--- a/src/crash/minidump_windows.zig
+++ b/src/crash/minidump_windows.zig
@@ -42,6 +42,8 @@ var crash_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
 var crash_dir: []const u8 = "";
 
 pub fn init(alloc: std.mem.Allocator) !void {
+    if (installed) return;
+
     const crash = try dir.defaultDir(alloc);
     defer alloc.free(crash.path);
 
@@ -67,7 +69,12 @@ pub fn deinit() void {
 }
 
 fn unhandledExceptionFilter(info: *windows.EXCEPTION_POINTERS) callconv(.winapi) c_long {
-    if (writing.swap(true, .seq_cst)) return EXCEPTION_EXECUTE_HANDLER;
+    if (writing.swap(true, .seq_cst)) {
+        if (previous_filter) |filter| return filter(info);
+        return EXCEPTION_EXECUTE_HANDLER;
+    }
+    defer writing.store(false, .seq_cst);
+
     writeMinidump(info) catch |err| {
         log.warn("failed to write windows minidump err={}", .{err});
     };


### PR DESCRIPTION
Summary:
- Adds a Windows-only local unhandled-exception filter that writes .dmp minidumps through DbgHelp into the existing crash directory.
- Keeps Sentry disabled on Windows and preserves the no-upload privacy model.
- Updates crash-report docs to reflect local minidump capture.

Validation:
- scripts/dev-windows.cmd zig build test -Dtest-filter=formatDumpPath passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Add local-only Windows minidump crash capture wired into the crash subsystem and document the new behavior.

New Features:
- Install a Windows-only unhandled-exception filter that writes local `.dmp` minidumps into the existing crash directory.

Enhancements:
- Integrate Windows minidump initialization into the crash subsystem lifecycle while keeping Sentry disabled on Windows.

Build:
- Link the Windows build against `dbghelp` to support local minidump generation.

Documentation:
- Update crash-report and getting-started documentation to describe local Windows minidump capture and its limitations.

Tests:
- Add unit tests for Windows minidump path formatting to ensure consistent dump file naming.