### PR TITLE
Fix Win32 configured startup grid size

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -770,11 +770,27 @@ pub fn init(
     // init stuff we should get rid of this. But this is required because
     // sizeCallback does retina-aware stuff we don't do here and don't want
     // to duplicate.
-    try self.resize(self.size.screen);
+    try self.resizeBeforeIoThreadStart(self.size.screen);
 
     // Give the renderer one more opportunity to finalize any surface
     // setup on the main thread prior to spinning up the rendering thread.
     try renderer_impl.finalizeSurfaceInit(rt_surface);
+
+    // Determine our initial window size if configured. We need to do this
+    // quite late in the process because our height/width are in grid dimensions,
+    // so we need to know our cell sizes first.
+    //
+    // This must happen before the IO thread starts. The exec backend opens the
+    // PTY at thread startup, and TUI applications can query the size
+    // immediately after launch.
+    self.recomputeInitialSize(.skip) catch |err| {
+        // We don't treat this as a fatal error because not setting
+        // an initial size shouldn't stop our terminal from working.
+        log.warn("unable to set initial window size: {}", .{err});
+    };
+    self.io.resizeBeforeThreadStart(self.size) catch |err| {
+        log.warn("unable to synchronize initial terminal size before IO thread start: {}", .{err});
+    };
 
     // Start our renderer thread
     self.renderer_thr = try std.Thread.spawn(
@@ -791,19 +807,6 @@ pub fn init(
         .{ &self.io_thread, &self.io },
     );
     self.io_thr.setName("io") catch {};
-
-    // Determine our initial window size if configured. We need to do this
-    // quite late in the process because our height/width are in grid dimensions,
-    // so we need to know our cell sizes first.
-    //
-    // Note: it is important to do this after the renderer is setup above.
-    // This allows the apprt to fully initialize the surface before we
-    // start messing with the window.
-    self.recomputeInitialSize() catch |err| {
-        // We don't treat this as a fatal error because not setting
-        // an initial size shouldn't stop our terminal from working.
-        log.warn("unable to set initial window size: {}", .{err});
-    };
 
     if (config.title) |title| {
         _ = try rt_app.performAction(
@@ -1996,15 +1999,14 @@ test "progress-style enable replays retained progress report" {
 
 const InitialSizeError = error{
     ContentScaleUnavailable,
+    SurfaceSizeUnavailable,
     AppActionFailed,
 };
 
 /// Recalculate the initial size of the window based on the
 /// configuration and invoke the apprt `initial_size` action if
 /// necessary.
-fn recomputeInitialSize(
-    self: *Surface,
-) InitialSizeError!void {
+fn recomputeInitialSize(self: *Surface, io_mode: ResizeIoMode) InitialSizeError!void {
     // Both width and height must be set for this to work, as
     // documented on the config options.
     if (self.config.window_height <= 0 or
@@ -2039,6 +2041,16 @@ fn recomputeInitialSize(
         .initial_size,
         .{ .width = final_width, .height = final_height },
     ) catch return error.AppActionFailed;
+
+    const surface_size = self.rt_surface.getSize() catch
+        return error.SurfaceSizeUnavailable;
+    const screen_size: rendererpkg.ScreenSize = .{
+        .width = surface_size.width,
+        .height = surface_size.height,
+    };
+    if (!self.size.screen.equals(screen_size)) {
+        self.resizeWithIoMode(screen_size, io_mode) catch return error.AppActionFailed;
+    }
 }
 
 /// Represents text read from the terminal and some metadata about it
@@ -2567,7 +2579,7 @@ fn setCellSize(self: *Surface, size: rendererpkg.CellSize) !void {
     self.queueIo(.{ .resize = self.size }, .unlocked);
 
     // Update our terminal default size if necessary.
-    self.recomputeInitialSize() catch |err| {
+    self.recomputeInitialSize(.queue) catch |err| {
         // We don't treat this as a fatal error because not setting
         // an initial size shouldn't stop our terminal from working.
         log.warn("unable to recompute initial window size: {}", .{err});
@@ -2649,6 +2661,19 @@ pub fn sizeCallback(self: *Surface, size: apprt.SurfaceSize) !void {
 }
 
 fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
+    try self.resizeWithIoMode(size, .queue);
+}
+
+fn resizeBeforeIoThreadStart(self: *Surface, size: rendererpkg.ScreenSize) !void {
+    try self.resizeWithIoMode(size, .skip);
+}
+
+const ResizeIoMode = enum {
+    queue,
+    skip,
+};
+
+fn resizeWithIoMode(self: *Surface, size: rendererpkg.ScreenSize, io_mode: ResizeIoMode) !void {
     // Save our screen size
     self.size.screen = size;
     self.balancePaddingIfNeeded();
@@ -2667,8 +2692,9 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
             "set. Is your padding reasonable?", .{});
     }
 
-    // Mail the IO thread
-    self.queueIo(.{ .resize = self.size }, .unlocked);
+    if (io_mode == .queue) {
+        self.queueIo(.{ .resize = self.size }, .unlocked);
+    }
 }
 
 /// Recalculate the balanced padding if needed.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -11672,6 +11672,16 @@ const Host = struct {
         self.forceHostCompositionPaint();
     }
 
+    fn syncVisibleSurfaceCoreSizesFromClientRects(self: *Host) void {
+        if (self.activeTab()) |tab| {
+            var it = tab.tree.iterator();
+            while (it.next()) |entry| {
+                if (!entry.view.window_visible) continue;
+                entry.view.syncCoreSizeFromClientRect();
+            }
+        }
+    }
+
     fn forceVisibleSurfaceRepaintsNow(self: *Host) void {
         if (self.activeTab()) |tab| {
             var it = tab.tree.iterator();
@@ -13875,6 +13885,19 @@ fn resizeSettleSurfaceAction(renderer_repaint_requested: bool) ResizeSettleSurfa
 
 fn surfacePixelSizeChanged(previous: apprt.SurfaceSize, next: apprt.SurfaceSize) bool {
     return previous.width != next.width or previous.height != next.height;
+}
+
+fn scaleInitialClientSize(size: apprt.SurfaceSize, scale: apprt.ContentScale) apprt.SurfaceSize {
+    return .{
+        .width = scaleInitialClientAxis(size.width, scale.x),
+        .height = scaleInitialClientAxis(size.height, scale.y),
+    };
+}
+
+fn scaleInitialClientAxis(value: u32, scale: f32) u32 {
+    const scaled = @ceil(@as(f64, @floatFromInt(value)) * @as(f64, @floatCast(scale)));
+    const max_u32: f64 = @floatFromInt(std.math.maxInt(u32));
+    return @intFromFloat(@min(max_u32, @max(1, scaled)));
 }
 
 fn surfaceActivationNeedsHostSync(
@@ -22165,7 +22188,8 @@ pub const Surface = struct {
         if (self.fullscreen or
             self.restore_maximized or
             !shouldResizeHostForInitialSize(self.hostSurfaceCount())) return;
-        try self.resizeClientArea(size.width, size.height);
+        const client_size = scaleInitialClientSize(self.default_client_size.?, self.content_scale);
+        try self.resizeClientArea(client_size.width, client_size.height);
     }
 
     fn hostSurfaceCount(self: *const Surface) usize {
@@ -22179,7 +22203,8 @@ pub const Surface = struct {
         const size = self.default_client_size orelse return;
         if (self.fullscreen) try self.leaveFullscreen();
         if (self.windowHwnd()) |hwnd| _ = ShowWindow(hwnd, SW_RESTORE);
-        try self.resizeClientArea(@intCast(size.width), @intCast(size.height));
+        const client_size = scaleInitialClientSize(size, self.content_scale);
+        try self.resizeClientArea(client_size.width, client_size.height);
     }
 
     fn setSizeLimit(self: *Surface, limit: apprt.action.SizeLimit) void {
@@ -22336,6 +22361,7 @@ pub const Surface = struct {
 
     fn resizeClientArea(self: *Surface, client_width: u32, client_height: u32) !void {
         const hwnd = self.windowHwnd() orelse return;
+        const hosted = self.host != null;
         var client_rect: RECT = undefined;
         if (GetClientRect(hwnd, &client_rect) == 0) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
@@ -22362,6 +22388,14 @@ pub const Surface = struct {
             SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE,
         ) == 0) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+
+        if (hosted) {
+            const host = self.host orelse unreachable;
+            try host.layout();
+            host.syncVisibleSurfaceCoreSizesFromClientRects();
+        } else {
+            self.syncCoreSizeFromClientRect();
         }
     }
 
@@ -30302,6 +30336,35 @@ test "win32 surfacePixelSizeChanged only trips on width or height deltas" {
     try std.testing.expect(!surfacePixelSizeChanged(stable, .{ .width = 800, .height = 600 }));
     try std.testing.expect(surfacePixelSizeChanged(stable, .{ .width = 801, .height = 600 }));
     try std.testing.expect(surfacePixelSizeChanged(stable, .{ .width = 800, .height = 601 }));
+}
+
+test "win32 scaleInitialClientSize converts logical initial size to physical pixels" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqualDeep(
+        apprt.SurfaceSize{ .width = 1680, .height = 810 },
+        scaleInitialClientSize(
+            .{ .width = 1120, .height = 540 },
+            .{ .x = 1.5, .y = 1.5 },
+        ),
+    );
+    try std.testing.expectEqualDeep(
+        apprt.SurfaceSize{ .width = 701, .height = 300 },
+        scaleInitialClientSize(
+            .{ .width = 467, .height = 200 },
+            .{ .x = 1.5, .y = 1.5 },
+        ),
+    );
+    try std.testing.expectEqualDeep(
+        apprt.SurfaceSize{
+            .width = std.math.maxInt(u32),
+            .height = std.math.maxInt(u32),
+        },
+        scaleInitialClientSize(
+            .{ .width = std.math.maxInt(u32), .height = std.math.maxInt(u32) },
+            .{ .x = 2.0, .y = 2.0 },
+        ),
+    );
 }
 
 test "win32 surfaceActivationNeedsHostSync only trips on activation-visible deltas" {

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -640,6 +640,38 @@ pub fn resize(
     self.renderer_wakeup.notify() catch {};
 }
 
+/// Resize terminal/backend state before the IO thread starts.
+///
+/// This lets an apprt apply startup window sizing before the exec backend opens
+/// its PTY. Unlike `resize`, this has no thread data yet and therefore cannot
+/// emit in-band size reports.
+pub fn resizeBeforeThreadStart(
+    self: *Termio,
+    size: renderer.Size,
+) !void {
+    self.size = size;
+    const grid_size = size.grid();
+
+    try self.backend.resize(grid_size, size.terminal());
+
+    {
+        self.renderer_state.mutex.lock();
+        defer self.renderer_state.mutex.unlock();
+
+        try self.terminal.resize(
+            self.alloc,
+            grid_size.columns,
+            grid_size.rows,
+        );
+
+        self.terminal.width_px = grid_size.columns * self.size.cell.width;
+        self.terminal.height_px = grid_size.rows * self.size.cell.height;
+        self.terminal.modes.set(.synchronized_output, false);
+    }
+
+    _ = self.renderer_mailbox.push(.{ .resize = size }, .{ .forever = {} });
+}
+
 /// Make a size report.
 pub fn sizeReport(self: *Termio, td: *ThreadData, style: termio.Message.SizeReport) !void {
     self.renderer_state.mutex.lock();

--- a/test/windows/interactive-win11-configured-size.ps1
+++ b/test/windows/interactive-win11-configured-size.ps1
@@ -1,0 +1,189 @@
+param(
+    [switch] $Rebuild,
+    [switch] $ResetState,
+    [int] $TimeoutSeconds = 15
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TimeoutSeconds -le 0) {
+    throw 'TimeoutSeconds must be greater than 0.'
+}
+
+$launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+. $libPath
+
+if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_CONFIGURED_SIZE_BOOTSTRAPPED) {
+    $forwardedArgs = @('-TimeoutSeconds', $TimeoutSeconds.ToString())
+    if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+    if ($ResetState) { $forwardedArgs += '-ResetState' }
+
+    $bootstrapExitCode = 0
+    Invoke-InteractiveWin11Bootstrap `
+        -RepoRoot $repoRoot `
+        -LauncherPath $launcherPath `
+        -EnvironmentVariable 'WINGHOSTTY_INTERACTIVE_WIN11_CONFIGURED_SIZE_BOOTSTRAPPED' `
+        -ArgumentList $forwardedArgs `
+        -ExitCode ([ref] $bootstrapExitCode)
+    exit $bootstrapExitCode
+}
+
+$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'configured-size' -ResetState:$ResetState -IncludeResourcesDir
+$repoRoot = $harness.RepoRoot
+$layout = $harness.Layout
+
+if (-not ('InteractiveWin11ConfiguredSizeNative' -as [type])) {
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class InteractiveWin11ConfiguredSizeNative {
+    [DllImport("user32.dll")]
+    public static extern uint GetDpiForWindow(IntPtr hwnd);
+}
+"@
+}
+
+$exePath = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
+$buildInputs = Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot
+$launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -BuildInputs $buildInputs
+$stdoutPath = Join-Path $layout.Logs 'interactive-win11-configured-size-stdout.log'
+$stderrPath = Join-Path $layout.Logs 'interactive-win11-configured-size-stderr.log'
+$configPath = Join-Path $layout.Temp 'interactive-win11-configured-size.conf'
+$payloadPath = Join-Path $layout.Temp 'interactive-win11-configured-size-payload.ps1'
+$resultPath = Join-Path $layout.Temp 'interactive-win11-configured-size-result.json'
+$configuredWidth = 140
+$configuredHeight = 45
+
+if ($launchAction -eq 'build') {
+    Invoke-InteractiveWin11Build -RepoRoot $repoRoot
+}
+
+Assert-InteractiveWin11ExeExists -ExePath $exePath
+
+@"
+window-width = $configuredWidth
+window-height = $configuredHeight
+confirm-close-surface = false
+font-size = 16
+"@ | Set-Content -LiteralPath $configPath -Encoding UTF8
+
+@"
+param(
+    [Parameter(Mandatory)] [string] `$ResultPath
+)
+
+`$result = [pscustomobject]@{
+    width = [Console]::WindowWidth
+    height = [Console]::WindowHeight
+}
+`$result | ConvertTo-Json -Compress | Set-Content -LiteralPath `$ResultPath -Encoding ASCII
+Start-Sleep -Seconds 30
+"@ | Set-Content -LiteralPath $payloadPath -Encoding UTF8
+
+Remove-Item -LiteralPath $stdoutPath, $stderrPath, $resultPath -ErrorAction SilentlyContinue
+
+$launchArgs = @(
+    '--single-instance=false'
+    "--class=winghostty-configured-size-$($layout.SandboxId)"
+    "--config-file=$configPath"
+    '-e'
+    'powershell.exe'
+    '-NoLogo'
+    '-NoProfile'
+    '-ExecutionPolicy'
+    'Bypass'
+    '-File'
+    $payloadPath
+    '-ResultPath'
+    $resultPath
+)
+
+$process = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList $launchArgs `
+    -WorkingDirectory $repoRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -PassThru
+
+$successPattern = 'started subcommand path='
+$runtimeFailurePattern = 'paint redraw failed|InvalidValue|surface closed|panic: reached unreachable code|error starting IO thread:'
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+$started = $false
+$result = $null
+$resultObservedAt = $null
+
+try {
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $process.Refresh()
+        [string] $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+
+        if ($stderr -match $runtimeFailurePattern) {
+            throw "unexpected runtime failure reported before size capture:`n$stderr"
+        }
+
+        if ($stderr.Contains($successPattern)) {
+            $started = $true
+        }
+
+        if (Test-Path -LiteralPath $resultPath) {
+            $raw = Get-Content -LiteralPath $resultPath -Raw
+            if (-not [string]::IsNullOrWhiteSpace($raw)) {
+                $result = $raw | ConvertFrom-Json
+                $resultObservedAt = [DateTime]::UtcNow
+            }
+        }
+
+        if ($null -ne $result) {
+            if ($started -or ([DateTime]::UtcNow - $resultObservedAt).TotalMilliseconds -ge 1000) {
+                break
+            }
+        }
+
+        if ($process.HasExited) {
+            if ($null -ne $result) {
+                break
+            }
+            throw "winghostty exited before configured-size validation completed (exit code $($process.ExitCode))"
+        }
+
+        Start-Sleep -Milliseconds 100
+    }
+
+    if ($null -eq $result) {
+        if (-not $started) {
+            throw "timed out after $TimeoutSeconds seconds waiting for shell startup"
+        }
+        throw "timed out after $TimeoutSeconds seconds waiting for console size result at $resultPath"
+    }
+
+    $width = [int] $result.width
+    $height = [int] $result.height
+
+    $process.Refresh()
+    $dpi = 96
+    if ($process.MainWindowHandle -ne [IntPtr]::Zero) {
+        $windowDpi = [InteractiveWin11ConfiguredSizeNative]::GetDpiForWindow($process.MainWindowHandle)
+        if ($windowDpi -gt 0) {
+            $dpi = [int] $windowDpi
+        }
+    }
+    $minWidth = $configuredWidth - 20
+    $minHeight = $configuredHeight - 10
+
+    if ($width -lt $minWidth -or $height -lt $minHeight) {
+        throw "configured initial PTY size is too small: ${width}x${height}; expected at least ${minWidth}x${minHeight} for dpi=$dpi"
+    }
+
+    [string] $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+    if ($stderr -match $runtimeFailurePattern) {
+        throw "unexpected runtime failure reported after size capture:`n$stderr"
+    }
+}
+finally {
+    Stop-InteractiveWin11Process -Process $process
+}
+
+Write-Host "interactive-win11 configured-size validation: PASS (pty=${width}x${height}, dpi=$dpi, result=$resultPath, stderr=$stderrPath)"

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -200,6 +200,7 @@ function Get-HarnessSummary {
 Invoke-Harness -ScriptName 'interactive-win11.ps1'
 Invoke-SuiteBuildIfNeeded
 Invoke-Harness -ScriptName 'interactive-win11-smoke.ps1' -TimeoutSeconds 10 -PassResetState
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-configured-size.ps1' -TimeoutSeconds 15
 Invoke-Harness -ScriptName 'interactive-win11-boo-performance.ps1' -TimeoutSeconds 25
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-boo-multitab.ps1' -TimeoutSeconds 25
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command.ps1' -TimeoutSeconds 20


### PR DESCRIPTION
Fixes #47.

## Summary
- synchronize Win32 programmatic startup sizing back into the live core surface before terminal IO starts
- refresh hosted child layout/client rects after successful programmatic resize
- add a Win11 interactive regression harness for configured startup grid dimensions and wire it into the composite validator

## Verification
- `scripts\dev-windows.cmd zig build -Demit-exe=true`
- `scripts\dev-windows.cmd zig build test -Dtest-filter=surfacePixelSizeChanged`
- `scripts\dev-windows.cmd zig build test -Dtest-filter=surfaceLayoutRuntimeSync`
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File test\windows\interactive-win11-configured-size.ps1 -TimeoutSeconds 15 -ResetState`
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File test\windows\interactive-win11-resize.ps1 -TimeoutSeconds 15`
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File test\windows\interactive-win11-validate.ps1`

Review loop requested: @codex @coderabbitai @greptileai @sourceryai @copilot please review this PR. I will resolve findings as they arrive.

## Summary by Sourcery

Ensure configured startup grid size on Windows is applied before terminal I/O starts and kept in sync with the core surface, and add an interactive Win11 regression harness to validate configured startup dimensions.

Bug Fixes:
- Apply the initial configured window size before the IO thread starts so PTY-backed applications observe the correct startup terminal dimensions.
- Resynchronize core surface size with the actual Win32 client rect after programmatic client-area resizes, including when hosted in a tabbed layout.

Enhancements:
- Extend initial size computation to update terminal layout when the runtime surface size changes, logging non-fatal failures instead of aborting.

Tests:
- Add a Win11 interactive configured-size harness and wire it into the composite validation script to automatically verify initial PTY dimensions under DPI scaling.