### PR TITLE
Add opt-in Windows job object limits

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -391,6 +391,14 @@ fn startWindows(self: *Command, arena: Allocator) !void {
             log.warn("windows job object attach failed; continuing without limits err={}", .{last_error});
             _ = windows.CloseHandle(handle);
             job_handle = null;
+
+            var exit_code: windows.DWORD = undefined;
+            if (windows.kernel32.GetExitCodeProcess(process_information.hProcess, &exit_code) == 0) {
+                return windows.unexpectedError(windows.kernel32.GetLastError());
+            }
+            if (exit_code != windows.exp.STILL_ACTIVE) {
+                return error.WindowsJobObjectAttachExitedChild;
+            }
         }
 
         if (windows.exp.kernel32.ResumeThread(process_information.hThread) == std.math.maxInt(windows.DWORD)) {
@@ -1078,6 +1086,7 @@ test "Command: windows job object plan attaches to local child process" {
         .args = &.{ "C:\\Windows\\System32\\cmd.exe", "/C", "exit", "0" },
         .windows_job_object_plan = .{
             .mode = .always,
+            .attach_policy = .hard_fail,
             .active_process_limit = 4,
         },
         .os_pre_exec = null,

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -32,6 +32,7 @@ const Allocator = std.mem.Allocator;
 const File = std.fs.File;
 const EnvMap = std.process.EnvMap;
 const apprt = @import("apprt.zig");
+const log = std.log.scoped(.command);
 
 /// Function prototype for a function executed /in the child process/ after the
 /// fork, but before exec'ing the command. If the function returns a u8, the
@@ -107,6 +108,13 @@ data: ?*anyopaque = null,
 
 /// Process ID is set after start is called.
 pid: ?posix.pid_t = null,
+
+/// Optional Windows Job Object plan and live handle. Inert on non-Windows
+/// builds.
+windows_job_object_plan: if (builtin.os.tag == .windows) apprt.win32_job_object.Plan else void =
+    if (builtin.os.tag == .windows) .{ .mode = .never } else {},
+windows_job_object_handle: if (builtin.os.tag == .windows) ?windows.HANDLE else void =
+    if (builtin.os.tag == .windows) null else {},
 
 /// The various methods a process may exit.
 pub const Exit = if (builtin.os.tag == .windows) union(enum) {
@@ -345,8 +353,14 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         .lpAttributeList = attribute_list,
     };
 
+    var job_handle = try self.createWindowsJobObjectForLaunch();
+    errdefer {
+        if (job_handle) |handle| _ = windows.CloseHandle(handle);
+    }
+
     var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
     if (attribute_list != null) flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
+    if (job_handle != null) flags |= windows.exp.CREATE_SUSPENDED;
 
     var process_information: windows.PROCESS_INFORMATION = undefined;
     if (windows.exp.kernel32.CreateProcessW(
@@ -361,8 +375,79 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         @ptrCast(&startup_info_ex.StartupInfo),
         &process_information,
     ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+    errdefer {
+        _ = windows.kernel32.TerminateProcess(process_information.hProcess, 1);
+        _ = windows.CloseHandle(process_information.hThread);
+        _ = windows.CloseHandle(process_information.hProcess);
+    }
+
+    if (job_handle) |handle| {
+        if (apprt.win32_job_object.AssignProcessToJobObject(handle, process_information.hProcess) == 0) {
+            const last_error = windows.kernel32.GetLastError();
+            if (self.windows_job_object_plan.attach_policy == .hard_fail) {
+                return windows.unexpectedError(last_error);
+            }
+
+            log.warn("windows job object attach failed; continuing without limits err={}", .{last_error});
+            _ = windows.CloseHandle(handle);
+            job_handle = null;
+        }
+
+        if (windows.exp.kernel32.ResumeThread(process_information.hThread) == std.math.maxInt(windows.DWORD)) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+    }
+
+    _ = windows.CloseHandle(process_information.hThread);
 
     self.pid = process_information.hProcess;
+    self.windows_job_object_handle = job_handle;
+}
+
+fn createWindowsJobObjectForLaunch(self: *Command) !?windows.HANDLE {
+    const plan = self.windows_job_object_plan;
+    switch (apprt.win32_job_object.attachTarget(plan, self.path)) {
+        .disabled => return null,
+        .unsupported_wsl => {
+            if (plan.attach_policy == .hard_fail) return error.UnsupportedJobObjectTarget;
+            log.warn("windows job object limits are not applied to WSL launches path={s}", .{self.path});
+            return null;
+        },
+        .attach => {},
+    }
+
+    const handle = apprt.win32_job_object.CreateJobObjectW(null, null) orelse {
+        const last_error = windows.kernel32.GetLastError();
+        if (plan.attach_policy == .hard_fail) return windows.unexpectedError(last_error);
+        log.warn("windows job object creation failed; continuing without limits err={}", .{last_error});
+        return null;
+    };
+    errdefer _ = windows.CloseHandle(handle);
+
+    if (plan.extendedLimitInformation()) |limits| {
+        if (apprt.win32_job_object.SetInformationJobObject(
+            handle,
+            .extended_limit_information,
+            &limits,
+            @sizeOf(apprt.win32_job_object.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+        ) == 0) {
+            const last_error = windows.kernel32.GetLastError();
+            if (plan.attach_policy == .hard_fail) return windows.unexpectedError(last_error);
+            log.warn("windows job object limit setup failed; continuing without limits err={}", .{last_error});
+            _ = windows.CloseHandle(handle);
+            return null;
+        }
+    }
+
+    return handle;
+}
+
+pub fn closeWindowsJobObject(self: *Command) void {
+    if (comptime builtin.os.tag != .windows) return;
+    if (self.windows_job_object_handle) |handle| {
+        _ = windows.CloseHandle(handle);
+        self.windows_job_object_handle = null;
+    }
 }
 
 fn safeWindowsCurrentDirectory(
@@ -983,6 +1068,32 @@ test "Command: custom working directory" {
     } else {
         try testing.expectEqualStrings("/tmp\n", contents);
     }
+}
+
+test "Command: windows job object plan attaches to local child process" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var cmd: Command = .{
+        .path = "C:\\Windows\\System32\\cmd.exe",
+        .args = &.{ "C:\\Windows\\System32\\cmd.exe", "/C", "exit", "0" },
+        .windows_job_object_plan = .{
+            .mode = .always,
+            .active_process_limit = 4,
+        },
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+    defer cmd.closeWindowsJobObject();
+
+    try cmd.testingStart();
+    try testing.expect(cmd.pid != null);
+    try testing.expect(cmd.windows_job_object_handle != null);
+    const exit = try cmd.wait(true);
+    try testing.expect(exit == .Exited);
+    try testing.expectEqual(@as(u32, 0), @as(u32, exit.Exited));
 }
 
 // Test validate an execveZ failure correctly terminates when error.ExecFailedInChild is correctly handled

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -723,6 +723,10 @@ pub fn init(
             .term = config.term,
             .rt_pre_exec_info = .init(config),
             .rt_post_fork_info = .init(config),
+            .windows_job_object_plan = apprt.win32_job_object.configPlan(config) catch |err| {
+                log.warn("invalid windows job object config err={}", .{err});
+                return err;
+            },
         });
         errdefer io_exec.deinit();
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -723,10 +723,12 @@ pub fn init(
             .term = config.term,
             .rt_pre_exec_info = .init(config),
             .rt_post_fork_info = .init(config),
-            .windows_job_object_plan = apprt.win32_job_object.configPlan(config) catch |err| {
-                log.warn("invalid windows job object config err={}", .{err});
-                return err;
-            },
+            .windows_job_object_plan = if (builtin.os.tag == .windows)
+                apprt.win32_job_object.configPlan(config) catch |err| {
+                    log.warn("invalid windows job object config err={}", .{err});
+                    return err;
+                }
+            else {},
         });
         errdefer io_exec.deinit();
 

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -1,9 +1,10 @@
 //! Minimal Windows Job Object ABI and config planning.
 //!
-//! This first slice is intentionally inert: it only exposes the Win32
-//! declarations and a pure mapping from existing compatibility config to a
-//! future Job Object plan. No live process spawning or enforcement is wired
-//! here yet.
+//! This layer exposes the Win32 declarations plus a small planning surface used
+//! by the Windows process launcher. Enforcement remains opt-in through the
+//! retained linux-cgroup compatibility settings, and WSL launches are excluded
+//! because limiting `wsl.exe` does not safely or predictably limit the Linux
+//! process tree.
 
 const std = @import("std");
 const windows = std.os.windows;
@@ -126,6 +127,18 @@ pub const Plan = struct {
     }
 };
 
+pub const AttachTarget = enum {
+    disabled,
+    attach,
+    unsupported_wsl,
+};
+
+pub fn attachTarget(plan: Plan, argv0: []const u8) AttachTarget {
+    if (!plan.wantsJobObject()) return .disabled;
+    if (isWslExecutable(argv0)) return .unsupported_wsl;
+    return .attach;
+}
+
 pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
     const mode = switch (config.@"linux-cgroup") {
         .never => Mode.never,
@@ -151,6 +164,22 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
         else
             null,
     };
+}
+
+fn isWslExecutable(path: []const u8) bool {
+    const base = basename(path);
+    return std.ascii.eqlIgnoreCase(base, "wsl.exe") or
+        std.ascii.eqlIgnoreCase(base, "wsl");
+}
+
+fn basename(path: []const u8) []const u8 {
+    var i: usize = path.len;
+    while (i > 0) : (i -= 1) {
+        const c = path[i - 1];
+        if (c == '\\' or c == '/') return path[i..];
+    }
+
+    return path;
 }
 
 test "win32 job object ABI declarations match expected Win32 values" {
@@ -251,6 +280,19 @@ test "win32 job object single-instance mode can request hard-fail attachment wit
     try std.testing.expect(plan.wantsJobObject());
     try std.testing.expect(!plan.hasLimits());
     try std.testing.expect(plan.extendedLimitInformation() == null);
+}
+
+test "win32 job object attach target skips WSL launches" {
+    const plan: Plan = .{ .mode = .always };
+
+    try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "pwsh.exe"));
+    try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "C:\\Windows\\System32\\cmd.exe"));
+    try std.testing.expectEqual(AttachTarget.unsupported_wsl, attachTarget(plan, "wsl.exe"));
+    try std.testing.expectEqual(
+        AttachTarget.unsupported_wsl,
+        attachTarget(plan, "C:\\Windows\\System32\\wsl.exe"),
+    );
+    try std.testing.expectEqual(AttachTarget.disabled, attachTarget(.{ .mode = .never }, "cmd.exe"));
 }
 
 test "win32 job object plan rejects process limits that exceed DWORD" {

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -168,8 +168,7 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
 
 fn isWslExecutable(path: []const u8) bool {
     const base = basename(path);
-    return std.ascii.eqlIgnoreCase(base, "wsl.exe") or
-        std.ascii.eqlIgnoreCase(base, "wsl");
+    return std.ascii.eqlIgnoreCase(base, "wsl.exe");
 }
 
 fn basename(path: []const u8) []const u8 {
@@ -286,6 +285,7 @@ test "win32 job object attach target skips WSL launches" {
     const plan: Plan = .{ .mode = .always };
 
     try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "pwsh.exe"));
+    try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "wsl"));
     try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "C:\\Windows\\System32\\cmd.exe"));
     try std.testing.expectEqual(AttachTarget.unsupported_wsl, attachTarget(plan, "wsl.exe"));
     try std.testing.expectEqual(

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -168,7 +168,8 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
 
 fn isWslExecutable(path: []const u8) bool {
     const base = basename(path);
-    return std.ascii.eqlIgnoreCase(base, "wsl.exe");
+    return std.ascii.eqlIgnoreCase(base, "wsl.exe") or
+        std.ascii.eqlIgnoreCase(base, "wsl");
 }
 
 fn basename(path: []const u8) []const u8 {
@@ -285,8 +286,8 @@ test "win32 job object attach target skips WSL launches" {
     const plan: Plan = .{ .mode = .always };
 
     try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "pwsh.exe"));
-    try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "wsl"));
     try std.testing.expectEqual(AttachTarget.attach, attachTarget(plan, "C:\\Windows\\System32\\cmd.exe"));
