### PR TITLE
docs(windows): add platform guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Full walk-through — installer, portable, uninstall —
 **[docs/getting-started.md](docs/getting-started.md)**.
 
 Windows-specific paths, shell behavior, app identity, notifications, quick
-terminal notes, and troubleshooting live in
+terminal, windows/tabs/splits, automation, and troubleshooting live in
 **[docs/windows.md](docs/windows.md)**.
 
 ## First run

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   ·
   <a href="docs/getting-started.md">Getting started</a>
   ·
+  <a href="docs/windows.md">Windows</a>
+  ·
   <a href="docs/status.md">Status</a>
   ·
   <a href="docs/windows-capability-matrix.md">Windows capability matrix</a>
@@ -121,6 +123,10 @@ signing is planned.
 
 Full walk-through — installer, portable, uninstall —
 **[docs/getting-started.md](docs/getting-started.md)**.
+
+Windows-specific paths, shell behavior, app identity, notifications, quick
+terminal notes, and troubleshooting live in
+**[docs/windows.md](docs/windows.md)**.
 
 ## First run
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,6 +191,8 @@ slate.
 
 - [docs/status.md](status.md) — what works, what's experimental, known
   caveats
+- [docs/windows.md](windows.md) — Windows-specific behavior,
+  troubleshooting, paths, app identity, notifications, and shell notes
 - [docs/windows-capability-matrix.md](windows-capability-matrix.md) —
   Windows-specific behavior and docs truth
 - [HACKING.md](../HACKING.md) — build, test, runtime notes (for

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,6 +7,9 @@ Last updated: 2026-05-09, against current fork HEAD.
 
 For a row-by-row mapping against official Ghostty docs, see
 [windows-capability-matrix.md](windows-capability-matrix.md).
+For Windows-specific install paths, app identity, shell behavior,
+notifications, quick terminal notes, and troubleshooting, see
+[windows.md](windows.md).
 
 ## Supported platform
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,172 @@
+# Windows
+
+This page collects Windows-specific behavior that differs from upstream
+Ghostty's macOS and Linux documentation. For a row-by-row upstream docs
+mapping, see [windows-capability-matrix.md](windows-capability-matrix.md).
+
+## Supported Systems
+
+- Windows 10 and Windows 11 on x64.
+- Native Win32 application runtime.
+- OpenGL 4.3 or newer through WGL.
+- `libghostty-vt` remains portable as a library, but this repository does not
+  ship macOS, Linux, GTK, Wayland, or X11 app runtimes.
+
+## Install Modes
+
+winghostty publishes two Windows artifacts:
+
+- `winghostty-<version>-windows-x64-setup.exe` for a normal installed app with
+  Start menu shortcuts and app identity metadata.
+- `winghostty-<version>-windows-x64-portable.zip` for portable use without an
+  installer.
+
+Releases are currently unsigned. Windows SmartScreen may warn on first launch;
+click **More info** and **Run anyway** if you trust the downloaded release.
+Unsigned installers are not eligible for `auto-update = download` staging
+because staging requires a valid Authenticode signature.
+
+## Paths
+
+Runtime state lives under:
+
+```text
+%LOCALAPPDATA%\winghostty\
+```
+
+Important files and directories:
+
+| Path | Purpose |
+| --- | --- |
+| `%LOCALAPPDATA%\winghostty\config.ghostty` | User config written on first launch. |
+| `%LOCALAPPDATA%\winghostty\session-state.json` | Window, tab, split, profile, cwd, and title restore state when `window-save-state` is enabled. |
+| `%LOCALAPPDATA%\winghostty\crash\` | Local crash dump directory. Nothing here is uploaded automatically. |
+| `%LOCALAPPDATA%\winghostty\shell-integration\` | Installed shell-integration payloads and manual fallbacks. |
+
+The portable ZIP carries the bundled resources next to the executable. Do not
+move only `winghostty.exe` out of the extracted tree; it needs the packaged
+`share` resources for themes, terminfo, shell integration, and other data.
+
+## Shells
+
+The profile picker detects common Windows shells:
+
+- PowerShell Desktop (`powershell.exe`)
+- PowerShell 7+ (`pwsh.exe`)
+- Command Prompt (`cmd.exe`)
+- Git Bash
+- WSL when explicitly configured
+
+PowerShell and supported Unix-like shells can use automatic shell integration.
+PowerShell integration emits OSC 7 working-directory updates and OSC 133 prompt
+markers. `cmd.exe` is a plain fallback shell today and does not provide
+automatic prompt, cwd, or command-finish integration.
+
+WSL is supported as an explicit launched shell:
+
+```ini
+command = wsl.exe
+```
+
+winghostty does not pick WSL implicitly because `wsl.exe --status` can report a
+healthy installation even when launching a session would fail.
+
+## App Identity
+
+Installed builds create Start menu shortcuts with winghostty's AppUserModelID.
+That identity is used by Windows for taskbar grouping and Action Center toast
+activation. Portable builds run without installer-created shortcuts, so taskbar
+and notification identity may be less stable.
+
+If Windows shows a stale icon after upgrading or switching between installed
+and portable builds, restart Explorer or clear the icon cache before treating
+it as a packaging regression.
+
+## Notifications and Progress
+
+Desktop notifications use WinRT toasts when available and fall back to in-app
+banners when Windows notification policy, Focus Assist, app identity, or runtime
+availability prevents a toast.
+
+Terminal progress reports are mapped to Windows taskbar progress for the active
+surface in each host window. Terminal apps can also set in-terminal progress
+state through Ghostty's shared VT/OSC support.
+
+## Windows, Tabs, Splits
+
+winghostty uses a native Win32 host window with:
+
+- tab bar, overflow handling, and drag reorder
+- horizontal and vertical splits
+- per-monitor DPI handling
+- DWM dark title bar integration
+- high-contrast palette switching
+- IME support
+- drag-and-drop of files into the terminal
+- native right-click context menus
+
+Session restore persists practical shape: host windows, tabs, split layout,
+selected profiles, working directories, and explicit titles. It does not
+restore terminal contents or child process state.
+
+## Quick Terminal and Global Hotkeys
+
+The quick terminal uses the same `toggle_quick_terminal` action and
+`quick-terminal-*` configuration family as Ghostty where the settings map to
+Windows. Global keybinds use Win32 `RegisterHotKey` while winghostty is
+running. Windows or other applications may reserve hotkeys first; check logs
+when a global binding does not register.
+
+`quick-terminal-keyboard-interactivity = exclusive` maps to focused input on
+Windows. Global keyboard capture is intentionally not implemented.
+
+## Automation
+
+The local automation surface uses the single-instance IPC path:
+
+```powershell
+winghostty +list-windows
+winghostty +perform-action new_tab
+winghostty +perform-action --surface-id=<surface_id> toggle_fullscreen
+```
+
+Automation intentionally rejects terminal-input, arbitrary file helper, and
+crash actions. New action variants are disabled for automation until reviewed
+and allowlisted.
+
+## Troubleshooting
+
+### SmartScreen
+
+Current releases are unsigned. SmartScreen warnings are expected until code
+signing lands. Verify `SHA256SUMS.txt` before running downloaded artifacts if
+you want an extra local check.
+
+### Focus Assist and Toasts
+
+If desktop notifications do not appear, check Windows notification settings,
+Focus Assist, and whether you are running an installed build with Start menu
+shortcuts. In-app banners should still appear for important app notices.
+
+### Global Hotkey Conflicts
+
+Global keybinds can fail when another application or Windows itself owns the
+same hotkey. Pick a different trigger or close the conflicting app, then reload
+config.
+
+### WSL Launch Failures
+
+Set WSL explicitly with `command = wsl.exe`. If launch still fails, verify the
+distribution starts in a normal PowerShell session first.
+
+### OpenGL Driver Issues
+
+winghostty needs OpenGL 4.3 or newer. If the window fails to render or exits
+early on older hardware, update GPU drivers before filing a rendering bug.
+
+### Stale Installed Build
+
+When testing a local build, make sure the `winghostty` found on `PATH` is the
+current `zig-out\bin` binary rather than an older Scoop or installer build.
+On Windows, `winghostty.com` may be selected before `winghostty.exe` for CLI
+invocations.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -62,7 +62,7 @@ PowerShell integration emits OSC 7 working-directory updates and OSC 133 prompt
 markers. `cmd.exe` is a plain fallback shell today and does not provide
 automatic prompt, cwd, or command-finish integration.
 
-WSL is supported as an explicit launched shell:
+WSL is supported as an explicitly launched shell:
 
 ```ini
 command = wsl.exe

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -28,11 +28,15 @@ because staging requires a valid Authenticode signature.
 
 ## Paths
 
-Runtime state lives under:
+By default, runtime state lives under:
 
 ```text
 %LOCALAPPDATA%\winghostty\
 ```
+
+The shared XDG helpers still honor `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, and
+`XDG_CACHE_HOME` when they are set on Windows; `%LOCALAPPDATA%` is the fallback
+used by the normal packaged app environment.
 
 Important files and directories:
 


### PR DESCRIPTION
## Summary
- Add a first-class Windows platform guide for winghostty
- Link the guide from README, getting-started, and status docs
- Document Windows paths, shell behavior, app identity, notifications, quick terminal, automation, and troubleshooting

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts/check-site-copy.ps1`

## Review loop
@codex @coderabbitai @greptileai Copilot: please review this branch. I will keep iterating on findings until the PR is clean to squash and merge.

## Summary by Sourcery

Document Windows-specific behavior and usage for winghostty and link the new guide from existing docs.

Documentation:
- Add a dedicated Windows platform guide covering supported systems, install modes, paths, shell behavior, app identity, notifications, quick terminal, automation, and troubleshooting.
- Link the Windows guide from the README, getting-started guide, and status documentation for easier discoverability.