### PR TITLE
test(win32): add IME candidate anchor harness

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19263,6 +19263,9 @@ const ImeWindowForms = struct {
     candidate: CANDIDATEFORM,
 };
 
+var ime_window_forms_trace_path_loaded = false;
+var ime_window_forms_trace_path: ?[]const u8 = null;
+
 fn scaledImeCoord(value: f64, scale: f32) i32 {
     const scale_f64: f64 = @floatCast(scale);
     return @intFromFloat(value * scale_f64);
@@ -19295,20 +19298,25 @@ fn imeWindowForms(ime_pos: apprt.IMEPos, content_scale: apprt.ContentScale) ImeW
     };
 }
 
+fn imeWindowFormsTracePath(alloc: Allocator) ?[]const u8 {
+    if (!ime_window_forms_trace_path_loaded) {
+        ime_window_forms_trace_path_loaded = true;
+        ime_window_forms_trace_path = internal_os.getEnvVarOwnedTrimmedNotEmpty(
+            alloc,
+            "WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE",
+        ) catch null;
+    }
+
+    return ime_window_forms_trace_path;
+}
+
 fn writeImeWindowFormsTrace(
     alloc: Allocator,
     ime_pos: apprt.IMEPos,
     content_scale: apprt.ContentScale,
     forms: ImeWindowForms,
 ) void {
-    const raw = std.process.getEnvVarOwned(
-        alloc,
-        "WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE",
-    ) catch return;
-    defer alloc.free(raw);
-
-    const trace_path = std.mem.trim(u8, raw, " \t\r\n");
-    if (trace_path.len == 0) return;
+    const trace_path = imeWindowFormsTracePath(alloc) orelse return;
 
     const file = std.fs.createFileAbsolute(trace_path, .{ .truncate = true }) catch |err| {
         log.warn("win32 IME form trace create failed path={s} err={}", .{ trace_path, err });

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2932,6 +2932,7 @@ pub const App = struct {
             self.core_app.alloc.free(path);
             self.startup_cwd = null;
         }
+        deinitImeWindowFormsTracePath(self.core_app.alloc);
         self.config.deinit();
         if (self.com_initialized) {
             CoUninitialize();
@@ -19308,6 +19309,12 @@ fn imeWindowFormsTracePath(alloc: Allocator) ?[]const u8 {
     }
 
     return ime_window_forms_trace_path;
+}
+
+fn deinitImeWindowFormsTracePath(alloc: Allocator) void {
+    if (ime_window_forms_trace_path) |path| alloc.free(path);
+    ime_window_forms_trace_path = null;
+    ime_window_forms_trace_path_loaded = false;
 }
 
 fn writeImeWindowFormsTrace(

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23422,8 +23422,11 @@ pub const Surface = struct {
         const himc = ImmGetContext(surface_hwnd) orelse return;
         defer _ = ImmReleaseContext(surface_hwnd, himc);
 
-        _ = ImmSetCompositionWindow(himc, &forms.composition);
-        _ = ImmSetCandidateWindow(himc, &forms.candidate);
+        const composition_set = ImmSetCompositionWindow(himc, &forms.composition) != 0;
+        const candidate_set = ImmSetCandidateWindow(himc, &forms.candidate) != 0;
+        if (composition_set and candidate_set) {
+            writeImeWindowFormsTrace(self.app.core_app.alloc, ime_pos, self.content_scale, forms);
+        }
     }
 
     fn handleImeResult(self: *Surface) void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23424,7 +23424,6 @@ pub const Surface = struct {
         if (!self.core_initialized) return;
         const ime_pos = self.core_surface.imePoint();
         const forms = imeWindowForms(ime_pos, self.content_scale);
-        writeImeWindowFormsTrace(self.app.core_app.alloc, ime_pos, self.content_scale, forms);
 
         const surface_hwnd = self.hwnd orelse return;
         const himc = ImmGetContext(surface_hwnd) orelse return;

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19295,6 +19295,78 @@ fn imeWindowForms(ime_pos: apprt.IMEPos, content_scale: apprt.ContentScale) ImeW
     };
 }
 
+fn writeImeWindowFormsTrace(
+    alloc: Allocator,
+    ime_pos: apprt.IMEPos,
+    content_scale: apprt.ContentScale,
+    forms: ImeWindowForms,
+) void {
+    const raw = std.process.getEnvVarOwned(
+        alloc,
+        "WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE",
+    ) catch return;
+    defer alloc.free(raw);
+
+    const trace_path = std.mem.trim(u8, raw, " \t\r\n");
+    if (trace_path.len == 0) return;
+
+    const file = std.fs.createFileAbsolute(trace_path, .{ .truncate = true }) catch |err| {
+        log.warn("win32 IME form trace create failed path={s} err={}", .{ trace_path, err });
+        return;
+    };
+    defer file.close();
+
+    var buffer: [1024]u8 = undefined;
+    var writer = file.writer(&buffer);
+    const stream = &writer.interface;
+    stream.print("{f}", .{std.json.fmt(.{
+        .ime_pos = .{
+            .x = ime_pos.x,
+            .y = ime_pos.y,
+            .width = ime_pos.width,
+            .height = ime_pos.height,
+        },
+        .content_scale = .{
+            .x = content_scale.x,
+            .y = content_scale.y,
+        },
+        .composition = .{
+            .dwStyle = forms.composition.dwStyle,
+            .ptCurrentPos = .{
+                .X = forms.composition.ptCurrentPos.x,
+                .Y = forms.composition.ptCurrentPos.y,
+            },
+            .rcArea = .{
+                .Left = forms.composition.rcArea.left,
+                .Top = forms.composition.rcArea.top,
+                .Right = forms.composition.rcArea.right,
+                .Bottom = forms.composition.rcArea.bottom,
+            },
+        },
+        .candidate = .{
+            .dwIndex = forms.candidate.dwIndex,
+            .dwStyle = forms.candidate.dwStyle,
+            .ptCurrentPos = .{
+                .X = forms.candidate.ptCurrentPos.x,
+                .Y = forms.candidate.ptCurrentPos.y,
+            },
+            .rcArea = .{
+                .Left = forms.candidate.rcArea.left,
+                .Top = forms.candidate.rcArea.top,
+                .Right = forms.candidate.rcArea.right,
+                .Bottom = forms.candidate.rcArea.bottom,
+            },
+        },
+    }, .{})}) catch |err| {
+        log.warn("win32 IME form trace write failed path={s} err={}", .{ trace_path, err });
+        return;
+    };
+    stream.flush() catch |err| {
+        log.warn("win32 IME form trace flush failed path={s} err={}", .{ trace_path, err });
+        return;
+    };
+}
+
 fn readSystemWheelSetting(action: UINT, fallback: u32) u32 {
     var value: UINT = fallback;
     if (SystemParametersInfoW(action, 0, @ptrCast(&value), 0) == 0) {
@@ -23342,11 +23414,14 @@ pub const Surface = struct {
 
     fn positionImeWindow(self: *Surface) void {
         if (!self.core_initialized) return;
+        const ime_pos = self.core_surface.imePoint();
+        const forms = imeWindowForms(ime_pos, self.content_scale);
+        writeImeWindowFormsTrace(self.app.core_app.alloc, ime_pos, self.content_scale, forms);
+
         const surface_hwnd = self.hwnd orelse return;
         const himc = ImmGetContext(surface_hwnd) orelse return;
         defer _ = ImmReleaseContext(surface_hwnd, himc);
 
-        const forms = imeWindowForms(self.core_surface.imePoint(), self.content_scale);
         _ = ImmSetCompositionWindow(himc, &forms.composition);
         _ = ImmSetCandidateWindow(himc, &forms.candidate);
     }

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -123,6 +123,28 @@ Run with:
 powershell.exe -ExecutionPolicy Bypass -File .\interactive-win11-resize.ps1 -ResetState -TimeoutSeconds 15
 ```
 
+## interactive-win11-ime-candidate.ps1
+
+Interactive Win11 validation for IME candidate anchoring. It launches
+`winghostty`, scripts the terminal cursor to a non-origin row/column,
+sends a synthetic mouse move near the surface origin to poison the old
+mouse-derived path, triggers `WM_IME_STARTCOMPOSITION` on the surface
+HWND, and reads the env-gated runtime trace for the composition/candidate
+forms computed inside `positionImeWindow()`.
+
+The harness verifies that the traced candidate form uses `CFS_EXCLUDE`,
+shares the composition point, exposes a caret-height exclusion rect, and
+lands near the scripted caret instead of the poisoned mouse coordinate. It
+does not assert that Windows created an IME context or that a real IME
+language pack renders a visible candidate popup; that remains
+manual/IME-environment coverage.
+
+Run with:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\interactive-win11-ime-candidate.ps1 -ResetState -TimeoutSeconds 18
+```
+
 ## interactive-win11-undo.ps1
 
 Interactive Win11 validation for the shipped undo/redo action set. It launches

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -386,7 +386,7 @@ try {
     [void] [Win11ImeCandidateNative]::SetFocus($surfaceHwnd)
 
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'scripted caret readiness' -Process $process -Condition {
-        $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+        $stderr = [string] (Get-InteractiveWin11TextFile -Path $stderrPath)
         if ($stderr -match $runtimeFailurePattern) {
             throw "unexpected runtime failure reported before IME probe:`n$stderr"
         }

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -202,6 +202,28 @@ function Send-WindowMessage {
     }
 }
 
+function Read-ImeFormTrace {
+    param(
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    try {
+        $content = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($content)) {
+            return $null
+        }
+
+        return $content | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
+}
+
 function Assert-ImeCandidateAnchoredToCaret {
     param(
         [Parameter(Mandatory)] $Forms,
@@ -368,11 +390,18 @@ try {
         -Message $WM_IME_STARTCOMPOSITION `
         -Description 'WM_IME_STARTCOMPOSITION'
 
+    $script:Win11ImeCandidateTrace = $null
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'IME form trace' -Process $process -Condition {
-        Test-Path -LiteralPath $tracePath
+        $trace = Read-ImeFormTrace -Path $tracePath
+        if ($null -eq $trace) {
+            return $false
+        }
+
+        $script:Win11ImeCandidateTrace = $trace
+        return $true
     }
 
-    $trace = Get-Content -LiteralPath $tracePath -Raw | ConvertFrom-Json
+    $trace = $script:Win11ImeCandidateTrace
     $forms = [pscustomobject]@{
         Composition = $trace.composition
         Candidate = $trace.candidate

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -1,0 +1,447 @@
+param(
+    [switch] $Rebuild,
+    [switch] $ResetState,
+    [int] $TimeoutSeconds = 18
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TimeoutSeconds -le 0) {
+    throw 'TimeoutSeconds must be greater than 0.'
+}
+
+$launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+. $libPath
+
+if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_IME_CANDIDATE_BOOTSTRAPPED) {
+    $forwardedArgs = @('-TimeoutSeconds', $TimeoutSeconds.ToString())
+    if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+    if ($ResetState) { $forwardedArgs += '-ResetState' }
+
+    $bootstrapExitCode = 0
+    Invoke-InteractiveWin11Bootstrap `
+        -RepoRoot $repoRoot `
+        -LauncherPath $launcherPath `
+        -EnvironmentVariable 'WINGHOSTTY_INTERACTIVE_WIN11_IME_CANDIDATE_BOOTSTRAPPED' `
+        -ArgumentList $forwardedArgs `
+        -ExitCode ([ref] $bootstrapExitCode)
+    exit $bootstrapExitCode
+}
+
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class Win11ImeCandidateNative {
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumChildWindows(IntPtr hWnd, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetClassNameW(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr SetFocus(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern IntPtr SendMessageTimeoutW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+
+}
+'@
+
+$CFS_POINT = 0x0002
+$CFS_EXCLUDE = 0x0080
+$SMTO_ABORTIFHUNG = 0x0002
+$SW_RESTORE = 9
+$WM_MOUSEMOVE = 0x0200
+$WM_IME_STARTCOMPOSITION = 0x010D
+$WM_IME_ENDCOMPOSITION = 0x010E
+$surfaceClassName = 'winghostty.win32'
+$hostClassName = 'winghostty.win32.host'
+$poisonX = 7
+$poisonY = 11
+
+function New-LParam {
+    param(
+        [Parameter(Mandatory)] [int] $X,
+        [Parameter(Mandatory)] [int] $Y
+    )
+
+    return [IntPtr] [int32] (((($Y -band 0xffff) -shl 16) -bor ($X -band 0xffff)) -band 0xffffffff)
+}
+
+function Get-WindowClassName {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd
+    )
+
+    $builder = [System.Text.StringBuilder]::new(256)
+    [void] [Win11ImeCandidateNative]::GetClassNameW($Hwnd, $builder, $builder.Capacity)
+    return $builder.ToString()
+}
+
+function Find-HostWindow {
+    param(
+        [Parameter(Mandatory)] [int] $ProcessId
+    )
+
+    $script:Win11ImeCandidateTargetProcessId = [uint32] $ProcessId
+    $script:Win11ImeCandidateFoundHost = [IntPtr]::Zero
+    $callback = [Win11ImeCandidateNative+EnumWindowsProc] {
+        param([IntPtr] $hwnd, [IntPtr] $lParam)
+
+        $windowProcessId = [uint32] 0
+        [void] [Win11ImeCandidateNative]::GetWindowThreadProcessId($hwnd, [ref] $windowProcessId)
+        if ($windowProcessId -ne $script:Win11ImeCandidateTargetProcessId) {
+            return $true
+        }
+
+        if ((Get-WindowClassName -Hwnd $hwnd) -eq $hostClassName) {
+            $script:Win11ImeCandidateFoundHost = $hwnd
+            return $false
+        }
+
+        return $true
+    }
+
+    [void] [Win11ImeCandidateNative]::EnumWindows($callback, [IntPtr]::Zero)
+    return $script:Win11ImeCandidateFoundHost
+}
+
+function Find-SurfaceWindow {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Parent
+    )
+
+    $script:Win11ImeCandidateFoundSurface = [IntPtr]::Zero
+    $callback = [Win11ImeCandidateNative+EnumWindowsProc] {
+        param([IntPtr] $hwnd, [IntPtr] $lParam)
+
+        if ((Get-WindowClassName -Hwnd $hwnd) -eq $surfaceClassName) {
+            $script:Win11ImeCandidateFoundSurface = $hwnd
+            return $false
+        }
+
+        return $true
+    }
+
+    [void] [Win11ImeCandidateNative]::EnumChildWindows($Parent, $callback, [IntPtr]::Zero)
+    return $script:Win11ImeCandidateFoundSurface
+}
+
+function Get-ClientRectObject {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd
+    )
+
+    $rect = [Win11ImeCandidateNative+RECT]::new()
+    if (-not [Win11ImeCandidateNative]::GetClientRect($Hwnd, [ref] $rect)) {
+        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw "GetClientRect failed for hwnd=$Hwnd (error=$lastError)"
+    }
+
+    return [pscustomobject]@{
+        Left = $rect.Left
+        Top = $rect.Top
+        Right = $rect.Right
+        Bottom = $rect.Bottom
+        Width = [Math]::Max(0, $rect.Right - $rect.Left)
+        Height = [Math]::Max(0, $rect.Bottom - $rect.Top)
+    }
+}
+
+function Send-WindowMessage {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd,
+        [Parameter(Mandatory)] [uint32] $Message,
+        [UIntPtr] $WParam = [UIntPtr]::Zero,
+        [IntPtr] $LParam = [IntPtr]::Zero,
+        [string] $Description = 'window message'
+    )
+
+    $result = [UIntPtr]::Zero
+    $status = [Win11ImeCandidateNative]::SendMessageTimeoutW(
+        $Hwnd,
+        $Message,
+        $WParam,
+        $LParam,
+        [uint32] $SMTO_ABORTIFHUNG,
+        [uint32] 1000,
+        [ref] $result
+    )
+    if ($status -eq [IntPtr]::Zero) {
+        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw "SendMessageTimeoutW failed for $Description (hwnd=$Hwnd msg=$Message error=$lastError)"
+    }
+}
+
+function Assert-ImeCandidateAnchoredToCaret {
+    param(
+        [Parameter(Mandatory)] $Forms,
+        [Parameter(Mandatory)] $SurfaceClientRect
+    )
+
+    $composition = $Forms.Composition
+    $candidate = $Forms.Candidate
+
+    if ($composition.dwStyle -ne $CFS_POINT) {
+        throw "composition form style was $($composition.dwStyle), expected CFS_POINT"
+    }
+    if ($candidate.dwIndex -ne 0) {
+        throw "candidate form index was $($candidate.dwIndex), expected 0"
+    }
+    if ($candidate.dwStyle -ne $CFS_EXCLUDE) {
+        throw "candidate form style was $($candidate.dwStyle), expected CFS_EXCLUDE"
+    }
+    if ($candidate.ptCurrentPos.X -ne $composition.ptCurrentPos.X -or
+        $candidate.ptCurrentPos.Y -ne $composition.ptCurrentPos.Y) {
+        throw "composition and candidate points diverged: composition=$($composition.ptCurrentPos.X),$($composition.ptCurrentPos.Y) candidate=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y)"
+    }
+
+    if ($candidate.rcArea.Left -ne $candidate.ptCurrentPos.X -or
+        $candidate.rcArea.Right -ne ($candidate.ptCurrentPos.X + 1) -or
+        $candidate.rcArea.Bottom -ne $candidate.ptCurrentPos.Y -or
+        $candidate.rcArea.Top -ge $candidate.rcArea.Bottom) {
+        throw "candidate exclusion rect is not caret-shaped: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) rect=$($candidate.rcArea.Left),$($candidate.rcArea.Top),$($candidate.rcArea.Right),$($candidate.rcArea.Bottom)"
+    }
+
+    if ($candidate.ptCurrentPos.X -lt 120 -or $candidate.ptCurrentPos.Y -lt 120) {
+        throw "candidate point stayed near the surface origin instead of the scripted caret: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y)"
+    }
+
+    $poisonRadius = 40
+    if ([Math]::Abs($candidate.ptCurrentPos.X - $poisonX) -le $poisonRadius -and
+        [Math]::Abs($candidate.ptCurrentPos.Y - $poisonY) -le $poisonRadius) {
+        throw "candidate point followed the poisoned mouse coordinate: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) poison=$poisonX,$poisonY"
+    }
+
+    $outerSlop = 4
+    if ($candidate.ptCurrentPos.X -lt (-$outerSlop) -or
+        $candidate.ptCurrentPos.Y -lt (-$outerSlop) -or
+        $candidate.ptCurrentPos.X -gt ($SurfaceClientRect.Width + $outerSlop) -or
+        $candidate.ptCurrentPos.Y -gt ($SurfaceClientRect.Height + $outerSlop)) {
+        throw "candidate point is outside the surface client rect: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) surface=$($SurfaceClientRect.Width)x$($SurfaceClientRect.Height)"
+    }
+}
+
+$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'ime-candidate' -ResetState:$ResetState -IncludeResourcesDir
+$repoRoot = $harness.RepoRoot
+$layout = $harness.Layout
+
+$exePath = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
+$buildInputs = Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot
+$launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -BuildInputs $buildInputs
+$stdoutPath = Join-Path $layout.Logs 'interactive-win11-ime-candidate-stdout.log'
+$stderrPath = Join-Path $layout.Logs 'interactive-win11-ime-candidate-stderr.log'
+$configPath = Join-Path $layout.Temp 'interactive-win11-ime-candidate.conf'
+$payloadPath = Join-Path $layout.Temp 'interactive-win11-ime-candidate-payload.ps1'
+$readyPath = Join-Path $layout.Temp 'interactive-win11-ime-candidate-ready.txt'
+$tracePath = Join-Path $layout.Temp 'interactive-win11-ime-candidate-trace.json'
+$resultPath = Join-Path $layout.Temp 'interactive-win11-ime-candidate-result.json'
+$instanceClass = "winghostty-ime-candidate-$($layout.SandboxId)"
+
+if ($launchAction -eq 'build') {
+    Invoke-InteractiveWin11Build -RepoRoot $repoRoot
+}
+
+Assert-InteractiveWin11ExeExists -ExePath $exePath
+
+@"
+window-width = 100
+window-height = 30
+confirm-close-surface = false
+font-size = 16
+"@ | Set-Content -LiteralPath $configPath -Encoding UTF8
+
+$readyPathLiteral = $readyPath.Replace("'", "''")
+@"
+`$esc = [char] 27
+[Console]::Write("`$esc[2J`$esc[H")
+for (`$row = 1; `$row -le 16; `$row++) {
+    [Console]::Write(("ime anchor row {0:D2} 0123456789012345678901234567890123456789`r`n" -f `$row))
+}
+[Console]::Write("`$esc[12;30H")
+'ready' | Set-Content -LiteralPath '$readyPathLiteral' -Encoding ASCII
+Start-Sleep -Seconds 30
+"@ | Set-Content -LiteralPath $payloadPath -Encoding UTF8
+
+Remove-Item -LiteralPath $stdoutPath, $stderrPath, $readyPath, $tracePath, $resultPath -ErrorAction SilentlyContinue
+
+$launchArgs = @(
+    '--single-instance=false'
+    "--class=$instanceClass"
+    "--config-file=$configPath"
+    '-e'
+    'powershell.exe'
+    '-NoLogo'
+    '-NoProfile'
+    '-ExecutionPolicy'
+    'Bypass'
+    '-File'
+    $payloadPath
+)
+
+$previousImeTraceFile = $env:WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE
+$env:WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE = $tracePath
+
+$process = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList $launchArgs `
+    -WorkingDirectory $repoRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -PassThru
+
+$successPattern = 'started subcommand path='
+$runtimeFailurePattern = 'paint redraw failed|InvalidValue|surface closed|panic: reached unreachable code|error starting IO thread:'
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+$forms = $null
+$surfaceRect = $null
+$surfaceHwnd = [IntPtr]::Zero
+
+try {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'host window' -Process $process -Condition {
+        (Find-HostWindow -ProcessId $process.Id) -ne [IntPtr]::Zero
+    }
+
+    $hostHwnd = Find-HostWindow -ProcessId $process.Id
+    [void] [Win11ImeCandidateNative]::ShowWindow($hostHwnd, $SW_RESTORE)
+    [void] [Win11ImeCandidateNative]::SetForegroundWindow($hostHwnd)
+
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
+        (Find-SurfaceWindow -Parent $hostHwnd) -ne [IntPtr]::Zero
+    }
+
+    $surfaceHwnd = Find-SurfaceWindow -Parent $hostHwnd
+    [void] [Win11ImeCandidateNative]::SetFocus($surfaceHwnd)
+
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'scripted caret readiness' -Process $process -Condition {
+        $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+        if ($stderr -match $runtimeFailurePattern) {
+            throw "unexpected runtime failure reported before IME probe:`n$stderr"
+        }
+
+        $stderr.Contains($successPattern) -and (Test-Path -LiteralPath $readyPath)
+    }
+
+    Start-Sleep -Milliseconds 700
+    $surfaceRect = Get-ClientRectObject -Hwnd $surfaceHwnd
+    if ($surfaceRect.Width -lt 360 -or $surfaceRect.Height -lt 240) {
+        throw "surface is too small for stable IME anchor validation: $($surfaceRect.Width)x$($surfaceRect.Height)"
+    }
+
+    Send-WindowMessage `
+        -Hwnd $surfaceHwnd `
+        -Message $WM_MOUSEMOVE `
+        -LParam (New-LParam -X $poisonX -Y $poisonY) `
+        -Description "poison WM_MOUSEMOVE at $poisonX,$poisonY"
+
+    Send-WindowMessage `
+        -Hwnd $surfaceHwnd `
+        -Message $WM_IME_STARTCOMPOSITION `
+        -Description 'WM_IME_STARTCOMPOSITION'
+
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'IME form trace' -Process $process -Condition {
+        Test-Path -LiteralPath $tracePath
+    }
+
+    $trace = Get-Content -LiteralPath $tracePath -Raw | ConvertFrom-Json
+    $forms = [pscustomobject]@{
+        Composition = $trace.composition
+        Candidate = $trace.candidate
+    }
+    Assert-ImeCandidateAnchoredToCaret -Forms $forms -SurfaceClientRect $surfaceRect
+
+    $result = [ordered]@{
+        surface = @{
+            width = $surfaceRect.Width
+            height = $surfaceRect.Height
+        }
+        poison = @{
+            x = $poisonX
+            y = $poisonY
+        }
+        imePos = @{
+            x = $trace.ime_pos.x
+            y = $trace.ime_pos.y
+            width = $trace.ime_pos.width
+            height = $trace.ime_pos.height
+        }
+        contentScale = @{
+            x = $trace.content_scale.x
+            y = $trace.content_scale.y
+        }
+        composition = @{
+            style = $forms.Composition.dwStyle
+            x = $forms.Composition.ptCurrentPos.X
+            y = $forms.Composition.ptCurrentPos.Y
+        }
+        candidate = @{
+            index = $forms.Candidate.dwIndex
+            style = $forms.Candidate.dwStyle
+            x = $forms.Candidate.ptCurrentPos.X
+            y = $forms.Candidate.ptCurrentPos.Y
+            left = $forms.Candidate.rcArea.Left
+            top = $forms.Candidate.rcArea.Top
+            right = $forms.Candidate.rcArea.Right
+            bottom = $forms.Candidate.rcArea.Bottom
+        }
+    }
+    $result | ConvertTo-Json -Depth 4 -Compress | Set-Content -LiteralPath $resultPath -Encoding ASCII
+
+    [string] $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
+    if ($stderr -match $runtimeFailurePattern) {
+        throw "unexpected runtime failure reported after IME probe:`n$stderr"
+    }
+}
+finally {
+    if ($null -ne $process -and -not $process.HasExited) {
+        try {
+            if ($surfaceHwnd -ne [IntPtr]::Zero) {
+                Send-WindowMessage `
+                    -Hwnd $surfaceHwnd `
+                    -Message $WM_IME_ENDCOMPOSITION `
+                    -Description 'WM_IME_ENDCOMPOSITION'
+            }
+        }
+        catch {
+        }
+    }
+
+    Stop-InteractiveWin11Process -Process $process
+    if ($null -eq $previousImeTraceFile) {
+        Remove-Item Env:WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE = $previousImeTraceFile
+    }
+}
+
+Write-Host ("interactive-win11 IME candidate validation: PASS (surface={0}x{1}, poison={2},{3}, ime-pos={4},{5},{6},{7}, composition={8},{9}, candidate={10},{11}, exclude={12},{13},{14},{15}, trace={16}, result={17}, stderr={18})" -f $surfaceRect.Width, $surfaceRect.Height, $poisonX, $poisonY, $trace.ime_pos.x, $trace.ime_pos.y, $trace.ime_pos.width, $trace.ime_pos.height, $forms.Composition.ptCurrentPos.X, $forms.Composition.ptCurrentPos.Y, $forms.Candidate.ptCurrentPos.X, $forms.Candidate.ptCurrentPos.Y, $forms.Candidate.rcArea.Left, $forms.Candidate.rcArea.Top, $forms.Candidate.rcArea.Right, $forms.Candidate.rcArea.Bottom, $tracePath, $resultPath, $stderrPath)

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -243,6 +243,8 @@ function Assert-ImeCandidateAnchoredToCaret {
 
     $composition = $Forms.Composition
     $candidate = $Forms.Candidate
+    $expectedCaretX = Get-ScaledImeCoord -Value $ImePos.x -Scale $ContentScale.x
+    $expectedCaretY = Get-ScaledImeCoord -Value $ImePos.y -Scale $ContentScale.y
     $expectedCaretHeight = [Math]::Max(1, (Get-ScaledImeCoord -Value $ImePos.height -Scale $ContentScale.y))
     $expectedRectTop = $candidate.rcArea.Bottom - $expectedCaretHeight
 
@@ -258,6 +260,12 @@ function Assert-ImeCandidateAnchoredToCaret {
     if ($candidate.ptCurrentPos.X -ne $composition.ptCurrentPos.X -or
         $candidate.ptCurrentPos.Y -ne $composition.ptCurrentPos.Y) {
         throw "composition and candidate points diverged: composition=$($composition.ptCurrentPos.X),$($composition.ptCurrentPos.Y) candidate=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y)"
+    }
+
+    $pointTolerance = 1
+    if ([Math]::Abs($candidate.ptCurrentPos.X - $expectedCaretX) -gt $pointTolerance -or
+        [Math]::Abs($candidate.ptCurrentPos.Y - $expectedCaretY) -gt $pointTolerance) {
+        throw "candidate point did not match the scaled IME caret: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) expected=$expectedCaretX,$expectedCaretY tolerance=$pointTolerance"
     }
 
     if ($candidate.rcArea.Left -ne $candidate.ptCurrentPos.X -or

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -224,14 +224,27 @@ function Read-ImeFormTrace {
     }
 }
 
+function Get-ScaledImeCoord {
+    param(
+        [Parameter(Mandatory)] [double] $Value,
+        [Parameter(Mandatory)] [double] $Scale
+    )
+
+    return [int] [Math]::Truncate($Value * $Scale)
+}
+
 function Assert-ImeCandidateAnchoredToCaret {
     param(
         [Parameter(Mandatory)] $Forms,
+        [Parameter(Mandatory)] $ImePos,
+        [Parameter(Mandatory)] $ContentScale,
         [Parameter(Mandatory)] $SurfaceClientRect
     )
 
     $composition = $Forms.Composition
     $candidate = $Forms.Candidate
+    $expectedCaretHeight = [Math]::Max(1, (Get-ScaledImeCoord -Value $ImePos.height -Scale $ContentScale.y))
+    $expectedRectTop = $candidate.rcArea.Bottom - $expectedCaretHeight
 
     if ($composition.dwStyle -ne $CFS_POINT) {
         throw "composition form style was $($composition.dwStyle), expected CFS_POINT"
@@ -250,8 +263,8 @@ function Assert-ImeCandidateAnchoredToCaret {
     if ($candidate.rcArea.Left -ne $candidate.ptCurrentPos.X -or
         $candidate.rcArea.Right -ne ($candidate.ptCurrentPos.X + 1) -or
         $candidate.rcArea.Bottom -ne $candidate.ptCurrentPos.Y -or
-        $candidate.rcArea.Top -ge $candidate.rcArea.Bottom) {
-        throw "candidate exclusion rect is not caret-shaped: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) rect=$($candidate.rcArea.Left),$($candidate.rcArea.Top),$($candidate.rcArea.Right),$($candidate.rcArea.Bottom)"
+        $candidate.rcArea.Top -ne $expectedRectTop) {
+        throw "candidate exclusion rect is not caret-shaped: point=$($candidate.ptCurrentPos.X),$($candidate.ptCurrentPos.Y) rect=$($candidate.rcArea.Left),$($candidate.rcArea.Top),$($candidate.rcArea.Right),$($candidate.rcArea.Bottom) expected-top=$expectedRectTop caret-height=$expectedCaretHeight"
     }
 
     if ($candidate.ptCurrentPos.X -lt 120 -or $candidate.ptCurrentPos.Y -lt 120) {
@@ -406,7 +419,11 @@ try {
         Composition = $trace.composition
         Candidate = $trace.candidate
     }
-    Assert-ImeCandidateAnchoredToCaret -Forms $forms -SurfaceClientRect $surfaceRect
+    Assert-ImeCandidateAnchoredToCaret `
+        -Forms $forms `
+        -ImePos $trace.ime_pos `
+        -ContentScale $trace.content_scale `
+        -SurfaceClientRect $surfaceRect
 
     $result = [ordered]@{
         surface = @{

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -212,6 +212,7 @@ else {
     Write-Host 'interactive-win11 shell command live validation: SKIP (set WINGHOSTTY_INTERACTIVE_RUN_FOREGROUND_HARNESS=1 to require the foreground-sensitive harness in the composite suite)'
 }
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-ime-candidate.ps1' -TimeoutSeconds 20
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-new-tab.ps1' -TimeoutSeconds 20
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-resize.ps1' -TimeoutSeconds 15
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-undo.ps1' -TimeoutSeconds 35


### PR DESCRIPTION
## Summary
- add an env-gated Win32 IME form trace from `positionImeWindow()` for harness-only inspection
- add `interactive-win11-ime-candidate.ps1` to script a non-origin caret, poison the old mouse-coordinate path, trigger IME composition, and assert candidate form placement near the caret
- wire the harness into `interactive-win11-validate.ps1` and document its scope/remaining manual popup gap

## Root Cause
Issue #67 / PR #70 fixed candidate anchoring by routing Win32 IME placement through `Surface.imePoint()` and setting both composition and candidate forms. The old bug used stale mouse-derived `cursor_pos`, so candidate UI could follow the mouse instead of the terminal caret. The original fix had deterministic Zig geometry coverage, but no automated runtime harness around the live Win32 surface/caret path.

## Validation
- `scripts/dev-windows.cmd zig fmt src/apprt/win32.zig`
- `scripts/dev-windows.cmd zig build test "-Dtest-filter=win32 IME windows"`
- PowerShell parser checks for `test/windows/interactive-win11-ime-candidate.ps1` and `test/windows/interactive-win11-validate.ps1`
- `powershell.exe -ExecutionPolicy Bypass -File test/windows/interactive-win11-ime-candidate.ps1 -ResetState -TimeoutSeconds 18`
  - local trace: poison `7,11`; IME pos `376.33,338.67`; candidate `564,508`; exclusion rect `564,466,565,508`
- `git diff --check`

## Remaining Gap
This verifies the runtime-computed Win32 IME candidate form against a real surface/caret path. It does not prove the OS rendered a visible candidate popup because that still depends on installed/enabled IME language packs and foreground candidate-window behavior.

## Summary by Sourcery

Add an env-gated Win32 IME form trace and a new interactive Win11 harness to validate IME candidate anchoring against the terminal caret.

Enhancements:
- Add optional JSON tracing of Win32 IME composition and candidate forms from positionImeWindow(), gated by an environment variable.
- Guard IME form tracing on successful composition and candidate window updates to avoid noisy or partial traces.

Documentation:
- Document the new interactive Win11 IME candidate anchoring harness and its validation scope in the Windows test README.

Tests:
- Introduce an interactive Win11 IME candidate anchoring PowerShell harness that drives winghostty, poisons mouse state, triggers IME composition, and asserts candidate placement near the caret.
- Include the new IME candidate harness in the composite interactive Win11 validation script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows IME candidate anchoring tracing, including saved trace output for composition and candidate placement.
  * Improved IME window positioning reliability by verifying results before continuing.

* **Tests**
  * Added a new interactive Windows 11 validation harness for IME candidate behavior.
  * Included the new harness in the Windows validation flow.

* **Documentation**
  * Expanded Windows test documentation with setup, execution, and expected results for the new IME candidate check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->