### PR TITLE
[codex] fix win32 dead key input

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -480,6 +480,7 @@ const MOD_ALT = 0x0001;
 const MOD_CONTROL = 0x0002;
 const MOD_SHIFT = 0x0004;
 const MOD_WIN = 0x0008;
+const TO_UNICODE_NO_STATE_CHANGE: UINT = 0x0004;
 const SWP_NOSIZE = 0x0001;
 const SWP_NOMOVE = 0x0002;
 const SWP_NOZORDER = 0x0004;
@@ -19452,6 +19453,18 @@ fn shouldCommitDeferredCharMessage(pending_wm_char_text: bool, ime_composing: bo
     return pending_wm_char_text and !ime_composing;
 }
 
+fn translateKeyTextToUnicode(
+    vk: UINT,
+    scan_code: UINT,
+    state: *const [256]u8,
+    utf16: *[4]u16,
+) i32 {
+    // TranslateMessage owns the stateful dead-key composition path. This
+    // helper only probes text metadata for key events, so it must not consume
+    // or reset the layout's pending dead key.
+    return ToUnicode(vk, scan_code, state, utf16, utf16.len, TO_UNICODE_NO_STATE_CHANGE);
+}
+
 fn translateKeyText(
     vk: UINT,
     lParam: LPARAM,
@@ -19463,7 +19476,7 @@ fn translateKeyText(
     };
 
     var utf16: [4]u16 = [_]u16{0} ** 4;
-    const count = ToUnicode(vk, scanCodeFromLParam(lParam), state, &utf16, utf16.len, 0);
+    const count = translateKeyTextToUnicode(vk, scanCodeFromLParam(lParam), state, &utf16);
     if (count <= 0) {
         return .{ .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk) };
     }
@@ -27438,6 +27451,7 @@ test "win32 keyFromVirtualKey maps core keys" {
 test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
+    try std.testing.expectEqual(@as(UINT, 0x0004), TO_UNICODE_NO_STATE_CHANGE);
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .key_a,
@@ -27449,6 +27463,12 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .space,
         .{},
         .{ .len = 1, .unshifted_codepoint = ' ' },
+    ));
+    try std.testing.expect(shouldDeferTextToCharMessage(
+        .press,
+        .quote,
+        .{},
+        .{ .unshifted_codepoint = '\'' },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,


### PR DESCRIPTION
## Summary

- Probe Win32 key text with `ToUnicode`'s no-keyboard-state-change flag.
- Keep dead-key/plain text input deferred to `WM_CHAR`, where `TranslateMessage` owns composition.
- Add focused regression coverage for dead-key deferral and the state-preserving flag.

## Root Cause

The Win32 keydown path called `ToUnicode(..., flags = 0)` while building key-event metadata. `ToUnicode` mutates the keyboard layout's pending dead-key state by default, so US-International dead keys could be consumed before the queued `WM_CHAR` composition path delivered the real character.

## Validation

- `git diff --check HEAD~1..HEAD`
- Not run: `zig build test -Dtest-filter=...` because `zig` is not installed in this local environment.

Closes #62.

## Summary by Sourcery

Preserve Win32 keyboard dead-key composition state while deriving key text metadata and extend tests to cover this behavior.

Bug Fixes:
- Prevent Win32 dead keys from being consumed prematurely when probing key text for keydown events.

Enhancements:
- Introduce a dedicated helper for calling ToUnicode with a no-state-change flag when translating key text metadata.

Tests:
- Add regression tests to verify deferred plain-text and dead-key handling, including the ToUnicode no-state-change flag value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows keyboard input handling to ensure consistent text translation behavior across different key states.

* **Tests**
  * Extended test coverage for keyboard input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->