### PR TITLE
Add Win32 VT conformance probe harness

### DIFF
--- a/docs/windows-vt-conformance.md
+++ b/docs/windows-vt-conformance.md
@@ -1,0 +1,46 @@
+# Windows VT Conformance
+
+`+vt-probe` is a deterministic capability inventory. It distinguishes shared
+parser/core support from behavior that has also been validated through the
+Win32 runtime.
+
+Each capability line includes:
+
+- `category`: protocol family (`terminfo`, `osc`, `csi`, or `graphics`).
+- `direction`: whether winghostty advertises, parses, or parses and emits it.
+- `win32-runtime`: Win32 validation status.
+- `evidence`: harness or test family behind the status.
+
+`win32-runtime` values:
+
+- `validated`: an interactive Win32 harness exercises the protocol behavior.
+- `parser-only`: parser/core support is known, but no Win32 GUI behavior is
+  validated.
+- `pending`: practical Win32 runtime coverage is still missing.
+- `not-applicable`: the claim is not a runtime protocol behavior.
+
+Current practical Win32 coverage:
+
+- OSC 9 desktop notification and OSC 133 command-finish state:
+  `test/windows/interactive-win11-command-finish.ps1`
+- OSC 9;4 taskbar progress:
+  `test/windows/interactive-win11-progress.ps1`
+- CSI ?2026 synchronized output repaint behavior:
+  `test/windows/interactive-win11-boo-performance.ps1`
+
+Run the fast metadata validator:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\test\windows\vt-probe-win32-conformance.ps1 -ResetState -TimeoutSeconds 10
+```
+
+Run the metadata validator plus the referenced Win32 runtime harnesses:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\test\windows\vt-probe-win32-conformance.ps1 -ResetState -Runtime
+```
+
+Known runtime gaps are intentionally visible in `+vt-probe`: OSC 7 cwd state,
+OSC 8 link interaction, OSC 52 clipboard prompts/reads/writes, color rendering
+for OSC 4 / 10 / 11 / 21, and Kitty graphics pixel validation do not yet have
+dedicated Win32 GUI harnesses.

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -185,16 +185,29 @@ pub fn writePlain(writer: *std.Io.Writer, probe: report) std.Io.Writer.Error!voi
 
     for (probe.capabilities) |entry| {
         try writer.print(
-            "capability={s} category={s} direction={s} win32-runtime={s} evidence={s}\n",
+            "capability={s} category={s} direction={s} win32-runtime={s} evidence=",
             .{
                 entry.id,
                 categoryString(entry.category),
                 directionString(entry.direction),
                 win32RuntimeString(entry.win32_runtime),
-                entry.evidence,
             },
         );
+        try writeQuoted(writer, entry.evidence);
+        try writer.writeByte('\n');
     }
