### PR TITLE
test(win32): cover shared window parity helpers

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -27709,6 +27709,32 @@ test "win32 sharedHostWindowFrameStateEquals ignores non-frame host state" {
     try std.testing.expect(!sharedHostWindowFrameStateEquals(&a, &b));
 }
 
+test "win32 shared host topmost and opacity equality track separate window state" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var a: Surface = undefined;
+    a.topmost = false;
+    a.background_opacity_default = 0.5;
+    a.background_opacity_force_opaque = false;
+
+    var b: Surface = a;
+    try std.testing.expect(sharedHostWindowTopmostEquals(&a, &b));
+    try std.testing.expect(sharedHostWindowOpacityEquals(&a, &b));
+
+    b.topmost = true;
+    try std.testing.expect(!sharedHostWindowTopmostEquals(&a, &b));
+    try std.testing.expect(sharedHostWindowOpacityEquals(&a, &b));
+
+    b.topmost = a.topmost;
+    b.background_opacity_force_opaque = true;
+    try std.testing.expect(sharedHostWindowTopmostEquals(&a, &b));
+    try std.testing.expect(!sharedHostWindowOpacityEquals(&a, &b));
+
+    b.background_opacity_force_opaque = false;
+    b.background_opacity_default = 0.5001;
+    try std.testing.expect(sharedHostWindowOpacityEquals(&a, &b));
+}
+
 test "win32 hostPresentShowCommand skips redundant maximize for visible hosts" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -723,7 +723,7 @@ pub const Action = union(enum) {
     ///
     /// Terminal windows always start as normal (not float-on-top) windows.
     ///
-    /// Only implemented on macOS.
+    /// Implemented on Win32 in this fork and on macOS.
     toggle_window_float_on_top,
 
     /// Toggle secure input mode.

--- a/src/input/helpgen_actions.zig
+++ b/src/input/helpgen_actions.zig
@@ -119,6 +119,6 @@ test "action docs reflect fork platform truth" {
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_decorations, "Only implemented on Linux.") == null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_visibility, "Implemented on Win32 in this fork") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_background_opacity, "Implemented on Win32 in this fork") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_float_on_top, "Implemented on Win32 in this fork") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_window_float_on_top, "Implemented on Win32 in this fork") != null);
     try std.testing.expect(std.mem.indexOf(u8, help_strings.KeybindAction.toggle_secure_input, "Implemented on Win32 in this fork") == null);
 }


### PR DESCRIPTION
Summary:
- Adds focused helper coverage for shared-host topmost and opacity state tracking.
- Corrects toggle_window_float_on_top docs to include Win32 support.

Validation:
- zig build test -Dtest-filter='shared host topmost' passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Add test coverage for Win32 shared host window topmost and opacity state parity and update related documentation.

Documentation:
- Clarify that `toggle_window_float_on_top` is implemented on Win32 in this fork as well as on macOS.

Tests:
- Add a Win32-specific test ensuring shared host topmost and opacity helpers track independent window state.