### PR TITLE
fix: classify startup paint gaps by start time

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -233,8 +233,6 @@ const RenderTrace = struct {
 
     fn notePaintDrawDuration(self: *RenderTrace, duration_ms: u64) void {
         if (!self.enabled()) return;
-        // Paint timing is recorded only by the Win32 UI thread, so the max
-        // value and its timestamp cannot be paired across concurrent writers.
         updateMaxAtomicWithTimestamp(
             &self.max_paint_draw_duration_ms,
             &self.max_paint_draw_duration_at_ms,
@@ -310,6 +308,7 @@ const RenderTrace = struct {
         const stream = &writer.interface;
         stream.print("{f}", .{std.json.fmt(.{
             .runtime_ms = GetTickCount64() - self.start_tick_ms,
+            .startup_window_ms = startup_window_ms,
             .renderer_update_frame_count = self.renderer_update_frame_count.load(.acquire),
             .renderer_draw_request_count = self.renderer_draw_request_count.load(.acquire),
             .wakeup_callback_count = self.wakeup_callback_count.load(.acquire),

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -233,6 +233,8 @@ const RenderTrace = struct {
 
     fn notePaintDrawDuration(self: *RenderTrace, duration_ms: u64) void {
         if (!self.enabled()) return;
+        // Paint timing is recorded only by the Win32 UI thread, so the max
+        // value and its timestamp cannot be paired across concurrent writers.
         updateMaxAtomicWithTimestamp(
             &self.max_paint_draw_duration_ms,
             &self.max_paint_draw_duration_at_ms,
@@ -282,7 +284,7 @@ const RenderTrace = struct {
             gap_ms,
             elapsed_ms,
         );
-        if (elapsed_ms > startup_window_ms) {
+        if (gapIsSustained(elapsed_ms, gap_ms)) {
             if (sustained) |targets| {
                 updateMaxAtomicWithTimestamp(
                     targets.max_gap_ms,
@@ -292,6 +294,10 @@ const RenderTrace = struct {
                 );
             }
         }
+    }
+
+    fn gapIsSustained(elapsed_ms: u64, gap_ms: u64) bool {
+        return elapsed_ms -| gap_ms >= startup_window_ms;
     }
 
     fn writeSnapshot(self: *const RenderTrace) void {
@@ -2316,6 +2322,13 @@ fn settingsFileSize(size: u64) win32_settings.SaveError!usize {
     const max_config_size = 16 * 1024 * 1024;
     if (size > max_config_size) return error.SerializeFailed;
     return @intCast(size);
+}
+
+test "win32 render trace classifies gaps by start time" {
+    try std.testing.expect(!RenderTrace.gapIsSustained(1250, 578));
+    try std.testing.expect(!RenderTrace.gapIsSustained(1299, 300));
+    try std.testing.expect(RenderTrace.gapIsSustained(1300, 300));
+    try std.testing.expect(!RenderTrace.gapIsSustained(500, 600));
 }
 
 test "win32 bounded UTF-8 prefix never splits a codepoint" {

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -140,6 +140,7 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         throw "Expected visible paint cadence to stay well above the prior stalled path (expected >= 250, got $($renderTrace.paint_draw_count))"
     }
     $requiredRenderTraceFields = @(
+        'startup_window_ms',
         'max_paint_gap_ms',
         'max_paint_gap_ended_at_ms',
         'max_sustained_paint_gap_ms',
@@ -154,7 +155,10 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         }
     }
 
-    $startupWindowMs = 1000
+    $startupWindowMs = [long]$renderTrace.startup_window_ms
+    if ($startupWindowMs -le 0) {
+        throw "Render trace startup window must be positive (got $startupWindowMs)"
+    }
     $startupDrawLeadMs = 500
     $startupPaintGapLimitMs = 750
     $startupMatchToleranceMs = 16

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -155,13 +155,20 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
     }
 
     $startupWindowMs = 1000
-    $startupDrawLeadMs = 250
+    $startupDrawLeadMs = 500
     $startupPaintGapLimitMs = 750
+    $startupMatchToleranceMs = 16
     $startupPaintStartMs = $renderTrace.max_paint_gap_ended_at_ms - $renderTrace.max_paint_gap_ms
+    $startupDurationDeltaMs = [Math]::Abs(
+        [long]$renderTrace.max_paint_gap_ms - [long]$renderTrace.max_paint_draw_duration_ms
+    )
+    $startupEndDeltaMs = [Math]::Abs(
+        [long]$renderTrace.max_paint_gap_ended_at_ms - [long]$renderTrace.max_paint_draw_duration_at_ms
+    )
     $startupPaintGap =
-        $renderTrace.max_paint_gap_ended_at_ms -le $startupWindowMs -and
-        $renderTrace.max_paint_gap_ms -eq $renderTrace.max_paint_draw_duration_ms -and
-        $renderTrace.max_paint_gap_ended_at_ms -eq $renderTrace.max_paint_draw_duration_at_ms -and
+        $startupPaintStartMs -lt $startupWindowMs -and
+        $startupDurationDeltaMs -le $startupMatchToleranceMs -and
+        $startupEndDeltaMs -le $startupMatchToleranceMs -and
         $startupPaintStartMs -ge $renderTrace.first_paint_at_ms -and
         $startupPaintStartMs - $renderTrace.first_paint_at_ms -le $startupDrawLeadMs
     if ($renderTrace.max_paint_gap_ms -gt 300 -and -not $startupPaintGap) {


### PR DESCRIPTION
## Summary
- classify sustained render gaps by when the gap starts, not when it ends
- keep startup initialization bounded to 750 ms and sustained cadence bounded to 300 ms
- anchor startup draws within 500 ms of first paint and tolerate one Windows clock tick
- add exact startup/sustained boundary regression coverage

## Evidence
- targeted Zig test passes
- PowerShell syntax and diff checks pass
- real Win11 boo-performance harness passes after rebuild
- independent Sol and Claude Fable audits report SAFE / no actionable residuals

Follow-up to #84 after the default-branch full evidence run exposed the crossed-startup-window misclassification.

## Summary by Sourcery

Classify render gaps as startup or sustained based on when the gap begins rather than when it ends.

Bug Fixes:
- Correctly identify sustained render gaps using a start-time window to avoid misclassifying long startup gaps as sustained issues.

Enhancements:
- Relax startup draw anchoring to allow paints within 500 ms of first paint and tolerate a small timing mismatch between gap and draw metrics.

Tests:
- Add a Zig unit test covering render gap classification by start time and update the Windows performance harness to validate the adjusted startup window and paint gap constraints.