+}
+
+fn writeQuoted(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
+    try writer.writeByte('"');
+    for (value) |byte| switch (byte) {
+        '\\', '"' => try writer.print("\\{c}", .{byte}),
+        '\n' => try writer.writeAll("\\n"),
+        '\r' => try writer.writeAll("\\r"),
+        '\t' => try writer.writeAll("\\t"),
+        else => try writer.writeByte(byte),
+    };
+    try writer.writeByte('"');
 }
 
 fn categoryString(value: category) []const u8 {
@@ -261,28 +274,28 @@ test "vt-probe terminfo claim tracks compiled terminfo" {
 
 test "vt-probe plain output is deterministic" {
     const testing = std.testing;
-    var buf: [4096]u8 = undefined;
-    var writer: std.Io.Writer = .fixed(&buf);
-    try writePlain(&writer, probeReport());
+    var writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer writer.deinit();
+    try writePlain(&writer.writer, probeReport());
 
     try testing.expectEqualStrings(
         \\probe=static
         \\term=xterm-ghostty
-        \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise win32-runtime=not-applicable evidence=terminfo-advertisement
-        \\capability=osc-7-working-directory category=osc direction=parse win32-runtime=parser-only evidence=powershell-shell-integration emits OSC 7; no Win32 GUI state harness
-        \\capability=osc-8-hyperlink category=osc direction=parse+emit win32-runtime=pending evidence=link storage/formatter covered by core tests; no Win32 click/tooltip harness
-        \\capability=osc-9-desktop-notification category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-command-finish.ps1
-        \\capability=osc-777-desktop-notification category=osc direction=parse win32-runtime=parser-only evidence=shared notification parser path; no dedicated Win32 OSC 777 payload harness
-        \\capability=osc-9-4-progress category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-progress.ps1
-        \\capability=osc-52-clipboard category=osc direction=parse+emit win32-runtime=pending evidence=Win32 clipboard policy exists; no non-interactive OSC 52 prompt/read/write harness
-        \\capability=osc-133-semantic-prompt category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-command-finish.ps1
-        \\capability=osc-4-palette category=osc direction=parse+emit win32-runtime=parser-only evidence=core color protocol tests; no Win32 rendered palette harness
-        \\capability=osc-10-11-colors category=osc direction=parse+emit win32-runtime=parser-only evidence=core color protocol tests; no Win32 rendered default-color harness
-        \\capability=osc-21-kitty-color-stack category=osc direction=parse win32-runtime=parser-only evidence=core kitty color protocol tests; no Win32 rendered color-stack harness
-        \\capability=csi-2026-synchronized-output category=csi direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-boo-performance.ps1
-        \\capability=kitty-graphics category=graphics direction=parse win32-runtime=pending evidence=core Kitty graphics tests; no Win32 pixel/renderer harness
+        \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise win32-runtime=not-applicable evidence="terminfo-advertisement"
+        \\capability=osc-7-working-directory category=osc direction=parse win32-runtime=parser-only evidence="powershell-shell-integration emits OSC 7; no Win32 GUI state harness"
+        \\capability=osc-8-hyperlink category=osc direction=parse+emit win32-runtime=pending evidence="link storage/formatter covered by core tests; no Win32 click/tooltip harness"
+        \\capability=osc-9-desktop-notification category=osc direction=parse win32-runtime=validated evidence="test/windows/interactive-win11-command-finish.ps1"
+        \\capability=osc-777-desktop-notification category=osc direction=parse win32-runtime=parser-only evidence="shared notification parser path; no dedicated Win32 OSC 777 payload harness"
+        \\capability=osc-9-4-progress category=osc direction=parse win32-runtime=validated evidence="test/windows/interactive-win11-progress.ps1"
+        \\capability=osc-52-clipboard category=osc direction=parse+emit win32-runtime=pending evidence="Win32 clipboard policy exists; no non-interactive OSC 52 prompt/read/write harness"
+        \\capability=osc-133-semantic-prompt category=osc direction=parse win32-runtime=validated evidence="test/windows/interactive-win11-command-finish.ps1"
+        \\capability=osc-4-palette category=osc direction=parse+emit win32-runtime=parser-only evidence="core color protocol tests; no Win32 rendered palette harness"
+        \\capability=osc-10-11-colors category=osc direction=parse+emit win32-runtime=parser-only evidence="core color protocol tests; no Win32 rendered default-color harness"
+        \\capability=osc-21-kitty-color-stack category=osc direction=parse win32-runtime=parser-only evidence="core kitty color protocol tests; no Win32 rendered color-stack harness"
+        \\capability=csi-2026-synchronized-output category=csi direction=parse win32-runtime=validated evidence="test/windows/interactive-win11-boo-performance.ps1"
+        \\capability=kitty-graphics category=graphics direction=parse win32-runtime=pending evidence="core Kitty graphics tests; no Win32 pixel/renderer harness"
         \\
     ,
-        writer.buffered(),
+        writer.written(),
     );
 }

--- a/src/cli/vt_probe.zig
+++ b/src/cli/vt_probe.zig
@@ -8,6 +8,7 @@ pub const category = enum {
     terminfo,
     osc,
     csi,
+    graphics,
 };
 
 pub const direction = enum {
@@ -16,10 +17,19 @@ pub const direction = enum {
     parse_emit,
 };
 
+pub const win32_runtime = enum {
+    not_applicable,
+    parser_only,
+    validated,
+    pending,
+};
+
 pub const capability = struct {
     id: []const u8,
     category: category,
     direction: direction,
+    win32_runtime: win32_runtime,
+    evidence: []const u8,
 };
 
 pub const report = struct {
@@ -35,61 +45,92 @@ const capabilities = [_]capability{
         .id = terminfoCapabilityId,
         .category = .terminfo,
         .direction = .advertise,
+        .win32_runtime = .not_applicable,
+        .evidence = "terminfo-advertisement",
     },
     .{
         .id = "osc-7-working-directory",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .parser_only,
+        .evidence = "powershell-shell-integration emits OSC 7; no Win32 GUI state harness",
     },
     .{
         .id = "osc-8-hyperlink",
         .category = .osc,
         .direction = .parse_emit,
+        .win32_runtime = .pending,
+        .evidence = "link storage/formatter covered by core tests; no Win32 click/tooltip harness",
     },
     .{
         .id = "osc-9-desktop-notification",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .validated,
+        .evidence = "test/windows/interactive-win11-command-finish.ps1",
     },
     .{
         .id = "osc-777-desktop-notification",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .parser_only,
+        .evidence = "shared notification parser path; no dedicated Win32 OSC 777 payload harness",
     },
     .{
         .id = "osc-9-4-progress",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .validated,
+        .evidence = "test/windows/interactive-win11-progress.ps1",
     },
     .{
         .id = "osc-52-clipboard",
         .category = .osc,
         .direction = .parse_emit,
+        .win32_runtime = .pending,
+        .evidence = "Win32 clipboard policy exists; no non-interactive OSC 52 prompt/read/write harness",
     },
     .{
         .id = "osc-133-semantic-prompt",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .validated,
+        .evidence = "test/windows/interactive-win11-command-finish.ps1",
     },
     .{
         .id = "osc-4-palette",
         .category = .osc,
         .direction = .parse_emit,
+        .win32_runtime = .parser_only,
+        .evidence = "core color protocol tests; no Win32 rendered palette harness",
     },
     .{
         .id = "osc-10-11-colors",
         .category = .osc,
         .direction = .parse_emit,
+        .win32_runtime = .parser_only,
+        .evidence = "core color protocol tests; no Win32 rendered default-color harness",
     },
     .{
         .id = "osc-21-kitty-color-stack",
         .category = .osc,
         .direction = .parse,
+        .win32_runtime = .parser_only,
+        .evidence = "core kitty color protocol tests; no Win32 rendered color-stack harness",
     },
     .{
         .id = "csi-2026-synchronized-output",
         .category = .csi,
         .direction = .parse,
+        .win32_runtime = .validated,
+        .evidence = "test/windows/interactive-win11-boo-performance.ps1",
+    },
+    .{
+        .id = "kitty-graphics",
+        .category = .graphics,
+        .direction = .parse,
+        .win32_runtime = .pending,
+        .evidence = "core Kitty graphics tests; no Win32 pixel/renderer harness",
     },
 };
 
@@ -144,11 +185,13 @@ pub fn writePlain(writer: *std.Io.Writer, probe: report) std.Io.Writer.Error!voi
 
     for (probe.capabilities) |entry| {
         try writer.print(
-            "capability={s} category={s} direction={s}\n",
+            "capability={s} category={s} direction={s} win32-runtime={s} evidence={s}\n",
             .{
                 entry.id,
                 categoryString(entry.category),
                 directionString(entry.direction),
+                win32RuntimeString(entry.win32_runtime),
+                entry.evidence,
             },
         );
     }
@@ -159,6 +202,7 @@ fn categoryString(value: category) []const u8 {
         .terminfo => "terminfo",
         .osc => "osc",
         .csi => "csi",
+        .graphics => "graphics",
     };
 }
 
@@ -170,13 +214,22 @@ fn directionString(value: direction) []const u8 {
     };
 }
 
+fn win32RuntimeString(value: win32_runtime) []const u8 {
+    return switch (value) {
+        .not_applicable => "not-applicable",
+        .parser_only => "parser-only",
+        .validated => "validated",
+        .pending => "pending",
+    };
+}
+
 test "vt-probe report includes core capabilities" {
     const testing = std.testing;
     const probe = probeReport();
 
     try testing.expectEqualStrings("static", probe.source);
     try testing.expectEqualStrings(defaultTerm, probe.term);
-    try testing.expectEqual(@as(usize, 12), probe.capabilities.len);
+    try testing.expectEqual(@as(usize, 13), probe.capabilities.len);
 
     try testing.expectEqualStrings(terminfoCapabilityId, probe.capabilities[0].id);
     try testing.expectEqualStrings("osc-7-working-directory", probe.capabilities[1].id);
@@ -190,6 +243,12 @@ test "vt-probe report includes core capabilities" {
     try testing.expectEqualStrings("osc-10-11-colors", probe.capabilities[9].id);
     try testing.expectEqualStrings("osc-21-kitty-color-stack", probe.capabilities[10].id);
     try testing.expectEqualStrings("csi-2026-synchronized-output", probe.capabilities[11].id);
+    try testing.expectEqualStrings("kitty-graphics", probe.capabilities[12].id);
+    try testing.expectEqual(win32_runtime.validated, probe.capabilities[3].win32_runtime);
+    try testing.expectEqual(win32_runtime.validated, probe.capabilities[5].win32_runtime);
+    try testing.expectEqual(win32_runtime.validated, probe.capabilities[7].win32_runtime);
+    try testing.expectEqual(win32_runtime.validated, probe.capabilities[11].win32_runtime);
+    try testing.expectEqual(win32_runtime.pending, probe.capabilities[12].win32_runtime);
 }
 
 test "vt-probe terminfo claim tracks compiled terminfo" {
@@ -202,25 +261,26 @@ test "vt-probe terminfo claim tracks compiled terminfo" {
 
 test "vt-probe plain output is deterministic" {
     const testing = std.testing;
-    var buf: [1024]u8 = undefined;
+    var buf: [4096]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
     try writePlain(&writer, probeReport());
 
     try testing.expectEqualStrings(
         \\probe=static
         \\term=xterm-ghostty
-        \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise
-        \\capability=osc-7-working-directory category=osc direction=parse
-        \\capability=osc-8-hyperlink category=osc direction=parse+emit
-        \\capability=osc-9-desktop-notification category=osc direction=parse
-        \\capability=osc-777-desktop-notification category=osc direction=parse
-        \\capability=osc-9-4-progress category=osc direction=parse
-        \\capability=osc-52-clipboard category=osc direction=parse+emit
-        \\capability=osc-133-semantic-prompt category=osc direction=parse
-        \\capability=osc-4-palette category=osc direction=parse+emit
-        \\capability=osc-10-11-colors category=osc direction=parse+emit
-        \\capability=osc-21-kitty-color-stack category=osc direction=parse
-        \\capability=csi-2026-synchronized-output category=csi direction=parse
+        \\capability=terminfo-xterm-ghostty category=terminfo direction=advertise win32-runtime=not-applicable evidence=terminfo-advertisement
+        \\capability=osc-7-working-directory category=osc direction=parse win32-runtime=parser-only evidence=powershell-shell-integration emits OSC 7; no Win32 GUI state harness
+        \\capability=osc-8-hyperlink category=osc direction=parse+emit win32-runtime=pending evidence=link storage/formatter covered by core tests; no Win32 click/tooltip harness
+        \\capability=osc-9-desktop-notification category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-command-finish.ps1
+        \\capability=osc-777-desktop-notification category=osc direction=parse win32-runtime=parser-only evidence=shared notification parser path; no dedicated Win32 OSC 777 payload harness
+        \\capability=osc-9-4-progress category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-progress.ps1
+        \\capability=osc-52-clipboard category=osc direction=parse+emit win32-runtime=pending evidence=Win32 clipboard policy exists; no non-interactive OSC 52 prompt/read/write harness
+        \\capability=osc-133-semantic-prompt category=osc direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-command-finish.ps1
+        \\capability=osc-4-palette category=osc direction=parse+emit win32-runtime=parser-only evidence=core color protocol tests; no Win32 rendered palette harness
+        \\capability=osc-10-11-colors category=osc direction=parse+emit win32-runtime=parser-only evidence=core color protocol tests; no Win32 rendered default-color harness
+        \\capability=osc-21-kitty-color-stack category=osc direction=parse win32-runtime=parser-only evidence=core kitty color protocol tests; no Win32 rendered color-stack harness
+        \\capability=csi-2026-synchronized-output category=csi direction=parse win32-runtime=validated evidence=test/windows/interactive-win11-boo-performance.ps1
+        \\capability=kitty-graphics category=graphics direction=parse win32-runtime=pending evidence=core Kitty graphics tests; no Win32 pixel/renderer harness
         \\
     ,
         writer.buffered(),

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -64,7 +64,7 @@ files under `src\` are newer than `zig-out\bin\winghostty.exe`. Pass
 ## vt-probe-win32-conformance.ps1
 
 Win32 VT protocol conformance metadata validation. It runs `+vt-probe` and
-asserts that each advertised protocol reports a separate Win32-runtime
+asserts that each capability reports a separate Win32-runtime
 classification:
 
 - `validated` means an interactive Win32 harness exercises the behavior.

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -61,6 +61,28 @@ The harness rebuilds automatically when `build.zig`, `build.zig.zon`, or
 files under `src\` are newer than `zig-out\bin\winghostty.exe`. Pass
 `-Rebuild` to force a full rebuild anyway.
 
+## vt-probe-win32-conformance.ps1
+
+Win32 VT protocol conformance metadata validation. It runs `+vt-probe` and
+asserts that each advertised protocol reports a separate Win32-runtime
+classification:
+
+- `validated` means an interactive Win32 harness exercises the behavior.
+- `parser-only` means shared parser/core support exists, but no Win32 GUI
+  behavior is validated.
+- `pending` means the Win32 behavior exists or is expected, but the practical
+  harness is still missing.
+
+Run the fast metadata check with:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\vt-probe-win32-conformance.ps1 -ResetState -TimeoutSeconds 10
+```
+
+Pass `-Runtime` to also run the heavier Win32 evidence harnesses currently
+referenced by `+vt-probe`: command finish / notification, taskbar progress,
+and synchronized-output repaint performance.
+
 ## interactive-win11-progress.ps1
 
 Interactive Win11 validation for native progress state changes. It

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -199,6 +199,7 @@ function Get-HarnessSummary {
 
 Invoke-Harness -ScriptName 'interactive-win11.ps1'
 Invoke-SuiteBuildIfNeeded
+Invoke-Harness -ScriptName 'vt-probe-win32-conformance.ps1' -TimeoutSeconds 10 -PassResetState
 Invoke-Harness -ScriptName 'interactive-win11-smoke.ps1' -TimeoutSeconds 10 -PassResetState
 Invoke-Harness -ScriptName 'interactive-win11-boo-performance.ps1' -TimeoutSeconds 25
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-boo-multitab.ps1' -TimeoutSeconds 25

--- a/test/windows/vt-probe-win32-conformance.ps1
+++ b/test/windows/vt-probe-win32-conformance.ps1
@@ -101,7 +101,7 @@ foreach ($entry in $expectedRuntime.GetEnumerator()) {
     }
 }
 
-if ($stdout -notmatch 'capability=osc-133-semantic-prompt .* win32-runtime=validated ') {
+if ($stdout -notmatch 'capability=osc-133-semantic-prompt .* win32-runtime=validated evidence="test/windows/interactive-win11-command-finish\.ps1"') {
     throw "OSC 133 command-finish evidence is missing from +vt-probe output.`nOutput:`n$stdout"
 }
 

--- a/test/windows/vt-probe-win32-conformance.ps1
+++ b/test/windows/vt-probe-win32-conformance.ps1
@@ -1,0 +1,137 @@
+param(
+    [switch] $Rebuild,
+    [switch] $ResetState,
+    [switch] $Runtime,
+    [int] $TimeoutSeconds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TimeoutSeconds -le 0) {
+    throw 'TimeoutSeconds must be greater than 0.'
+}
+
+$launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+. $libPath
+
+if (-not $env:WINGHOSTTY_VT_PROBE_WIN32_CONFORMANCE_BOOTSTRAPPED) {
+    $forwardedArgs = @('-TimeoutSeconds', $TimeoutSeconds.ToString())
+    if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+    if ($ResetState) { $forwardedArgs += '-ResetState' }
+    if ($Runtime) { $forwardedArgs += '-Runtime' }
+
+    $bootstrapExitCode = 0
+    Invoke-InteractiveWin11Bootstrap `
+        -RepoRoot $repoRoot `
+        -LauncherPath $launcherPath `
+        -EnvironmentVariable 'WINGHOSTTY_VT_PROBE_WIN32_CONFORMANCE_BOOTSTRAPPED' `
+        -ArgumentList $forwardedArgs `
+        -ExitCode ([ref] $bootstrapExitCode)
+    exit $bootstrapExitCode
+}
+
+$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'vt-conformance' -ResetState:$ResetState -IncludeResourcesDir
+$repoRoot = $harness.RepoRoot
+$layout = $harness.Layout
+
+$exePath = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
+$buildInputs = Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot
+$launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -BuildInputs $buildInputs
+$stdoutPath = Join-Path $layout.Logs 'vt-probe-win32-conformance-stdout.log'
+$stderrPath = Join-Path $layout.Logs 'vt-probe-win32-conformance-stderr.log'
+
+if ($launchAction -eq 'build') {
+    Invoke-InteractiveWin11Build -RepoRoot $repoRoot
+}
+
+Assert-InteractiveWin11ExeExists -ExePath $exePath
+Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+
+$process = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList '+vt-probe' `
+    -WorkingDirectory $repoRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -WindowStyle Hidden `
+    -PassThru
+$processHandle = $process.Handle
+
+try {
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        throw "+vt-probe did not exit within ${TimeoutSeconds}s"
+    }
+
+    $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
+    if ($exitCode -ne 0) {
+        throw "+vt-probe exited with code $exitCode"
+    }
+}
+finally {
+    Stop-InteractiveWin11Process -Process $process
+}
+
+$stdout = Get-InteractiveWin11TextFile -Path $stdoutPath
+$stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+if (-not [string]::IsNullOrWhiteSpace($stderr)) {
+    throw "+vt-probe wrote unexpected stderr:`n$stderr"
+}
+
+$expectedRuntime = [ordered]@{
+    'osc-7-working-directory' = 'parser-only'
+    'osc-8-hyperlink' = 'pending'
+    'osc-9-desktop-notification' = 'validated'
+    'osc-777-desktop-notification' = 'parser-only'
+    'osc-9-4-progress' = 'validated'
+    'osc-52-clipboard' = 'pending'
+    'osc-4-palette' = 'parser-only'
+    'osc-10-11-colors' = 'parser-only'
+    'osc-21-kitty-color-stack' = 'parser-only'
+    'csi-2026-synchronized-output' = 'validated'
+    'kitty-graphics' = 'pending'
+}
+
+foreach ($entry in $expectedRuntime.GetEnumerator()) {
+    $escapedId = [regex]::Escape([string] $entry.Key)
+    $escapedRuntime = [regex]::Escape([string] $entry.Value)
+    if ($stdout -notmatch "capability=$escapedId .* win32-runtime=$escapedRuntime ") {
+        throw "Missing or incorrect Win32 runtime classification for $($entry.Key): expected $($entry.Value).`nOutput:`n$stdout"
+    }
+}
+
+if ($stdout -notmatch 'capability=osc-133-semantic-prompt .* win32-runtime=validated ') {
+    throw "OSC 133 command-finish evidence is missing from +vt-probe output.`nOutput:`n$stdout"
+}
+
+if ($Runtime) {
+    $runtimeHarnesses = @(
+        @{ Script = 'interactive-win11-command-finish.ps1'; Timeout = 12 },
+        @{ Script = 'interactive-win11-progress.ps1'; Timeout = 20 },
+        @{ Script = 'interactive-win11-boo-performance.ps1'; Timeout = 25 }
+    )
+
+    foreach ($runtimeHarness in $runtimeHarnesses) {
+        $scriptPath = Join-Path $PSScriptRoot $runtimeHarness.Script
+        $args = @(
+            '-NoLogo'
+            '-NoProfile'
+            '-ExecutionPolicy'
+            'Bypass'
+            '-File'
+            $scriptPath
+            '-TimeoutSeconds'
+            ($runtimeHarness.Timeout.ToString())
+        )
+        if ($ResetState) { $args += '-ResetState' }
+
+        & powershell.exe @args
+        if ($LASTEXITCODE -ne 0) {
+            throw "$($runtimeHarness.Script) failed with exit code $LASTEXITCODE"
+        }
+    }
+}
+
+$mode = if ($Runtime) { 'runtime' } else { 'metadata' }
+Write-Host "vt-probe Win32 conformance validation: PASS (mode=$mode, stdout=$stdoutPath)"

--- a/test/windows/vt-probe-win32-conformance.ps1
+++ b/test/windows/vt-probe-win32-conformance.ps1
@@ -114,7 +114,7 @@ if ($Runtime) {
 
     foreach ($runtimeHarness in $runtimeHarnesses) {
         $scriptPath = Join-Path $PSScriptRoot $runtimeHarness.Script
-        $args = @(
+        $scriptArgs = @(
             '-NoLogo'
             '-NoProfile'
             '-ExecutionPolicy'
@@ -124,9 +124,9 @@ if ($Runtime) {
             '-TimeoutSeconds'
             ($runtimeHarness.Timeout.ToString())
         )
-        if ($ResetState) { $args += '-ResetState' }
+        if ($ResetState) { $scriptArgs += '-ResetState' }
 
-        & powershell.exe @args
+        & powershell.exe @scriptArgs
         if ($LASTEXITCODE -ne 0) {
             throw "$($runtimeHarness.Script) failed with exit code $LASTEXITCODE"
         }


### PR DESCRIPTION
Adds the Win32 VT conformance probe harness and runtime evidence integration. Validation: zig fmt, vt-probe tests, PowerShell syntax checks, metadata mode, runtime mode, and git diff checks passed. @codex @coderabbitai @greptileai Copilot: please review this branch; I will iterate on findings until it is clean to squash and merge.

## Summary by Sourcery

Add Win32 VT conformance metadata to vt-probe and integrate a Windows harness that validates reported capabilities against runtime evidence.

Enhancements:
- Extend vt-probe capabilities with a graphics category, Win32 runtime classification, and evidence metadata, and expose them in the plain-text report output.

Documentation:
- Document Windows VT conformance semantics, current coverage, and usage of the new vt-probe Win32 conformance harness in a dedicated guide.

Tests:
- Add a vt-probe Win32 conformance PowerShell harness and integrate it into the interactive Windows validation suite to check capability classifications and optional runtime evidence runs.