### PR TITLE
fix(win32): harden tab drag data object format

### DIFF
--- a/src/apprt/win32_tab_drag_ole.zig
+++ b/src/apprt/win32_tab_drag_ole.zig
@@ -2,8 +2,10 @@
 //!
 //! Implements `IDataObject`, `IDropSource`, and `IEnumFORMATETC` as minimal
 //! COM objects that ferry a `CF_WINGHOSTTY_TAB` payload through the system
-//! `DoDragDrop` loop. Each struct is one-shot: allocate, call `doDragDrop`,
-//! release.
+//! `DoDragDrop` loop. The payload is intentionally process-local metadata
+//! (PID + opaque pointer), not a serialised terminal/session image; drop
+//! targets must reject it when the PID differs. Each struct is one-shot:
+//! allocate, call `doDragDrop`, release.
 //!
 //! Thread safety: `doDragDrop` and all COM callbacks run on the STA-
 //! initialised UI thread. The apprt arranges `CoInitializeEx(STA)` in
@@ -195,6 +197,13 @@ fn loadUser32() ?User32Fns {
 
 fn iidEqual(a: *const GUID, b: *const GUID) bool {
     return std.mem.eql(u8, std.mem.asBytes(a), std.mem.asBytes(b));
+}
+
+fn formatEtcMatches(fmt: *const FORMATETC, cf_id: WORD) bool {
+    return fmt.cfFormat == cf_id and
+        fmt.dwAspect == DVASPECT_CONTENT and
+        fmt.lindex == -1 and
+        fmt.tymed & TYMED_HGLOBAL != 0;
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -508,8 +517,7 @@ pub const DataObject = struct {
         const self = fromObj(self_obj);
         pmedium.* = std.mem.zeroes(STGMEDIUM);
 
-        if (pformatetc.cfFormat != self.cf_id) return DV_E_FORMATETC;
-        if (pformatetc.tymed & TYMED_HGLOBAL == 0) return DV_E_FORMATETC;
+        if (!formatEtcMatches(pformatetc, self.cf_id)) return DV_E_FORMATETC;
 
         const k32 = loadKernel32() orelse return E_OUTOFMEMORY;
         const size = @sizeOf(Payload);
@@ -542,7 +550,7 @@ pub const DataObject = struct {
         pformatetc: *const FORMATETC,
     ) callconv(.winapi) HRESULT {
         const self = fromObj(self_obj);
-        if (pformatetc.cfFormat == self.cf_id and pformatetc.tymed & TYMED_HGLOBAL != 0) {
+        if (formatEtcMatches(pformatetc, self.cf_id)) {
             return S_OK;
         }
         return DV_E_FORMATETC;
@@ -709,6 +717,28 @@ test "QueryGetData returns S_OK for matching format, DV_E_FORMATETC otherwise" {
         .tymed = 0, // not TYMED_HGLOBAL
     };
     try testing.expectEqual(DV_E_FORMATETC, DataObject.QueryGetData(&dobj.obj, &fmt_bad_tymed));
+
+    // Wrong aspect -> DV_E_FORMATETC. The tab payload is only meaningful
+    // as ordinary content, not thumbnail/icon/alternate render data.
+    var fmt_bad_aspect = FORMATETC{
+        .cfFormat = TEST_CF,
+        .ptd = null,
+        .dwAspect = 2,
+        .lindex = -1,
+        .tymed = TYMED_HGLOBAL,
+    };
+    try testing.expectEqual(DV_E_FORMATETC, DataObject.QueryGetData(&dobj.obj, &fmt_bad_aspect));
+
+    // Indexed requests are unsupported; this object offers exactly one
+    // process-local tab metadata blob.
+    var fmt_bad_lindex = FORMATETC{
+        .cfFormat = TEST_CF,
+        .ptd = null,
+        .dwAspect = DVASPECT_CONTENT,
+        .lindex = 0,
+        .tymed = TYMED_HGLOBAL,
+    };
+    try testing.expectEqual(DV_E_FORMATETC, DataObject.QueryGetData(&dobj.obj, &fmt_bad_lindex));
 }
 
 test "GetData allocates HGLOBAL with correct payload bytes" {
@@ -741,6 +771,26 @@ test "GetData allocates HGLOBAL with correct payload bytes" {
 
     // Clean up.
     _ = k32.GlobalFree(stg.u.hGlobal);
+}
+
+test "GetData rejects unsupported FORMATETC variants before allocating" {
+    const payload = makeTestPayload();
+    var dobj = DataObject.initWithFormat(testing.allocator, payload, TEST_CF);
+
+    var fmt_bad_aspect = FORMATETC{
+        .cfFormat = TEST_CF,
+        .ptd = null,
+        .dwAspect = 2,
+        .lindex = -1,
+        .tymed = TYMED_HGLOBAL,
+    };
+    var stg: STGMEDIUM = undefined;
+
+    const hr = DataObject.GetData(&dobj.obj, &fmt_bad_aspect, &stg);
+    try testing.expectEqual(DV_E_FORMATETC, hr);
+    try testing.expectEqual(@as(DWORD, 0), stg.tymed);
+    try testing.expect(stg.u.raw == null);
+    try testing.expect(stg.pUnkForRelease == null);
 }
 
 test "FormatEnumerator.Next returns one format then S_FALSE" {

--- a/src/apprt/win32_tab_drag_ole.zig
+++ b/src/apprt/win32_tab_drag_ole.zig
@@ -55,6 +55,7 @@ const TYMED_HGLOBAL: DWORD = 1;
 
 // DVASPECT.
 const DVASPECT_CONTENT: DWORD = 1;
+const DVASPECT_THUMBNAIL: DWORD = 2;
 
 // DATADIR.
 const DATADIR_GET: DWORD = 1;
@@ -201,6 +202,7 @@ fn iidEqual(a: *const GUID, b: *const GUID) bool {
 
 fn formatEtcMatches(fmt: *const FORMATETC, cf_id: WORD) bool {
     return fmt.cfFormat == cf_id and
+        fmt.ptd == null and
         fmt.dwAspect == DVASPECT_CONTENT and
         fmt.lindex == -1 and
         fmt.tymed & TYMED_HGLOBAL != 0;
@@ -723,11 +725,21 @@ test "QueryGetData returns S_OK for matching format, DV_E_FORMATETC otherwise" {
     var fmt_bad_aspect = FORMATETC{
         .cfFormat = TEST_CF,
         .ptd = null,
-        .dwAspect = 2,
+        .dwAspect = DVASPECT_THUMBNAIL,
         .lindex = -1,
         .tymed = TYMED_HGLOBAL,
     };
     try testing.expectEqual(DV_E_FORMATETC, DataObject.QueryGetData(&dobj.obj, &fmt_bad_aspect));
+
+    var target_device: u8 = 0;
+    var fmt_bad_target_device = FORMATETC{
+        .cfFormat = TEST_CF,
+        .ptd = &target_device,
+        .dwAspect = DVASPECT_CONTENT,
+        .lindex = -1,
+        .tymed = TYMED_HGLOBAL,
+    };
+    try testing.expectEqual(DV_E_FORMATETC, DataObject.QueryGetData(&dobj.obj, &fmt_bad_target_device));
 
     // Indexed requests are unsupported; this object offers exactly one
     // process-local tab metadata blob.
@@ -780,7 +792,7 @@ test "GetData rejects unsupported FORMATETC variants before allocating" {
     var fmt_bad_aspect = FORMATETC{
         .cfFormat = TEST_CF,
         .ptd = null,
-        .dwAspect = 2,
+        .dwAspect = DVASPECT_THUMBNAIL,
         .lindex = -1,
         .tymed = TYMED_HGLOBAL,
     };
@@ -788,6 +800,17 @@ test "GetData rejects unsupported FORMATETC variants before allocating" {
 
     const hr = DataObject.GetData(&dobj.obj, &fmt_bad_aspect, &stg);
     try testing.expectEqual(DV_E_FORMATETC, hr);
+    try testing.expectEqual(@as(DWORD, 0), stg.tymed);
+    try testing.expect(stg.u.raw == null);
+    try testing.expect(stg.pUnkForRelease == null);
+
+    var fmt_bad_lindex = fmt_bad_aspect;
+    fmt_bad_lindex.dwAspect = DVASPECT_CONTENT;
+    fmt_bad_lindex.lindex = 0;
+    stg = undefined;
+
+    const lindex_hr = DataObject.GetData(&dobj.obj, &fmt_bad_lindex, &stg);
+    try testing.expectEqual(DV_E_FORMATETC, lindex_hr);
     try testing.expectEqual(@as(DWORD, 0), stg.tymed);
     try testing.expect(stg.u.raw == null);
     try testing.expect(stg.pUnkForRelease == null);


### PR DESCRIPTION
Summary:
- Hardens the Win32 tab OLE data object to only advertise and serve exact supported FORMATETC requests.
- Clarifies that CF_WINGHOSTTY_TAB is process-local metadata, not a serialized live terminal image.
- Adds targeted tests for unsupported OLE aspect/index requests.

Validation:
- zig build test -Dtest-filter=DataObject passed
- zig build test -Dtest-filter=FormatEnumerator passed
- zig build test -Dtest-filter=win32_tab_drag passed
- git diff --check passed

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Restrict the Win32 tab drag OLE data object to only accept and advertise a single well-defined tab metadata format and add tests to cover unsupported format variants.

Bug Fixes:
- Ensure IDataObject only serves requests matching the exact FORMATETC (content aspect, unindexed, HGLOBAL) for the tab drag format to avoid mishandling unsupported variants.

Enhancements:
- Clarify in documentation that the CF_WINGHOSTTY_TAB payload is process-local metadata rather than a serialized terminal image.

Tests:
- Add unit tests verifying QueryGetData and GetData reject unsupported FORMATETC combinations (wrong aspect, indexed requests, or bad tymed) without allocating resources.