### PR TITLE
Add Win32 UIA text provider

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19669,6 +19669,7 @@ const TerminalUiaContext = struct {
             .release = release,
             .name = terminalUiaName,
             .value = terminalUiaValue,
+            .visible_value = terminalUiaVisibleValue,
             .focused = terminalUiaFocused,
         };
     }
@@ -19701,6 +19702,12 @@ const TerminalUiaContext = struct {
         defer snapshot.deinit();
 
         return snapshot.takeText();
+    }
+
+    fn terminalUiaVisibleValue(ctx: *anyopaque, alloc: Allocator) ![]u8 {
+        // TerminalFormatter formats the active rendered screen using
+        // PageList .screen bounds, so this excludes offscreen scrollback.
+        return terminalUiaValue(ctx, alloc);
     }
 
     fn terminalUiaFocused(ctx: *anyopaque) bool {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19670,6 +19670,7 @@ const TerminalUiaContext = struct {
             .name = terminalUiaName,
             .value = terminalUiaValue,
             .visible_value = terminalUiaVisibleValue,
+            .visible_range = terminalUiaVisibleRange,
             .focused = terminalUiaFocused,
         };
     }
@@ -19722,6 +19723,32 @@ const TerminalUiaContext = struct {
         defer snapshot.deinit();
 
         return snapshot.takeText();
+    }
+
+    fn terminalUiaVisibleRange(ctx: *anyopaque, alloc: Allocator) !win32_uia.OffsetRange {
+        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const surface = self.surface orelse return .{ .start = 0, .end = 0 };
+        if (!surface.core_initialized) return .{ .start = 0, .end = 0 };
+
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        var document = try win32_uia.snapshotTerminalPlainText(
+            alloc,
+            surface.core_surface.renderer_state.terminal,
+        );
+        defer document.deinit();
+
+        var visible = try win32_uia.snapshotTerminalVisiblePlainText(
+            alloc,
+            surface.core_surface.renderer_state.terminal,
+        );
+        defer visible.deinit();
+
+        return win32_uia.visibleRangeInDocument(&document, &visible) orelse .{ .start = 0, .end = 0 };
     }
 
     fn terminalUiaFocused(ctx: *anyopaque) bool {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19705,9 +19705,23 @@ const TerminalUiaContext = struct {
     }
 
     fn terminalUiaVisibleValue(ctx: *anyopaque, alloc: Allocator) ![]u8 {
-        // TerminalFormatter formats the active rendered screen using
-        // PageList .screen bounds, so this excludes offscreen scrollback.
-        return terminalUiaValue(ctx, alloc);
+        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const surface = self.surface orelse return try alloc.dupe(u8, "");
+        if (!surface.core_initialized) return try alloc.dupe(u8, "");
+
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        var snapshot = try win32_uia.snapshotTerminalVisiblePlainText(
+            alloc,
+            surface.core_surface.renderer_state.terminal,
+        );
+        defer snapshot.deinit();
+
+        return snapshot.takeText();
     }
 
     fn terminalUiaFocused(ctx: *anyopaque) bool {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19671,6 +19671,7 @@ const TerminalUiaContext = struct {
             .value = terminalUiaValue,
             .visible_value = terminalUiaVisibleValue,
             .visible_range = terminalUiaVisibleRange,
+            .snapshot = terminalUiaSnapshot,
             .focused = terminalUiaFocused,
         };
     }
@@ -19749,6 +19750,49 @@ const TerminalUiaContext = struct {
         defer visible.deinit();
 
         return win32_uia.visibleRangeInDocument(&document, &visible) orelse .{ .start = 0, .end = 0 };
+    }
+
+    fn terminalUiaSnapshot(ctx: *anyopaque, alloc: Allocator) !win32_uia.widgets.TerminalSnapshot {
+        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const surface = self.surface orelse return try terminalUiaEmptySnapshot(alloc);
+        if (!surface.core_initialized) return try terminalUiaEmptySnapshot(alloc);
+
+        surface.core_surface.renderer_state.mutex.lock();
+        defer surface.core_surface.renderer_state.mutex.unlock();
+
+        var document = try win32_uia.snapshotTerminalPlainText(
+            alloc,
+            surface.core_surface.renderer_state.terminal,
+        );
+        defer document.deinit();
+
+        var visible = try win32_uia.snapshotTerminalVisiblePlainText(
+            alloc,
+            surface.core_surface.renderer_state.terminal,
+        );
+        defer visible.deinit();
+
+        const visible_range = win32_uia.visibleRangeInDocument(&document, &visible) orelse win32_uia.OffsetRange{ .start = 0, .end = 0 };
+
+        return .{
+            .document_text = document.takeText(),
+            .visible_text = visible.takeText(),
+            .visible_range = visible_range,
+        };
+    }
+
+    fn terminalUiaEmptySnapshot(alloc: Allocator) !win32_uia.widgets.TerminalSnapshot {
+        const document_text = try alloc.dupe(u8, "");
+        errdefer alloc.free(document_text);
+        const visible_text = try alloc.dupe(u8, "");
+        return .{
+            .document_text = document_text,
+            .visible_text = visible_text,
+            .visible_range = .{ .start = 0, .end = 0 },
+        };
     }
 
     fn terminalUiaFocused(ctx: *anyopaque) bool {

--- a/src/apprt/win32_uia/com.zig
+++ b/src/apprt/win32_uia/com.zig
@@ -25,6 +25,8 @@ pub const E_OUTOFMEMORY: HRESULT = @bitCast(@as(u32, 0x8007000E));
 pub const IID_IUnknown = GUID.parse("{00000000-0000-0000-C000-000000000046}");
 pub const IID_IRawElementProviderSimple = GUID.parse("{D6DD68D1-86FD-4332-8666-9ABEDEA2D24C}");
 pub const IID_IValueProvider = GUID.parse("{C7935180-6FB3-4201-B174-7DF73ADBF64A}");
+pub const IID_ITextProvider = GUID.parse("{3589C92C-63F3-4367-99BB-ADA653B77CF2}");
+pub const IID_ITextRangeProvider = GUID.parse("{5347AD7B-C355-46F8-AFF5-909033582F63}");
 
 /// UIA object IDs passed as WM_GETOBJECT.lParam by the system / client.
 /// These are negative in the Windows headers; cast to LPARAM via bitcast.
@@ -36,8 +38,10 @@ pub const ProviderOptions_ServerSideProvider: i32 = 0x2;
 /// VARIANT variant-type tags that we actually emit.
 pub const VT_EMPTY: u16 = 0;
 pub const VT_I4: u16 = 3;
+pub const VT_R8: u16 = 5;
 pub const VT_BSTR: u16 = 8;
 pub const VT_BOOL: u16 = 11;
+pub const VT_UNKNOWN: u16 = 13;
 
 pub const VARIANT_TRUE: i16 = -1;
 pub const VARIANT_FALSE: i16 = 0;
@@ -141,6 +145,80 @@ pub const IValueProvider = extern struct {
     vtbl: *const IValueProviderVtbl,
 };
 
+// ── ITextProvider / ITextRangeProvider ─────────────────────────────────
+
+pub const SAFEARRAY = opaque {};
+
+pub const UiaPoint = extern struct {
+    x: f64,
+    y: f64,
+};
+
+pub const TextUnit_Character: i32 = 0;
+pub const TextUnit_Format: i32 = 1;
+pub const TextUnit_Word: i32 = 2;
+pub const TextUnit_Line: i32 = 3;
+pub const TextUnit_Paragraph: i32 = 4;
+pub const TextUnit_Page: i32 = 5;
+pub const TextUnit_Document: i32 = 6;
+
+pub const TextPatternRangeEndpoint_Start: i32 = 0;
+pub const TextPatternRangeEndpoint_End: i32 = 1;
+
+pub const SupportedTextSelection_None: i32 = 0;
+pub const SupportedTextSelection_Single: i32 = 1;
+pub const SupportedTextSelection_Multiple: i32 = 2;
+
+pub const ITextProviderVtbl = extern struct {
+    // IUnknown
+    QueryInterface: *const fn (*ITextProvider, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*ITextProvider) callconv(.winapi) u32,
+    Release: *const fn (*ITextProvider) callconv(.winapi) u32,
+
+    // ITextProvider
+    GetSelection: *const fn (*ITextProvider, *?*SAFEARRAY) callconv(.winapi) HRESULT,
+    GetVisibleRanges: *const fn (*ITextProvider, *?*SAFEARRAY) callconv(.winapi) HRESULT,
+    RangeFromChild: *const fn (*ITextProvider, ?*IRawElementProviderSimple, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    RangeFromPoint: *const fn (*ITextProvider, UiaPoint, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    get_DocumentRange: *const fn (*ITextProvider, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    get_SupportedTextSelection: *const fn (*ITextProvider, *i32) callconv(.winapi) HRESULT,
+};
+
+pub const ITextProvider = extern struct {
+    vtbl: *const ITextProviderVtbl,
+};
+
+pub const ITextRangeProviderVtbl = extern struct {
+    // IUnknown
+    QueryInterface: *const fn (*ITextRangeProvider, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*ITextRangeProvider) callconv(.winapi) u32,
+    Release: *const fn (*ITextRangeProvider) callconv(.winapi) u32,
+
+    // ITextRangeProvider
+    Clone: *const fn (*ITextRangeProvider, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    Compare: *const fn (*ITextRangeProvider, ?*ITextRangeProvider, *BOOL) callconv(.winapi) HRESULT,
+    CompareEndpoints: *const fn (*ITextRangeProvider, i32, ?*ITextRangeProvider, i32, *i32) callconv(.winapi) HRESULT,
+    ExpandToEnclosingUnit: *const fn (*ITextRangeProvider, i32) callconv(.winapi) HRESULT,
+    FindAttribute: *const fn (*ITextRangeProvider, i32, VARIANT, BOOL, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    FindText: *const fn (*ITextRangeProvider, ?[*:0]const u16, BOOL, BOOL, *?*ITextRangeProvider) callconv(.winapi) HRESULT,
+    GetAttributeValue: *const fn (*ITextRangeProvider, i32, *VARIANT) callconv(.winapi) HRESULT,
+    GetBoundingRectangles: *const fn (*ITextRangeProvider, *?*SAFEARRAY) callconv(.winapi) HRESULT,
+    GetEnclosingElement: *const fn (*ITextRangeProvider, *?*IRawElementProviderSimple) callconv(.winapi) HRESULT,
+    GetText: *const fn (*ITextRangeProvider, i32, *?[*:0]u16) callconv(.winapi) HRESULT,
+    Move: *const fn (*ITextRangeProvider, i32, i32, *i32) callconv(.winapi) HRESULT,
+    MoveEndpointByUnit: *const fn (*ITextRangeProvider, i32, i32, i32, *i32) callconv(.winapi) HRESULT,
+    MoveEndpointByRange: *const fn (*ITextRangeProvider, i32, ?*ITextRangeProvider, i32) callconv(.winapi) HRESULT,
+    Select: *const fn (*ITextRangeProvider) callconv(.winapi) HRESULT,
+    AddToSelection: *const fn (*ITextRangeProvider) callconv(.winapi) HRESULT,
+    RemoveFromSelection: *const fn (*ITextRangeProvider) callconv(.winapi) HRESULT,
+    ScrollIntoView: *const fn (*ITextRangeProvider, BOOL) callconv(.winapi) HRESULT,
+    GetChildren: *const fn (*ITextRangeProvider, *?*SAFEARRAY) callconv(.winapi) HRESULT,
+};
+
+pub const ITextRangeProvider = extern struct {
+    vtbl: *const ITextRangeProviderVtbl,
+};
+
 // ── StructureChangeType ─────────────────────────────────────────────────
 // Values for UiaRaiseStructureChangedEvent's second parameter. From
 // uiautomationcore.h.
@@ -206,6 +284,9 @@ pub extern "uiautomationcore" fn UiaClientsAreListening() callconv(.winapi) BOOL
 pub extern "oleaut32" fn SysAllocString(psz: [*:0]const u16) callconv(.winapi) ?[*:0]u16;
 pub extern "oleaut32" fn SysFreeString(bstr: ?[*:0]u16) callconv(.winapi) void;
 pub extern "oleaut32" fn SysStringLen(bstr: ?[*:0]const u16) callconv(.winapi) u32;
+pub extern "oleaut32" fn SafeArrayCreateVector(vt: u16, lLbound: i32, cElements: u32) callconv(.winapi) ?*SAFEARRAY;
+pub extern "oleaut32" fn SafeArrayPutElement(psa: *SAFEARRAY, rgIndices: *i32, pv: *anyopaque) callconv(.winapi) HRESULT;
+pub extern "oleaut32" fn SafeArrayDestroy(psa: ?*SAFEARRAY) callconv(.winapi) HRESULT;
 
 /// Live HWND text query. Used by the UIA Name provider so screen
 /// readers see the current window title after a rename.

--- a/src/apprt/win32_uia/com.zig
+++ b/src/apprt/win32_uia/com.zig
@@ -20,6 +20,7 @@ pub const E_NOTIMPL: HRESULT = @bitCast(@as(u32, 0x80004001));
 pub const E_POINTER: HRESULT = @bitCast(@as(u32, 0x80004003));
 pub const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
 pub const E_OUTOFMEMORY: HRESULT = @bitCast(@as(u32, 0x8007000E));
+pub const E_INVALIDARG: HRESULT = @bitCast(@as(u32, 0x80070057));
 
 // COM GUIDs (IID = interface ID).
 pub const IID_IUnknown = GUID.parse("{00000000-0000-0000-C000-000000000046}");
@@ -62,6 +63,7 @@ pub const VARIANT = extern struct {
         i4: i32,
         bstr: ?[*:0]u16,
         bool_val: i16,
+        unknown: ?*IUnknown,
     },
 
     pub fn empty() VARIANT {
@@ -81,6 +83,10 @@ pub const VARIANT = extern struct {
             .vt = VT_BOOL,
             .value = .{ .bool_val = if (b) VARIANT_TRUE else VARIANT_FALSE },
         };
+    }
+
+    pub fn fromUnknown(p: ?*IUnknown) VARIANT {
+        return .{ .vt = VT_UNKNOWN, .value = .{ .unknown = p } };
     }
 
     // Compile-time assertion that our VARIANT matches the Windows ABI
@@ -279,13 +285,14 @@ pub extern "uiautomationcore" fn UiaRaiseAutomationPropertyChangedEvent(
 /// Report whether a UIA client is currently listening for a given event
 /// so we can skip the raise entirely when nobody cares.
 pub extern "uiautomationcore" fn UiaClientsAreListening() callconv(.winapi) BOOL;
+pub extern "uiautomationcore" fn UiaGetReservedNotSupportedValue(value: *?*IUnknown) callconv(.winapi) HRESULT;
 
 /// BSTR alloc / free helpers for the string properties (Name, LocalizedControlType).
 pub extern "oleaut32" fn SysAllocString(psz: [*:0]const u16) callconv(.winapi) ?[*:0]u16;
 pub extern "oleaut32" fn SysFreeString(bstr: ?[*:0]u16) callconv(.winapi) void;
 pub extern "oleaut32" fn SysStringLen(bstr: ?[*:0]const u16) callconv(.winapi) u32;
 pub extern "oleaut32" fn SafeArrayCreateVector(vt: u16, lLbound: i32, cElements: u32) callconv(.winapi) ?*SAFEARRAY;
-pub extern "oleaut32" fn SafeArrayPutElement(psa: *SAFEARRAY, rgIndices: *i32, pv: *anyopaque) callconv(.winapi) HRESULT;
+pub extern "oleaut32" fn SafeArrayPutElement(psa: *SAFEARRAY, rgIndices: *i32, pv: ?*anyopaque) callconv(.winapi) HRESULT;
 pub extern "oleaut32" fn SafeArrayDestroy(psa: ?*SAFEARRAY) callconv(.winapi) HRESULT;
 
 /// Live HWND text query. Used by the UIA Name provider so screen

--- a/src/apprt/win32_uia/constants.zig
+++ b/src/apprt/win32_uia/constants.zig
@@ -13,6 +13,7 @@ pub const UIA_WindowControlTypeId: i32 = 50032;
 // ── Pattern IDs ────────────────────────────────────────────────────────
 
 pub const UIA_ValuePatternId: i32 = 10002;
+pub const UIA_TextPatternId: i32 = 10014;
 
 // ── Properties ──────────────────────────────────────────────────────────
 // UIA_PropertyId values. 30000-series.

--- a/src/apprt/win32_uia/mod.zig
+++ b/src/apprt/win32_uia/mod.zig
@@ -32,6 +32,7 @@ pub const UiaRootObjectId = com.UiaRootObjectId;
 pub const IRawElementProviderSimple = com.IRawElementProviderSimple;
 pub const snapshotTerminalPlainText = text.snapshotTerminalPlainText;
 pub const snapshotTerminalVisiblePlainText = text.snapshotTerminalVisiblePlainText;
+pub const visibleRangeInDocument = text.visibleRangeInDocument;
 
 /// Handle `WM_GETOBJECT` for the main host HWND. Returns `null` if the
 /// caller should fall through to `DefWindowProcW`; otherwise returns

--- a/src/apprt/win32_uia/mod.zig
+++ b/src/apprt/win32_uia/mod.zig
@@ -7,8 +7,8 @@
 //!     buttons are still announced.
 //!
 //! Per-widget providers (tabs, command palette rows, settings fields)
-//! are added with the widgets they expose. Terminal scrollback is not
-//! exposed through `ITextProvider`.
+//! are added with the widgets they expose. Terminal text is exposed
+//! through a read-only `ITextProvider` / `ITextRangeProvider` slice.
 
 const std = @import("std");
 const com = @import("com.zig");

--- a/src/apprt/win32_uia/mod.zig
+++ b/src/apprt/win32_uia/mod.zig
@@ -31,6 +31,7 @@ pub const HRESULT = com.HRESULT;
 pub const UiaRootObjectId = com.UiaRootObjectId;
 pub const IRawElementProviderSimple = com.IRawElementProviderSimple;
 pub const snapshotTerminalPlainText = text.snapshotTerminalPlainText;
+pub const snapshotTerminalVisiblePlainText = text.snapshotTerminalVisiblePlainText;
 
 /// Handle `WM_GETOBJECT` for the main host HWND. Returns `null` if the
 /// caller should fall through to `DefWindowProcW`; otherwise returns

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -151,6 +151,34 @@ pub fn snapshotTerminalVisiblePlainText(
     return snapshotFromTextAndPins(alloc, &text_writer, &pin_map);
 }
 
+pub fn visibleRangeInDocument(
+    document: *const TerminalTextSnapshot,
+    visible: *const TerminalTextSnapshot,
+) ?OffsetRange {
+    if (visible.text.len == 0) return .{ .start = 0, .end = 0 };
+    if (visible.pin_map.len > document.pin_map.len) return null;
+
+    const max_start = document.pin_map.len - visible.pin_map.len;
+    for (0..max_start + 1) |start| {
+        if (!pinSlicesEqual(
+            document.pin_map[start .. start + visible.pin_map.len],
+            visible.pin_map,
+        )) continue;
+
+        return .{ .start = start, .end = start + visible.text.len };
+    }
+
+    return null;
+}
+
+fn pinSlicesEqual(lhs: []const terminal.Pin, rhs: []const terminal.Pin) bool {
+    if (lhs.len != rhs.len) return false;
+    for (lhs, rhs) |a, b| {
+        if (a.node != b.node or a.x != b.x or a.y != b.y or a.garbage != b.garbage) return false;
+    }
+    return true;
+}
+
 fn snapshotFromTextAndPins(
     alloc: std.mem.Allocator,
     text_writer: *std.Io.Writer.Allocating,
@@ -332,6 +360,33 @@ test "snapshotTerminalVisiblePlainText excludes scrollback rows" {
     try std.testing.expect(std.mem.indexOf(u8, document.text, "line1") != null);
     try std.testing.expect(std.mem.indexOf(u8, visible.text, "line1") == null);
     try std.testing.expect(std.mem.indexOf(u8, visible.text, "line5") != null);
+}
+
+test "visibleRangeInDocument maps viewport pins into document offsets" {
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
+
+    try t.printString("line1\nline2\nline3\nline4\nline5\n");
+
+    var document = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        &t,
+    );
+    defer document.deinit();
+
+    var visible = try snapshotTerminalVisiblePlainText(
+        std.testing.allocator,
+        &t,
+    );
+    defer visible.deinit();
+
+    const range = visibleRangeInDocument(&document, &visible).?;
+    try std.testing.expect(range.start > 0);
+    try std.testing.expectEqualStrings(visible.text, document.text[range.start..range.end]);
 }
 
 test "snapshotTerminalPlainText preserves blank rows in line map" {

--- a/src/apprt/win32_uia/text.zig
+++ b/src/apprt/win32_uia/text.zig
@@ -125,6 +125,37 @@ pub fn snapshotTerminalPlainText(
     formatter.pin_map = .{ .alloc = alloc, .map = &pin_map };
     try formatter.format(&text_writer.writer);
 
+    return snapshotFromTextAndPins(alloc, &text_writer, &pin_map);
+}
+
+pub fn snapshotTerminalVisiblePlainText(
+    alloc: std.mem.Allocator,
+    terminal_state: *const terminal.Terminal,
+) !TerminalTextSnapshot {
+    var text_writer: std.Io.Writer.Allocating = .init(alloc);
+    defer text_writer.deinit();
+
+    var pin_map: std.ArrayList(terminal.Pin) = .empty;
+    defer pin_map.deinit(alloc);
+
+    const screen = terminal_state.screens.active;
+    var formatter = terminal.formatter.PageListFormatter.init(
+        &screen.pages,
+        .plain,
+    );
+    formatter.top_left = screen.pages.getTopLeft(.viewport);
+    formatter.bottom_right = screen.pages.getBottomRight(.viewport) orelse return error.UnknownPoint;
+    formatter.pin_map = .{ .alloc = alloc, .map = &pin_map };
+    try formatter.format(&text_writer.writer);
+
+    return snapshotFromTextAndPins(alloc, &text_writer, &pin_map);
+}
+
+fn snapshotFromTextAndPins(
+    alloc: std.mem.Allocator,
+    text_writer: *std.Io.Writer.Allocating,
+    pin_map: *std.ArrayList(terminal.Pin),
+) !TerminalTextSnapshot {
     const text = try text_writer.toOwnedSlice();
     errdefer alloc.free(text);
 
@@ -274,6 +305,33 @@ test "snapshotTerminalPlainText includes scrollback rows" {
         OffsetRange{ .start = 24, .end = 29 },
         snapshot.lineUtf16Range(4).?,
     );
+}
+
+test "snapshotTerminalVisiblePlainText excludes scrollback rows" {
+    var t = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 3,
+        .max_scrollback = 10_000,
+    });
+    defer t.deinit(std.testing.allocator);
+
+    try t.printString("line1\nline2\nline3\nline4\nline5\n");
+
+    var document = try snapshotTerminalPlainText(
+        std.testing.allocator,
+        &t,
+    );
+    defer document.deinit();
+
+    var visible = try snapshotTerminalVisiblePlainText(
+        std.testing.allocator,
+        &t,
+    );
+    defer visible.deinit();
+
+    try std.testing.expect(std.mem.indexOf(u8, document.text, "line1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, visible.text, "line1") == null);
+    try std.testing.expect(std.mem.indexOf(u8, visible.text, "line5") != null);
 }
 
 test "snapshotTerminalPlainText preserves blank rows in line map" {

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -496,7 +496,7 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) callconv(.winapi) com.HRESULT {
         const self = fromText(self_text);
-        return self.createDocumentRange(out);
+        return self.createRange(.{ .start = 0, .end = 0 }, out);
     }
 
     fn get_DocumentRange(
@@ -523,11 +523,13 @@ pub const TerminalProvider = struct {
         defer _ = TerminalTextRangeProvider.Release(range.?);
 
         const array = com.SafeArrayCreateVector(com.VT_UNKNOWN, 0, 1) orelse return com.E_OUTOFMEMORY;
-        errdefer _ = com.SafeArrayDestroy(array);
 
         var index: i32 = 0;
         const put_hr = com.SafeArrayPutElement(array, &index, @ptrCast(range.?));
-        if (put_hr != com.S_OK) return put_hr;
+        if (put_hr != com.S_OK) {
+            _ = com.SafeArrayDestroy(array);
+            return put_hr;
+        }
 
         out.* = array;
         return com.S_OK;
@@ -542,15 +544,38 @@ pub const TerminalProvider = struct {
             std.log.warn("uia: TerminalProvider text snapshot failed err={}", .{err});
             return com.E_OUTOFMEMORY;
         };
-        errdefer self.alloc.free(text);
 
+        return self.createRangeFromText(text, .{ .start = 0, .end = text.len }, out);
+    }
+
+    fn createRange(
+        self: *TerminalProvider,
+        range_offsets: terminal_text.OffsetRange,
+        out: *?*com.ITextRangeProvider,
+    ) com.HRESULT {
+        out.* = null;
+        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider text snapshot failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+
+        return self.createRangeFromText(text, range_offsets, out);
+    }
+
+    fn createRangeFromText(
+        self: *TerminalProvider,
+        text: []u8,
+        range_offsets: terminal_text.OffsetRange,
+        out: *?*com.ITextRangeProvider,
+    ) com.HRESULT {
         const range = TerminalTextRangeProvider.create(
             self.alloc,
             self,
             text,
-            .{ .start = 0, .end = text.len },
+            range_offsets,
         ) catch |err| {
             std.log.warn("uia: TerminalTextRangeProvider.create failed err={}", .{err});
+            self.alloc.free(text);
             return com.E_OUTOFMEMORY;
         };
         out.* = &range.base;
@@ -660,8 +685,10 @@ const TerminalTextRangeProvider = struct {
         const self = fromBase(self_base);
         out.* = null;
         const text_copy = self.alloc.dupe(u8, self.text) catch return com.E_OUTOFMEMORY;
-        errdefer self.alloc.free(text_copy);
-        const clone = create(self.alloc, self.parent, text_copy, self.range) catch return com.E_OUTOFMEMORY;
+        const clone = create(self.alloc, self.parent, text_copy, self.range) catch {
+            self.alloc.free(text_copy);
+            return com.E_OUTOFMEMORY;
+        };
         out.* = &clone.base;
         return com.S_OK;
     }
@@ -678,8 +705,7 @@ const TerminalTextRangeProvider = struct {
         const rhs = fromBase(other_range);
         out.* = if (self.parent == rhs.parent and
             self.range.start == rhs.range.start and
-            self.range.end == rhs.range.end and
-            std.mem.eql(u8, self.text, rhs.text)) 1 else 0;
+            self.range.end == rhs.range.end) 1 else 0;
         return com.S_OK;
     }
 
@@ -692,7 +718,7 @@ const TerminalTextRangeProvider = struct {
     ) callconv(.winapi) com.HRESULT {
         const self = fromBase(self_base);
         const other_range = other orelse return com.E_POINTER;
-        if (other_range.vtbl != &vtbl) return com.E_NOINTERFACE;
+        if (other_range.vtbl != &vtbl) return com.E_INVALIDARG;
         const rhs = fromBase(other_range);
         const lhs_value = if (endpoint == com.TextPatternRangeEndpoint_End) self.range.end else self.range.start;
         const rhs_value = if (target_endpoint == com.TextPatternRangeEndpoint_End) rhs.range.end else rhs.range.start;
@@ -739,7 +765,13 @@ const TerminalTextRangeProvider = struct {
         _: i32,
         out: *com.VARIANT,
     ) callconv(.winapi) com.HRESULT {
-        out.* = com.VARIANT.empty();
+        var not_supported: ?*com.IUnknown = null;
+        const hr = com.UiaGetReservedNotSupportedValue(&not_supported);
+        if (hr != com.S_OK) {
+            out.* = com.VARIANT.empty();
+            return hr;
+        }
+        out.* = com.VARIANT.fromUnknown(not_supported);
         return com.S_OK;
     }
 
@@ -1168,6 +1200,26 @@ test "TerminalTextRangeProvider clone and enclosing element retain parent" {
     try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetEnclosingElement(clone.?, &enclosing));
     try std.testing.expect(enclosing != null);
     try std.testing.expectEqual(@as(u32, 3), TerminalProvider.Release(enclosing.?));
+}
+
+test "TerminalProvider RangeFromPoint returns a degenerate text range" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(
+        com.S_OK,
+        TerminalProvider.RangeFromPoint(&p.text_iface, .{ .x = 0, .y = 0 }, &range),
+    );
+    defer _ = TerminalTextRangeProvider.Release(range.?);
+
+    var out: ?[*:0]u16 = null;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetText(range.?, -1, &out));
+    defer com.SysFreeString(out);
+    try std.testing.expectEqual(@as(u32, 0), com.SysStringLen(out));
 }
 
 test "TerminalProvider ValueValueProperty returns non-null BSTR" {

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -59,6 +59,7 @@ pub const TerminalState = struct {
     name: *const fn (ctx: *anyopaque, buf: []u8) []const u8,
     value: *const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8,
     visible_value: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8 = null,
+    visible_range: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror!terminal_text.OffsetRange = null,
     focused: *const fn (ctx: *anyopaque) bool,
 };
 
@@ -605,11 +606,8 @@ pub const TerminalProvider = struct {
         defer self.alloc.free(visible_text);
 
         const visible_offset = self.byteOffsetForScreenPoint(visible_text, point);
-        const document_offset = documentByteOffsetForVisibleOffset(
-            document_text,
-            visible_text,
-            visible_offset,
-        );
+        const visible_range = self.visibleRange(document_text.len, visible_text.len) catch return com.E_OUTOFMEMORY;
+        const document_offset = visibleOffsetToDocumentOffset(document_text, visible_range, visible_offset);
         const hr = self.createRangeFromText(document_text, .{ .start = document_offset, .end = document_offset }, out);
         if (hr == com.S_OK) document_text_owned = false;
         return hr;
@@ -621,6 +619,21 @@ pub const TerminalProvider = struct {
             std.log.warn("uia: TerminalProvider visible text snapshot failed err={}", .{err});
             return err;
         };
+    }
+
+    fn visibleRange(
+        self: *TerminalProvider,
+        document_len: usize,
+        visible_len: usize,
+    ) !terminal_text.OffsetRange {
+        const raw_range = if (self.state.visible_range) |range_fn|
+            try range_fn(self.state.ctx, self.alloc)
+        else
+            terminal_text.OffsetRange{ .start = 0, .end = visible_len };
+
+        const start = @min(raw_range.start, document_len);
+        const end = @min(@max(start, raw_range.end), document_len);
+        return .{ .start = start, .end = end };
     }
 
     fn byteOffsetForScreenPoint(self: *TerminalProvider, text: []const u8, point: com.UiaPoint) usize {
@@ -798,6 +811,7 @@ const TerminalTextRangeProvider = struct {
         const other_range = other orelse return com.E_POINTER;
         if (other_range.vtbl != &vtbl) return com.E_INVALIDARG;
         const rhs = fromBase(other_range);
+        if (self.parent != rhs.parent) return com.E_INVALIDARG;
         const lhs_value = if (endpoint == com.TextPatternRangeEndpoint_End) self.range.end else self.range.start;
         const rhs_value = if (target_endpoint == com.TextPatternRangeEndpoint_End) rhs.range.end else rhs.range.start;
         out.* = if (lhs_value < rhs_value) -1 else if (lhs_value > rhs_value) 1 else 0;
@@ -1077,12 +1091,15 @@ fn utf8BoundaryAtOrBefore(text: []const u8, offset: usize) usize {
     return index;
 }
 
-fn documentByteOffsetForVisibleOffset(document_text: []const u8, visible_text: []const u8, visible_offset: usize) usize {
+fn visibleOffsetToDocumentOffset(
+    document_text: []const u8,
+    visible_range: terminal_text.OffsetRange,
+    visible_offset: usize,
+) usize {
     if (document_text.len == 0) return 0;
-    if (visible_text.len == 0) return 0;
 
-    const visible_start = std.mem.lastIndexOf(u8, document_text, visible_text) orelse 0;
-    const raw_offset = @min(document_text.len, visible_start + @min(visible_offset, visible_text.len));
+    const visible_len = visible_range.end - visible_range.start;
+    const raw_offset = @min(document_text.len, visible_range.start + @min(visible_offset, visible_len));
     return utf8BoundaryAtOrBefore(document_text, raw_offset);
 }
 
@@ -1344,6 +1361,36 @@ test "TerminalTextRangeProvider clone and enclosing element retain parent" {
     try std.testing.expectEqual(@as(u32, 3), TerminalProvider.Release(enclosing.?));
 }
 
+test "TerminalTextRangeProvider CompareEndpoints rejects different parents" {
+    var left_data = TestTerminalStateData{};
+    var right_data = TestTerminalStateData{};
+
+    var left = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), testTerminalState(&left_data));
+    defer _ = TerminalProvider.Release(&left.base);
+    var right = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x2), testTerminalState(&right_data));
+    defer _ = TerminalProvider.Release(&right.base);
+
+    var left_range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(com.S_OK, TerminalProvider.get_DocumentRange(&left.text_iface, &left_range));
+    defer _ = TerminalTextRangeProvider.Release(left_range.?);
+
+    var right_range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(com.S_OK, TerminalProvider.get_DocumentRange(&right.text_iface, &right_range));
+    defer _ = TerminalTextRangeProvider.Release(right_range.?);
+
+    var comparison: i32 = 0;
+    try std.testing.expectEqual(
+        com.E_INVALIDARG,
+        TerminalTextRangeProvider.CompareEndpoints(
+            left_range.?,
+            com.TextPatternRangeEndpoint_Start,
+            right_range,
+            com.TextPatternRangeEndpoint_Start,
+            &comparison,
+        ),
+    );
+}
+
 test "TerminalProvider RangeFromPoint returns a degenerate text range" {
     var state_data = TestTerminalStateData{};
     const state = testTerminalState(&state_data);
@@ -1368,6 +1415,7 @@ test "TerminalProvider RangeFromPoint returns document-coordinate offsets" {
     var state_data = TestTerminalStateData{
         .value_text = "scrollback\nvisible",
         .visible_value_text = "visible",
+        .visible_range = .{ .start = 11, .end = 18 },
     };
     const state = testTerminalState(&state_data);
 
@@ -1492,10 +1540,12 @@ const TestTerminalStateData = struct {
     name_calls: u32 = 0,
     value_calls: u32 = 0,
     visible_value_calls: u32 = 0,
+    visible_range_calls: u32 = 0,
     retains: u32 = 0,
     releases: u32 = 0,
     value_text: []const u8 = "hello\nworld",
     visible_value_text: []const u8 = "visible",
+    visible_range: terminal_text.OffsetRange = .{ .start = 0, .end = 7 },
 };
 
 fn testTerminalState(data: *TestTerminalStateData) TerminalState {
@@ -1528,6 +1578,12 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
             return try alloc.dupe(u8, d.visible_value_text);
         }
 
+        fn visibleRange(ctx: *anyopaque, _: std.mem.Allocator) !terminal_text.OffsetRange {
+            const d: *TestTerminalStateData = @ptrCast(@alignCast(ctx));
+            d.visible_range_calls += 1;
+            return d.visible_range;
+        }
+
         fn focused(ctx: *anyopaque) bool {
             _ = ctx;
             return true;
@@ -1540,6 +1596,7 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
         .name = callbacks.name,
         .value = callbacks.value,
         .visible_value = callbacks.visibleValue,
+        .visible_range = callbacks.visibleRange,
         .focused = callbacks.focused,
     };
 }

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -608,9 +608,11 @@ pub const TerminalProvider = struct {
     }
 
     fn byteOffsetForScreenPoint(self: *TerminalProvider, text: []const u8, point: com.UiaPoint) usize {
+        const x = safeI32FromUiaCoord(point.x) orelse return 0;
+        const y = safeI32FromUiaCoord(point.y) orelse return 0;
         var client_point = POINT{
-            .x = @intFromFloat(point.x),
-            .y = @intFromFloat(point.y),
+            .x = x,
+            .y = y,
         };
         var client_rect: RECT = undefined;
         if (ScreenToClient(self.hwnd, &client_point) == 0 or
@@ -1059,6 +1061,13 @@ fn utf8BoundaryAtOrBefore(text: []const u8, offset: usize) usize {
     return index;
 }
 
+fn safeI32FromUiaCoord(coord: f64) ?i32 {
+    if (!std.math.isFinite(coord)) return null;
+    const min_i32_float: f64 = @floatFromInt(std.math.minInt(i32));
+    const max_i32_float: f64 = @floatFromInt(std.math.maxInt(i32));
+    return @intFromFloat(std.math.clamp(coord, min_i32_float, max_i32_float));
+}
+
 test "PaletteListProvider refcount balances" {
     var counter: u32 = 0;
     const name_fn = struct {
@@ -1340,6 +1349,19 @@ test "TerminalProvider point mapping uses client coordinates and UTF-8 boundarie
     try std.testing.expectEqual(
         @as(usize, text.len),
         byteOffsetForClientPoint(text, rect, .{ .x = 100, .y = 19 }),
+    );
+}
+
+test "safeI32FromUiaCoord rejects non-finite values and clamps range" {
+    try std.testing.expectEqual(@as(?i32, null), safeI32FromUiaCoord(std.math.nan(f64)));
+    try std.testing.expectEqual(@as(?i32, null), safeI32FromUiaCoord(std.math.inf(f64)));
+    try std.testing.expectEqual(
+        @as(?i32, std.math.maxInt(i32)),
+        safeI32FromUiaCoord(@as(f64, @floatFromInt(std.math.maxInt(i32))) + 1000.0),
+    );
+    try std.testing.expectEqual(
+        @as(?i32, std.math.minInt(i32)),
+        safeI32FromUiaCoord(@as(f64, @floatFromInt(std.math.minInt(i32))) - 1000.0),
     );
 }
 

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -60,7 +60,14 @@ pub const TerminalState = struct {
     value: *const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8,
     visible_value: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8 = null,
     visible_range: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror!terminal_text.OffsetRange = null,
+    snapshot: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror!TerminalSnapshot = null,
     focused: *const fn (ctx: *anyopaque) bool,
+};
+
+pub const TerminalSnapshot = struct {
+    document_text: []u8,
+    visible_text: []u8,
+    visible_range: terminal_text.OffsetRange,
 };
 
 pub const PaletteListProvider = struct {
@@ -595,21 +602,17 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const document_text = self.state.value(self.state.ctx, self.alloc) catch |err| {
-            std.log.warn("uia: TerminalProvider text snapshot failed err={}", .{err});
-            return com.E_OUTOFMEMORY;
-        };
+        const terminal_snapshot = self.terminalSnapshot() catch return com.E_OUTOFMEMORY;
+        defer self.alloc.free(terminal_snapshot.visible_text);
+
+        const document_text = terminal_snapshot.document_text;
         var document_text_owned = true;
         defer if (document_text_owned) self.alloc.free(document_text);
 
-        const visible_text = self.visibleText() catch return com.E_OUTOFMEMORY;
-        defer self.alloc.free(visible_text);
-
-        const visible_offset = self.byteOffsetForScreenPoint(visible_text, point);
-        const visible_range = self.visibleRange(document_text.len, visible_text.len) catch return com.E_OUTOFMEMORY;
-        const document_offset = visibleOffsetToDocumentOffset(document_text, visible_range, visible_offset);
+        const visible_offset = self.byteOffsetForScreenPoint(terminal_snapshot.visible_text, point);
+        const document_offset = visibleOffsetToDocumentOffset(document_text, terminal_snapshot.visible_range, visible_offset);
+        document_text_owned = false;
         const hr = self.createRangeFromText(document_text, .{ .start = document_offset, .end = document_offset }, out);
-        if (hr == com.S_OK) document_text_owned = false;
         return hr;
     }
 
@@ -621,19 +624,31 @@ pub const TerminalProvider = struct {
         };
     }
 
-    fn visibleRange(
-        self: *TerminalProvider,
-        document_len: usize,
-        visible_len: usize,
-    ) !terminal_text.OffsetRange {
-        const raw_range = if (self.state.visible_range) |range_fn|
-            try range_fn(self.state.ctx, self.alloc)
-        else
-            terminal_text.OffsetRange{ .start = 0, .end = visible_len };
+    fn terminalSnapshot(self: *TerminalProvider) !TerminalSnapshot {
+        const raw_snapshot = if (self.state.snapshot) |snapshot_fn| snapshot: {
+            break :snapshot try snapshot_fn(self.state.ctx, self.alloc);
+        } else snapshot: {
+            const document_text = try self.state.value(self.state.ctx, self.alloc);
+            errdefer self.alloc.free(document_text);
 
-        const start = @min(raw_range.start, document_len);
-        const end = @min(@max(start, raw_range.end), document_len);
-        return .{ .start = start, .end = end };
+            const visible_text = try self.alloc.dupe(u8, document_text);
+            break :snapshot TerminalSnapshot{
+                .document_text = document_text,
+                .visible_text = visible_text,
+                .visible_range = .{ .start = 0, .end = document_text.len },
+            };
+        };
+
+        errdefer self.alloc.free(raw_snapshot.document_text);
+        errdefer self.alloc.free(raw_snapshot.visible_text);
+
+        const start = @min(raw_snapshot.visible_range.start, raw_snapshot.document_text.len);
+        const end = @min(@max(start, raw_snapshot.visible_range.end), raw_snapshot.document_text.len);
+        return .{
+            .document_text = raw_snapshot.document_text,
+            .visible_text = raw_snapshot.visible_text,
+            .visible_range = .{ .start = start, .end = end },
+        };
     }
 
     fn byteOffsetForScreenPoint(self: *TerminalProvider, text: []const u8, point: com.UiaPoint) usize {
@@ -823,11 +838,14 @@ const TerminalTextRangeProvider = struct {
         unit: i32,
     ) callconv(.winapi) com.HRESULT {
         const self = fromBase(self_base);
-        if (unit == com.TextUnit_Document) {
-            self.range = .{ .start = 0, .end = self.text.len };
-            return com.S_OK;
-        }
-        return com.E_NOTIMPL;
+        self.range = switch (unit) {
+            com.TextUnit_Character => characterByteRange(self.text, self.range.start),
+            com.TextUnit_Word, com.TextUnit_Format => wordByteRange(self.text, self.range.start),
+            com.TextUnit_Line => lineByteRangeForOffset(self.text, self.range.start),
+            com.TextUnit_Paragraph, com.TextUnit_Page, com.TextUnit_Document => .{ .start = 0, .end = self.text.len },
+            else => return com.E_INVALIDARG,
+        };
+        return com.S_OK;
     }
 
     fn FindAttribute(
@@ -1083,6 +1101,43 @@ fn lineByteRange(text: []const u8, target_line: usize) terminal_text.OffsetRange
     var end = text.len;
     if (end > start and text[end - 1] == '\n') end -= 1;
     return .{ .start = start, .end = end };
+}
+
+fn lineByteRangeForOffset(text: []const u8, offset: usize) terminal_text.OffsetRange {
+    const safe_offset = @min(offset, text.len);
+    var start = safe_offset;
+    while (start > 0 and text[start - 1] != '\n') : (start -= 1) {}
+
+    var end = safe_offset;
+    while (end < text.len and text[end] != '\n') : (end += 1) {}
+
+    return .{
+        .start = utf8BoundaryAtOrBefore(text, start),
+        .end = utf8BoundaryAtOrBefore(text, end),
+    };
+}
+
+fn characterByteRange(text: []const u8, offset: usize) terminal_text.OffsetRange {
+    if (text.len == 0) return .{ .start = 0, .end = 0 };
+
+    const start = utf8BoundaryAtOrBefore(text, @min(offset, text.len - 1));
+    const len = std.unicode.utf8ByteSequenceLength(text[start]) catch 1;
+    return .{ .start = start, .end = @min(text.len, start + len) };
+}
+
+fn wordByteRange(text: []const u8, offset: usize) terminal_text.OffsetRange {
+    if (text.len == 0) return .{ .start = 0, .end = 0 };
+
+    var start = utf8BoundaryAtOrBefore(text, @min(offset, text.len - 1));
+    while (start > 0 and !std.ascii.isWhitespace(text[start - 1])) : (start -= 1) {}
+
+    var end = @min(offset, text.len);
+    while (end < text.len and !std.ascii.isWhitespace(text[end])) : (end += 1) {}
+
+    return .{
+        .start = utf8BoundaryAtOrBefore(text, start),
+        .end = utf8BoundaryAtOrBefore(text, end),
+    };
 }
 
 fn utf8BoundaryAtOrBefore(text: []const u8, offset: usize) usize {
@@ -1391,6 +1446,32 @@ test "TerminalTextRangeProvider CompareEndpoints rejects different parents" {
     );
 }
 
+test "TerminalTextRangeProvider ExpandToEnclosingUnit supports basic units" {
+    var state_data = TestTerminalStateData{ .value_text = "hello world\nnext" };
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    const text = try std.testing.allocator.dupe(u8, state_data.value_text);
+    var range_provider = try TerminalTextRangeProvider.create(
+        std.testing.allocator,
+        p,
+        text,
+        .{ .start = 7, .end = 7 },
+    );
+    defer _ = TerminalTextRangeProvider.Release(&range_provider.base);
+
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.ExpandToEnclosingUnit(&range_provider.base, com.TextUnit_Word));
+    try std.testing.expectEqual(terminal_text.OffsetRange{ .start = 6, .end = 11 }, range_provider.range);
+
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.ExpandToEnclosingUnit(&range_provider.base, com.TextUnit_Line));
+    try std.testing.expectEqual(terminal_text.OffsetRange{ .start = 0, .end = 11 }, range_provider.range);
+
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.ExpandToEnclosingUnit(&range_provider.base, com.TextUnit_Document));
+    try std.testing.expectEqual(terminal_text.OffsetRange{ .start = 0, .end = state_data.value_text.len }, range_provider.range);
+}
+
 test "TerminalProvider RangeFromPoint returns a degenerate text range" {
     var state_data = TestTerminalStateData{};
     const state = testTerminalState(&state_data);
@@ -1584,6 +1665,22 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
             return d.visible_range;
         }
 
+        fn snapshot(ctx: *anyopaque, alloc: std.mem.Allocator) !TerminalSnapshot {
+            const d: *TestTerminalStateData = @ptrCast(@alignCast(ctx));
+            d.value_calls += 1;
+            d.visible_value_calls += 1;
+            d.visible_range_calls += 1;
+
+            const document_text = try alloc.dupe(u8, d.value_text);
+            errdefer alloc.free(document_text);
+            const visible_text = try alloc.dupe(u8, d.visible_value_text);
+            return .{
+                .document_text = document_text,
+                .visible_text = visible_text,
+                .visible_range = d.visible_range,
+            };
+        }
+
         fn focused(ctx: *anyopaque) bool {
             _ = ctx;
             return true;
@@ -1597,6 +1694,7 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
         .value = callbacks.value,
         .visible_value = callbacks.visibleValue,
         .visible_range = callbacks.visibleRange,
+        .snapshot = callbacks.snapshot,
         .focused = callbacks.focused,
     };
 }

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -58,6 +58,7 @@ pub const TerminalState = struct {
     release: ?*const fn (ctx: *anyopaque) void = null,
     name: *const fn (ctx: *anyopaque, buf: []u8) []const u8,
     value: *const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8,
+    visible_value: ?*const fn (ctx: *anyopaque, alloc: std.mem.Allocator) anyerror![]u8 = null,
     focused: *const fn (ctx: *anyopaque) bool,
 };
 
@@ -555,13 +556,12 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+        const value_fn = self.state.visible_value orelse self.state.value;
+        const text = value_fn(self.state.ctx, self.alloc) catch |err| {
             std.log.warn("uia: TerminalProvider visible text snapshot failed err={}", .{err});
             return com.E_OUTOFMEMORY;
         };
 
-        // TerminalState.value is the active rendered screen snapshot; expose
-        // that as the visible range and keep DocumentRange as a separate path.
         return self.createRangeFromText(text, .{ .start = 0, .end = text.len }, out);
     }
 
@@ -1212,7 +1212,8 @@ test "TerminalProvider visible ranges returns a SAFEARRAY" {
 
     try std.testing.expectEqual(com.S_OK, hr);
     try std.testing.expect(ranges != null);
-    try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
+    try std.testing.expectEqual(@as(u32, 0), state_data.value_calls);
+    try std.testing.expectEqual(@as(u32, 1), state_data.visible_value_calls);
 }
 
 test "TerminalProvider reports document control type" {
@@ -1442,9 +1443,11 @@ test "TerminalProvider value allocation failure returns E_OUTOFMEMORY" {
 const TestTerminalStateData = struct {
     name_calls: u32 = 0,
     value_calls: u32 = 0,
+    visible_value_calls: u32 = 0,
     retains: u32 = 0,
     releases: u32 = 0,
     value_text: []const u8 = "hello\nworld",
+    visible_value_text: []const u8 = "visible",
 };
 
 fn testTerminalState(data: *TestTerminalStateData) TerminalState {
@@ -1471,6 +1474,12 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
             return try alloc.dupe(u8, d.value_text);
         }
 
+        fn visibleValue(ctx: *anyopaque, alloc: std.mem.Allocator) ![]u8 {
+            const d: *TestTerminalStateData = @ptrCast(@alignCast(ctx));
+            d.visible_value_calls += 1;
+            return try alloc.dupe(u8, d.visible_value_text);
+        }
+
         fn focused(ctx: *anyopaque) bool {
             _ = ctx;
             return true;
@@ -1482,6 +1491,7 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
         .release = callbacks.release,
         .name = callbacks.name,
         .value = callbacks.value,
+        .visible_value = callbacks.visibleValue,
         .focused = callbacks.focused,
     };
 }

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -594,10 +594,25 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const text = self.visibleText() catch return com.E_OUTOFMEMORY;
+        const document_text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider text snapshot failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+        var document_text_owned = true;
+        defer if (document_text_owned) self.alloc.free(document_text);
 
-        const offset = self.byteOffsetForScreenPoint(text, point);
-        return self.createRangeFromText(text, .{ .start = offset, .end = offset }, out);
+        const visible_text = self.visibleText() catch return com.E_OUTOFMEMORY;
+        defer self.alloc.free(visible_text);
+
+        const visible_offset = self.byteOffsetForScreenPoint(visible_text, point);
+        const document_offset = documentByteOffsetForVisibleOffset(
+            document_text,
+            visible_text,
+            visible_offset,
+        );
+        const hr = self.createRangeFromText(document_text, .{ .start = document_offset, .end = document_offset }, out);
+        if (hr == com.S_OK) document_text_owned = false;
+        return hr;
     }
 
     fn visibleText(self: *TerminalProvider) ![]u8 {
@@ -1062,6 +1077,15 @@ fn utf8BoundaryAtOrBefore(text: []const u8, offset: usize) usize {
     return index;
 }
 
+fn documentByteOffsetForVisibleOffset(document_text: []const u8, visible_text: []const u8, visible_offset: usize) usize {
+    if (document_text.len == 0) return 0;
+    if (visible_text.len == 0) return 0;
+
+    const visible_start = std.mem.lastIndexOf(u8, document_text, visible_text) orelse 0;
+    const raw_offset = @min(document_text.len, visible_start + @min(visible_offset, visible_text.len));
+    return utf8BoundaryAtOrBefore(document_text, raw_offset);
+}
+
 fn safeI32FromUiaCoord(coord: f64) ?i32 {
     if (!std.math.isFinite(coord)) return null;
     const min_i32_float: f64 = @floatFromInt(std.math.minInt(i32));
@@ -1338,6 +1362,29 @@ test "TerminalProvider RangeFromPoint returns a degenerate text range" {
     try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetText(range.?, -1, &out));
     defer com.SysFreeString(out);
     try std.testing.expectEqual(@as(u32, 0), com.SysStringLen(out));
+}
+
+test "TerminalProvider RangeFromPoint returns document-coordinate offsets" {
+    var state_data = TestTerminalStateData{
+        .value_text = "scrollback\nvisible",
+        .visible_value_text = "visible",
+    };
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(
+        com.S_OK,
+        TerminalProvider.RangeFromPoint(&p.text_iface, .{ .x = 0, .y = 0 }, &range),
+    );
+    defer _ = TerminalTextRangeProvider.Release(range.?);
+
+    const concrete: *TerminalTextRangeProvider = @ptrCast(@alignCast(range.?));
+    try std.testing.expectEqual(terminal_text.OffsetRange{ .start = 11, .end = 11 }, concrete.range);
+    try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
+    try std.testing.expectEqual(@as(u32, 1), state_data.visible_value_calls);
 }
 
 test "TerminalProvider point mapping uses client coordinates and UTF-8 boundaries" {

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -556,11 +556,7 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const value_fn = self.state.visible_value orelse self.state.value;
-        const text = value_fn(self.state.ctx, self.alloc) catch |err| {
-            std.log.warn("uia: TerminalProvider visible text snapshot failed err={}", .{err});
-            return com.E_OUTOFMEMORY;
-        };
+        const text = self.visibleText() catch return com.E_OUTOFMEMORY;
 
         return self.createRangeFromText(text, .{ .start = 0, .end = text.len }, out);
     }
@@ -598,13 +594,18 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
-            std.log.warn("uia: TerminalProvider point text snapshot failed err={}", .{err});
-            return com.E_OUTOFMEMORY;
-        };
+        const text = self.visibleText() catch return com.E_OUTOFMEMORY;
 
         const offset = self.byteOffsetForScreenPoint(text, point);
         return self.createRangeFromText(text, .{ .start = offset, .end = offset }, out);
+    }
+
+    fn visibleText(self: *TerminalProvider) ![]u8 {
+        const value_fn = self.state.visible_value orelse self.state.value;
+        return value_fn(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider visible text snapshot failed err={}", .{err});
+            return err;
+        };
     }
 
     fn byteOffsetForScreenPoint(self: *TerminalProvider, text: []const u8, point: com.UiaPoint) usize {

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -25,6 +25,21 @@ const com = @import("com.zig");
 const constants = @import("constants.zig");
 const terminal_text = @import("text.zig");
 
+const POINT = extern struct {
+    x: i32,
+    y: i32,
+};
+
+const RECT = extern struct {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+};
+
+extern "user32" fn GetClientRect(hWnd: com.HWND, lpRect: *RECT) callconv(.winapi) com.BOOL;
+extern "user32" fn ScreenToClient(hWnd: com.HWND, lpPoint: *POINT) callconv(.winapi) com.BOOL;
+
 /// Shape-of-life contract callers implement so the provider can ask
 /// the owning widget for its current live text. Decouples the
 /// provider from `Host` (which lives in `win32.zig` and would pull a
@@ -478,7 +493,7 @@ pub const TerminalProvider = struct {
         out: *?*com.SAFEARRAY,
     ) callconv(.winapi) com.HRESULT {
         const self = fromText(self_text);
-        return self.singleRangeArray(out);
+        return self.singleVisibleRangeArray(out);
     }
 
     fn RangeFromChild(
@@ -492,11 +507,11 @@ pub const TerminalProvider = struct {
 
     fn RangeFromPoint(
         self_text: *com.ITextProvider,
-        _: com.UiaPoint,
+        point: com.UiaPoint,
         out: *?*com.ITextRangeProvider,
     ) callconv(.winapi) com.HRESULT {
         const self = fromText(self_text);
-        return self.createRange(.{ .start = 0, .end = 0 }, out);
+        return self.createRangeFromPoint(point, out);
     }
 
     fn get_DocumentRange(
@@ -515,10 +530,10 @@ pub const TerminalProvider = struct {
         return com.S_OK;
     }
 
-    fn singleRangeArray(self: *TerminalProvider, out: *?*com.SAFEARRAY) com.HRESULT {
+    fn singleVisibleRangeArray(self: *TerminalProvider, out: *?*com.SAFEARRAY) com.HRESULT {
         out.* = null;
         var range: ?*com.ITextRangeProvider = null;
-        const range_hr = self.createDocumentRange(&range);
+        const range_hr = self.createVisibleRange(&range);
         if (range_hr != com.S_OK) return range_hr;
         defer _ = TerminalTextRangeProvider.Release(range.?);
 
@@ -533,6 +548,21 @@ pub const TerminalProvider = struct {
 
         out.* = array;
         return com.S_OK;
+    }
+
+    fn createVisibleRange(
+        self: *TerminalProvider,
+        out: *?*com.ITextRangeProvider,
+    ) com.HRESULT {
+        out.* = null;
+        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider visible text snapshot failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+
+        // TerminalState.value is the active rendered screen snapshot; expose
+        // that as the visible range and keep DocumentRange as a separate path.
+        return self.createRangeFromText(text, .{ .start = 0, .end = text.len }, out);
     }
 
     fn createDocumentRange(
@@ -560,6 +590,36 @@ pub const TerminalProvider = struct {
         };
 
         return self.createRangeFromText(text, range_offsets, out);
+    }
+
+    fn createRangeFromPoint(
+        self: *TerminalProvider,
+        point: com.UiaPoint,
+        out: *?*com.ITextRangeProvider,
+    ) com.HRESULT {
+        out.* = null;
+        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider point text snapshot failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+
+        const offset = self.byteOffsetForScreenPoint(text, point);
+        return self.createRangeFromText(text, .{ .start = offset, .end = offset }, out);
+    }
+
+    fn byteOffsetForScreenPoint(self: *TerminalProvider, text: []const u8, point: com.UiaPoint) usize {
+        var client_point = POINT{
+            .x = @intFromFloat(point.x),
+            .y = @intFromFloat(point.y),
+        };
+        var client_rect: RECT = undefined;
+        if (ScreenToClient(self.hwnd, &client_point) == 0 or
+            GetClientRect(self.hwnd, &client_rect) == 0)
+        {
+            return 0;
+        }
+
+        return byteOffsetForClientPoint(text, client_rect, client_point);
     }
 
     fn createRangeFromText(
@@ -952,6 +1012,53 @@ fn utf8PrefixForUtf16Limit(text: []const u8, max_utf16_len: usize) ![]const u8 {
     return text[0..byte_index];
 }
 
+fn byteOffsetForClientPoint(text: []const u8, client_rect: RECT, point: POINT) usize {
+    if (text.len == 0) return 0;
+
+    const line_count = countTextLines(text);
+    const width: usize = @intCast(@max(1, client_rect.right - client_rect.left));
+    const height: usize = @intCast(@max(1, client_rect.bottom - client_rect.top));
+    const x: usize = @intCast(std.math.clamp(point.x - client_rect.left, 0, client_rect.right - client_rect.left));
+    const y: usize = @intCast(std.math.clamp(point.y - client_rect.top, 0, client_rect.bottom - client_rect.top));
+
+    const line_index = @min(line_count - 1, @divTrunc(y * line_count, height));
+    const line_range = lineByteRange(text, line_index);
+    const line_len = line_range.end - line_range.start;
+    if (line_len == 0) return line_range.start;
+
+    const raw_offset = line_range.start + @min(line_len, @divTrunc(x * (line_len + 1), width));
+    return utf8BoundaryAtOrBefore(text, raw_offset);
+}
+
+fn countTextLines(text: []const u8) usize {
+    var count: usize = 1;
+    for (text, 0..) |c, i| {
+        if (c == '\n' and i + 1 < text.len) count += 1;
+    }
+    return count;
+}
+
+fn lineByteRange(text: []const u8, target_line: usize) terminal_text.OffsetRange {
+    var line_index: usize = 0;
+    var start: usize = 0;
+    for (text, 0..) |c, i| {
+        if (c != '\n' or i + 1 == text.len) continue;
+        if (line_index == target_line) return .{ .start = start, .end = i };
+        line_index += 1;
+        start = i + 1;
+    }
+
+    var end = text.len;
+    if (end > start and text[end - 1] == '\n') end -= 1;
+    return .{ .start = start, .end = end };
+}
+
+fn utf8BoundaryAtOrBefore(text: []const u8, offset: usize) usize {
+    var index = @min(offset, text.len);
+    while (index > 0 and index < text.len and (text[index] & 0b1100_0000) == 0b1000_0000) : (index -= 1) {}
+    return index;
+}
+
 test "PaletteListProvider refcount balances" {
     var counter: u32 = 0;
     const name_fn = struct {
@@ -1220,6 +1327,20 @@ test "TerminalProvider RangeFromPoint returns a degenerate text range" {
     try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetText(range.?, -1, &out));
     defer com.SysFreeString(out);
     try std.testing.expectEqual(@as(u32, 0), com.SysStringLen(out));
+}
+
+test "TerminalProvider point mapping uses client coordinates and UTF-8 boundaries" {
+    const text = "A🔥B\nworld";
+    const rect = RECT{ .left = 0, .top = 0, .right = 100, .bottom = 20 };
+
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        byteOffsetForClientPoint(text, rect, .{ .x = 35, .y = 0 }),
+    );
+    try std.testing.expectEqual(
+        @as(usize, text.len),
+        byteOffsetForClientPoint(text, rect, .{ .x = 100, .y = 19 }),
+    );
 }
 
 test "TerminalProvider ValueValueProperty returns non-null BSTR" {

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -564,9 +564,15 @@ pub const TerminalProvider = struct {
         out: *?*com.ITextRangeProvider,
     ) com.HRESULT {
         out.* = null;
-        const text = self.visibleText() catch return com.E_OUTOFMEMORY;
+        const terminal_snapshot = self.terminalSnapshot() catch return com.E_OUTOFMEMORY;
+        defer self.alloc.free(terminal_snapshot.visible_text);
 
-        return self.createRangeFromText(text, .{ .start = 0, .end = text.len }, out);
+        const document_text = terminal_snapshot.document_text;
+        var document_text_owned = true;
+        defer if (document_text_owned) self.alloc.free(document_text);
+
+        document_text_owned = false;
+        return self.createRangeFromText(document_text, terminal_snapshot.visible_range, out);
     }
 
     fn createDocumentRange(
@@ -1309,7 +1315,7 @@ test "TerminalProvider visible ranges returns a SAFEARRAY" {
 
     try std.testing.expectEqual(com.S_OK, hr);
     try std.testing.expect(ranges != null);
-    try std.testing.expectEqual(@as(u32, 0), state_data.value_calls);
+    try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
     try std.testing.expectEqual(@as(u32, 1), state_data.visible_value_calls);
 }
 

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -23,6 +23,7 @@
 const std = @import("std");
 const com = @import("com.zig");
 const constants = @import("constants.zig");
+const terminal_text = @import("text.zig");
 
 /// Shape-of-life contract callers implement so the provider can ask
 /// the owning widget for its current live text. Decouples the
@@ -187,6 +188,7 @@ pub const PaletteListProvider = struct {
 pub const TerminalProvider = struct {
     base: com.IRawElementProviderSimple,
     value_iface: com.IValueProvider,
+    text_iface: com.ITextProvider,
     refcount: std.atomic.Value(u32),
     alloc: std.mem.Allocator,
     hwnd: com.HWND,
@@ -211,6 +213,18 @@ pub const TerminalProvider = struct {
         .get_IsReadOnly = TerminalProvider.get_IsReadOnly,
     };
 
+    const text_vtbl: com.ITextProviderVtbl = .{
+        .QueryInterface = TerminalProvider.TextQueryInterface,
+        .AddRef = TerminalProvider.TextAddRef,
+        .Release = TerminalProvider.TextRelease,
+        .GetSelection = TerminalProvider.GetSelection,
+        .GetVisibleRanges = TerminalProvider.GetVisibleRanges,
+        .RangeFromChild = TerminalProvider.RangeFromChild,
+        .RangeFromPoint = TerminalProvider.RangeFromPoint,
+        .get_DocumentRange = TerminalProvider.get_DocumentRange,
+        .get_SupportedTextSelection = TerminalProvider.get_SupportedTextSelection,
+    };
+
     pub fn create(
         alloc: std.mem.Allocator,
         hwnd: com.HWND,
@@ -221,6 +235,7 @@ pub const TerminalProvider = struct {
         self.* = .{
             .base = .{ .vtbl = &simple_vtbl },
             .value_iface = .{ .vtbl = &value_vtbl },
+            .text_iface = .{ .vtbl = &text_vtbl },
             .refcount = std.atomic.Value(u32).init(1),
             .alloc = alloc,
             .hwnd = hwnd,
@@ -235,6 +250,10 @@ pub const TerminalProvider = struct {
 
     fn fromValue(p: *com.IValueProvider) *TerminalProvider {
         return @fieldParentPtr("value_iface", p);
+    }
+
+    fn fromText(p: *com.ITextProvider) *TerminalProvider {
+        return @fieldParentPtr("text_iface", p);
     }
 
     pub fn QueryInterface(
@@ -252,6 +271,15 @@ pub const TerminalProvider = struct {
         out: *?*anyopaque,
     ) callconv(.winapi) com.HRESULT {
         const self = fromValue(self_value);
+        return self.queryInterface(iid, out);
+    }
+
+    fn TextQueryInterface(
+        self_text: *com.ITextProvider,
+        iid: *const com.GUID,
+        out: *?*anyopaque,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromText(self_text);
         return self.queryInterface(iid, out);
     }
 
@@ -273,6 +301,11 @@ pub const TerminalProvider = struct {
             _ = self.refcount.fetchAdd(1, .monotonic);
             return com.S_OK;
         }
+        if (iidEqual(iid, &com.IID_ITextProvider)) {
+            out.* = @ptrCast(&self.text_iface);
+            _ = self.refcount.fetchAdd(1, .monotonic);
+            return com.S_OK;
+        }
         return com.E_NOINTERFACE;
     }
 
@@ -286,6 +319,11 @@ pub const TerminalProvider = struct {
         return self.refcount.fetchAdd(1, .monotonic) + 1;
     }
 
+    fn TextAddRef(self_text: *com.ITextProvider) callconv(.winapi) u32 {
+        const self = fromText(self_text);
+        return self.refcount.fetchAdd(1, .monotonic) + 1;
+    }
+
     pub fn Release(self_base: *com.IRawElementProviderSimple) callconv(.winapi) u32 {
         const self = fromBase(self_base);
         return self.release();
@@ -293,6 +331,11 @@ pub const TerminalProvider = struct {
 
     fn ValueRelease(self_value: *com.IValueProvider) callconv(.winapi) u32 {
         const self = fromValue(self_value);
+        return self.release();
+    }
+
+    fn TextRelease(self_text: *com.ITextProvider) callconv(.winapi) u32 {
+        const self = fromText(self_text);
         return self.release();
     }
 
@@ -323,6 +366,9 @@ pub const TerminalProvider = struct {
         out.* = null;
         if (pattern_id == constants.UIA_ValuePatternId) {
             out.* = @ptrCast(&self.value_iface);
+            _ = self.refcount.fetchAdd(1, .monotonic);
+        } else if (pattern_id == constants.UIA_TextPatternId) {
+            out.* = @ptrCast(&self.text_iface);
             _ = self.refcount.fetchAdd(1, .monotonic);
         }
         return com.S_OK;
@@ -418,6 +464,373 @@ pub const TerminalProvider = struct {
         defer self.alloc.free(text);
         return allocBstrFromUtf8(self.alloc, text);
     }
+
+    fn GetSelection(
+        _: *com.ITextProvider,
+        out: *?*com.SAFEARRAY,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = com.SafeArrayCreateVector(com.VT_UNKNOWN, 0, 0);
+        return if (out.* == null) com.E_OUTOFMEMORY else com.S_OK;
+    }
+
+    fn GetVisibleRanges(
+        self_text: *com.ITextProvider,
+        out: *?*com.SAFEARRAY,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromText(self_text);
+        return self.singleRangeArray(out);
+    }
+
+    fn RangeFromChild(
+        _: *com.ITextProvider,
+        _: ?*com.IRawElementProviderSimple,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = null;
+        return com.E_NOTIMPL;
+    }
+
+    fn RangeFromPoint(
+        self_text: *com.ITextProvider,
+        _: com.UiaPoint,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromText(self_text);
+        return self.createDocumentRange(out);
+    }
+
+    fn get_DocumentRange(
+        self_text: *com.ITextProvider,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromText(self_text);
+        return self.createDocumentRange(out);
+    }
+
+    fn get_SupportedTextSelection(
+        _: *com.ITextProvider,
+        out: *i32,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = com.SupportedTextSelection_None;
+        return com.S_OK;
+    }
+
+    fn singleRangeArray(self: *TerminalProvider, out: *?*com.SAFEARRAY) com.HRESULT {
+        out.* = null;
+        var range: ?*com.ITextRangeProvider = null;
+        const range_hr = self.createDocumentRange(&range);
+        if (range_hr != com.S_OK) return range_hr;
+        defer _ = TerminalTextRangeProvider.Release(range.?);
+
+        const array = com.SafeArrayCreateVector(com.VT_UNKNOWN, 0, 1) orelse return com.E_OUTOFMEMORY;
+        errdefer _ = com.SafeArrayDestroy(array);
+
+        var index: i32 = 0;
+        const put_hr = com.SafeArrayPutElement(array, &index, @ptrCast(range.?));
+        if (put_hr != com.S_OK) return put_hr;
+
+        out.* = array;
+        return com.S_OK;
+    }
+
+    fn createDocumentRange(
+        self: *TerminalProvider,
+        out: *?*com.ITextRangeProvider,
+    ) com.HRESULT {
+        out.* = null;
+        const text = self.state.value(self.state.ctx, self.alloc) catch |err| {
+            std.log.warn("uia: TerminalProvider text snapshot failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+        errdefer self.alloc.free(text);
+
+        const range = TerminalTextRangeProvider.create(
+            self.alloc,
+            self,
+            text,
+            .{ .start = 0, .end = text.len },
+        ) catch |err| {
+            std.log.warn("uia: TerminalTextRangeProvider.create failed err={}", .{err});
+            return com.E_OUTOFMEMORY;
+        };
+        out.* = &range.base;
+        return com.S_OK;
+    }
+};
+
+const TerminalTextRangeProvider = struct {
+    base: com.ITextRangeProvider,
+    refcount: std.atomic.Value(u32),
+    alloc: std.mem.Allocator,
+    parent: *TerminalProvider,
+    text: []u8,
+    range: terminal_text.OffsetRange,
+
+    const vtbl: com.ITextRangeProviderVtbl = .{
+        .QueryInterface = QueryInterface,
+        .AddRef = AddRef,
+        .Release = Release,
+        .Clone = Clone,
+        .Compare = Compare,
+        .CompareEndpoints = CompareEndpoints,
+        .ExpandToEnclosingUnit = ExpandToEnclosingUnit,
+        .FindAttribute = FindAttribute,
+        .FindText = FindText,
+        .GetAttributeValue = GetAttributeValue,
+        .GetBoundingRectangles = GetBoundingRectangles,
+        .GetEnclosingElement = GetEnclosingElement,
+        .GetText = GetText,
+        .Move = Move,
+        .MoveEndpointByUnit = MoveEndpointByUnit,
+        .MoveEndpointByRange = MoveEndpointByRange,
+        .Select = Select,
+        .AddToSelection = AddToSelection,
+        .RemoveFromSelection = RemoveFromSelection,
+        .ScrollIntoView = ScrollIntoView,
+        .GetChildren = GetChildren,
+    };
+
+    fn create(
+        alloc: std.mem.Allocator,
+        parent: *TerminalProvider,
+        text: []u8,
+        range: terminal_text.OffsetRange,
+    ) !*TerminalTextRangeProvider {
+        const self = try alloc.create(TerminalTextRangeProvider);
+        _ = TerminalProvider.AddRef(&parent.base);
+        self.* = .{
+            .base = .{ .vtbl = &vtbl },
+            .refcount = std.atomic.Value(u32).init(1),
+            .alloc = alloc,
+            .parent = parent,
+            .text = text,
+            .range = normalizeRange(range, text.len),
+        };
+        return self;
+    }
+
+    fn fromBase(p: *com.ITextRangeProvider) *TerminalTextRangeProvider {
+        return @fieldParentPtr("base", p);
+    }
+
+    fn normalizeRange(range: terminal_text.OffsetRange, text_len: usize) terminal_text.OffsetRange {
+        const start = @min(range.start, text_len);
+        const end = @min(@max(range.end, start), text_len);
+        return .{ .start = start, .end = end };
+    }
+
+    fn QueryInterface(
+        self_base: *com.ITextRangeProvider,
+        iid: *const com.GUID,
+        out: *?*anyopaque,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        out.* = null;
+        if (iidEqual(iid, &com.IID_IUnknown) or
+            iidEqual(iid, &com.IID_ITextRangeProvider))
+        {
+            out.* = @ptrCast(&self.base);
+            _ = self.refcount.fetchAdd(1, .monotonic);
+            return com.S_OK;
+        }
+        return com.E_NOINTERFACE;
+    }
+
+    fn AddRef(self_base: *com.ITextRangeProvider) callconv(.winapi) u32 {
+        const self = fromBase(self_base);
+        return self.refcount.fetchAdd(1, .monotonic) + 1;
+    }
+
+    fn Release(self_base: *com.ITextRangeProvider) callconv(.winapi) u32 {
+        const self = fromBase(self_base);
+        const prev = self.refcount.fetchSub(1, .acq_rel);
+        if (prev == 1) {
+            self.alloc.free(self.text);
+            _ = TerminalProvider.Release(&self.parent.base);
+            self.alloc.destroy(self);
+            return 0;
+        }
+        return prev - 1;
+    }
+
+    fn Clone(
+        self_base: *com.ITextRangeProvider,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        out.* = null;
+        const text_copy = self.alloc.dupe(u8, self.text) catch return com.E_OUTOFMEMORY;
+        errdefer self.alloc.free(text_copy);
+        const clone = create(self.alloc, self.parent, text_copy, self.range) catch return com.E_OUTOFMEMORY;
+        out.* = &clone.base;
+        return com.S_OK;
+    }
+
+    fn Compare(
+        self_base: *com.ITextRangeProvider,
+        other: ?*com.ITextRangeProvider,
+        out: *com.BOOL,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        out.* = 0;
+        const other_range = other orelse return com.S_OK;
+        if (other_range.vtbl != &vtbl) return com.S_OK;
+        const rhs = fromBase(other_range);
+        out.* = if (self.parent == rhs.parent and
+            self.range.start == rhs.range.start and
+            self.range.end == rhs.range.end and
+            std.mem.eql(u8, self.text, rhs.text)) 1 else 0;
+        return com.S_OK;
+    }
+
+    fn CompareEndpoints(
+        self_base: *com.ITextRangeProvider,
+        endpoint: i32,
+        other: ?*com.ITextRangeProvider,
+        target_endpoint: i32,
+        out: *i32,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        const other_range = other orelse return com.E_POINTER;
+        if (other_range.vtbl != &vtbl) return com.E_NOINTERFACE;
+        const rhs = fromBase(other_range);
+        const lhs_value = if (endpoint == com.TextPatternRangeEndpoint_End) self.range.end else self.range.start;
+        const rhs_value = if (target_endpoint == com.TextPatternRangeEndpoint_End) rhs.range.end else rhs.range.start;
+        out.* = if (lhs_value < rhs_value) -1 else if (lhs_value > rhs_value) 1 else 0;
+        return com.S_OK;
+    }
+
+    fn ExpandToEnclosingUnit(
+        self_base: *com.ITextRangeProvider,
+        unit: i32,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        if (unit == com.TextUnit_Document) {
+            self.range = .{ .start = 0, .end = self.text.len };
+            return com.S_OK;
+        }
+        return com.E_NOTIMPL;
+    }
+
+    fn FindAttribute(
+        _: *com.ITextRangeProvider,
+        _: i32,
+        _: com.VARIANT,
+        _: com.BOOL,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = null;
+        return com.S_OK;
+    }
+
+    fn FindText(
+        _: *com.ITextRangeProvider,
+        _: ?[*:0]const u16,
+        _: com.BOOL,
+        _: com.BOOL,
+        out: *?*com.ITextRangeProvider,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = null;
+        return com.E_NOTIMPL;
+    }
+
+    fn GetAttributeValue(
+        _: *com.ITextRangeProvider,
+        _: i32,
+        out: *com.VARIANT,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = com.VARIANT.empty();
+        return com.S_OK;
+    }
+
+    fn GetBoundingRectangles(
+        _: *com.ITextRangeProvider,
+        out: *?*com.SAFEARRAY,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = com.SafeArrayCreateVector(com.VT_R8, 0, 0);
+        return if (out.* == null) com.E_OUTOFMEMORY else com.S_OK;
+    }
+
+    fn GetEnclosingElement(
+        self_base: *com.ITextRangeProvider,
+        out: *?*com.IRawElementProviderSimple,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        out.* = &self.parent.base;
+        _ = TerminalProvider.AddRef(&self.parent.base);
+        return com.S_OK;
+    }
+
+    fn GetText(
+        self_base: *com.ITextRangeProvider,
+        max_length: i32,
+        out: *?[*:0]u16,
+    ) callconv(.winapi) com.HRESULT {
+        const self = fromBase(self_base);
+        out.* = allocBstrFromUtf8Max(
+            self.alloc,
+            self.text[self.range.start..self.range.end],
+            max_length,
+        ) orelse return com.E_OUTOFMEMORY;
+        return com.S_OK;
+    }
+
+    fn Move(
+        _: *com.ITextRangeProvider,
+        _: i32,
+        _: i32,
+        out: *i32,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = 0;
+        return com.E_NOTIMPL;
+    }
+
+    fn MoveEndpointByUnit(
+        _: *com.ITextRangeProvider,
+        _: i32,
+        _: i32,
+        _: i32,
+        out: *i32,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = 0;
+        return com.E_NOTIMPL;
+    }
+
+    fn MoveEndpointByRange(
+        _: *com.ITextRangeProvider,
+        _: i32,
+        _: ?*com.ITextRangeProvider,
+        _: i32,
+    ) callconv(.winapi) com.HRESULT {
+        return com.E_NOTIMPL;
+    }
+
+    fn Select(_: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
+        return com.E_NOTIMPL;
+    }
+
+    fn AddToSelection(_: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
+        return com.E_NOTIMPL;
+    }
+
+    fn RemoveFromSelection(_: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
+        return com.E_NOTIMPL;
+    }
+
+    fn ScrollIntoView(
+        _: *com.ITextRangeProvider,
+        _: com.BOOL,
+    ) callconv(.winapi) com.HRESULT {
+        return com.S_OK;
+    }
+
+    fn GetChildren(
+        _: *com.ITextRangeProvider,
+        out: *?*com.SAFEARRAY,
+    ) callconv(.winapi) com.HRESULT {
+        out.* = com.SafeArrayCreateVector(com.VT_UNKNOWN, 0, 0);
+        return if (out.* == null) com.E_OUTOFMEMORY else com.S_OK;
+    }
 };
 
 /// Handle `WM_GETOBJECT` for the palette list HWND. `state` gives the
@@ -480,6 +893,31 @@ fn allocBstrFromUtf8(alloc: std.mem.Allocator, text: []const u8) ?[*:0]u16 {
     const written = std.unicode.utf8ToUtf16Le(buf, text) catch return null;
     std.debug.assert(written == utf16_len);
     return com.SysAllocString(@ptrCast(buf.ptr));
+}
+
+fn allocBstrFromUtf8Max(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+    max_utf16_len: i32,
+) ?[*:0]u16 {
+    if (max_utf16_len < 0) return allocBstrFromUtf8(alloc, text);
+    const limited = utf8PrefixForUtf16Limit(text, @intCast(max_utf16_len)) catch return null;
+    return allocBstrFromUtf8(alloc, limited);
+}
+
+fn utf8PrefixForUtf16Limit(text: []const u8, max_utf16_len: usize) ![]const u8 {
+    var byte_index: usize = 0;
+    var utf16_len: usize = 0;
+    while (byte_index < text.len) {
+        const seq_len = try std.unicode.utf8ByteSequenceLength(text[byte_index]);
+        if (byte_index + seq_len > text.len) return error.TruncatedUtf8;
+        const codepoint = try std.unicode.utf8Decode(text[byte_index .. byte_index + seq_len]);
+        const next_utf16_len = utf16_len + if (codepoint <= 0xFFFF) @as(usize, 1) else 2;
+        if (next_utf16_len > max_utf16_len) break;
+        byte_index += seq_len;
+        utf16_len = next_utf16_len;
+    }
+    return text[0..byte_index];
 }
 
 test "PaletteListProvider refcount balances" {
@@ -550,6 +988,34 @@ test "TerminalProvider exposes Value pattern provider" {
     _ = TerminalProvider.ValueRelease(@ptrCast(@alignCast(out.?)));
 }
 
+test "TerminalProvider QueryInterface accepts TextProvider" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var out: ?*anyopaque = null;
+    const hr = TerminalProvider.QueryInterface(&p.base, &com.IID_ITextProvider, &out);
+    try std.testing.expectEqual(com.S_OK, hr);
+    try std.testing.expect(out != null);
+    _ = TerminalProvider.TextRelease(@ptrCast(@alignCast(out.?)));
+}
+
+test "TerminalProvider exposes Text pattern provider" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var out: ?*com.IUnknown = null;
+    const hr = TerminalProvider.GetPatternProvider(&p.base, constants.UIA_TextPatternId, &out);
+    try std.testing.expectEqual(com.S_OK, hr);
+    try std.testing.expect(out != null);
+    _ = TerminalProvider.TextRelease(@ptrCast(@alignCast(out.?)));
+}
+
 test "TerminalProvider refcount and state retain balance across value provider refs" {
     var state_data = TestTerminalStateData{};
     const state = testTerminalState(&state_data);
@@ -570,6 +1036,35 @@ test "TerminalProvider refcount and state retain balance across value provider r
     try std.testing.expectEqual(@as(u32, 0), TerminalProvider.Release(&p.base));
     try std.testing.expectEqual(@as(u32, 1), state_data.retains);
     try std.testing.expectEqual(@as(u32, 1), state_data.releases);
+}
+
+test "TerminalProvider text provider reports no selectable text" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var selection: i32 = -1;
+    const hr = TerminalProvider.get_SupportedTextSelection(&p.text_iface, &selection);
+    try std.testing.expectEqual(com.S_OK, hr);
+    try std.testing.expectEqual(com.SupportedTextSelection_None, selection);
+}
+
+test "TerminalProvider visible ranges returns a SAFEARRAY" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var ranges: ?*com.SAFEARRAY = null;
+    const hr = TerminalProvider.GetVisibleRanges(&p.text_iface, &ranges);
+    defer _ = com.SafeArrayDestroy(ranges);
+
+    try std.testing.expectEqual(com.S_OK, hr);
+    try std.testing.expect(ranges != null);
+    try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
 }
 
 test "TerminalProvider reports document control type" {
@@ -601,6 +1096,78 @@ test "TerminalProvider get_Value returns non-null BSTR" {
     try std.testing.expectEqual(@as(u32, 11), com.SysStringLen(out));
     try std.testing.expectEqualSlices(u16, std.unicode.utf8ToUtf16LeStringLiteral("hello\nworld"), out.?[0..11]);
     try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
+}
+
+test "TerminalProvider DocumentRange returns terminal text" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var range: ?*com.ITextRangeProvider = null;
+    const range_hr = TerminalProvider.get_DocumentRange(&p.text_iface, &range);
+    try std.testing.expectEqual(com.S_OK, range_hr);
+    defer _ = TerminalTextRangeProvider.Release(range.?);
+
+    var out: ?[*:0]u16 = null;
+    const text_hr = TerminalTextRangeProvider.GetText(range.?, -1, &out);
+    defer com.SysFreeString(out);
+
+    try std.testing.expectEqual(com.S_OK, text_hr);
+    try std.testing.expect(out != null);
+    try std.testing.expectEqual(@as(u32, 11), com.SysStringLen(out));
+    try std.testing.expectEqualSlices(u16, std.unicode.utf8ToUtf16LeStringLiteral("hello\nworld"), out.?[0..11]);
+    try std.testing.expectEqual(@as(u32, 1), state_data.value_calls);
+}
+
+test "TerminalTextRangeProvider GetText honors UTF-16 maxLength" {
+    var state_data = TestTerminalStateData{ .value_text = "A🔥B" };
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(com.S_OK, TerminalProvider.get_DocumentRange(&p.text_iface, &range));
+    defer _ = TerminalTextRangeProvider.Release(range.?);
+
+    var one: ?[*:0]u16 = null;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetText(range.?, 1, &one));
+    defer com.SysFreeString(one);
+    try std.testing.expectEqual(@as(u32, 1), com.SysStringLen(one));
+    try std.testing.expectEqualSlices(u16, std.unicode.utf8ToUtf16LeStringLiteral("A"), one.?[0..1]);
+
+    var three: ?[*:0]u16 = null;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetText(range.?, 3, &three));
+    defer com.SysFreeString(three);
+    try std.testing.expectEqual(@as(u32, 3), com.SysStringLen(three));
+    try std.testing.expectEqualSlices(u16, std.unicode.utf8ToUtf16LeStringLiteral("A🔥"), three.?[0..3]);
+}
+
+test "TerminalTextRangeProvider clone and enclosing element retain parent" {
+    var state_data = TestTerminalStateData{};
+    const state = testTerminalState(&state_data);
+
+    var p = try TerminalProvider.create(std.testing.allocator, @ptrFromInt(0x1), state);
+    defer _ = TerminalProvider.Release(&p.base);
+
+    var range: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(com.S_OK, TerminalProvider.get_DocumentRange(&p.text_iface, &range));
+    defer _ = TerminalTextRangeProvider.Release(range.?);
+
+    var clone: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.Clone(range.?, &clone));
+    defer _ = TerminalTextRangeProvider.Release(clone.?);
+
+    var same: com.BOOL = 0;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.Compare(range.?, clone, &same));
+    try std.testing.expectEqual(@as(com.BOOL, 1), same);
+
+    var enclosing: ?*com.IRawElementProviderSimple = null;
+    try std.testing.expectEqual(com.S_OK, TerminalTextRangeProvider.GetEnclosingElement(clone.?, &enclosing));
+    try std.testing.expect(enclosing != null);
+    try std.testing.expectEqual(@as(u32, 3), TerminalProvider.Release(enclosing.?));
 }
 
 test "TerminalProvider ValueValueProperty returns non-null BSTR" {
@@ -682,6 +1249,7 @@ const TestTerminalStateData = struct {
     value_calls: u32 = 0,
     retains: u32 = 0,
     releases: u32 = 0,
+    value_text: []const u8 = "hello\nworld",
 };
 
 fn testTerminalState(data: *TestTerminalStateData) TerminalState {
@@ -705,7 +1273,7 @@ fn testTerminalState(data: *TestTerminalStateData) TerminalState {
         fn value(ctx: *anyopaque, alloc: std.mem.Allocator) ![]u8 {
             const d: *TestTerminalStateData = @ptrCast(@alignCast(ctx));
             d.value_calls += 1;
-            return try alloc.dupe(u8, "hello\nworld");
+            return try alloc.dupe(u8, d.value_text);
         }
 
         fn focused(ctx: *anyopaque) bool {


### PR DESCRIPTION
Adds a read-only Win32 UIA Text provider and range provider for terminal text snapshots. Validation: zig fmt, TerminalProvider tests, TerminalTextRangeProvider tests, full zig build, and git diff checks passed. @codex @coderabbitai @greptileai Copilot: please review this branch; I will iterate on findings until it is clean to squash and merge.

## Summary by Sourcery

Add a read-only Win32 UI Automation text provider and range provider for terminal text snapshots, wiring them into the existing terminal UIA provider.

New Features:
- Expose UIA TextPattern support on the terminal provider via ITextProvider and ITextRangeProvider backed by terminal text snapshots.

Enhancements:
- Implement UTF-8 to UTF-16 conversion helpers that respect a maximum UTF-16 length for UIA GetText calls.
- Extend COM and UIA constant definitions to cover text-related interfaces, enums, and SAFEARRAY helpers.

Tests:
- Add unit tests covering text provider QueryInterface and pattern exposure, visible ranges, document range text content, UTF-16 length limiting, and range cloning/enclosing element behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added UI Automation text provider support for terminal content, enabling screen readers and assistive technologies to access terminal text
  * Implemented text range navigation and selection capabilities
  * Added support for retrieving visible terminal text separately from scrollback content

* **Tests**
  * Expanded test coverage for text provider functionality, UTF-16 handling, and text range operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amanthanvi/winghostty/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->