+    try std.testing.expectEqual(AttachTarget.unsupported_wsl, attachTarget(plan, "wsl"));
     try std.testing.expectEqual(AttachTarget.unsupported_wsl, attachTarget(plan, "wsl.exe"));
     try std.testing.expectEqual(
         AttachTarget.unsupported_wsl,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3044,32 +3044,35 @@ keybind: Keybinds = .{},
 ///
 /// These keys continue to parse so existing configs remain loadable.
 ///
-/// In the Windows-only fork they are compatibility-only inputs to the inert
-/// Win32 Job Object planning layer. They do not attach processes to a job or
-/// enforce limits unless future runtime wiring explicitly opts in.
+/// In the Windows-only fork they are compatibility inputs to the Win32 Job
+/// Object planning layer. They are opt-in and apply only to Windows-local
+/// child processes; WSL launches are not attached because a Windows Job Object
+/// cannot safely enforce limits on the Linux process tree behind `wsl.exe`.
 ///
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// Selects whether the inert Win32 Job Object planning layer should synthesize
-/// a compatibility plan. `.never` preserves current Windows behavior.
+/// Selects whether the Win32 Job Object planning layer should synthesize a
+/// compatibility plan. `.never` preserves default Windows behavior.
 @"linux-cgroup": LinuxCgroup = .never,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// Compatibility-only input for inert Win32 Job Object planning. No live
-/// memory limit is enforced in the current Windows runtime.
+/// Compatibility input for Win32 Job Object planning. When `linux-cgroup` is
+/// enabled for a Windows-local launch, this sets `JOB_OBJECT_LIMIT_JOB_MEMORY`.
 @"linux-cgroup-memory-limit": ?u64 = null,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// Compatibility-only input for inert Win32 Job Object planning. No live
-/// process-count limit is enforced in the current Windows runtime.
+/// Compatibility input for Win32 Job Object planning. When `linux-cgroup` is
+/// enabled for a Windows-local launch, this sets
+/// `JOB_OBJECT_LIMIT_ACTIVE_PROCESS`.
 @"linux-cgroup-processes-limit": ?u64 = null,
 
 /// Retained compatibility setting from Linux-specific runtime features.
 ///
-/// Compatibility-only input for inert Win32 Job Object planning. No current
-/// runtime attach path hard-fails based on this setting.
+/// Compatibility input for Win32 Job Object planning. When true, Job Object
+/// creation, limit setup, attachment failure, or unsupported WSL targets fail
+/// the launch instead of continuing without limits.
 @"linux-cgroup-hard-fail": bool = false,
 
 /// Retained compatibility settings from the removed GTK runtime.

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -75,6 +75,7 @@ pub const exp = struct {
     pub const HPCON = windows.LPVOID;
 
     pub const CREATE_UNICODE_ENVIRONMENT = 0x00000400;
+    pub const CREATE_SUSPENDED = 0x00000004;
     pub const EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
     pub const LPPROC_THREAD_ATTRIBUTE_LIST = ?*anyopaque;
     pub const FILE_FLAG_FIRST_PIPE_INSTANCE = 0x00080000;
@@ -126,6 +127,9 @@ pub const exp = struct {
             lpTotalBytesAvail: ?*windows.DWORD,
             lpBytesLeftThisMessage: ?*windows.DWORD,
         ) callconv(.winapi) windows.BOOL;
+        pub extern "kernel32" fn ResumeThread(
+            hThread: windows.HANDLE,
+        ) callconv(.winapi) windows.DWORD;
         // Duplicated here because lpCommandLine is not marked optional in zig std
         pub extern "kernel32" fn CreateProcessW(
             lpApplicationName: ?windows.LPWSTR,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -623,6 +623,7 @@ pub const Config = struct {
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
+    windows_job_object_plan: apprt.win32_job_object.Plan = .{ .mode = .never },
 };
 
 const Subprocess = struct {
@@ -643,6 +644,7 @@ const Subprocess = struct {
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
+    windows_job_object_plan: apprt.win32_job_object.Plan,
 
     /// Union that represents the running process type.
     const Process = union(enum) {
@@ -936,6 +938,7 @@ const Subprocess = struct {
 
             .rt_pre_exec_info = cfg.rt_pre_exec_info,
             .rt_post_fork_info = cfg.rt_post_fork_info,
+            .windows_job_object_plan = cfg.windows_job_object_plan,
 
             // Should be initialized with initTerminal call.
             .grid_size = .{},
@@ -1105,6 +1108,7 @@ const Subprocess = struct {
             .rt_pre_exec_info = self.rt_pre_exec_info,
             .rt_post_fork = if (comptime @hasDecl(apprt.runtime, "post_fork")) apprt.runtime.post_fork.postFork else null,
             .rt_post_fork_info = self.rt_post_fork_info,
+            .windows_job_object_plan = self.windows_job_object_plan,
             .data = self,
         };
 
@@ -1153,6 +1157,10 @@ const Subprocess = struct {
     /// Called to notify that we exited externally so we can unset our
     /// running state.
     pub fn externalExit(self: *Subprocess) void {
+        switch (self.process orelse return) {
+            .fork_exec => |*cmd| cmd.closeWindowsJobObject(),
+            .flatpak => {},
+        }
         self.process = null;
     }
 
@@ -1207,6 +1215,7 @@ const Subprocess = struct {
     /// process. This also waits for the command to exit and will return the
     /// exit code.
     fn killCommand(command: *Command) !void {
+        defer command.closeWindowsJobObject();
         if (command.pid) |pid| {
             switch (builtin.os.tag) {
                 .windows => {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -32,6 +32,7 @@ const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.io_exec);
 const flatpak_support = false;
+const WindowsJobObjectPlan = if (builtin.os.tag == .windows) apprt.win32_job_object.Plan else void;
 const darwin = if (builtin.os.tag.isDarwin()) struct {
     fn setThreadName(name: [*:0]const u8) void {
         internal_os.macos.pthread_setname_np(name);
@@ -197,11 +198,17 @@ pub fn threadEnter(
     );
     read_thread.setName("io-reader") catch {};
 
+    const command: ?*Command = if (self.subprocess.process) |*subprocess| switch (subprocess.*) {
+        .fork_exec => |*cmd| cmd,
+        .flatpak => null,
+    } else null;
+
     // Setup our threadata backend state to be our own
     td.backend = .{ .exec = .{
         .start = process_start,
         .write_stream = stream,
         .process = process,
+        .command = command,
         .read_thread = read_thread,
         .read_thread_pipe = pipe[1],
         .read_thread_fd = pty_fds.read,
@@ -325,6 +332,7 @@ fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
     assert(td.backend == .exec);
     const execdata = &td.backend.exec;
     execdata.exited = true;
+    if (execdata.command) |cmd| cmd.closeWindowsJobObject();
 
     // Determine how long the process was running for.
     const runtime_ms: ?u64 = runtime: {
@@ -557,6 +565,9 @@ pub const ThreadData = struct {
     /// The process watcher
     process: ?xev.Process,
 
+    /// Command backing the process watcher, if this is a local child.
+    command: ?*Command = null,
+
     /// This is the pool of available (unused) write requests. If you grab
     /// one from the pool, you must put it back when you're done!
     write_req_pool: SegmentedPool(xev.WriteRequest, WRITE_REQ_PREALLOC) = .{},
@@ -623,7 +634,7 @@ pub const Config = struct {
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
-    windows_job_object_plan: apprt.win32_job_object.Plan = .{ .mode = .never },
+    windows_job_object_plan: WindowsJobObjectPlan = if (builtin.os.tag == .windows) .{ .mode = .never } else {},
 };
 
 const Subprocess = struct {
@@ -644,7 +655,7 @@ const Subprocess = struct {
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
-    windows_job_object_plan: apprt.win32_job_object.Plan,
+    windows_job_object_plan: WindowsJobObjectPlan,
 
     /// Union that represents the running process type.
     const Process = union(enum) {


### PR DESCRIPTION
Wires opt-in Windows Job Object limits into local Windows process spawning while explicitly excluding WSL targets. Validation: zig fmt, win32_job_object tests, windows job object tests, full zig build, and git diff checks passed. @codex @coderabbitai @greptileai Copilot: please review this branch; I will iterate on findings until it is clean to squash and merge.

## Summary by Sourcery

Wire optional Windows Job Object resource limits into local Windows process launching while leaving behavior unchanged elsewhere and for WSL targets.

New Features:
- Add opt-in Windows Job Object configuration to command execution so Windows-local child processes can be launched under resource-limited job objects.

Enhancements:
- Track and clean up Windows Job Object handles alongside process lifecycle, including external exits and kill paths.
- Extend Windows process startup flags and kernel32 bindings to support suspended launches and thread resumption when attaching job objects.
- Add logic to skip attaching job objects for WSL executables and to downgrade failures to warnings unless hard-fail is configured.

Documentation:
- Clarify configuration keys formerly tied to Linux cgroups as compatibility inputs that now control Windows Job Object planning and failure behavior.

Tests:
- Add unit tests for Windows Job Object attach targeting, including WSL exclusion behavior, and for successful command execution under a job object.