### PR TITLE
fix: map OSC 52 selectors on Windows

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -3,7 +3,7 @@
 What currently works in winghostty, what is experimental, and what is out of
 scope. When this page disagrees with a commit message, trust this page.
 
-Last updated: 2026-05-09, against current fork HEAD.
+Last updated: 2026-05-24, against current fork HEAD.
 
 For a row-by-row mapping against official Ghostty docs, see
 [windows-capability-matrix.md](windows-capability-matrix.md).
@@ -25,9 +25,9 @@ For a row-by-row mapping against official Ghostty docs, see
 - VT parsing, screen / scrollback / alt-screen, DEC and xterm behaviors
 - 256-color and true-color
 - Bracketed paste, mouse tracking, OSC 8 hyperlinks, OSC 10 / 11 / 52.
-  Windows has one native clipboard, so OSC 52 `c`, `s`, and `p` writes all
-  target the standard Windows clipboard; OSC 52 read replies preserve the
-  requested selector in the response.
+  Windows has one native clipboard, so OSC 52 writes using selectors `c`, `s`,
+  and `p` all target the standard Windows clipboard; OSC 52 read replies
+  preserve the requested selector in the response.
 - Bidi, combining marks, grapheme cluster rendering
 - Kitty graphics protocol and inline image display
 - Shell integration for bash, zsh, fish, PowerShell; `cmd.exe` is a plain

--- a/docs/status.md
+++ b/docs/status.md
@@ -24,7 +24,10 @@ For a row-by-row mapping against official Ghostty docs, see
 
 - VT parsing, screen / scrollback / alt-screen, DEC and xterm behaviors
 - 256-color and true-color
