### PR TITLE
docs: clarify theme trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A minimal config:
 font-family = JetBrains Mono
 font-size   = 12
 # Pick a theme from: winghostty +list-themes
+# Theme files are config files; only use themes from sources you trust.
 theme       = Dracula
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,7 @@ Add a few options:
 font-family = JetBrains Mono
 font-size   = 12
 # Pick a theme from: winghostty +list-themes
+# Theme files are config files; only use themes from sources you trust.
 theme       = Dracula
 ```
 

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -1921,7 +1921,7 @@ fn paint(hwnd: HWND, owner: *SettingsWindow) void {
             const labels = [_][]const u8{
                 "Font family fallbacks (comma-separated)",
                 "Font size (pt)",
-                "Terminal theme name or light/dark pair",
+                "Terminal theme name, trusted path, or light/dark pair",
                 "Background opacity (0.0 .. 1.0)",
                 "Window theme",
                 "Cursor style",

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -1921,7 +1921,7 @@ fn paint(hwnd: HWND, owner: *SettingsWindow) void {
             const labels = [_][]const u8{
                 "Font family fallbacks (comma-separated)",
                 "Font size (pt)",
-                "Terminal theme name, trusted path, or light/dark pair",
+                "Terminal theme name, absolute path, or light/dark pair",
                 "Background opacity (0.0 .. 1.0)",
                 "Window theme",
                 "Cursor style",

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -841,6 +841,7 @@ const Preview = struct {
                     try std.fmt.allocPrint(alloc, "theme = {s}", .{theme.theme}),
                     "",
                     "Save the configuration file and then reload it to apply the new theme.",
+                    "Theme files are config files; only use themes from sources you trust.",
                     "",
                     "Or press 'w' to write an auto theme file to your system's preferred default config path.",
                     "Then add the following line to your winghostty configuration and reload:",

--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -836,12 +836,13 @@ const Preview = struct {
                 child.fill(.{ .style = self.ui_standard() });
 
                 const save_instructions = [_][]const u8{
+                    "Theme files are config files; only use themes from sources you trust.",
+                    "",
                     "To apply this theme, add the following line to your winghostty configuration:",
                     "",
                     try std.fmt.allocPrint(alloc, "theme = {s}", .{theme.theme}),
                     "",
                     "Save the configuration file and then reload it to apply the new theme.",
-                    "Theme files are config files; only use themes from sources you trust.",
                     "",
                     "Or press 'w' to write an auto theme file to your system's preferred default config path.",
                     "Then add the following line to your winghostty configuration and reload:",

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -603,10 +603,10 @@ language: ?[:0]const u8 = null,
 /// To see a list of available themes, run `winghostty +list-themes`.
 ///
 /// A theme file is simply another winghostty configuration file. They share
-/// the same syntax and same configuration options. A theme can set any valid
-/// configuration option so please do not use a theme file from an untrusted
-/// source. The built-in themes are audited to only set safe configuration
-/// options.
+/// the same syntax and same configuration options. A theme is not limited to
+/// colors and can set any valid configuration option, so only use theme files
+/// from sources you trust. The built-in themes are audited to only set safe
+/// configuration options.
 ///
 /// Some options cannot be set within theme files. The reason these are not
 /// supported should be self-evident. A theme file cannot set `theme` or

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -603,10 +603,9 @@ language: ?[:0]const u8 = null,
 /// To see a list of available themes, run `winghostty +list-themes`.
 ///
 /// A theme file is simply another winghostty configuration file. They share
-/// the same syntax and same configuration options. A theme is not limited to
-/// colors and can set any valid configuration option, so only use theme files
-/// from sources you trust. The built-in themes are audited to only set safe
-/// configuration options.
+/// the same syntax and can set most configuration options. A theme is not
+/// limited to colors, so only use theme files from sources you trust. The
+/// built-in themes are audited to only set safe configuration options.
 ///
 /// Some options cannot be set within theme files. The reason these are not
 /// supported should be self-evident. A theme file cannot set `theme` or


### PR DESCRIPTION
Summary:
- Clarifies that Ghostty theme files are full config files, not just color files.
- Adds trust-boundary wording in config docs, settings UI copy, list-themes instructions, README, and getting-started docs.

Validation:
- zig build test -Dtest-filter=theme passed
- git diff --check passed
- prettier unavailable on PATH

Review loop: @codex @coderabbitai @greptileai @Copilot please review this branch. I will resolve findings before merge.

## Summary by Sourcery

Clarify Ghostty theme files as full configuration files and emphasize trust boundaries across configuration docs, UI labels, and theme-listing output.

Enhancements:
- Clarify config documentation comments to state that themes are not limited to colors and should only be used from trusted sources.
- Update Windows settings UI label to indicate themes may be specified by trusted file paths.
- Extend `+list-themes` CLI output to warn that theme files are full config files and should only be used from trusted sources.

Documentation:
- Document that theme files are full configuration files and can change any option, recommending only using themes from trusted sources in README and getting-started guides.