-- Bracketed paste, mouse tracking, OSC 8 hyperlinks, OSC 10 / 11 / 52
+- Bracketed paste, mouse tracking, OSC 8 hyperlinks, OSC 10 / 11 / 52.
+  Windows has one native clipboard, so OSC 52 `c`, `s`, and `p` writes all
+  target the standard Windows clipboard; OSC 52 read replies preserve the
+  requested selector in the response.
 - Bidi, combining marks, grapheme cluster rendering
 - Kitty graphics protocol and inline image display
 - Shell integration for bash, zsh, fish, PowerShell; `cmd.exe` is a plain

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -36,6 +36,7 @@ Last reviewed: 2026-05-09.
 | [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and update prompts backed by GitHub Releases. `download` can stage signed, checksum-matching installer releases, but install/apply remains manual. |
 | [Configuration: `window-save-state`](https://ghostty.org/docs/config/reference) | Windows persists practical session shape under `%LOCALAPPDATA%\winghostty\session-state.json`: host windows, tabs, splits, selected profiles, working directories, and explicit titles. Terminal contents and child process state are not restored. |
 | [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |
+| OSC 52 primary/selection clipboard selectors | Windows exposes one native clipboard. OSC 52 writes for `c`, `s`, and `p` therefore write the standard Windows clipboard. OSC 52 read replies still echo the requested selector (`c`, `s`, or `p`) so terminal clients can correlate the response. |
 
 ## No-op Compatibility
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -4,7 +4,7 @@ Maps current official Ghostty docs surfaces to winghostty behavior on
 Windows. Keep this short. Update rows when Windows behavior changes or when
 upstream docs add or remove a surface that this fork cares about.
 
-Last reviewed: 2026-05-09.
+Last reviewed: 2026-05-24.
 
 ## Status legend
 
@@ -36,7 +36,7 @@ Last reviewed: 2026-05-09.
 | [Configuration: `auto-update`](https://ghostty.org/docs/config/reference) | Windows supports stable-release checking and update prompts backed by GitHub Releases. `download` can stage signed, checksum-matching installer releases, but install/apply remains manual. |
 | [Configuration: `window-save-state`](https://ghostty.org/docs/config/reference) | Windows persists practical session shape under `%LOCALAPPDATA%\winghostty\session-state.json`: host windows, tabs, splits, selected profiles, working directories, and explicit titles. Terminal contents and child process state are not restored. |
 | [Features overview](https://ghostty.org/docs/features) | Accessibility is partial: the Win32 host exposes a UI Automation root provider and the command palette exposes a list provider, but terminal scrollback is not yet exposed through `ITextProvider`. |
-| OSC 52 primary/selection clipboard selectors | Windows exposes one native clipboard. OSC 52 writes for `c`, `s`, and `p` therefore write the standard Windows clipboard. OSC 52 read replies still echo the requested selector (`c`, `s`, or `p`) so terminal clients can correlate the response. |
+| OSC 52 primary/selection clipboard selectors | Windows exposes one native clipboard. OSC 52 writes using selectors `c`, `s`, and `p` all target the standard Windows clipboard. OSC 52 read replies still echo the requested selector (`c`, `s`, or `p`) so terminal clients can correlate the response. |
 
 ## No-op Compatibility
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6864,6 +6864,10 @@ test "Surface: OSC 52 clipboard backing preserves supported selectors" {
         apprt.Clipboard.primary,
         resolveOSC52ClipboardBacking(.primary, false, true),
     );
+    try std.testing.expectEqual(
+        apprt.Clipboard.standard,
+        resolveOSC52ClipboardBacking(.primary, true, false),
+    );
 }
 
 test "Surface: rectangle selection logic" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2377,7 +2377,8 @@ fn clipboardWrite(self: *const Surface, data: []const u8, loc: apprt.Clipboard) 
     // them to confirm the clipboard access. Each app runtime handles this
     // differently.
     const confirm = self.config.clipboard_write == .ask;
-    self.rt_surface.setClipboard(loc, &.{.{
+    const backing = self.osc52ClipboardBacking(loc);
+    self.rt_surface.setClipboard(backing, &.{.{
         .mime = "text/plain",
         .data = buf,
     }}, confirm) catch |err| {
@@ -6300,11 +6301,34 @@ pub fn completeClipboardRequest(
             confirmed,
         ),
 
-        .osc_52_write => |clipboard| try self.rt_surface.setClipboard(clipboard, &.{.{
-            .mime = "text/plain",
-            .data = data,
-        }}, !confirmed),
+        .osc_52_write => |clipboard| {
+            const backing = self.osc52ClipboardBacking(clipboard);
+            try self.rt_surface.setClipboard(backing, &.{.{
+                .mime = "text/plain",
+                .data = data,
+            }}, !confirmed);
+        },
     }
+}
+
+fn osc52ClipboardBacking(self: *const Surface, requested: apprt.Clipboard) apprt.Clipboard {
+    return resolveOSC52ClipboardBacking(
+        requested,
+        self.rt_surface.supportsClipboard(.selection),
+        self.rt_surface.supportsClipboard(.primary),
+    );
+}
+
+fn resolveOSC52ClipboardBacking(
+    requested: apprt.Clipboard,
+    supports_selection: bool,
+    supports_primary: bool,
+) apprt.Clipboard {
+    return switch (requested) {
+        .standard => .standard,
+        .selection => if (supports_selection) .selection else .standard,
+        .primary => if (supports_primary) .primary else .standard,
+    };
 }
 
 /// This starts a clipboard request, with some basic validation. For example,
@@ -6813,6 +6837,32 @@ test "Surface: selection logic" {
         9, 3, // expected start
         0, 3, // expected end
         false, // regular selection
+    );
+}
+
+test "Surface: OSC 52 clipboard backing falls back without selection clipboard support" {
+    try std.testing.expectEqual(
+        apprt.Clipboard.standard,
+        resolveOSC52ClipboardBacking(.standard, false, false),
+    );
+    try std.testing.expectEqual(
+        apprt.Clipboard.standard,
+        resolveOSC52ClipboardBacking(.selection, false, false),
+    );
+    try std.testing.expectEqual(
+        apprt.Clipboard.standard,
+        resolveOSC52ClipboardBacking(.primary, false, false),
+    );
+}
+
+test "Surface: OSC 52 clipboard backing preserves supported selectors" {
+    try std.testing.expectEqual(
+        apprt.Clipboard.selection,
+        resolveOSC52ClipboardBacking(.selection, true, false),
+    );
+    try std.testing.expectEqual(
+        apprt.Clipboard.primary,
+        resolveOSC52ClipboardBacking(.primary, false, true),
     );
 }
 


### PR DESCRIPTION
## Summary
- Map OSC 52 primary/selection selectors to the standard Windows clipboard backing
- Keep selector correlation for OSC 52 reads while documenting Windows' single native clipboard behavior
- Add focused tests for clipboard backing resolution and OSC 52 behavior

## Validation
- `zig fmt src\Surface.zig`
- `zig build test '-Dtest-filter=clipboard backing'`
- `zig build test '-Dtest-filter=OSC 52'`
- `git diff --check`

## Review loop
@codex @coderabbitai @greptileai Copilot: please review this branch. I will keep iterating on findings until the PR is clean to squash and merge.

## Summary by Sourcery

Align OSC 52 clipboard handling with platform capabilities and document Windows-specific behavior.

Bug Fixes:
- Ensure OSC 52 clipboard writes on platforms with a single clipboard, such as Windows, correctly target the standard clipboard backing while preserving selector semantics for reads.

Enhancements:
- Introduce an abstraction to resolve OSC 52 clipboard backing based on requested selector and platform clipboard support.
- Refine Surface clipboard APIs to consistently use resolved OSC 52 clipboard backings for both direct and OSC 52-initiated writes.

Documentation:
- Document Windows OSC 52 clipboard behavior and limitations in the general status docs and the Windows capability matrix.

Tests:
- Add focused tests covering OSC 52 clipboard backing resolution and selector preservation based on platform clipboard support.