### PR TITLE
test/windows: make interactive validation fail closed and reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,7 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
+          use-cache: false
 
       - name: Install Inno Setup
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
+          # Failed and cancelled jobs can save incomplete generated files.
+          use-cache: false
 
       - name: Zig version
         run: zig version
@@ -105,6 +107,7 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
+          use-cache: false
 
       - name: Run portable package CLI smoke
         shell: pwsh
@@ -130,6 +133,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.run_interactive_win11)
     runs-on: [self-hosted, Windows, X64, winghostty-interactive]
     timeout-minutes: 30
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ runner.temp }}\zig-global-cache
+      ZIG_LOCAL_CACHE_DIR: ${{ runner.temp }}\zig-local-cache
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Flagship verification contract checks
         shell: pwsh
@@ -102,6 +103,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
@@ -137,6 +140,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
@@ -148,6 +153,8 @@ jobs:
 
       - name: Prove interactive runner provenance
         shell: pwsh
+        env:
+          WINGHOSTTY_EXPECTED_CHECKOUT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: ./test/windows/assert-interactive-runner.ps1 -OutputPath "$env:RUNNER_TEMP/winghostty-runner-provenance.json"
 
       - name: Run interactive Win11 composite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,9 +133,6 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.run_interactive_win11)
     runs-on: [self-hosted, Windows, X64, winghostty-interactive]
     timeout-minutes: 30
-    env:
-      ZIG_GLOBAL_CACHE_DIR: ${{ runner.temp }}\zig-global-cache
-      ZIG_LOCAL_CACHE_DIR: ${{ runner.temp }}\zig-local-cache
 
     steps:
       - name: Checkout code
@@ -155,6 +152,9 @@ jobs:
 
       - name: Run interactive Win11 composite
         shell: pwsh
+        env:
+          ZIG_GLOBAL_CACHE_DIR: ${{ runner.temp }}\zig-global-cache
+          ZIG_LOCAL_CACHE_DIR: ${{ runner.temp }}\zig-local-cache
         run: |
           $quick = '${{ github.event_name }}' -eq 'pull_request'
           if ($quick) {

--- a/.github/workflows/windows-arm64.yml
+++ b/.github/workflows/windows-arm64.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -55,7 +55,8 @@ zig build -Demit-exe=true
 x64 packaging also requires LLVM's `llvm-objdump` on `PATH` or in the
 standard LLVM installation directory. The packaging gate disassembles every
 runtime PE and rejects AMD-only SSE4a instructions so published x64 builds
-retain the documented baseline CPU compatibility.
+retain the documented baseline CPU compatibility. Executable PE sections are
+treated as code; intentional constants must remain in non-executable sections.
 
 If Zig cannot hydrate its dependency cache automatically in your
 environment, seed the Windows build dependency cache first:

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -52,6 +52,11 @@ Build the app first:
 zig build -Demit-exe=true
 ```
 
+x64 packaging also requires LLVM's `llvm-objdump` on `PATH` or in the
+standard LLVM installation directory. The packaging gate disassembles every
+runtime PE and rejects AMD-only SSE4a instructions so published x64 builds
+retain the documented baseline CPU compatibility.
+
 If Zig cannot hydrate its dependency cache automatically in your
 environment, seed the Windows build dependency cache first:
 

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -58,19 +58,51 @@ if (-not $objdumpPath) {
 
 $objdumpOutput = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).txt"
 $objdumpError = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).err"
+$objdumpTimeoutMs = 120000
 try {
-    # Native redirection avoids PowerShell object creation for every decoded
-    # instruction while keeping the full disassembly out of process memory.
-    # Keep stderr separate so Windows PowerShell 5.1 does not turn native
-    # diagnostic lines into terminating ErrorRecord objects.
-    $previousErrorActionPreference = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
+    # Copy native streams directly to disk. PowerShell 5.1 otherwise creates
+    # one object per decoded line and wraps native stderr in ErrorRecords.
+    $processStart = [System.Diagnostics.ProcessStartInfo]::new()
+    $processStart.UseShellExecute = $false
+    $processStart.CreateNoWindow = $true
+    $processStart.RedirectStandardOutput = $true
+    $processStart.RedirectStandardError = $true
+    if ([System.IO.Path]::GetExtension($objdumpPath) -in @('.cmd', '.bat')) {
+        # The regression fixture supplies a command shim; production resolves
+        # the real llvm-objdump executable.
+        $processStart.FileName = $env:ComSpec
+        $processStart.Arguments = "/d /s /c `"`"$objdumpPath`" --disassemble --no-show-raw-insn `"$fullPath`"`""
+    }
+    else {
+        $processStart.FileName = $objdumpPath
+        $processStart.Arguments = "--disassemble --no-show-raw-insn `"$fullPath`""
+    }
+
+    $objdumpProcess = [System.Diagnostics.Process]::new()
+    $objdumpProcess.StartInfo = $processStart
+    $stdoutStream = [System.IO.File]::Open($objdumpOutput, 'Create', 'Write', 'None')
+    $stderrStream = [System.IO.File]::Open($objdumpError, 'Create', 'Write', 'None')
     try {
-        & $objdumpPath --disassemble --no-show-raw-insn $fullPath > $objdumpOutput 2> $objdumpError
-        $objdumpExitCode = $LASTEXITCODE
+        if (-not $objdumpProcess.Start()) {
+            throw "Failed to start llvm-objdump while checking $fullPath."
+        }
+        $stdoutCopy = $objdumpProcess.StandardOutput.BaseStream.CopyToAsync($stdoutStream)
+        $stderrCopy = $objdumpProcess.StandardError.BaseStream.CopyToAsync($stderrStream)
+        $objdumpCompleted = $objdumpProcess.WaitForExit($objdumpTimeoutMs)
+        if (-not $objdumpCompleted) {
+            $objdumpProcess.Kill()
+            $objdumpProcess.WaitForExit()
+        }
+        [System.Threading.Tasks.Task]::WaitAll([System.Threading.Tasks.Task[]]@($stdoutCopy, $stderrCopy))
+        if (-not $objdumpCompleted) {
+            throw "llvm-objdump timed out after $objdumpTimeoutMs ms while checking $fullPath."
+        }
+        $objdumpExitCode = $objdumpProcess.ExitCode
     }
     finally {
-        $ErrorActionPreference = $previousErrorActionPreference
+        $stdoutStream.Dispose()
+        $stderrStream.Dispose()
+        $objdumpProcess.Dispose()
     }
     if ($objdumpExitCode -ne 0) {
         $details = @(

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -59,6 +59,7 @@ if (-not $objdumpPath) {
 $objdumpOutput = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).txt"
 $objdumpError = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).err"
 $objdumpTimeoutMs = 120000
+$objdumpKillTimeoutMs = 5000
 $streamCopyTimeoutMs = 30000
 try {
     # Copy native streams directly to disk. PowerShell 5.1 otherwise creates
@@ -84,7 +85,9 @@ try {
         $objdumpCompleted = $objdumpProcess.WaitForExit($objdumpTimeoutMs)
         if (-not $objdumpCompleted) {
             $objdumpProcess.Kill()
-            $objdumpProcess.WaitForExit()
+            if (-not $objdumpProcess.WaitForExit($objdumpKillTimeoutMs)) {
+                throw "llvm-objdump did not exit after termination within $objdumpKillTimeoutMs ms while checking $fullPath."
+            }
         }
         $streamsCompleted = [System.Threading.Tasks.Task]::WaitAll(
             [System.Threading.Tasks.Task[]]@($stdoutCopy, $stderrCopy),

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -57,26 +57,43 @@ if (-not $objdumpPath) {
 }
 
 $objdumpOutput = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).txt"
+$objdumpError = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).err"
 try {
     # Native redirection avoids PowerShell object creation for every decoded
     # instruction while keeping the full disassembly out of process memory.
-    & $objdumpPath --disassemble --no-show-raw-insn $fullPath > $objdumpOutput 2>&1
-    $objdumpExitCode = $LASTEXITCODE
+    # Keep stderr separate so Windows PowerShell 5.1 does not turn native
+    # diagnostic lines into terminating ErrorRecord objects.
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $objdumpPath --disassemble --no-show-raw-insn $fullPath > $objdumpOutput 2> $objdumpError
+        $objdumpExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
     if ($objdumpExitCode -ne 0) {
-        $details = @(Get-Content -LiteralPath $objdumpOutput -Tail 20) -join [Environment]::NewLine
+        $details = @(
+            Get-Content -LiteralPath $objdumpError -Tail 20
+            Get-Content -LiteralPath $objdumpOutput -Tail 20
+        ) -join [Environment]::NewLine
         throw "llvm-objdump failed with exit code $objdumpExitCode while checking $fullPath`:$([Environment]::NewLine)$details"
     }
 
+    # The PE contract marks executable sections as code. Treat any decoded
+    # SSE4a there as a build failure; embedded constants belong in a
+    # non-executable section and must not be hidden behind a byte allowlist.
     $decodedMatches = @(Select-String `
         -LiteralPath $objdumpOutput `
         -Pattern '^\s*[0-9A-Fa-f]+:\s+(extrq|insertq|movntsd|movntss)\b')
     if ($decodedMatches.Count -gt 0) {
         $details = @($decodedMatches | ForEach-Object { $_.Line.Trim() }) -join [Environment]::NewLine
-        throw "Windows x64 baseline check failed: found AMD-only SSE4a instructions:$([Environment]::NewLine)$details"
+        throw "Windows x64 baseline check failed: found decoded AMD-only SSE4a instructions in executable sections. Move intentional data to a non-executable section; do not allowlist instruction bytes.$([Environment]::NewLine)$details"
     }
 }
 finally {
     Remove-Item -LiteralPath $objdumpOutput -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $objdumpError -Force -ErrorAction SilentlyContinue
 }
 
 Write-Host "CPU baseline check: passed for $fullPath"

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -26,98 +26,10 @@ try {
         }
 
         $machine = $reader.ReadUInt16()
-        $sectionCount = $reader.ReadUInt16()
-        $stream.Position = $peOffset + 20
-        $optionalHeaderSize = $reader.ReadUInt16()
-        $sectionTable = $peOffset + 24 + $optionalHeaderSize
-
         if ($machine -ne 0x8664) {
             Write-Host "CPU baseline check: skipped non-x64 PE $fullPath"
             return
         }
-
-        $textSection = $null
-        for ($i = 0; $i -lt $sectionCount; $i++) {
-            $stream.Position = $sectionTable + ($i * 40)
-            $nameBytes = $reader.ReadBytes(8)
-            $name = [System.Text.Encoding]::ASCII.GetString($nameBytes).TrimEnd([char]0)
-            $virtualSize = $reader.ReadUInt32()
-            $virtualAddress = $reader.ReadUInt32()
-            $rawSize = $reader.ReadUInt32()
-            $rawPointer = $reader.ReadUInt32()
-            if ($name -eq ".text") {
-                $textSection = [pscustomobject]@{
-                    VirtualSize = $virtualSize
-                    VirtualAddress = $virtualAddress
-                    RawSize = $rawSize
-                    RawPointer = $rawPointer
-                }
-                break
-            }
-        }
-
-        if ($null -eq $textSection) {
-            throw "Missing .text section: $fullPath"
-        }
-
-        $stream.Position = $textSection.RawPointer
-        $textSize = [Math]::Min([uint64]$textSection.VirtualSize, [uint64]$textSection.RawSize)
-        if ($textSize -eq 0 -or $textSize -gt [int]::MaxValue) {
-            throw "Invalid .text section size: $textSize ($fullPath)"
-        }
-        $text = $reader.ReadBytes([int]$textSize)
-        if ($text.Length -ne $textSize) {
-            throw "Truncated .text section: expected $textSize bytes, read $($text.Length) ($fullPath)"
-        }
-        $matches = [System.Collections.Generic.List[string]]::new()
-
-        for ($i = 0; $i -le $text.Length - 4; $i++) {
-            $prefix = $text[$i]
-            if (($prefix -ne 0x66) -and ($prefix -ne 0xF2)) {
-                continue
-            }
-
-            $opcodeOffset = $i + 1
-            if ($text[$opcodeOffset] -ge 0x40 -and $text[$opcodeOffset] -le 0x4F) {
-                $opcodeOffset++
-            }
-            if ($opcodeOffset + 2 -ge $text.Length -or
-                $text[$opcodeOffset] -ne 0x0F -or
-                $text[$opcodeOffset + 1] -notin @(0x78, 0x79)) {
-                continue
-            }
-
-            $opcodeByte = $text[$opcodeOffset + 1]
-            $modRmOffset = $opcodeOffset + 2
-            $modRm = $text[$modRmOffset]
-
-            # EXTRQ and INSERTQ operate only on XMM registers. A three-byte
-            # prefix found inside another instruction is not an SSE4a opcode.
-            if (($modRm -band 0xC0) -ne 0xC0) {
-                continue
-            }
-            # The immediate EXTRQ form is /0; other ModRM.reg values do not
-            # encode EXTRQ. Both 0x78 forms also require two immediate bytes.
-            if ($prefix -eq 0x66 -and $opcodeByte -eq 0x78 -and ($modRm -band 0x38) -ne 0) {
-                continue
-            }
-            $instructionEnd = $modRmOffset + $(if ($opcodeByte -eq 0x78) { 2 } else { 0 })
-            if ($instructionEnd -ge $text.Length) {
-                continue
-            }
-
-            $rva = $textSection.VirtualAddress + $i
-            $fileOffset = $textSection.RawPointer + $i
-            $opcode = ($text[$i..$instructionEnd] | ForEach-Object { "{0:X2}" -f $_ }) -join " "
-            $matches.Add(("RVA 0x{0:X8}, file offset 0x{1:X8}, opcode {2}" -f $rva, $fileOffset, $opcode))
-        }
-
-        if ($matches.Count -gt 0) {
-            $details = $matches -join [Environment]::NewLine
-            throw "Windows x64 baseline check failed: found AMD-only SSE4a EXTRQ/INSERTQ opcodes in .text:$([Environment]::NewLine)$details"
-        }
-
-        Write-Host "CPU baseline check: passed for $fullPath"
     }
     finally {
         $reader.Dispose()
@@ -126,3 +38,45 @@ try {
 finally {
     $stream.Dispose()
 }
+
+$objdumpCommand = Get-Command llvm-objdump -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+$objdumpPath = if ($null -ne $objdumpCommand) { $objdumpCommand.Source } else { $null }
+if (-not $objdumpPath) {
+    foreach ($candidate in @(
+        (Join-Path $env:ProgramFiles "LLVM\bin\llvm-objdump.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "LLVM\bin\llvm-objdump.exe")
+    )) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            $objdumpPath = $candidate
+            break
+        }
+    }
+}
+if (-not $objdumpPath) {
+    throw "Windows x64 baseline check requires llvm-objdump on PATH or in the standard LLVM install directory."
+}
+
+$objdumpOutput = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).txt"
+try {
+    # Native redirection avoids PowerShell object creation for every decoded
+    # instruction while keeping the full disassembly out of process memory.
+    & $objdumpPath --disassemble --no-show-raw-insn $fullPath > $objdumpOutput 2>&1
+    $objdumpExitCode = $LASTEXITCODE
+    if ($objdumpExitCode -ne 0) {
+        $details = @(Get-Content -LiteralPath $objdumpOutput -Tail 20) -join [Environment]::NewLine
+        throw "llvm-objdump failed with exit code $objdumpExitCode while checking $fullPath`:$([Environment]::NewLine)$details"
+    }
+
+    $decodedMatches = @(Select-String `
+        -LiteralPath $objdumpOutput `
+        -Pattern '^\s*[0-9A-Fa-f]+:\s+(extrq|insertq|movntsd|movntss)\b')
+    if ($decodedMatches.Count -gt 0) {
+        $details = @($decodedMatches | ForEach-Object { $_.Line.Trim() }) -join [Environment]::NewLine
+        throw "Windows x64 baseline check failed: found AMD-only SSE4a instructions:$([Environment]::NewLine)$details"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $objdumpOutput -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "CPU baseline check: passed for $fullPath"

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -39,7 +39,7 @@ finally {
     $stream.Dispose()
 }
 
-$objdumpCommand = Get-Command llvm-objdump -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+$objdumpCommand = Get-Command llvm-objdump.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
 $objdumpPath = if ($null -ne $objdumpCommand) { $objdumpCommand.Source } else { $null }
 if (-not $objdumpPath) {
     foreach ($candidate in @(
@@ -59,6 +59,7 @@ if (-not $objdumpPath) {
 $objdumpOutput = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).txt"
 $objdumpError = Join-Path ([System.IO.Path]::GetTempPath()) "winghostty-objdump-$([Guid]::NewGuid().ToString('N')).err"
 $objdumpTimeoutMs = 120000
+$streamCopyTimeoutMs = 30000
 try {
     # Copy native streams directly to disk. PowerShell 5.1 otherwise creates
     # one object per decoded line and wraps native stderr in ErrorRecords.
@@ -67,16 +68,8 @@ try {
     $processStart.CreateNoWindow = $true
     $processStart.RedirectStandardOutput = $true
     $processStart.RedirectStandardError = $true
-    if ([System.IO.Path]::GetExtension($objdumpPath) -in @('.cmd', '.bat')) {
-        # The regression fixture supplies a command shim; production resolves
-        # the real llvm-objdump executable.
-        $processStart.FileName = $env:ComSpec
-        $processStart.Arguments = "/d /s /c `"`"$objdumpPath`" --disassemble --no-show-raw-insn `"$fullPath`"`""
-    }
-    else {
-        $processStart.FileName = $objdumpPath
-        $processStart.Arguments = "--disassemble --no-show-raw-insn `"$fullPath`""
-    }
+    $processStart.FileName = $objdumpPath
+    $processStart.Arguments = "--disassemble --no-show-raw-insn `"$fullPath`""
 
     $objdumpProcess = [System.Diagnostics.Process]::new()
     $objdumpProcess.StartInfo = $processStart
@@ -93,7 +86,13 @@ try {
             $objdumpProcess.Kill()
             $objdumpProcess.WaitForExit()
         }
-        [System.Threading.Tasks.Task]::WaitAll([System.Threading.Tasks.Task[]]@($stdoutCopy, $stderrCopy))
+        $streamsCompleted = [System.Threading.Tasks.Task]::WaitAll(
+            [System.Threading.Tasks.Task[]]@($stdoutCopy, $stderrCopy),
+            $streamCopyTimeoutMs
+        )
+        if (-not $streamsCompleted) {
+            throw "llvm-objdump stream cleanup timed out after $streamCopyTimeoutMs ms while checking $fullPath."
+        }
         if (-not $objdumpCompleted) {
             throw "llvm-objdump timed out after $objdumpTimeoutMs ms while checking $fullPath."
         }

--- a/scripts/check-windows-x64-baseline.ps1
+++ b/scripts/check-windows-x64-baseline.ps1
@@ -61,22 +61,55 @@ try {
         }
 
         $stream.Position = $textSection.RawPointer
-        $text = $reader.ReadBytes($textSection.RawSize)
+        $textSize = [Math]::Min([uint64]$textSection.VirtualSize, [uint64]$textSection.RawSize)
+        if ($textSize -eq 0 -or $textSize -gt [int]::MaxValue) {
+            throw "Invalid .text section size: $textSize ($fullPath)"
+        }
+        $text = $reader.ReadBytes([int]$textSize)
+        if ($text.Length -ne $textSize) {
+            throw "Truncated .text section: expected $textSize bytes, read $($text.Length) ($fullPath)"
+        }
         $matches = [System.Collections.Generic.List[string]]::new()
 
-        for ($i = 0; $i -le $text.Length - 3; $i++) {
+        for ($i = 0; $i -le $text.Length - 4; $i++) {
             $prefix = $text[$i]
             if (($prefix -ne 0x66) -and ($prefix -ne 0xF2)) {
                 continue
             }
 
-            if (($text[$i + 1] -eq 0x0F) -and
-                (($text[$i + 2] -eq 0x78) -or ($text[$i + 2] -eq 0x79))) {
-                $rva = $textSection.VirtualAddress + $i
-                $fileOffset = $textSection.RawPointer + $i
-                $opcode = "{0:X2} {1:X2} {2:X2}" -f $text[$i], $text[$i + 1], $text[$i + 2]
-                $matches.Add(("RVA 0x{0:X8}, file offset 0x{1:X8}, opcode {2}" -f $rva, $fileOffset, $opcode))
+            $opcodeOffset = $i + 1
+            if ($text[$opcodeOffset] -ge 0x40 -and $text[$opcodeOffset] -le 0x4F) {
+                $opcodeOffset++
             }
+            if ($opcodeOffset + 2 -ge $text.Length -or
+                $text[$opcodeOffset] -ne 0x0F -or
+                $text[$opcodeOffset + 1] -notin @(0x78, 0x79)) {
+                continue
+            }
+
+            $opcodeByte = $text[$opcodeOffset + 1]
+            $modRmOffset = $opcodeOffset + 2
+            $modRm = $text[$modRmOffset]
+
+            # EXTRQ and INSERTQ operate only on XMM registers. A three-byte
+            # prefix found inside another instruction is not an SSE4a opcode.
+            if (($modRm -band 0xC0) -ne 0xC0) {
+                continue
+            }
+            # The immediate EXTRQ form is /0; other ModRM.reg values do not
+            # encode EXTRQ. Both 0x78 forms also require two immediate bytes.
+            if ($prefix -eq 0x66 -and $opcodeByte -eq 0x78 -and ($modRm -band 0x38) -ne 0) {
+                continue
+            }
+            $instructionEnd = $modRmOffset + $(if ($opcodeByte -eq 0x78) { 2 } else { 0 })
+            if ($instructionEnd -ge $text.Length) {
+                continue
+            }
+
+            $rva = $textSection.VirtualAddress + $i
+            $fileOffset = $textSection.RawPointer + $i
+            $opcode = ($text[$i..$instructionEnd] | ForEach-Object { "{0:X2}" -f $_ }) -join " "
+            $matches.Add(("RVA 0x{0:X8}, file offset 0x{1:X8}, opcode {2}" -f $rva, $fileOffset, $opcode))
         }
 
         if ($matches.Count -gt 0) {

--- a/scripts/dev-windows.cmd
+++ b/scripts/dev-windows.cmd
@@ -84,8 +84,8 @@ set "TMP=%_TMP_DIR%"
 if not exist "%LOCALAPPDATA%" mkdir "%LOCALAPPDATA%" >nul 2>nul
 if not exist "%APPDATA%" mkdir "%APPDATA%" >nul 2>nul
 if not exist "%TEMP%" mkdir "%TEMP%" >nul 2>nul
-set "ZIG_GLOBAL_CACHE_DIR=%LOCALAPPDATA%\zig"
-set "ZIG_LOCAL_CACHE_DIR=%CD%\.zig-cache"
+if "%ZIG_GLOBAL_CACHE_DIR%"=="" set "ZIG_GLOBAL_CACHE_DIR=%LOCALAPPDATA%\zig"
+if "%ZIG_LOCAL_CACHE_DIR%"=="" set "ZIG_LOCAL_CACHE_DIR=%CD%\.zig-cache"
 set "PATH=%GIT_CMD%;%GIT_USR_BIN%;%ZIG_HOME%;%PATH%"
 
 echo == Versions ==

--- a/scripts/dev-windows.ps1
+++ b/scripts/dev-windows.ps1
@@ -105,8 +105,12 @@ $env:SystemDrive = $systemDrive
 New-Item -ItemType Directory -Force -Path $env:APPDATA | Out-Null
 New-Item -ItemType Directory -Force -Path $env:LOCALAPPDATA | Out-Null
 New-Item -ItemType Directory -Force -Path $env:TEMP | Out-Null
-$env:ZIG_GLOBAL_CACHE_DIR = Join-Path $env:LOCALAPPDATA "zig"
-$env:ZIG_LOCAL_CACHE_DIR = Join-Path (Get-Location) ".zig-cache"
+if ([string]::IsNullOrWhiteSpace($env:ZIG_GLOBAL_CACHE_DIR)) {
+    $env:ZIG_GLOBAL_CACHE_DIR = Join-Path $env:LOCALAPPDATA "zig"
+}
+if ([string]::IsNullOrWhiteSpace($env:ZIG_LOCAL_CACHE_DIR)) {
+    $env:ZIG_LOCAL_CACHE_DIR = Join-Path (Get-Location) ".zig-cache"
+}
 
 $bootstrap = @"
 call "$vsDevCmd" -arch=$Architecture || exit /b 1

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -127,9 +127,16 @@ if (-not ('InteractiveWin11MessageNative' -as [type])) {
 using System;
 using System.Runtime.InteropServices;
 public static class InteractiveWin11MessageNative {
-    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] private static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
     [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
-    [DllImport("kernel32.dll")] public static extern void SetLastError(uint errorCode);
+    [DllImport("kernel32.dll")] private static extern void SetLastError(uint errorCode);
+
+    public static IntPtr SendMessageTimeoutWithError(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result, out int lastError) {
+        SetLastError(0);
+        IntPtr status = SendMessageTimeoutW(hwnd, message, wparam, lparam, flags, timeout, out result);
+        lastError = Marshal.GetLastWin32Error();
+        return status;
+    }
 }
 '@
 }
@@ -180,18 +187,17 @@ function Invoke-InteractiveWin11Message {
     }
 
     $sendResult = [UIntPtr]::Zero
-    # SendMessageTimeoutW does not guarantee setting last-error on failure.
-    [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
-    $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
+    $lastError = 0
+    $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutWithError(
         $Hwnd,
         $Message,
         $WParam,
         $LParam,
         $Flags,
         $sendTimeoutMs,
-        [ref] $sendResult
+        [ref] $sendResult,
+        [ref] $lastError
     )
-    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
     if ($sendStatus -eq [IntPtr]::Zero) {
         if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
             throw "SendMessageTimeoutW timed out for $Description hwnd=$Hwnd error=$lastError"
@@ -488,13 +494,17 @@ function Wait-InteractiveWin11Until {
         [System.Diagnostics.Process] $Process
     )
 
-    while ([DateTime]::UtcNow -lt $Deadline) {
+    while ($true) {
         if ($null -ne $Process -and $Process.HasExited) {
             throw "winghostty exited while waiting for ${Description} (exit code $($Process.ExitCode))"
         }
 
         if (& $Condition) {
             return
+        }
+
+        if ([DateTime]::UtcNow -ge $Deadline) {
+            break
         }
 
         Start-Sleep -Milliseconds 100
@@ -655,8 +665,15 @@ function Get-InteractiveWin11ProcessExitCode {
     }
 
     $Process.Refresh()
-    if ($nativeExitCode -eq 259 -and -not $Process.HasExited) {
-        throw "Process has not exited yet for pid=$($Process.Id)"
+    if ($nativeExitCode -eq 259) {
+        if (-not $Process.HasExited) {
+            throw "Process has not exited yet for pid=$($Process.Id)"
+        }
+
+        if (-not [InteractiveWin11ProcessNative]::GetExitCodeProcess($ProcessHandle, [ref] $nativeExitCode)) {
+            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "Exit code could not be re-read for pid=$($Process.Id): $lastError"
+        }
     }
 
     return [BitConverter]::ToInt32([BitConverter]::GetBytes($nativeExitCode), 0)

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -505,12 +505,12 @@ function Wait-InteractiveWin11Until {
             throw "winghostty exited while waiting for ${Description} (exit code $($Process.ExitCode))"
         }
 
-        if (& $Condition) {
-            return
-        }
-
         if ([DateTime]::UtcNow -ge $Deadline) {
             break
+        }
+
+        if (& $Condition) {
+            return
         }
 
         Start-Sleep -Milliseconds 100

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -530,30 +530,21 @@ function Get-InteractiveWin11RequiredJsonFile {
 function Show-InteractiveWin11Window {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
-        [Parameter(Mandatory)] [string] $NativeTypeName,
+        [Parameter(Mandatory)] [type] $NativeType,
         [int] $ShowCode = 9,
         [switch] $SetForeground
     )
 
-    $nativeType = switch ($NativeTypeName) {
-        'InteractiveWin11BooMultiTabNative' { [InteractiveWin11BooMultiTabNative]; break }
-        'InteractiveWin11BooPerfNative' { [InteractiveWin11BooPerfNative]; break }
-        default { $null }
-    }
-    if ($null -eq $nativeType) {
-        throw "Unsupported native helper type: $NativeTypeName"
-    }
-
-    [void] $nativeType::ShowWindow($Hwnd, $ShowCode)
+    [void] $NativeType::ShowWindow($Hwnd, $ShowCode)
     if ($SetForeground) {
-        [void] $nativeType::SetForegroundWindow($Hwnd)
+        [void] $NativeType::SetForegroundWindow($Hwnd)
     }
 }
 
 function Show-InteractiveWin11ProcessMainWindow {
     param(
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
-        [Parameter(Mandatory)] [string] $NativeTypeName,
+        [Parameter(Mandatory)] [type] $NativeType,
         [int] $ShowCode = 9,
         [switch] $SetForeground,
         [int] $ReadyTimeoutSeconds = 5
@@ -565,7 +556,7 @@ function Show-InteractiveWin11ProcessMainWindow {
         if ($Process.MainWindowHandle -ne [IntPtr]::Zero) {
             Show-InteractiveWin11Window `
                 -Hwnd $Process.MainWindowHandle `
-                -NativeTypeName $NativeTypeName `
+                -NativeType $NativeType `
                 -ShowCode $ShowCode `
                 -SetForeground:$SetForeground
             return

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -144,6 +144,7 @@ public static class InteractiveWin11MessageNative {
 $script:InteractiveWin11SmtoNormal = [uint32]0
 $script:InteractiveWin11SmtoBlock = [uint32]0x0001
 $script:InteractiveWin11ErrorSuccess = 0
+$script:InteractiveWin11ErrorInvalidWindowHandle = 1400
 $script:InteractiveWin11ErrorTimeout = 1460
 
 function Get-InteractiveWin11MessageTimeoutMs {
@@ -169,6 +170,7 @@ function Invoke-InteractiveWin11Message {
         [Parameter(Mandatory)] [DateTime] $Deadline,
         [Parameter(Mandatory)] [string] $Description,
         [uint32] $Flags = $script:InteractiveWin11SmtoNormal,
+        [int[]] $ToleratedErrors = @(),
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
@@ -201,6 +203,10 @@ function Invoke-InteractiveWin11Message {
     if ($sendStatus -eq [IntPtr]::Zero) {
         if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
             throw "SendMessageTimeoutW timed out for $Description hwnd=$Hwnd error=$lastError"
+        }
+        if ($lastError -in $ToleratedErrors) {
+            Write-Warning "SendMessageTimeoutW returned tolerated Win32 error $lastError for $Description hwnd=$Hwnd."
+            return $sendResult
         }
         $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
         throw "SendMessageTimeoutW failed for $Description hwnd=$Hwnd ($detail)."

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -279,6 +279,7 @@ function Invoke-InteractiveWin11PostMessage {
         [Parameter(Mandatory)] [uint32] $Message,
         [UIntPtr] $WParam = [UIntPtr]::Zero,
         [IntPtr] $LParam = [IntPtr]::Zero,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
         [Parameter(Mandatory)] [string] $Description,
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
@@ -289,8 +290,8 @@ function Invoke-InteractiveWin11PostMessage {
     }
 
     [void](Assert-InteractiveWin11WindowOwner -Hwnd $Hwnd -Process $Process -Description $Description -Verb 'post')
-
     $lastError = 0
+    if ($Deadline -le [DateTime]::UtcNow) { throw "Timed out waiting for $Description." }
     if (-not [InteractiveWin11MessageNativeV2]::PostMessageWithError($Hwnd, $Message, $WParam, $LParam, [ref] $lastError)) {
         $detail = if ($lastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $lastError" }
         throw "PostMessageW failed for $Description hwnd=$Hwnd $detail."

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -128,6 +128,7 @@ using System;
 using System.Runtime.InteropServices;
 public static class InteractiveWin11MessageNativeV2 {
     [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] private static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
+    [DllImport("user32.dll", SetLastError=true)] private static extern bool PostMessageW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam);
     [DllImport("user32.dll", SetLastError=true)] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
     public static uint GetWindowThreadProcessIdWithError(IntPtr hwnd, out uint processId, out int lastError) {
         SetLastError(0);
@@ -140,6 +141,12 @@ public static class InteractiveWin11MessageNativeV2 {
     public static IntPtr SendMessageTimeoutWithError(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result, out int lastError) {
         SetLastError(0);
         IntPtr status = SendMessageTimeoutW(hwnd, message, wparam, lparam, flags, timeout, out result);
+        lastError = Marshal.GetLastWin32Error();
+        return status;
+    }
+    public static bool PostMessageWithError(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, out int lastError) {
+        SetLastError(0);
+        bool status = PostMessageW(hwnd, message, wparam, lparam);
         lastError = Marshal.GetLastWin32Error();
         return status;
     }
@@ -236,6 +243,39 @@ function Invoke-InteractiveWin11Message {
     }
 
     return $sendResult
+}
+
+function Invoke-InteractiveWin11PostMessage {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd,
+        [Parameter(Mandatory)] [uint32] $Message,
+        [UIntPtr] $WParam = [UIntPtr]::Zero,
+        [IntPtr] $LParam = [IntPtr]::Zero,
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
+    )
+
+    $Process.Refresh()
+    if ($Process.HasExited) {
+        throw "Refusing to post $Description because winghostty already exited (exit code $($Process.ExitCode))."
+    }
+
+    $windowProcessId = [uint32]0
+    $windowLastError = 0
+    $windowThreadId = [InteractiveWin11MessageNativeV2]::GetWindowThreadProcessIdWithError($Hwnd, [ref] $windowProcessId, [ref] $windowLastError)
+    if ($windowThreadId -eq 0) {
+        $detail = if ($windowLastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $windowLastError" }
+        throw "Refusing to post $Description to invalid hwnd=$Hwnd $detail."
+    }
+    if ($windowProcessId -ne [uint32]$Process.Id) {
+        throw "Refusing to post $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
+    }
+
+    $lastError = 0
+    if (-not [InteractiveWin11MessageNativeV2]::PostMessageWithError($Hwnd, $Message, $WParam, $LParam, [ref] $lastError)) {
+        $detail = if ($lastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $lastError" }
+        throw "PostMessageW failed for $Description hwnd=$Hwnd $detail."
+    }
 }
 
 function Get-InteractiveWin11LaunchArguments {

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -128,7 +128,7 @@ using System;
 using System.Runtime.InteropServices;
 public static class InteractiveWin11MessageNative {
     [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] private static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
-    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+    [DllImport("user32.dll", SetLastError=true)] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
     [DllImport("kernel32.dll")] private static extern void SetLastError(uint errorCode);
 
     public static IntPtr SendMessageTimeoutWithError(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result, out int lastError) {
@@ -171,8 +171,14 @@ function Invoke-InteractiveWin11Message {
         [Parameter(Mandatory)] [string] $Description,
         [uint32] $Flags = $script:InteractiveWin11SmtoNormal,
         [int[]] $ToleratedErrors = @(),
+        [ref] $ObservedToleratedError,
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
+
+    if ($ToleratedErrors.Count -gt 0) {
+        if ($null -eq $ObservedToleratedError) { throw 'ToleratedErrors requires an ObservedToleratedError output reference.' }
+        $ObservedToleratedError.Value = 0
+    }
 
     $Process.Refresh()
     if ($Process.HasExited) {
@@ -184,7 +190,17 @@ function Invoke-InteractiveWin11Message {
     # phase work cannot turn a stale HWND into a cross-process message.
     $windowProcessId = [uint32]0
     $windowThreadId = [InteractiveWin11MessageNative]::GetWindowThreadProcessId($Hwnd, [ref] $windowProcessId)
-    if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Process.Id) {
+    $windowLastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($windowThreadId -eq 0) {
+        if ($windowLastError -in $ToleratedErrors) {
+            $ObservedToleratedError.Value = $windowLastError
+            Write-Warning "GetWindowThreadProcessId returned tolerated Win32 error $windowLastError for $Description hwnd=$Hwnd."
+            return [UIntPtr]::Zero
+        }
+        $detail = if ($windowLastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $windowLastError" }
+        throw "Refusing to send $Description to invalid hwnd=$Hwnd $detail."
+    }
+    if ($windowProcessId -ne [uint32]$Process.Id) {
         throw "Refusing to send $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
     }
 
@@ -205,6 +221,7 @@ function Invoke-InteractiveWin11Message {
             throw "SendMessageTimeoutW timed out for $Description hwnd=$Hwnd error=$lastError"
         }
         if ($lastError -in $ToleratedErrors) {
+            $ObservedToleratedError.Value = $lastError
             Write-Warning "SendMessageTimeoutW returned tolerated Win32 error $lastError for $Description hwnd=$Hwnd."
             return $sendResult
         }

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -174,6 +174,36 @@ function Get-InteractiveWin11MessageTimeoutMs {
     return [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
 }
 
+function Assert-InteractiveWin11WindowOwner {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [ValidateSet('send', 'post')] [string] $Verb,
+        [int[]] $ToleratedErrors = @(),
+        [ref] $ObservedToleratedError
+    )
+
+    $windowProcessId = [uint32]0
+    $windowLastError = 0
+    $windowThreadId = [InteractiveWin11MessageNativeV2]::GetWindowThreadProcessIdWithError($Hwnd, [ref] $windowProcessId, [ref] $windowLastError)
+    if ($windowThreadId -eq 0) {
+        if ($windowLastError -in $ToleratedErrors) {
+            if ($null -eq $ObservedToleratedError) { throw 'ToleratedErrors requires an ObservedToleratedError output reference.' }
+            $ObservedToleratedError.Value = $windowLastError
+            Write-Warning "GetWindowThreadProcessId returned tolerated Win32 error $windowLastError for $Description hwnd=$Hwnd."
+            return $false
+        }
+        $detail = if ($windowLastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $windowLastError" }
+        throw "Refusing to $Verb $Description to invalid hwnd=$Hwnd $detail."
+    }
+    if ($windowProcessId -ne [uint32]$Process.Id) {
+        throw "Refusing to $Verb $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
+    }
+
+    return $true
+}
+
 function Invoke-InteractiveWin11Message {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
@@ -201,20 +231,18 @@ function Invoke-InteractiveWin11Message {
     $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description "$Description hwnd=$Hwnd"
     # Keep ownership validation immediately adjacent to the send so lengthy
     # phase work cannot turn a stale HWND into a cross-process message.
-    $windowProcessId = [uint32]0
-    $windowLastError = 0
-    $windowThreadId = [InteractiveWin11MessageNativeV2]::GetWindowThreadProcessIdWithError($Hwnd, [ref] $windowProcessId, [ref] $windowLastError)
-    if ($windowThreadId -eq 0) {
-        if ($windowLastError -in $ToleratedErrors) {
-            $ObservedToleratedError.Value = $windowLastError
-            Write-Warning "GetWindowThreadProcessId returned tolerated Win32 error $windowLastError for $Description hwnd=$Hwnd."
-            return [UIntPtr]::Zero
-        }
-        $detail = if ($windowLastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $windowLastError" }
-        throw "Refusing to send $Description to invalid hwnd=$Hwnd $detail."
+    $ownershipArgs = @{
+        Hwnd = $Hwnd
+        Process = $Process
+        Description = $Description
+        Verb = 'send'
+        ToleratedErrors = $ToleratedErrors
     }
-    if ($windowProcessId -ne [uint32]$Process.Id) {
-        throw "Refusing to send $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
+    if ($null -ne $ObservedToleratedError) {
+        $ownershipArgs.ObservedToleratedError = $ObservedToleratedError
+    }
+    if (-not (Assert-InteractiveWin11WindowOwner @ownershipArgs)) {
+        return [UIntPtr]::Zero
     }
 
     $sendResult = [UIntPtr]::Zero
@@ -260,16 +288,7 @@ function Invoke-InteractiveWin11PostMessage {
         throw "Refusing to post $Description because winghostty already exited (exit code $($Process.ExitCode))."
     }
 
-    $windowProcessId = [uint32]0
-    $windowLastError = 0
-    $windowThreadId = [InteractiveWin11MessageNativeV2]::GetWindowThreadProcessIdWithError($Hwnd, [ref] $windowProcessId, [ref] $windowLastError)
-    if ($windowThreadId -eq 0) {
-        $detail = if ($windowLastError -eq 0) { 'without a Win32 error' } else { "with Win32 error $windowLastError" }
-        throw "Refusing to post $Description to invalid hwnd=$Hwnd $detail."
-    }
-    if ($windowProcessId -ne [uint32]$Process.Id) {
-        throw "Refusing to post $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
-    }
+    [void](Assert-InteractiveWin11WindowOwner -Hwnd $Hwnd -Process $Process -Description $Description -Verb 'post')
 
     $lastError = 0
     if (-not [InteractiveWin11MessageNativeV2]::PostMessageWithError($Hwnd, $Message, $WParam, $LParam, [ref] $lastError)) {

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -122,13 +122,19 @@ function Get-InteractiveWin11Environment {
     }
 }
 
-if (-not ('InteractiveWin11MessageNative' -as [type])) {
+if (-not ('InteractiveWin11MessageNativeV2' -as [type])) {
     Add-Type @'
 using System;
 using System.Runtime.InteropServices;
-public static class InteractiveWin11MessageNative {
+public static class InteractiveWin11MessageNativeV2 {
     [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] private static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
     [DllImport("user32.dll", SetLastError=true)] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+    public static uint GetWindowThreadProcessIdWithError(IntPtr hwnd, out uint processId, out int lastError) {
+        SetLastError(0);
+        uint result = GetWindowThreadProcessId(hwnd, out processId);
+        lastError = Marshal.GetLastWin32Error();
+        return result;
+    }
     [DllImport("kernel32.dll")] private static extern void SetLastError(uint errorCode);
 
     public static IntPtr SendMessageTimeoutWithError(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result, out int lastError) {
@@ -189,8 +195,8 @@ function Invoke-InteractiveWin11Message {
     # Keep ownership validation immediately adjacent to the send so lengthy
     # phase work cannot turn a stale HWND into a cross-process message.
     $windowProcessId = [uint32]0
-    $windowThreadId = [InteractiveWin11MessageNative]::GetWindowThreadProcessId($Hwnd, [ref] $windowProcessId)
-    $windowLastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    $windowLastError = 0
+    $windowThreadId = [InteractiveWin11MessageNativeV2]::GetWindowThreadProcessIdWithError($Hwnd, [ref] $windowProcessId, [ref] $windowLastError)
     if ($windowThreadId -eq 0) {
         if ($windowLastError -in $ToleratedErrors) {
             $ObservedToleratedError.Value = $windowLastError
@@ -206,7 +212,7 @@ function Invoke-InteractiveWin11Message {
 
     $sendResult = [UIntPtr]::Zero
     $lastError = 0
-    $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutWithError(
+    $sendStatus = [InteractiveWin11MessageNativeV2]::SendMessageTimeoutWithError(
         $Hwnd,
         $Message,
         $WParam,

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -559,6 +559,8 @@ function Get-InteractiveWin11ProcessExitCode {
         $Process.Refresh()
         if ($Process.HasExited) {
             $managedExitCode = $Process.ExitCode
+            # PowerShell can surface a blank ExitCode for an exited GUI child;
+            # retain the native handle fallback for that adapter edge case.
             if ($null -ne $managedExitCode) { return [int] $managedExitCode }
         }
     }

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -535,9 +535,13 @@ function Show-InteractiveWin11Window {
         [switch] $SetForeground
     )
 
-    $nativeType = $NativeTypeName -as [type]
+    $nativeType = switch ($NativeTypeName) {
+        'InteractiveWin11BooMultiTabNative' { [InteractiveWin11BooMultiTabNative]; break }
+        'InteractiveWin11BooPerfNative' { [InteractiveWin11BooPerfNative]; break }
+        default { $null }
+    }
     if ($null -eq $nativeType) {
-        throw "Missing native helper type: $NativeTypeName"
+        throw "Unsupported native helper type: $NativeTypeName"
     }
 
     [void] $nativeType::ShowWindow($Hwnd, $ShowCode)

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -122,6 +122,87 @@ function Get-InteractiveWin11Environment {
     }
 }
 
+if (-not ('InteractiveWin11MessageNative' -as [type])) {
+    Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class InteractiveWin11MessageNative {
+    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+    [DllImport("kernel32.dll")] public static extern void SetLastError(uint errorCode);
+}
+'@
+}
+
+$script:InteractiveWin11SmtoNormal = [uint32]0
+$script:InteractiveWin11SmtoBlock = [uint32]0x0001
+$script:InteractiveWin11ErrorSuccess = 0
+$script:InteractiveWin11ErrorTimeout = 1460
+
+function Get-InteractiveWin11MessageTimeoutMs {
+    param(
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [string] $Description
+    )
+
+    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
+    if ($remainingMs -le 0) {
+        throw "Deadline elapsed before sending $Description."
+    }
+
+    return [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
+}
+
+function Invoke-InteractiveWin11Message {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $Hwnd,
+        [Parameter(Mandatory)] [uint32] $Message,
+        [UIntPtr] $WParam = [UIntPtr]::Zero,
+        [IntPtr] $LParam = [IntPtr]::Zero,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [string] $Description,
+        [uint32] $Flags = $script:InteractiveWin11SmtoNormal,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
+    )
+
+    $Process.Refresh()
+    if ($Process.HasExited) {
+        throw "Refusing to send $Description because winghostty already exited (exit code $($Process.ExitCode))."
+    }
+
+    $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description "$Description hwnd=$Hwnd"
+    # Keep ownership validation immediately adjacent to the send so lengthy
+    # phase work cannot turn a stale HWND into a cross-process message.
+    $windowProcessId = [uint32]0
+    $windowThreadId = [InteractiveWin11MessageNative]::GetWindowThreadProcessId($Hwnd, [ref] $windowProcessId)
+    if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Process.Id) {
+        throw "Refusing to send $Description to hwnd=$Hwnd because owner pid=$windowProcessId does not match expected pid=$($Process.Id)."
+    }
+
+    $sendResult = [UIntPtr]::Zero
+    # SendMessageTimeoutW does not guarantee setting last-error on failure.
+    [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
+    $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
+        $Hwnd,
+        $Message,
+        $WParam,
+        $LParam,
+        $Flags,
+        $sendTimeoutMs,
+        [ref] $sendResult
+    )
+    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($sendStatus -eq [IntPtr]::Zero) {
+        if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
+            throw "SendMessageTimeoutW timed out for $Description hwnd=$Hwnd error=$lastError"
+        }
+        $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
+        throw "SendMessageTimeoutW failed for $Description hwnd=$Hwnd ($detail)."
+    }
+
+    return $sendResult
+}
+
 function Get-InteractiveWin11LaunchArguments {
     param(
         [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
@@ -573,7 +654,8 @@ function Get-InteractiveWin11ProcessExitCode {
         throw "Exit code could not be read for pid=$($Process.Id): $lastError"
     }
 
-    if ($nativeExitCode -eq 259) {
+    $Process.Refresh()
+    if ($nativeExitCode -eq 259 -and -not $Process.HasExited) {
         throw "Process has not exited yet for pid=$($Process.Id)"
     }
 

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -745,6 +745,7 @@ function Get-InteractiveWin11ProcessExitCode {
         }
     }
     catch {
+        Write-Verbose "Managed exit-code fast path failed for pid=$($Process.Id); falling back to native GetExitCodeProcess: $($_.Exception.Message)"
     }
 
     [uint32] $nativeExitCode = 0

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -558,7 +558,8 @@ function Get-InteractiveWin11ProcessExitCode {
     try {
         $Process.Refresh()
         if ($Process.HasExited) {
-            return [int] $Process.ExitCode
+            $managedExitCode = $Process.ExitCode
+            if ($null -ne $managedExitCode) { return [int] $managedExitCode }
         }
     }
     catch {
@@ -574,7 +575,7 @@ function Get-InteractiveWin11ProcessExitCode {
         throw "Process has not exited yet for pid=$($Process.Id)"
     }
 
-    return [int] $nativeExitCode
+    return [BitConverter]::ToInt32([BitConverter]::GetBytes($nativeExitCode), 0)
 }
 
 function Reset-InteractiveWin11Sandbox {

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -416,6 +416,9 @@ try {
         Push-Location $repoRoot
         try {
             & zig build -Demit-exe=true -Demit-lib-vt=true -Doptimize=ReleaseFast "-Dtarget=$zigTarget" -Dcpu=baseline "-Dversion-string=$Version"
+            if ($LASTEXITCODE -ne 0) {
+                throw "Zig build failed with exit code $LASTEXITCODE."
+            }
         }
         finally {
             Pop-Location
@@ -433,9 +436,9 @@ try {
             throw "Expected build output was not found: $runtimePath"
         }
         Assert-PeMachine -PathToCheck $runtimePath -ExpectedArchitecture $Architecture
-    }
-    if ($Architecture -eq "x64") {
-        & (Join-Path $repoRoot "scripts/check-windows-x64-baseline.ps1") -Path $exePath
+        if ($Architecture -eq "x64") {
+            & (Join-Path $repoRoot "scripts/check-windows-x64-baseline.ps1") -Path $runtimePath
+        }
     }
 
     Write-Host "Packaging phase: stage portable tree"

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -89,10 +89,12 @@ pub const resourcesDir = internal_os.resourcesDir;
 
 const RenderTrace = struct {
     const startup_window_ms: u64 = 1000;
+    const paint_gap_limit_ms: u64 = 300;
 
-    const SustainedGapTargets = struct {
+    const PaintGapTargets = struct {
         max_gap_ms: *std.atomic.Value(u64),
         max_gap_ended_at_ms: *std.atomic.Value(u64),
+        over_limit_count: *std.atomic.Value(u64),
     };
 
     path: ?[]const u8 = null,
@@ -117,6 +119,7 @@ const RenderTrace = struct {
     max_swap_gap_ended_at_ms: std.atomic.Value(u64) = .init(0),
     max_sustained_paint_gap_ms: std.atomic.Value(u64) = .init(0),
     max_sustained_paint_gap_ended_at_ms: std.atomic.Value(u64) = .init(0),
+    paint_gap_over_limit_count: std.atomic.Value(u64) = .init(0),
     max_paint_draw_duration_ms: std.atomic.Value(u64) = .init(0),
     max_paint_draw_duration_at_ms: std.atomic.Value(u64) = .init(0),
     paint_draw_duration_over_20ms_count: std.atomic.Value(u64) = .init(0),
@@ -243,6 +246,7 @@ const RenderTrace = struct {
             .{
                 .max_gap_ms = &self.max_sustained_paint_gap_ms,
                 .max_gap_ended_at_ms = &self.max_sustained_paint_gap_ended_at_ms,
+                .over_limit_count = &self.paint_gap_over_limit_count,
             },
         );
     }
@@ -283,7 +287,7 @@ const RenderTrace = struct {
         max_gap_ms: *std.atomic.Value(u64),
         max_gap_ended_at_ms: *std.atomic.Value(u64),
         first_at_ms: *std.atomic.Value(u64),
-        sustained: ?SustainedGapTargets,
+        paint_gaps: ?PaintGapTargets,
     ) void {
         const now = GetTickCount64();
         const elapsed_ms = elapsedTraceMs(self.start_tick_ms, now);
@@ -298,8 +302,11 @@ const RenderTrace = struct {
             gap_ms,
             elapsed_ms,
         );
-        if (gapIsSustained(elapsed_ms, gap_ms)) {
-            if (sustained) |targets| {
+        if (paint_gaps) |targets| {
+            if (gapExceedsPaintLimit(gap_ms)) {
+                _ = targets.over_limit_count.fetchAdd(1, .acq_rel);
+            }
+            if (gapIsSustained(elapsed_ms, gap_ms)) {
                 updateMaxAtomicWithTimestamp(
                     targets.max_gap_ms,
                     targets.max_gap_ended_at_ms,
@@ -314,6 +321,10 @@ const RenderTrace = struct {
         return elapsed_ms -| gap_ms >= startup_window_ms;
     }
 
+    fn gapExceedsPaintLimit(gap_ms: u64) bool {
+        return gap_ms > paint_gap_limit_ms;
+    }
+
     fn writeSnapshot(self: *const RenderTrace) void {
         const trace_path = self.path orelse return;
         const file = std.fs.createFileAbsolute(trace_path, .{ .truncate = true }) catch return;
@@ -325,6 +336,7 @@ const RenderTrace = struct {
         stream.print("{f}", .{std.json.fmt(.{
             .runtime_ms = GetTickCount64() - self.start_tick_ms,
             .startup_window_ms = startup_window_ms,
+            .paint_gap_limit_ms = paint_gap_limit_ms,
             .renderer_update_frame_count = self.renderer_update_frame_count.load(.acquire),
             .renderer_draw_request_count = self.renderer_draw_request_count.load(.acquire),
             .wakeup_callback_count = self.wakeup_callback_count.load(.acquire),
@@ -345,6 +357,7 @@ const RenderTrace = struct {
             .max_swap_gap_ended_at_ms = self.max_swap_gap_ended_at_ms.load(.acquire),
             .max_sustained_paint_gap_ms = self.max_sustained_paint_gap_ms.load(.acquire),
             .max_sustained_paint_gap_ended_at_ms = self.max_sustained_paint_gap_ended_at_ms.load(.acquire),
+            .paint_gap_over_limit_count = self.paint_gap_over_limit_count.load(.acquire),
             .max_paint_draw_duration_ms = self.max_paint_draw_duration_ms.load(.acquire),
             .max_paint_draw_duration_at_ms = self.max_paint_draw_duration_at_ms.load(.acquire),
             .paint_draw_duration_over_20ms_count = self.paint_draw_duration_over_20ms_count.load(.acquire),
@@ -2359,6 +2372,11 @@ test "win32 render trace classifies gaps by start time" {
     try std.testing.expect(!RenderTrace.gapIsSustained(1299, 300));
     try std.testing.expect(RenderTrace.gapIsSustained(1300, 300));
     try std.testing.expect(!RenderTrace.gapIsSustained(500, 600));
+}
+
+test "win32 render trace classifies visible paint gaps" {
+    try std.testing.expect(!RenderTrace.gapExceedsPaintLimit(300));
+    try std.testing.expect(RenderTrace.gapExceedsPaintLimit(301));
 }
 
 test "win32 render trace init rejects and frees a second process owner" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -22451,7 +22451,10 @@ pub const Surface = struct {
             self.shell_committed = true;
             if (self.window_focused) app.commitShellSurfaceFocus(self);
         }
-        app.auditShellNativeMapping("surface-create");
+        // Existing-host tab/split creation is intentionally provisional here:
+        // the shell reducer selects the new entity before the caller activates
+        // its native surface. The activation path performs the stable audit.
+        if (opts.host_id == null) app.auditShellNativeMapping("surface-create");
     }
 
     pub fn deinit(self: *Surface) void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -89,6 +89,7 @@ pub const resourcesDir = internal_os.resourcesDir;
 
 const RenderTrace = struct {
     const startup_window_ms: u64 = 1000;
+    const startup_paint_gap_ceiling_ms: u64 = 1500;
     const paint_gap_limit_ms: u64 = 300;
 
     const PaintGapTargets = struct {
@@ -336,6 +337,7 @@ const RenderTrace = struct {
         stream.print("{f}", .{std.json.fmt(.{
             .runtime_ms = GetTickCount64() - self.start_tick_ms,
             .startup_window_ms = startup_window_ms,
+            .startup_paint_gap_ceiling_ms = startup_paint_gap_ceiling_ms,
             .paint_gap_limit_ms = paint_gap_limit_ms,
             .renderer_update_frame_count = self.renderer_update_frame_count.load(.acquire),
             .renderer_draw_request_count = self.renderer_draw_request_count.load(.acquire),
@@ -2375,6 +2377,7 @@ test "win32 render trace classifies gaps by start time" {
 }
 
 test "win32 render trace classifies visible paint gaps" {
+    try std.testing.expect(RenderTrace.startup_paint_gap_ceiling_ms >= RenderTrace.startup_window_ms);
     try std.testing.expect(!RenderTrace.gapExceedsPaintLimit(300));
     try std.testing.expect(RenderTrace.gapExceedsPaintLimit(301));
 }

--- a/test/windows/assert-interactive-runner.ps1
+++ b/test/windows/assert-interactive-runner.ps1
@@ -79,9 +79,14 @@ try {
     if ($identity.IsSystem) { throw 'Interactive runner must not run as LocalSystem.' }
     if ($inputDesktop -ne 'Default') { throw "Interactive runner input desktop must be Default; got '$inputDesktop'." }
 
+    $expectedCommit = if ([string]::IsNullOrWhiteSpace($env:WINGHOSTTY_EXPECTED_CHECKOUT_SHA)) {
+        $env:GITHUB_SHA
+    } else {
+        $env:WINGHOSTTY_EXPECTED_CHECKOUT_SHA
+    }
     $checkedOutCommit = (& git -C $env:GITHUB_WORKSPACE rev-parse HEAD).Trim()
-    if ($LASTEXITCODE -ne 0 -or $checkedOutCommit -ne $env:GITHUB_SHA) {
-        throw "Interactive runner checkout $checkedOutCommit does not match GITHUB_SHA $($env:GITHUB_SHA)."
+    if ($LASTEXITCODE -ne 0 -or $checkedOutCommit -ne $expectedCommit) {
+        throw "Interactive runner checkout $checkedOutCommit does not match expected commit $expectedCommit."
     }
 
     $explorer = @(Get-Process explorer -ErrorAction SilentlyContinue | Where-Object SessionId -eq $processSession)
@@ -105,7 +110,9 @@ try {
         workflow = $env:GITHUB_WORKFLOW
         run_id = $env:GITHUB_RUN_ID
         run_attempt = $env:GITHUB_RUN_ATTEMPT
-        commit = $env:GITHUB_SHA
+        commit = $expectedCommit
+        checked_out_commit = $checkedOutCommit
+        github_sha = $env:GITHUB_SHA
     }
     if ($OutputPath) {
         $parent = Split-Path -Parent $OutputPath

--- a/test/windows/cli-detached-action.ps1
+++ b/test/windows/cli-detached-action.ps1
@@ -140,6 +140,7 @@ try {
         if (-not $process.HasExited) {
             throw $sendError
         }
+        Write-Warning "WM_CLOSE send raced detached CLI process exit: $sendError"
     }
     $closeProcess = $process
     Wait-InteractiveWin11Until -Deadline $closeDeadline -Description 'detached CLI action exit' -Condition {

--- a/test/windows/cli-detached-action.ps1
+++ b/test/windows/cli-detached-action.ps1
@@ -15,6 +15,7 @@ if ($TimeoutSeconds -le 0) {
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $exePath = if ($ExePath) { $ExePath } else { Join-Path $repoRoot 'zig-out\bin\winghostty.exe' }
 $expectedTitle = 'winghostty CLI action failed'
+. (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
 
 if (-not (Test-Path $exePath)) {
     throw "Missing built executable: $exePath. Run `zig build -Demit-exe=true` first."
@@ -44,36 +45,12 @@ using System.Text;
 
 public static class DetachedCliActionNative {
     [DllImport("user32.dll", SetLastError=true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PostMessageW(IntPtr hwnd, uint msg, UIntPtr wParam, IntPtr lParam);
-
-    [DllImport("kernel32.dll", SetLastError=true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
-
-    [DllImport("user32.dll", SetLastError=true)]
     public static extern int GetWindowTextLengthW(IntPtr hwnd);
 
     [DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
     public static extern int GetWindowTextW(IntPtr hwnd, StringBuilder lpString, int nMaxCount);
 }
 "@
-}
-
-function Get-DetachedCliExitCode {
-    param([System.Diagnostics.Process] $Process)
-
-    $Process.Refresh()
-    if ($null -ne $Process.ExitCode) {
-        return [int] $Process.ExitCode
-    }
-
-    [uint32] $nativeExitCode = 0
-    if (-not [DetachedCliActionNative]::GetExitCodeProcess($Process.Handle, [ref] $nativeExitCode)) {
-        throw "Unable to read exit code for detached CLI action: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
-    }
-
-    return [int] $nativeExitCode
 }
 
 function Get-DetachedCliWindowTitle {
@@ -116,6 +93,7 @@ finally {
         Remove-Item Env:GHOSTTY_RESOURCES_DIR -ErrorAction SilentlyContinue
     }
 }
+$processHandle = $process.Handle
 
 $dialogHandle = [IntPtr]::Zero
 $observedTitle = ''
@@ -139,22 +117,37 @@ try {
 
     if ($observedTitle -ne $expectedTitle) {
         if ($process.HasExited) {
-            $exitCode = Get-DetachedCliExitCode -Process $process
+            $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
             throw "Detached CLI action exited without a visible error dialog (exit code $exitCode)."
         }
 
         throw "Detached CLI action did not expose the expected error dialog within ${TimeoutSeconds}s (observed title: '$observedTitle')."
     }
 
-    if (-not [DetachedCliActionNative]::PostMessageW($dialogHandle, 0x0010, [UIntPtr]::Zero, [IntPtr]::Zero)) {
-        throw "Unable to close detached CLI error dialog: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    $closeDeadline = [DateTime]::UtcNow.AddSeconds(5)
+    try {
+        [void](Invoke-InteractiveWin11Message `
+            -Hwnd $dialogHandle `
+            -Message 0x0010 `
+            -Deadline $closeDeadline `
+            -Description 'WM_CLOSE detached CLI error dialog' `
+            -Flags $script:InteractiveWin11SmtoBlock `
+            -Process $process)
+    }
+    catch {
+        $sendError = $_
+        $process.Refresh()
+        if (-not $process.HasExited) {
+            throw $sendError
+        }
+    }
+    $closeProcess = $process
+    Wait-InteractiveWin11Until -Deadline $closeDeadline -Description 'detached CLI action exit' -Condition {
+        $closeProcess.Refresh()
+        $closeProcess.HasExited
     }
 
-    if (-not $process.WaitForExit(5000)) {
-        throw 'Detached CLI action did not exit after its error dialog was closed.'
-    }
-
-    $finalExitCode = Get-DetachedCliExitCode -Process $process
+    $finalExitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
     if ($finalExitCode -ne 1) {
         throw "Detached CLI action should exit with code 1 after its error dialog closes, got $finalExitCode."
     }

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -16,45 +16,8 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-if (-not ('CliShellCommandNative' -as [type])) {
-    Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-
-public static class CliShellCommandNative {
-    [DllImport("kernel32.dll", SetLastError=true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
-}
-"@
-}
-
-function Get-CliShellExitCode {
-    param(
-        [System.Diagnostics.Process] $Process,
-        [IntPtr] $ProcessHandle
-    )
-
-    try {
-        $Process.Refresh()
-        if ($Process.HasExited) {
-            return [int] $Process.ExitCode
-        }
-    }
-    catch {
-        # Fall through to the native lookup.
-    }
-
-    [uint32] $nativeExitCode = 0
-    if (-not [CliShellCommandNative]::GetExitCodeProcess($ProcessHandle, [ref] $nativeExitCode)) {
-        throw "Unable to read exit code for pid=$($Process.Id): $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
-    }
-    if ($nativeExitCode -eq 259) {
-        throw "Process has not exited yet for pid=$($Process.Id)"
-    }
-
-    return [int] $nativeExitCode
-}
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
 
 function Format-CmdArgument {
     param(
@@ -85,7 +48,6 @@ function Format-PowerShellLiteral {
     return "'" + $Argument.Replace("'", "''") + "'"
 }
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $binDir = if ($BinDir) { $BinDir } else { Join-Path $repoRoot 'zig-out\bin' }
 $guiExe = Join-Path $binDir 'winghostty.exe'
 $commandExe = Join-Path $binDir 'winghostty.com'
@@ -168,7 +130,7 @@ switch ($Shell) {
                     }
                 }
 
-                $exitCode = Get-CliShellExitCode -Process $process -ProcessHandle $processHandle
+                $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
                 $stdoutText = if (Test-Path -LiteralPath $stdoutPath) {
                     Get-Content -LiteralPath $stdoutPath -Raw
                 } else {

--- a/test/windows/flagship/Invoke-InteractiveWin11.ps1
+++ b/test/windows/flagship/Invoke-InteractiveWin11.ps1
@@ -110,6 +110,7 @@ finally {
         $measurements = [ordered]@{
             paint_draw_count = [long]$render.paint_draw_count
             startup_window_ms = [long]$render.startup_window_ms
+            startup_paint_gap_ceiling_ms = [long]$render.startup_paint_gap_ceiling_ms
             paint_gap_limit_ms = [long]$render.paint_gap_limit_ms
             paint_gap_over_limit_count = [long]$render.paint_gap_over_limit_count
             max_paint_gap_ms = [long]$render.max_paint_gap_ms

--- a/test/windows/flagship/Invoke-InteractiveWin11.ps1
+++ b/test/windows/flagship/Invoke-InteractiveWin11.ps1
@@ -109,6 +109,9 @@ finally {
         $boo = Get-Content -LiteralPath (Join-Path $perfLayout.Temp 'interactive-win11-boo-performance-boo.json') -Raw | ConvertFrom-Json
         $measurements = [ordered]@{
             paint_draw_count = [long]$render.paint_draw_count
+            startup_window_ms = [long]$render.startup_window_ms
+            paint_gap_limit_ms = [long]$render.paint_gap_limit_ms
+            paint_gap_over_limit_count = [long]$render.paint_gap_over_limit_count
             max_paint_gap_ms = [long]$render.max_paint_gap_ms
             max_sustained_paint_gap_ms = [long]$render.max_sustained_paint_gap_ms
             max_paint_draw_duration_ms = [long]$render.max_paint_draw_duration_ms

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -238,6 +238,18 @@ function Test-ExecutionContextMemberChain {
 function Test-CommandResolutionMutationNode {
     param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
 
+    if ($Node -is [System.Management.Automation.Language.ConvertExpressionAst] -and
+        (($Node.Type.TypeName.FullName -replace '\s', '').ToLowerInvariant() -in @('type', 'system.type'))) {
+        return $Node.Child -isnot [System.Management.Automation.Language.StringConstantExpressionAst] -or
+            (Test-DynamicScriptTypeName -TypeName $Node.Child.Value)
+    }
+    if ($Node -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+        $Node.Operator -eq [System.Management.Automation.Language.TokenKind]::As -and
+        $Node.Right -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        (($Node.Right.TypeName.FullName -replace '\s', '').ToLowerInvariant() -in @('type', 'system.type'))) {
+        return $Node.Left -isnot [System.Management.Automation.Language.StringConstantExpressionAst] -or
+            (Test-DynamicScriptTypeName -TypeName $Node.Left.Value)
+    }
     if ($Node -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
         (Test-DynamicScriptTypeName -TypeName $Node.Value)) {
         $isTypeConversion = $Node.Parent -is [System.Management.Automation.Language.ConvertExpressionAst] -and
@@ -380,7 +392,11 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation." + "ScriptBlock")' }
     [pscustomobject]@{ Reject = $true; Text = '$typeName = "System.Management.Automation.ScriptBlock"; [PSObject].Assembly.GetType($typeName)' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [type]"System.Management.Automation.ScriptBlock"' }
+    [pscustomobject]@{ Reject = $true; Text = '$typeName = "System.Management.Automation.ScriptBlock"; $factory = [type]$typeName' }
+    [pscustomobject]@{ Reject = $true; Text = '$factory = [type]("System.Management.Automation." + "ScriptBlock")' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = "System.Management.Automation.ScriptBlock" -as [type]' }
+    [pscustomobject]@{ Reject = $true; Text = '$typeName = "System.Management.Automation.ScriptBlock"; $factory = $typeName -as [type]' }
+    [pscustomobject]@{ Reject = $false; Text = '$factory = "WinghosttyStatefulNative" -as [type]' }
     [pscustomobject]@{ Reject = $true; Text = '[runspacefactory]::CreateRunspace()' }
     [pscustomobject]@{ Reject = $true; Text = '[System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()' }
     [pscustomobject]@{ Reject = $false; Text = '[ScriptBlock]::CreateDelegate("x")' }

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -579,8 +579,9 @@ $paletteThemeFunctions = @($paletteThemeAst.FindAll({
     $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
 }, $true))
 $openThemeQueryFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Open-ThemeQuery')
-if ($paletteThemeFunctions.Count -ne 1 -or $openThemeQueryFunctions.Count -ne 1) {
-    throw 'Palette theme harness must define only the exact Open-ThemeQuery function.'
+$postHighContrastFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Invoke-PostHighContrastPresentationCanary')
+if ($paletteThemeFunctions.Count -ne 2 -or $openThemeQueryFunctions.Count -ne 1 -or $postHighContrastFunctions.Count -ne 1) {
+    throw 'Palette theme harness must define only its exact query and post-High-Contrast presentation functions.'
 }
 $openThemeQueryParameters = @($openThemeQueryFunctions[0].Parameters)
 if ($openThemeQueryParameters.Count -ne 4 -or
@@ -606,11 +607,253 @@ if ($openThemeQueryStatements.Count -ne 6 -or
     $openThemeQueryStatements[5].Extent.Text.Trim() -ne 'return $edit.Hwnd') {
     throw 'Palette query opening must preserve its complete fail-closed command, wait, edit, and return sequence.'
 }
+$postHighContrastParameters = @($postHighContrastFunctions[0].Parameters)
+$postHighContrastBody = $postHighContrastFunctions[0].Body
+$postHighContrastStatements = @($postHighContrastBody.EndBlock.Statements)
+$postHighContrastTraps = @($postHighContrastBody.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.TrapStatementAst]
+}, $true))
+if ($postHighContrastParameters.Count -ne 2 -or
+    $postHighContrastParameters[0].Extent.Text.Trim() -ne '[string]$Name' -or
+    $postHighContrastParameters[1].Extent.Text.Trim() -ne '[int]$ExpectedRgb' -or
+    $null -ne $postHighContrastBody.DynamicParamBlock -or $null -ne $postHighContrastBody.BeginBlock -or
+    $null -ne $postHighContrastBody.ProcessBlock -or $null -ne $postHighContrastBody.CleanBlock -or
+    $postHighContrastTraps.Count -ne 0 -or $postHighContrastStatements.Count -ne 3 -or
+    $postHighContrastStatements[0].Extent.Text.Trim() -ne '$lastError = $null' -or
+    $postHighContrastStatements[2].Extent.Text.Trim() -ne 'throw "Post-High-Contrast presentation did not recover after two fresh processes: $($lastError.Exception.Message)"') {
+    throw 'Post-High-Contrast presentation must preserve its exact canary parameter contract.'
+}
+$postHighContrastLoops = @($postHighContrastBody.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ForEachStatementAst]
+}, $true))
+if ($postHighContrastLoops.Count -ne 1 -or
+    -not [object]::ReferenceEquals($postHighContrastStatements[1], $postHighContrastLoops[0]) -or
+    $postHighContrastLoops[0].Variable.VariablePath.UserPath -ne 'attempt' -or
+    $postHighContrastLoops[0].Condition.Extent.Text.Trim() -ne '1..2') {
+    throw 'Post-High-Contrast presentation must use one exact two-attempt loop.'
+}
+$postHighContrastLoopStatements = @($postHighContrastLoops[0].Body.Statements)
+if ($postHighContrastLoopStatements.Count -ne 2 -or
+    $postHighContrastLoopStatements[0].Extent.Text.Trim() -ne '$canary = $null' -or
+    $postHighContrastLoopStatements[1] -isnot [System.Management.Automation.Language.TryStatementAst]) {
+    throw 'Post-High-Contrast presentation must guard each complete canary lifecycle with one try/catch.'
+}
+$postHighContrastTry = $postHighContrastLoopStatements[1]
+$postHighContrastTryStatements = @($postHighContrastTry.Body.Statements)
+if ($postHighContrastTry.CatchClauses.Count -ne 1 -or $null -ne $postHighContrastTry.Finally -or
+    $postHighContrastTryStatements.Count -ne 13 -or
+    $postHighContrastTryStatements[0].Extent.Text.Trim() -ne '$canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"' -or
+    $postHighContrastTryStatements[1].Extent.Text.Trim() -ne '$runs.Add($canary)' -or
+    $postHighContrastTryStatements[2].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $postHighContrastTryStatements[3].Extent.Text.Trim() -ne '$canaryHost = Wait-StatefulHost $canary $deadline' -or
+    $postHighContrastTryStatements[4].Extent.Text.Trim() -notmatch '(?s)^Wait-InteractiveWin11Until -Deadline \$deadline -Description ''post-High-Contrast canary tab'' -Process \$canary\.Process -Condition \{\s*\(Get-StatefulTabCount \$canaryHost\) -eq 1\s*\}$' -or
+    $postHighContrastTryStatements[5].Extent.Text.Trim() -ne '$canarySurface = Wait-StatefulSurface $canaryHost $canary $deadline' -or
+    $postHighContrastTryStatements[6].Extent.Text.Trim() -ne 'Show-StatefulHost $canaryHost' -or
+    $postHighContrastTryStatements[7].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $postHighContrastTryStatements[8].Extent.Text.Trim() -ne '$stablePresentation = [Diagnostics.Stopwatch]::new()' -or
+    $postHighContrastTryStatements[9].Extent.Text.Trim() -notmatch '(?s)^Wait-InteractiveWin11Until -Deadline \$deadline -Description ''post-High-Contrast canary framebuffer'' -Process \$canary\.Process -Condition \{\s*if \(\(\(Get-StatefulPixel \$canarySurface\.Hwnd\) -band 0xFFFFFF\) -ne \$ExpectedRgb\) \{\s*\$stablePresentation\.Reset\(\)\s*return \$false\s*\}\s*if \(-not \$stablePresentation\.IsRunning\) \{ \$stablePresentation\.Start\(\) \}\s*return \$stablePresentation\.Elapsed -ge \[TimeSpan\]::FromSeconds\(2\)\s*\}$' -or
+    $postHighContrastTryStatements[10].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $postHighContrastTryStatements[11].Extent.Text.Trim() -ne 'Close-StatefulHost $canaryHost $canary $deadline' -or
+    $postHighContrastTryStatements[12].Extent.Text.Trim() -ne 'return') {
+    throw 'Post-High-Contrast presentation must preserve its exact launch, readiness, framebuffer, and close sequence with three fresh deadlines.'
+}
+$postHighContrastCatchStatements = @($postHighContrastTry.CatchClauses[0].Body.Statements)
+if ($postHighContrastCatchStatements.Count -ne 3 -or
+    $postHighContrastCatchStatements[0].Extent.Text.Trim() -ne '$lastError = $_' -or
+    $postHighContrastCatchStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$null -ne \$canary -and -not \$canary\.Process\.HasExited\) \{\s*try \{ Stop-InteractiveWin11Process -Process \$canary\.Process \}\s*catch \{\s*throw "Post-High-Contrast presentation attempt \$attempt failed: \$\(\$lastError\.Exception\.Message\); process cleanup also failed: \$\(\$_\.Exception\.Message\)"\s*\}\s*\}$' -or
+    $postHighContrastCatchStatements[2].Extent.Text.Trim() -ne 'if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }') {
+    throw 'Post-High-Contrast presentation must preserve nullable failed-attempt cleanup and bounded retry reporting.'
+}
+$postHighContrastCalls = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Invoke-PostHighContrastPresentationCanary'
+}, $true))
 $paletteMainTries = @($paletteThemeAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.TryStatementAst] -and
         $node.Parent -is [System.Management.Automation.Language.NamedBlockAst]
 }, $true))
+$recoveryCanaryCalls = @($postHighContrastCalls | Where-Object {
+    $_.Extent.Text.Trim() -eq "Invoke-PostHighContrastPresentationCanary 'palette-theme-recovery-canary' `$draculaRgb"
+})
+$restoreCanaryCalls = @($postHighContrastCalls | Where-Object {
+    $_.Extent.Text.Trim() -eq "Invoke-PostHighContrastPresentationCanary 'palette-theme-restore-canary' `$themeRgb"
+})
+$markerRemoveCommands = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Remove-Item -LiteralPath $hcRecoveryPath -Force -ErrorAction Stop'
+}, $true))
+if ($paletteMainTries.Count -ne 1 -or $postHighContrastCalls.Count -ne 2 -or
+    $recoveryCanaryCalls.Count -ne 1 -or $restoreCanaryCalls.Count -ne 1 -or
+    $markerRemoveCommands.Count -ne 2) {
+    throw 'High Contrast recovery marker removal must follow one successful fresh-process presentation canary.'
+}
+$recoveryCallStatement = Get-DirectStatementBlockChild -Node $recoveryCanaryCalls[0] -StatementBlock $recoveryCanaryCalls[0].Parent.Parent
+$recoveryRemoveCommands = @($markerRemoveCommands | Where-Object {
+    [object]::ReferenceEquals($_.Parent.Parent, $recoveryCanaryCalls[0].Parent.Parent)
+})
+$recoveryBlockStatements = @($recoveryCanaryCalls[0].Parent.Parent.Statements)
+if ($null -eq $recoveryCallStatement -or $recoveryRemoveCommands.Count -ne 1 -or
+    [Array]::IndexOf($recoveryBlockStatements, $recoveryRemoveCommands[0].Parent) -ne
+        ([Array]::IndexOf($recoveryBlockStatements, $recoveryCallStatement) + 1)) {
+    throw 'Interrupted High Contrast recovery must delete its marker immediately after a direct successful canary call.'
+}
+$hcRestoredIfs = @($paletteMainTries[0].Finally.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.IfStatementAst] -and
+        $_.Clauses.Count -eq 1 -and $_.Clauses[0].Item1.Extent.Text.Trim() -eq '$hcRestored'
+})
+$hcPresentationReadyIfs = @($paletteMainTries[0].Finally.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.IfStatementAst] -and
+        $_.Clauses.Count -eq 1 -and $_.Clauses[0].Item1.Extent.Text.Trim() -eq '$hcPresentationReady'
+})
+$presentationReadyAssignments = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $node.Left.VariablePath.UserPath -eq 'hcPresentationReady'
+}, $true))
+$presentationReadyFalse = @($presentationReadyAssignments | Where-Object {
+    $_.Right.Extent.Text.Trim() -eq '$false'
+})
+$presentationReadyTrue = @($presentationReadyAssignments | Where-Object {
+    $_.Right.Extent.Text.Trim() -eq '$true'
+})
+$presentationReadyMutationCommands = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -match '(^|\\)((Set|New|Remove|Clear)-Variable|sv|nv|rv|clv)$' -and
+        $node.Extent.Text -match '(?i)hcPresentationReady'
+}, $true))
+if ($hcRestoredIfs.Count -ne 1 -or $hcPresentationReadyIfs.Count -ne 1 -or
+    $presentationReadyAssignments.Count -ne 2 -or $presentationReadyMutationCommands.Count -ne 0 -or
+    $presentationReadyFalse.Count -ne 1 -or $presentationReadyTrue.Count -ne 1 -or
+    -not [object]::ReferenceEquals($presentationReadyFalse[0], $paletteMainTries[0].Finally.Statements[2]) -or
+    $hcRestoredIfs[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $hcRestoredIfs[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.TryStatementAst]) {
+    throw 'High Contrast cleanup must initialize and gate one exact post-restore presentation proof.'
+}
+$restoreCanaryTry = $hcRestoredIfs[0].Clauses[0].Item2.Statements[0]
+if ($restoreCanaryTry.Body.Statements.Count -ne 2 -or
+    -not [object]::ReferenceEquals($restoreCanaryTry.Body.Statements[0], $restoreCanaryCalls[0].Parent) -or
+    -not [object]::ReferenceEquals($restoreCanaryTry.Body.Statements[1], $presentationReadyTrue[0]) -or
+    $restoreCanaryTry.CatchClauses.Count -ne 1 -or $null -ne $restoreCanaryTry.Finally -or
+    $restoreCanaryTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
+    $restoreCanaryTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne '[void]$cleanupErrors.Add("High Contrast post-restore presentation failed: $($_.Exception.Message)")') {
+    throw 'Restored High Contrast state must become presentation-ready only after the direct canary succeeds.'
+}
+$markerCleanupBody = $hcPresentationReadyIfs[0].Clauses[0].Item2
+if ($markerCleanupBody.Statements.Count -ne 1 -or
+    $markerCleanupBody.Statements[0] -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $markerCleanupBody.Statements[0].Body.Statements.Count -ne 1 -or
+    -not [object]::ReferenceEquals($markerCleanupBody.Statements[0].Body.Statements[0],
+        @($markerRemoveCommands | Where-Object { -not [object]::ReferenceEquals($_, $recoveryRemoveCommands[0]) })[0].Parent) -or
+    $markerCleanupBody.Statements[0].CatchClauses.Count -ne 1 -or
+    $markerCleanupBody.Statements[0].CatchClauses[0].Body.Statements.Count -ne 1 -or
+    $markerCleanupBody.Statements[0].CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne '[void]$cleanupErrors.Add("High Contrast recovery marker cleanup failed: $($_.Exception.Message)")') {
+    throw 'High Contrast recovery marker cleanup must be directly and exclusively gated by successful presentation.'
+}
+$testCanaryMutationShape = {
+    param([string] $Content)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -ne 0) { return $false }
+    $functions = @($ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq 'Invoke-PostHighContrastPresentationCanary'
+    }, $true))
+    if ($functions.Count -ne 1) { return $false }
+    $loops = @($functions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.ForEachStatementAst]
+    }, $true))
+    if ($loops.Count -ne 1 -or $loops[0].Body.Statements.Count -ne 2 -or
+        $loops[0].Body.Statements[1] -isnot [System.Management.Automation.Language.TryStatementAst]) {
+        return $false
+    }
+    $statements = @($loops[0].Body.Statements[1].Body.Statements)
+    return $statements.Count -eq 13 -and
+        $statements[0].Extent.Text.Trim() -eq '$canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"' -and
+        $statements[1].Extent.Text.Trim() -eq '$runs.Add($canary)' -and
+        $statements[2].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
+        $statements[7].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
+        $statements[8].Extent.Text.Trim() -eq '$stablePresentation = [Diagnostics.Stopwatch]::new()' -and
+        $statements[10].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
+        $statements[11].Extent.Text.Trim() -eq 'Close-StatefulHost $canaryHost $canary $deadline' -and
+        $statements[12].Extent.Text.Trim() -eq 'return'
+}
+$testMarkerMutationShape = {
+    param([string] $Content)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -ne 0) { return $false }
+    $assignments = @($ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.VariablePath.UserPath -eq 'hcPresentationReady'
+    }, $true))
+    $trueAssignments = @($assignments | Where-Object { $_.Right.Extent.Text.Trim() -eq '$true' })
+    $falseAssignments = @($assignments | Where-Object { $_.Right.Extent.Text.Trim() -eq '$false' })
+    $mutationCommands = @($ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -match '(^|\\)((Set|New|Remove|Clear)-Variable|sv|nv|rv|clv)$' -and
+            $node.Extent.Text -match '(?i)hcPresentationReady'
+    }, $true))
+    return $assignments.Count -eq 2 -and $trueAssignments.Count -eq 1 -and
+        $falseAssignments.Count -eq 1 -and $mutationCommands.Count -eq 0
+}
+if (-not (& $testCanaryMutationShape $paletteThemeHarnessText) -or
+    -not (& $testMarkerMutationShape $paletteThemeHarnessText)) {
+    throw 'High Contrast mutation probes do not recognize the protected production shape.'
+}
+$deadlineMutationPattern = [regex]::new(
+    '(?m)^(\s*Show-StatefulHost \$canaryHost\r?\n)\s*\$deadline = \[DateTime\]::UtcNow\.AddSeconds\(\$TimeoutSeconds\)\r?\n'
+)
+$missingDeadlineMutation = $deadlineMutationPattern.Replace($paletteThemeHarnessText, '$1', 1)
+$earlyReturnPattern = [regex]::new(
+    '(?s)(function Invoke-PostHighContrastPresentationCanary.*?foreach \(\$attempt in 1\.\.2\).*?try \{\r?\n)'
+)
+$earlyReturnMutation = $earlyReturnPattern.Replace($paletteThemeHarnessText, '$1            return' + [Environment]::NewLine, 1)
+$failOpenMarkerPattern = [regex]::new(
+    '(\[void\]\$cleanupErrors\.Add\("High Contrast post-restore presentation failed: \$\(\$_\.Exception\.Message\)"\))'
+)
+$failOpenMarkerMutation = $failOpenMarkerPattern.Replace(
+    $paletteThemeHarnessText,
+    '$hcPresentationReady = $true' + [Environment]::NewLine + '            $1',
+    1
+)
+$moduleMutatorMarkerMutation = $failOpenMarkerPattern.Replace(
+    $paletteThemeHarnessText,
+    'Microsoft.PowerShell.Utility\Set-Variable hcPresentationReady $true' + [Environment]::NewLine + '            $1',
+    1
+)
+$aliasMutatorMarkerMutation = $failOpenMarkerPattern.Replace(
+    $paletteThemeHarnessText,
+    'sv hcPresentationReady $true' + [Environment]::NewLine + '            $1',
+    1
+)
+if ($missingDeadlineMutation -eq $paletteThemeHarnessText -or
+    $earlyReturnMutation -eq $paletteThemeHarnessText -or
+    $failOpenMarkerMutation -eq $paletteThemeHarnessText -or
+    $moduleMutatorMarkerMutation -eq $paletteThemeHarnessText -or
+    $aliasMutatorMarkerMutation -eq $paletteThemeHarnessText -or
+    (& $testCanaryMutationShape $missingDeadlineMutation) -or
+    (& $testCanaryMutationShape $earlyReturnMutation) -or
+    (& $testMarkerMutationShape $failOpenMarkerMutation) -or
+    (& $testMarkerMutationShape $moduleMutatorMarkerMutation) -or
+    (& $testMarkerMutationShape $aliasMutatorMarkerMutation)) {
+    throw 'High Contrast contract failed to reject a deadline, dead-code, or fail-open marker mutation.'
+}
 $paletteOpenCalls = @($paletteThemeAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.CommandAst] -and
@@ -905,10 +1148,16 @@ $sessionSnapshotOutputIfs = @($sessionSnapshotFunctions[0].FindAll({
     $node -is [System.Management.Automation.Language.IfStatementAst] -and
         $node.Extent.Text -match '^if \(\(Test-Path \$out\) -and \(Get-Item \$out\)\.Length -gt 0\)'
 }, $true))
+$sessionSnapshotExitIfs = @($sessionSnapshotFunctions[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(\$queryExitCode -ne 0\)'
+}, $true))
 if ($sessionSnapshotRetryLoops.Count -ne 1 -or $sessionSnapshotWaitIfs.Count -ne 1 -or
-    $sessionSnapshotOutputIfs.Count -ne 1 -or
+    $sessionSnapshotExitIfs.Count -ne 1 -or $sessionSnapshotOutputIfs.Count -ne 1 -or
     -not [object]::ReferenceEquals($sessionSnapshotRetryLoops[0].Parent, $sessionSnapshotFunctions[0].Body.EndBlock) -or
     -not (Test-DirectStatementBlockChild -Node $sessionSnapshotWaitIfs[0] -StatementBlock $sessionSnapshotRetryLoops[0].Body) -or
+    -not (Test-DirectStatementBlockChild -Node $sessionSnapshotExitIfs[0] -StatementBlock $sessionSnapshotRetryLoops[0].Body) -or
     -not (Test-DirectStatementBlockChild -Node $sessionSnapshotOutputIfs[0] -StatementBlock $sessionSnapshotRetryLoops[0].Body)) {
     throw 'Session restore automation snapshot control flow must remain directly inside one retry loop.'
 }
@@ -926,9 +1175,10 @@ $sessionSnapshotCausalPrefix = @(
     '$out = Join-Path $layout.Logs "$Name-$attempt.json"',
     '$err = Join-Path $layout.Logs "$Name-$attempt.stderr.log"',
     '$query = Start-Process -FilePath $cli -ArgumentList @(''+list-windows'', "--class=$instanceClass") -WorkingDirectory $repoRoot -RedirectStandardOutput $out -RedirectStandardError $err -PassThru',
+    '$queryHandle = $query.Handle',
     '$remainingMs = [Math]::Max(0, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)'
 )
-if ($sessionSnapshotLoopStatements.Count -lt 7) {
+if ($sessionSnapshotLoopStatements.Count -ne 12) {
     throw 'Session restore automation snapshot retry loop is missing causal statements.'
 }
 for ($i = 0; $i -lt $sessionSnapshotCausalPrefix.Count; $i++) {
@@ -936,10 +1186,18 @@ for ($i = 0; $i -lt $sessionSnapshotCausalPrefix.Count; $i++) {
         throw 'Session restore automation snapshot path, launch, and deadline statements are not in causal order.'
     }
 }
-if (-not [object]::ReferenceEquals($sessionSnapshotLoopStatements[4], $sessionSnapshotWaitIfs[0]) -or
-    $sessionSnapshotLoopStatements[5].Extent.Text.Trim() -ne '$query.Refresh()' -or
-    -not [object]::ReferenceEquals($sessionSnapshotLoopStatements[6], $sessionSnapshotOutputIfs[0])) {
-    throw 'Session restore automation snapshot must wait, refresh, then inspect fresh output.'
+if (-not [object]::ReferenceEquals($sessionSnapshotLoopStatements[5], $sessionSnapshotWaitIfs[0]) -or
+    $sessionSnapshotLoopStatements[6].Extent.Text.Trim() -ne '$query.Refresh()' -or
+    $sessionSnapshotLoopStatements[7].Extent.Text.Trim() -ne '$queryExitCode = Get-InteractiveWin11ProcessExitCode -Process $query -ProcessHandle $queryHandle' -or
+    -not [object]::ReferenceEquals($sessionSnapshotLoopStatements[8], $sessionSnapshotExitIfs[0]) -or
+    $sessionSnapshotExitIfs[0].Clauses[0].Item2.Statements.Count -ne 3 -or
+    $sessionSnapshotExitIfs[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$lastError = if ((Test-Path $err) -and (Get-Item $err).Length -gt 0) { "exit ${queryExitCode}: $(Get-Content $err -Raw)" } else { "exit $queryExitCode" }' -or
+    $sessionSnapshotExitIfs[0].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'Start-Sleep -Milliseconds 250' -or
+    $sessionSnapshotExitIfs[0].Clauses[0].Item2.Statements[2].Extent.Text.Trim() -ne 'continue' -or
+    -not [object]::ReferenceEquals($sessionSnapshotLoopStatements[9], $sessionSnapshotOutputIfs[0]) -or
+    $sessionSnapshotLoopStatements[10].Extent.Text.Trim() -ne '$lastError = if ((Test-Path $err) -and (Get-Item $err).Length -gt 0) { Get-Content $err -Raw } else { ''empty stdout'' }' -or
+    $sessionSnapshotLoopStatements[11].Extent.Text.Trim() -ne 'Start-Sleep -Milliseconds 250') {
+    throw 'Session restore automation snapshot must wait, refresh, require a zero signed exit code, then parse fresh output.'
 }
 $sessionRunsAssignments = @($sessionHarnessAst.FindAll({
     param($node)
@@ -1027,6 +1285,7 @@ $sessionForbiddenTermination = @($sessionHarnessAst.FindAll({
 }, $true))
 $sessionBootstrapBody = $sessionBootstrapIfs[0].Clauses[0].Item2
 $sessionSnapshotWaitBody = $sessionSnapshotWaitIfs[0].Clauses[0].Item2
+$sessionSnapshotExitBody = $sessionSnapshotExitIfs[0].Clauses[0].Item2
 $sessionSnapshotOutputBody = $sessionSnapshotOutputIfs[0].Clauses[0].Item2
 $sessionBootstrapExits = @($sessionControlTransfers | Where-Object {
     $_ -is [System.Management.Automation.Language.ExitStatementAst] -and
@@ -1037,8 +1296,10 @@ $sessionBootstrapExits = @($sessionControlTransfers | Where-Object {
 $sessionSnapshotContinues = @($sessionControlTransfers | Where-Object {
     $_ -is [System.Management.Automation.Language.ContinueStatementAst] -and
     $_.Extent.Text.Trim() -eq 'continue' -and
-    [object]::ReferenceEquals($_.Parent, $sessionSnapshotWaitBody) -and
-    [object]::ReferenceEquals($_, $sessionSnapshotWaitBody.Statements[-1])
+    (([object]::ReferenceEquals($_.Parent, $sessionSnapshotWaitBody) -and
+        [object]::ReferenceEquals($_, $sessionSnapshotWaitBody.Statements[-1])) -or
+     ([object]::ReferenceEquals($_.Parent, $sessionSnapshotExitBody) -and
+        [object]::ReferenceEquals($_, $sessionSnapshotExitBody.Statements[-1])))
 })
 $sessionSnapshotReturns = @($sessionControlTransfers | Where-Object {
     $_ -is [System.Management.Automation.Language.ReturnStatementAst] -and
@@ -1107,8 +1368,8 @@ if ($sessionInvariantIfs.Count -ne 1 -or $sessionInvariantThrows.Count -ne 1 -or
     $sessionEapAssignments[0].Extent.Text.Trim() -ne '$ErrorActionPreference = ''Stop''' -or
     -not [object]::ReferenceEquals($sessionEapAssignments[0], $sessionTopLevelStatements[0]) -or
     $sessionForbiddenTermination.Count -ne 0 -or
-    $sessionControlTransfers.Count -ne 3 -or $sessionBootstrapExits.Count -ne 1 -or
-    $sessionSnapshotContinues.Count -ne 1 -or $sessionSnapshotReturns.Count -ne 1 -or
+    $sessionControlTransfers.Count -ne 4 -or $sessionBootstrapExits.Count -ne 1 -or
+    $sessionSnapshotContinues.Count -ne 2 -or $sessionSnapshotReturns.Count -ne 1 -or
     $sessionInstanceClassIndex -ne ($sessionRunsInitializationIndex + 1) -or
     $sessionSnapshotFunctionIndex -ne ($sessionInstanceClassIndex + 1) -or
     $sessionMainTryIndex -ne ($sessionSnapshotFunctionIndex + 1) -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1579,6 +1579,10 @@ Assert-WorkflowContract `
     -Path $windowsPackager `
     -Pattern '(?ms)foreach \(\$runtimeFile in \$runtimeFiles\).*?Assert-PeMachine.*?if \(\$Architecture -eq "x64"\).*?check-windows-x64-baseline\.ps1.*?-Path \$runtimePath' `
     -Description 'Windows packaging checks every x64 runtime PE for baseline compatibility'
+Assert-WorkflowContract `
+    -Path (Join-Path $repoRoot 'scripts\check-windows-x64-baseline.ps1') `
+    -Pattern '(?ms)\$objdumpTimeoutMs = 120000.*?WaitForExit\(\$objdumpTimeoutMs\).*?\$objdumpProcess\.Kill\(\).*?llvm-objdump timed out' `
+    -Description 'Windows x64 baseline disassembly is time-bounded and kills a timed-out tool'
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content (Get-Content -LiteralPath $releasePreflight -Raw) -HeaderPattern '^function\s+Assert-WingetArchitectureCoverage(?=\s|\{)') `
     -Pattern '(?ms)Assert-WingetArchitectureCoverage.*?Architecture:.*?arm64,x64' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -254,10 +254,13 @@ Assert-TextContract `
     -Description 'ephemeral interactive retries cannot restore failed Zig build caches' `
     -Context "$testWorkflow :: windows-interactive :: Setup Zig"
 Assert-TextContract `
-    -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
+    -Content (Get-YamlStepText `
+        -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
+        -Name 'Run interactive Win11 composite' `
+        -Source "$testWorkflow :: windows-interactive") `
     -Pattern '(?ms)env:\s+ZIG_GLOBAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-global-cache\s+ZIG_LOCAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-local-cache' `
     -Description 'interactive builds use clean per-job Zig caches' `
-    -Context "$testWorkflow :: windows-interactive"
+    -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\dev-windows.cmd') `
     -Pattern '(?s)if "%ZIG_GLOBAL_CACHE_DIR%"=="" set "ZIG_GLOBAL_CACHE_DIR=.*?if "%ZIG_LOCAL_CACHE_DIR%"=="" set "ZIG_LOCAL_CACHE_DIR=' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -437,6 +437,7 @@ $interactiveWin11Lib = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
 $statefulWin11Lib = Join-Path $repoRoot 'test\windows\interactive-win11-stateful-lib.ps1'
 $sessionRestoreHarness = Join-Path $repoRoot 'test\windows\interactive-win11-session-restore.ps1'
 $paletteThemeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-palette-theme.ps1'
+$interactivePrSmoke = Join-Path $repoRoot 'test\windows\interactive-win11-pr-smoke.ps1'
 $releaseCopyChecker = Join-Path $repoRoot 'scripts\check-release-copy.ps1'
 $releasePreflight = Join-Path $repoRoot 'scripts\release-preflight.ps1'
 $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
@@ -1483,6 +1484,10 @@ Assert-TextContract `
     -Pattern '(?ms)include-hidden-files: true.*?github\.workspace.*?\.sandbox/win11/\*\*/logs/\*\*' `
     -Description 'interactive evidence upload includes the actual hidden sandbox log tree' `
     -Context "$testWorkflow :: Upload interactive evidence"
+Assert-WorkflowContract `
+    -Path $interactivePrSmoke `
+    -Pattern "(?ms)if \(\`$harness -eq 'interactive-win11-undo\.ps1'\) \{\s*\`$harnessArgs \+= @\('-TimeoutSeconds', '35'\)\s*\}" `
+    -Description 'interactive PR smoke preserves the documented undo harness timeout'
 Assert-WorkflowContract `
     -Path $accessibilityChecker `
     -Pattern '\[DateTimeOffset\]::TryParse\(' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -257,6 +257,9 @@ function Test-CommandResolutionMutationNode {
         return $true
     }
     if ($Node -is [System.Management.Automation.Language.MemberExpressionAst]) {
+        if ($Node.Member -isnot [System.Management.Automation.Language.StringConstantExpressionAst]) {
+            return $true
+        }
         $memberName = Get-MemberExpressionName -Node $Node
         if ($Node.Extent.Text -match '(?is)TypeAccelerators.*(?:Add|Remove)\b') { return $true }
         if ((Test-DynamicScriptTypeExpression -Node $Node.Expression) -and
@@ -347,6 +350,8 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '$global:ExecutionContext.InvokeCommand.NewScriptBlock("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ic = $ExecutionContext.InvokeCommand; $ic.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ic = ${ExecutionContext}.SessionState.InvokeCommand; $ic.NewScriptBlock("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$member = "Create"; [ScriptBlock]::$member("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$member = "InvokeCommand"; $ExecutionContext.$member.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ec = $($ExecutionContext)' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [ScriptBlock]' }
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock].GetMethod("Create")' }
@@ -1585,7 +1590,7 @@ Assert-WorkflowContract `
     -Description 'Windows packaging checks every x64 runtime PE for baseline compatibility'
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\check-windows-x64-baseline.ps1') `
-    -Pattern '(?ms)\$objdumpTimeoutMs = 120000.*?WaitForExit\(\$objdumpTimeoutMs\).*?\$objdumpProcess\.Kill\(\).*?llvm-objdump timed out' `
+    -Pattern '(?ms)Get-Command llvm-objdump\.exe.*?\$objdumpTimeoutMs = 120000.*?\$streamCopyTimeoutMs = 30000.*?WaitForExit\(\$objdumpTimeoutMs\).*?\$objdumpProcess\.Kill\(\).*?WaitAll\(.*?\$streamCopyTimeoutMs.*?llvm-objdump stream cleanup timed out' `
     -Description 'Windows x64 baseline disassembly is time-bounded and kills a timed-out tool'
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content (Get-Content -LiteralPath $releasePreflight -Raw) -HeaderPattern '^function\s+Assert-WingetArchitectureCoverage(?=\s|\{)') `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -263,9 +263,11 @@ function Test-CommandResolutionMutationNode {
             $memberName -in @('Create', 'GetMethod', 'GetMethods')) {
             return $true
         }
-        if ($memberName -in @('InvokeScript', 'NewScriptBlock') -and
-            ((Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('InvokeCommand')) -or
-                (Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('SessionState', 'InvokeCommand')))) {
+        # Reject access to the InvokeCommand object itself so assigning it to
+        # an alias cannot bypass the direct member-chain checks.
+        if ($memberName -eq 'InvokeCommand' -and
+            ((Test-ExecutionContextRoot -Node $Node.Expression) -or
+                (Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('SessionState')))) {
             return $true
         }
         if ($memberName -eq 'InvokeProvider' -and
@@ -343,13 +345,15 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '${ExecutionContext}.SessionState.InvokeCommand.''InvokeScript''("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$($ExecutionContext).InvokeCommand.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$global:ExecutionContext.InvokeCommand.NewScriptBlock("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ic = $ExecutionContext.InvokeCommand; $ic.InvokeScript("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ic = ${ExecutionContext}.SessionState.InvokeCommand; $ic.NewScriptBlock("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ec = $($ExecutionContext)' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [ScriptBlock]' }
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock].GetMethod("Create")' }
     [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation.ScriptBlock")' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [type]"System.Management.Automation.ScriptBlock"' }
     [pscustomobject]@{ Reject = $false; Text = '[ScriptBlock]::CreateDelegate("x")' }
-    [pscustomobject]@{ Reject = $false; Text = '$ExecutionContext.InvokeCommand.InvokeScriptBlock("x")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ExecutionContext.InvokeCommand.InvokeScriptBlock("x")' }
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("[ScriptBlock]::Create")' }
     [pscustomobject]@{ Reject = $false; Text = 'Write-Host "ScriptBlock"' }
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("System.Management.Automation.ScriptBlock")' }

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1,3 +1,5 @@
+#requires -Version 7.1
+
 [CmdletBinding()]
 param()
 
@@ -116,14 +118,33 @@ function Get-PowerShellBlockText {
         [ref]$errors
     )
     if ($errors.Count -ne 0) { throw "PowerShell contract source does not parse: $($errors[0].Message)" }
-    $block = $ast.FindAll({
+    $blocks = @($ast.FindAll({
         param($node)
         ($node -is [System.Management.Automation.Language.FunctionDefinitionAst] -or
-            $node -is [System.Management.Automation.Language.IfStatementAst]) -and
-        $node.Extent.Text -match $HeaderPattern
-    }, $true) | Sort-Object { $_.Extent.Text.Length } | Select-Object -First 1
-    if ($null -eq $block) { throw "PowerShell block not found: $HeaderPattern" }
-    $block.Extent.Text
+            $node -is [System.Management.Automation.Language.IfStatementAst] -or
+            $node -is [System.Management.Automation.Language.ForEachStatementAst]) -and
+            $node.Extent.Text -match $HeaderPattern
+    }, $true))
+    if ($blocks.Count -ne 1) { throw "Expected exactly one PowerShell block for '$HeaderPattern'; found $($blocks.Count)." }
+    $blocks[0].Extent.Text
+}
+
+function Test-DirectStatementBlockChild {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [System.Management.Automation.Language.StatementBlockAst] $StatementBlock
+    )
+
+    $ancestor = $Node.Parent
+    while ($null -ne $ancestor -and $ancestor -isnot [System.Management.Automation.Language.StatementBlockAst]) {
+        if ($ancestor -isnot [System.Management.Automation.Language.PipelineAst] -and
+            $ancestor -isnot [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $ancestor -isnot [System.Management.Automation.Language.CommandExpressionAst]) {
+            return $false
+        }
+        $ancestor = $ancestor.Parent
+    }
+    [object]::ReferenceEquals($ancestor, $StatementBlock)
 }
 
 $stepBoundaryProbe = @'
@@ -196,11 +217,432 @@ $readinessWorkflow = Join-Path $repoRoot '.github\workflows\release-readiness.ym
 $testWorkflow = Join-Path $repoRoot '.github\workflows\test.yml'
 $accessibilityChecker = Join-Path $repoRoot 'scripts\check-accessibility-evidence.ps1'
 $runnerProvenanceChecker = Join-Path $repoRoot 'test\windows\assert-interactive-runner.ps1'
+$sessionRestoreHarness = Join-Path $repoRoot 'test\windows\interactive-win11-session-restore.ps1'
 $releaseCopyChecker = Join-Path $repoRoot 'scripts\check-release-copy.ps1'
 $releasePreflight = Join-Path $repoRoot 'scripts\release-preflight.ps1'
 $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
 $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
+$sessionRestoreHarnessText = Get-Content -LiteralPath $sessionRestoreHarness -Raw
+$sessionRestoreTabSeedLoop = Get-PowerShellBlockText `
+    -Content $sessionRestoreHarnessText `
+    -HeaderPattern '^foreach \(\$targetTabCount in 2\.\.3\)'
+$sessionLoopTokens = $null
+$sessionLoopErrors = $null
+$sessionLoopAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $sessionRestoreTabSeedLoop,
+    [ref]$sessionLoopTokens,
+    [ref]$sessionLoopErrors
+)
+if ($sessionLoopErrors.Count -ne 0) { throw "Session restore tab-seed loop does not parse: $($sessionLoopErrors[0].Message)" }
+$sessionLoopNodes = @($sessionLoopAst.FindAll({ param($node) $true }, $true))
+$sessionDeadlineNodes = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $_.Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)'
+})
+$sessionCommandNodes = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.CommandAst] -and
+    $_.Extent.Text.Trim() -eq 'Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process'
+})
+$sessionWaitNodes = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.CommandAst] -and
+    $_.Extent.Text.Trim() -match '(?s)^Wait-InteractiveWin11Until -Deadline \$deadline -Description "live tab count \$targetTabCount" -Process \$first\.Process -Condition \{\s*\(Get-StatefulTabCount \$hostHwnd\) -eq \$targetTabCount\s*\}$'
+})
+$sessionBarrierNodes = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+    $_.Extent.Text.Trim() -eq '(Get-StatefulTabCount $hostHwnd) -eq $targetTabCount'
+})
+$sessionReadyNodes = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.CommandAst] -and
+    $_.Extent.Text.Trim() -eq 'Invoke-InteractiveWin11Message -Hwnd $hostHwnd -Message 0 -Deadline $deadline -Description "live tab $targetTabCount readiness barrier" -Process $first.Process'
+})
+if ($sessionDeadlineNodes.Count -ne 1 -or $sessionCommandNodes.Count -ne 1 -or
+    $sessionWaitNodes.Count -ne 1 -or $sessionBarrierNodes.Count -ne 1 -or
+    $sessionReadyNodes.Count -ne 1) {
+    throw 'Session restore tab-seed loop must contain one exact deadline, send, count wait, equality barrier, and pump-readiness barrier per iteration.'
+}
+$sessionParsedSeedLoops = @($sessionLoopNodes | Where-Object {
+    $_ -is [System.Management.Automation.Language.ForEachStatementAst] -and
+    $_.Extent.Text -match '^foreach \(\$targetTabCount in 2\.\.3\)'
+})
+if ($sessionParsedSeedLoops.Count -ne 1 -or $sessionParsedSeedLoops[0].Body.Statements.Count -ne 4) {
+    throw 'Session restore tab-seed contract must parse to one loop containing exactly four executable statements.'
+}
+foreach ($node in @($sessionDeadlineNodes[0], $sessionCommandNodes[0], $sessionWaitNodes[0], $sessionReadyNodes[0])) {
+    if (-not (Test-DirectStatementBlockChild -Node $node -StatementBlock $sessionParsedSeedLoops[0].Body)) {
+        throw 'Session restore tab-seed operations must be direct, executable statements in the loop body.'
+    }
+}
+$sessionSeedOffsets = @(
+    $sessionDeadlineNodes[0].Extent.StartOffset,
+    $sessionCommandNodes[0].Extent.StartOffset,
+    $sessionWaitNodes[0].Extent.StartOffset,
+    $sessionBarrierNodes[0].Extent.StartOffset,
+    $sessionReadyNodes[0].Extent.StartOffset
+)
+for ($i = 1; $i -lt $sessionSeedOffsets.Count; $i++) {
+    if ($sessionSeedOffsets[$i - 1] -ge $sessionSeedOffsets[$i]) {
+        throw 'Session restore tab-seed operations are not in fail-closed causal order.'
+    }
+}
+$sessionHarnessTokens = $null
+$sessionHarnessErrors = $null
+$sessionHarnessAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $sessionRestoreHarnessText,
+    [ref]$sessionHarnessTokens,
+    [ref]$sessionHarnessErrors
+)
+if ($sessionHarnessErrors.Count -ne 0) { throw "Session restore harness does not parse: $($sessionHarnessErrors[0].Message)" }
+$sessionMainTries = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.TryStatementAst] -and
+        $node.Parent -is [System.Management.Automation.Language.NamedBlockAst]
+}, $true))
+$sessionSeedLoops = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ForEachStatementAst] -and
+        $node.Extent.Text -match '^foreach \(\$targetTabCount in 2\.\.3\)'
+}, $true))
+if ($sessionMainTries.Count -ne 1 -or $sessionSeedLoops.Count -ne 1 -or
+    -not (Test-DirectStatementBlockChild -Node $sessionSeedLoops[0] -StatementBlock $sessionMainTries[0].Body)) {
+    throw 'Session restore tab seeding must be one direct, executable loop in the main try body.'
+}
+$sessionBurstCommands = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process'
+}, $true))
+$sessionExplicitStarts = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq "Start-StatefulApp `$layout `$exe `$repoRoot 'session-explicit-command' @('-e', 'cmd.exe', '/k')"
+}, $true))
+$sessionBurstWaits = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq "Wait-InteractiveWin11Until -Deadline `$deadline -Description 'asynchronous burst-created tabs' -Process `$explicit.Process -Condition { (Get-StatefulTabCount `$explicitHost) -eq 3 }"
+}, $true))
+$sessionBurstReady = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq "Invoke-InteractiveWin11Message -Hwnd `$explicitHost -Message 0 -Deadline `$deadline -Description 'asynchronous tab burst readiness barrier' -Process `$explicit.Process"
+}, $true))
+$sessionExplicitCloses = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Close-StatefulHost $explicitHost $explicit $deadline'
+}, $true))
+$sessionExactDeadlines = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)'
+}, $true))
+$sessionInvariantLoops = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ForEachStatementAst] -and
+        $node.Parent -is [System.Management.Automation.Language.NamedBlockAst] -and
+        $node.Extent.Text.Trim() -match '(?s)^foreach \(\$run in \$runs\) \{\s*if \(Select-String -LiteralPath \$run\.Stderr -SimpleMatch ''shell/native invariant failed'' -Quiet\) \{\s*throw "Shell/native invariant failure reported by \$\(\$run\.Stderr\)\."\s*\}\s*\}$'
+}, $true))
+if ($sessionExplicitStarts.Count -ne 1 -or $sessionBurstCommands.Count -ne 2 -or
+    $sessionBurstWaits.Count -ne 1 -or $sessionBurstReady.Count -ne 1 -or
+    $sessionExplicitCloses.Count -ne 1 -or $sessionInvariantLoops.Count -ne 1) {
+    throw 'Session restore validation must preserve the explicit-process burst phase, its exact-count/pump barriers, and invariant-log rejection.'
+}
+$sessionBurstDeadlines = @($sessionExactDeadlines | Where-Object {
+    (Test-DirectStatementBlockChild -Node $_ -StatementBlock $sessionMainTries[0].Body) -and
+    $_.Extent.StartOffset -gt $sessionBurstCommands[1].Extent.EndOffset -and
+    $_.Extent.EndOffset -lt $sessionBurstWaits[0].Extent.StartOffset
+})
+$sessionCloseDeadlines = @($sessionExactDeadlines | Where-Object {
+    (Test-DirectStatementBlockChild -Node $_ -StatementBlock $sessionMainTries[0].Body) -and
+    $_.Extent.StartOffset -gt $sessionBurstReady[0].Extent.EndOffset -and
+    $_.Extent.EndOffset -lt $sessionExplicitCloses[0].Extent.StartOffset
+})
+if ($sessionBurstDeadlines.Count -ne 1 -or $sessionCloseDeadlines.Count -ne 1) {
+    throw 'Session restore asynchronous burst and close phases must each receive one fresh exact deadline.'
+}
+$sessionDirectBurstNodes = @(
+    $sessionExplicitStarts[0],
+    $sessionBurstCommands[0],
+    $sessionBurstCommands[1],
+    $sessionBurstDeadlines[0],
+    $sessionBurstWaits[0],
+    $sessionBurstReady[0],
+    $sessionCloseDeadlines[0],
+    $sessionExplicitCloses[0]
+)
+foreach ($node in $sessionDirectBurstNodes) {
+    if (-not (Test-DirectStatementBlockChild -Node $node -StatementBlock $sessionMainTries[0].Body)) {
+        throw 'Session restore asynchronous burst operations must be direct, executable statements in the main try body.'
+    }
+}
+$sessionInvariantIfs = @($sessionInvariantLoops[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst]
+}, $true))
+$sessionInvariantThrows = @($sessionInvariantLoops[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ThrowStatementAst] -and
+        $node.Extent.Text.Trim() -eq 'throw "Shell/native invariant failure reported by $($run.Stderr)."'
+}, $true))
+$sessionPassCommands = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+    $node.Extent.Text.Trim() -eq 'Write-Host "interactive-win11 session-restore validation: PASS (state=$statePath)"'
+}, $true))
+if ($sessionPassCommands.Count -ne 1) {
+    throw 'Session restore story must contain one exact PASS sentinel.'
+}
+$sessionBootstrapIfs = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(-not \$env:WINGHOSTTY_INTERACTIVE_WIN11_SESSION_RESTORE_BOOTSTRAPPED\)'
+}, $true))
+if ($sessionBootstrapIfs.Count -ne 1) {
+    throw 'Session restore story must contain one exact bootstrap guard.'
+}
+$sessionSnapshotFunctions = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'Get-SessionAutomationSnapshot' -and
+        $node.Extent.Text -match '^function Get-SessionAutomationSnapshot\(\[string\]\$Name, \[DateTime\]\$Deadline\)'
+}, $true))
+if ($sessionSnapshotFunctions.Count -ne 1) {
+    throw 'Session restore story must contain one exact automation snapshot helper.'
+}
+$sessionSnapshotRetryLoops = @($sessionSnapshotFunctions[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ForEachStatementAst] -and
+        $node.Extent.Text -match '^foreach \(\$attempt in 1\.\.3\)'
+}, $true))
+$sessionSnapshotWaitIfs = @($sessionSnapshotFunctions[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(-not \$query\.WaitForExit\(\$remainingMs\)\)'
+}, $true))
+$sessionSnapshotOutputIfs = @($sessionSnapshotFunctions[0].FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(\(Test-Path \$out\) -and \(Get-Item \$out\)\.Length -gt 0\)'
+}, $true))
+if ($sessionSnapshotRetryLoops.Count -ne 1 -or $sessionSnapshotWaitIfs.Count -ne 1 -or
+    $sessionSnapshotOutputIfs.Count -ne 1 -or
+    -not [object]::ReferenceEquals($sessionSnapshotRetryLoops[0].Parent, $sessionSnapshotFunctions[0].Body.EndBlock) -or
+    -not (Test-DirectStatementBlockChild -Node $sessionSnapshotWaitIfs[0] -StatementBlock $sessionSnapshotRetryLoops[0].Body) -or
+    -not (Test-DirectStatementBlockChild -Node $sessionSnapshotOutputIfs[0] -StatementBlock $sessionSnapshotRetryLoops[0].Body)) {
+    throw 'Session restore automation snapshot control flow must remain directly inside one retry loop.'
+}
+$sessionSnapshotFunctionStatements = @($sessionSnapshotFunctions[0].Body.EndBlock.Statements)
+if ($sessionSnapshotFunctionStatements.Count -ne 5 -or
+    $sessionSnapshotFunctionStatements[0].Extent.Text.Trim() -ne '$cli = Join-Path (Split-Path -Parent $exe) ''winghostty.com''' -or
+    $sessionSnapshotFunctionStatements[1].Extent.Text.Trim() -ne 'if (-not (Test-Path -LiteralPath $cli)) { throw "Missing automation CLI shim: $cli" }' -or
+    $sessionSnapshotFunctionStatements[2].Extent.Text.Trim() -ne '$lastError = ''''' -or
+    -not [object]::ReferenceEquals($sessionSnapshotFunctionStatements[3], $sessionSnapshotRetryLoops[0]) -or
+    $sessionSnapshotFunctionStatements[4].Extent.Text.Trim() -ne 'throw "Session automation query failed after three attempts: $lastError"') {
+    throw 'Session restore automation snapshot helper setup, retry, and terminal failure are not in causal order.'
+}
+$sessionSnapshotLoopStatements = @($sessionSnapshotRetryLoops[0].Body.Statements)
+$sessionSnapshotCausalPrefix = @(
+    '$out = Join-Path $layout.Logs "$Name-$attempt.json"',
+    '$err = Join-Path $layout.Logs "$Name-$attempt.stderr.log"',
+    '$query = Start-Process -FilePath $cli -ArgumentList @(''+list-windows'', "--class=$instanceClass") -WorkingDirectory $repoRoot -RedirectStandardOutput $out -RedirectStandardError $err -PassThru',
+    '$remainingMs = [Math]::Max(0, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)'
+)
+if ($sessionSnapshotLoopStatements.Count -lt 7) {
+    throw 'Session restore automation snapshot retry loop is missing causal statements.'
+}
+for ($i = 0; $i -lt $sessionSnapshotCausalPrefix.Count; $i++) {
+    if ($sessionSnapshotLoopStatements[$i].Extent.Text.Trim() -ne $sessionSnapshotCausalPrefix[$i]) {
+        throw 'Session restore automation snapshot path, launch, and deadline statements are not in causal order.'
+    }
+}
+if (-not [object]::ReferenceEquals($sessionSnapshotLoopStatements[4], $sessionSnapshotWaitIfs[0]) -or
+    $sessionSnapshotLoopStatements[5].Extent.Text.Trim() -ne '$query.Refresh()' -or
+    -not [object]::ReferenceEquals($sessionSnapshotLoopStatements[6], $sessionSnapshotOutputIfs[0])) {
+    throw 'Session restore automation snapshot must wait, refresh, then inspect fresh output.'
+}
+$sessionRunsAssignments = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left.Extent.Text -eq '$runs' -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true))
+$sessionInstanceClassAssignments = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$instanceClass = "winghostty-interactive-$($layout.SandboxId)"'
+}, $true))
+$sessionTopLevelStatements = @($sessionHarnessAst.EndBlock.Statements)
+$sessionRunsInitializationIndex = -1
+$sessionInstanceClassIndex = -1
+$sessionSnapshotFunctionIndex = -1
+$sessionMainTryIndex = -1
+$sessionInvariantIndex = -1
+$sessionPassIndex = -1
+for ($i = 0; $i -lt $sessionTopLevelStatements.Count; $i++) {
+    if ($sessionRunsAssignments.Count -eq 1 -and [object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionRunsAssignments[0])) { $sessionRunsInitializationIndex = $i }
+    if ($sessionInstanceClassAssignments.Count -eq 1 -and [object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionInstanceClassAssignments[0])) { $sessionInstanceClassIndex = $i }
+    if ([object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionSnapshotFunctions[0])) { $sessionSnapshotFunctionIndex = $i }
+    if ([object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionMainTries[0])) { $sessionMainTryIndex = $i }
+    if ([object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionInvariantLoops[0])) { $sessionInvariantIndex = $i }
+    if ([object]::ReferenceEquals($sessionTopLevelStatements[$i], $sessionPassCommands[0].Parent)) { $sessionPassIndex = $i }
+}
+$sessionControlTransfers = @($sessionHarnessAst.FindAll({
+    param($node)
+    ($node -is [System.Management.Automation.Language.ReturnStatementAst] -or
+        $node -is [System.Management.Automation.Language.BreakStatementAst] -or
+        $node -is [System.Management.Automation.Language.ContinueStatementAst] -or
+        $node -is [System.Management.Automation.Language.ExitStatementAst]) -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true))
+$sessionFunctionDefinitions = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true))
+$sessionRunsInvocations = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+        $node.Expression.Extent.Text -eq '$runs' -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true) | Sort-Object { $_.Extent.StartOffset })
+$sessionExpectedRunsInvocations = @(
+    '$runs.Add($first)',
+    '$runs.Add($explicit)',
+    '$runs.Add($second)',
+    '$runs.Add($third)'
+)
+$sessionExpectedStartAssignments = @(
+    '$first = Start-StatefulApp $layout $exe $repoRoot ''session-save'' @(''--single-instance=true'')',
+    '$explicit = Start-StatefulApp $layout $exe $repoRoot ''session-explicit-command'' @(''-e'', ''cmd.exe'', ''/k'')',
+    '$second = Start-StatefulApp $layout $exe $repoRoot ''session-restore'' @(''--single-instance=true'')',
+    '$third = Start-StatefulApp $layout $exe $repoRoot ''session-corrupt'''
+)
+$sessionStartAssignments = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -in $sessionExpectedStartAssignments
+}, $true) | Sort-Object { $_.Extent.StartOffset })
+$sessionAllStartCommands = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Start-StatefulApp' -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true) | Sort-Object { $_.Extent.StartOffset })
+$sessionEapAssignments = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left.Extent.Text -eq '$ErrorActionPreference' -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true))
+$sessionForbiddenTermination = @($sessionHarnessAst.FindAll({
+    param($node)
+    (($node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $node.Expression -is [System.Management.Automation.Language.TypeExpressionAst] -and
+            $node.Expression.TypeName.FullName -in @('Environment', 'System.Environment') -and
+            $node.Member.Extent.Text -eq 'Exit') -or
+        ($node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -match '(^|\\)(Stop-Process|taskkill(?:\.exe)?|Invoke-Expression|iex)$')) -and
+        $node.Extent.EndOffset -le $sessionPassCommands[0].Extent.EndOffset
+}, $true))
+$sessionBootstrapBody = $sessionBootstrapIfs[0].Clauses[0].Item2
+$sessionSnapshotWaitBody = $sessionSnapshotWaitIfs[0].Clauses[0].Item2
+$sessionSnapshotOutputBody = $sessionSnapshotOutputIfs[0].Clauses[0].Item2
+$sessionBootstrapExits = @($sessionControlTransfers | Where-Object {
+    $_ -is [System.Management.Automation.Language.ExitStatementAst] -and
+    $_.Extent.Text.Trim() -eq 'exit $code' -and
+    [object]::ReferenceEquals($_.Parent, $sessionBootstrapBody) -and
+    [object]::ReferenceEquals($_, $sessionBootstrapBody.Statements[-1])
+})
+$sessionSnapshotContinues = @($sessionControlTransfers | Where-Object {
+    $_ -is [System.Management.Automation.Language.ContinueStatementAst] -and
+    $_.Extent.Text.Trim() -eq 'continue' -and
+    [object]::ReferenceEquals($_.Parent, $sessionSnapshotWaitBody) -and
+    [object]::ReferenceEquals($_, $sessionSnapshotWaitBody.Statements[-1])
+})
+$sessionSnapshotReturns = @($sessionControlTransfers | Where-Object {
+    $_ -is [System.Management.Automation.Language.ReturnStatementAst] -and
+    $_.Extent.Text.Trim() -eq 'return Get-Content $out -Raw | ConvertFrom-Json' -and
+    $sessionSnapshotOutputBody.Statements.Count -eq 1 -and
+    [object]::ReferenceEquals($_.Parent, $sessionSnapshotOutputBody) -and
+    [object]::ReferenceEquals($_, $sessionSnapshotOutputBody.Statements[0])
+})
+if ($sessionRunsInvocations.Count -eq $sessionExpectedRunsInvocations.Count) {
+    for ($i = 0; $i -lt $sessionExpectedRunsInvocations.Count; $i++) {
+        if ($sessionRunsInvocations[$i].Extent.Text.Trim() -ne $sessionExpectedRunsInvocations[$i]) {
+            throw 'Session restore invariant evidence set was mutated or reordered.'
+        }
+    }
+}
+if ($sessionStartAssignments.Count -eq $sessionExpectedStartAssignments.Count -and
+    $sessionRunsInvocations.Count -eq $sessionExpectedRunsInvocations.Count -and
+    $sessionAllStartCommands.Count -eq $sessionExpectedStartAssignments.Count) {
+    $sessionMainTryStatements = @($sessionMainTries[0].Body.Statements)
+    for ($i = 0; $i -lt $sessionExpectedStartAssignments.Count; $i++) {
+        if ($sessionStartAssignments[$i].Extent.Text.Trim() -ne $sessionExpectedStartAssignments[$i] -or
+            -not [object]::ReferenceEquals($sessionAllStartCommands[$i].Parent.Parent, $sessionStartAssignments[$i]) -or
+            -not (Test-DirectStatementBlockChild -Node $sessionStartAssignments[$i] -StatementBlock $sessionMainTries[0].Body) -or
+            -not (Test-DirectStatementBlockChild -Node $sessionRunsInvocations[$i] -StatementBlock $sessionMainTries[0].Body)) {
+            throw 'Session restore process launch and evidence registration must be direct main-story statements.'
+        }
+        $startIndex = -1
+        $addIndex = -1
+        for ($statementIndex = 0; $statementIndex -lt $sessionMainTryStatements.Count; $statementIndex++) {
+            if ([object]::ReferenceEquals($sessionMainTryStatements[$statementIndex], $sessionStartAssignments[$i])) { $startIndex = $statementIndex }
+            if ([object]::ReferenceEquals($sessionMainTryStatements[$statementIndex], $sessionRunsInvocations[$i].Parent.Parent)) { $addIndex = $statementIndex }
+        }
+        if ($addIndex -ne ($startIndex + 1)) {
+            throw 'Session restore must register each launched process immediately for cleanup and invariant scanning.'
+        }
+    }
+}
+if ($sessionInvariantIfs.Count -ne 1 -or $sessionInvariantThrows.Count -ne 1 -or
+    $sessionFunctionDefinitions.Count -ne 1 -or
+    -not [object]::ReferenceEquals($sessionFunctionDefinitions[0], $sessionSnapshotFunctions[0]) -or
+    $sessionRunsAssignments.Count -ne 1 -or
+    $sessionRunsAssignments[0].Extent.Text.Trim() -ne '$runs = [Collections.Generic.List[object]]::new()' -or
+    $sessionInstanceClassAssignments.Count -ne 1 -or
+    $sessionRunsInvocations.Count -ne $sessionExpectedRunsInvocations.Count -or
+    $sessionStartAssignments.Count -ne $sessionExpectedStartAssignments.Count -or
+    $sessionAllStartCommands.Count -ne $sessionExpectedStartAssignments.Count -or
+    $sessionEapAssignments.Count -ne 1 -or
+    $sessionEapAssignments[0].Extent.Text.Trim() -ne '$ErrorActionPreference = ''Stop''' -or
+    -not [object]::ReferenceEquals($sessionEapAssignments[0], $sessionTopLevelStatements[0]) -or
+    $sessionForbiddenTermination.Count -ne 0 -or
+    $sessionControlTransfers.Count -ne 3 -or $sessionBootstrapExits.Count -ne 1 -or
+    $sessionSnapshotContinues.Count -ne 1 -or $sessionSnapshotReturns.Count -ne 1 -or
+    $sessionInstanceClassIndex -ne ($sessionRunsInitializationIndex + 1) -or
+    $sessionSnapshotFunctionIndex -ne ($sessionInstanceClassIndex + 1) -or
+    $sessionMainTryIndex -ne ($sessionSnapshotFunctionIndex + 1) -or
+    $sessionInvariantIndex -ne ($sessionMainTryIndex + 1) -or
+    $sessionPassIndex -ne ($sessionInvariantIndex + 1) -or
+    $sessionPassIndex -ne ($sessionTopLevelStatements.Count - 1) -or
+    $sessionInvariantLoops[0].Extent.StartOffset -le $sessionMainTries[0].Extent.EndOffset -or
+    $sessionInvariantLoops[0].Extent.EndOffset -ge $sessionPassCommands[0].Extent.StartOffset) {
+    throw 'Session restore story must reach invariant rejection after cleanup and before the PASS sentinel without an early control transfer.'
+}
+$sessionBurstOffsets = @(
+    $sessionExplicitStarts[0].Extent.StartOffset,
+    $sessionBurstCommands[0].Extent.StartOffset,
+    $sessionBurstCommands[1].Extent.StartOffset,
+    $sessionBurstDeadlines[0].Extent.StartOffset,
+    $sessionBurstWaits[0].Extent.StartOffset,
+    $sessionBurstReady[0].Extent.StartOffset,
+    $sessionCloseDeadlines[0].Extent.StartOffset,
+    $sessionExplicitCloses[0].Extent.StartOffset
+)
+for ($i = 1; $i -lt $sessionBurstOffsets.Count; $i++) {
+    if ($sessionBurstOffsets[$i - 1] -ge $sessionBurstOffsets[$i]) {
+        throw 'Session restore asynchronous burst operations are not in fail-closed causal order.'
+    }
+}
+$betweenBurstPosts = $sessionRestoreHarnessText.Substring(
+    $sessionBurstCommands[0].Extent.EndOffset,
+    $sessionBurstCommands[1].Extent.StartOffset - $sessionBurstCommands[0].Extent.EndOffset
+)
+if ($betweenBurstPosts -notmatch '^\s*$') {
+    throw 'Session restore asynchronous new-tab posts must remain adjacent.'
+}
 Assert-TextContract `
     -Content (Get-YamlStepText -Content $releaseWorkflowText -Name 'Release preflight' -Source $releaseWorkflow) `
     -Pattern '(?ms)check-release-copy\.ps1 -ExpectedVersion.*?\r?\n\s+if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.1
+#requires -Version 7.3
 
 [CmdletBinding()]
 param()
@@ -147,6 +147,222 @@ function Test-DirectStatementBlockChild {
     [object]::ReferenceEquals($ancestor, $StatementBlock)
 }
 
+function Get-DirectStatementBlockChild {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [System.Management.Automation.Language.StatementBlockAst] $StatementBlock
+    )
+
+    $statement = $Node
+    $ancestor = $Node.Parent
+    while ($null -ne $ancestor -and $ancestor -isnot [System.Management.Automation.Language.StatementBlockAst]) {
+        $statement = $ancestor
+        $ancestor = $ancestor.Parent
+    }
+    if (-not [object]::ReferenceEquals($ancestor, $StatementBlock)) { return $null }
+    return $statement
+}
+
+function Get-MemberExpressionName {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.MemberExpressionAst] $Node)
+
+    return ([string] $Node.Member.Value).Trim()
+}
+
+function Test-DynamicScriptTypeName {
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $TypeName)
+
+    $typeName = (($TypeName -split ',', 2)[0] -replace '\s', '')
+    return $typeName -in @(
+        'ScriptBlock',
+        'System.Management.Automation.ScriptBlock',
+        'PowerShell',
+        'System.Management.Automation.PowerShell'
+    )
+}
+
+function Test-DynamicScriptTypeExpression {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
+
+    return $Node -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        (Test-DynamicScriptTypeName -TypeName $Node.TypeName.FullName)
+}
+
+function Test-ExecutionContextRoot {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
+
+    while ($Node -is [System.Management.Automation.Language.ParenExpressionAst] -or
+        $Node -is [System.Management.Automation.Language.SubExpressionAst]) {
+        $pipeline = if ($Node -is [System.Management.Automation.Language.ParenExpressionAst]) {
+            $Node.Pipeline
+        } else {
+            $statements = @($Node.SubExpression.Statements)
+            if ($Node.SubExpression.Traps.Count -ne 0 -or $statements.Count -ne 1 -or
+                $statements[0] -isnot [System.Management.Automation.Language.PipelineAst]) {
+                return $false
+            }
+            $statements[0]
+        }
+        $elements = @($pipeline.PipelineElements)
+        if ($elements.Count -ne 1 -or $elements[0] -isnot [System.Management.Automation.Language.CommandExpressionAst]) {
+            return $false
+        }
+        $Node = $elements[0].Expression
+    }
+    if ($Node -isnot [System.Management.Automation.Language.VariableExpressionAst]) { return $false }
+    return (($Node.VariablePath.UserPath -split ':')[-1] -eq 'ExecutionContext')
+}
+
+function Test-ExecutionContextMemberChain {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [string[]] $Members
+    )
+
+    if ($Node -isnot [System.Management.Automation.Language.MemberExpressionAst] -or
+        (Get-MemberExpressionName -Node $Node) -ne $Members[-1]) {
+        return $false
+    }
+    if ($Members.Count -eq 1) { return Test-ExecutionContextRoot -Node $Node.Expression }
+    return Test-ExecutionContextMemberChain -Node $Node.Expression -Members @($Members[0..($Members.Count - 2)])
+}
+
+function Test-CommandResolutionMutationNode {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
+
+    if ($Node -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        (Test-DynamicScriptTypeName -TypeName $Node.Value)) {
+        $isTypeConversion = $Node.Parent -is [System.Management.Automation.Language.ConvertExpressionAst] -and
+            (($Node.Parent.Type.TypeName.FullName -replace '\s', '') -in @('type', 'System.Type'))
+        $isGetTypeArgument = $Node.Parent -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            (Get-MemberExpressionName -Node $Node.Parent) -eq 'GetType' -and
+            @($Node.Parent.Arguments | Where-Object { [object]::ReferenceEquals($_, $Node) }).Count -eq 1
+        if ($isTypeConversion -or $isGetTypeArgument) { return $true }
+    }
+    if ($Node -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        (($Node.VariablePath.UserPath -split ':')[-1] -eq 'ExecutionContext')) {
+        $ancestor = $Node.Parent
+        while ($null -ne $ancestor -and $ancestor -isnot [System.Management.Automation.Language.AssignmentStatementAst]) {
+            $ancestor = $ancestor.Parent
+        }
+        if ($ancestor -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $ancestor.Right -is [System.Management.Automation.Language.CommandExpressionAst] -and
+            (Test-ExecutionContextRoot -Node $ancestor.Right.Expression)) {
+            return $true
+        }
+    }
+    if ($Node -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        (Test-DynamicScriptTypeExpression -Node $Node) -and
+        $Node.Parent -isnot [System.Management.Automation.Language.MemberExpressionAst]) {
+        return $true
+    }
+    if ($Node -is [System.Management.Automation.Language.MemberExpressionAst]) {
+        $memberName = Get-MemberExpressionName -Node $Node
+        if ($Node.Extent.Text -match '(?is)TypeAccelerators.*(?:Add|Remove)\b') { return $true }
+        if ((Test-DynamicScriptTypeExpression -Node $Node.Expression) -and
+            $memberName -in @('Create', 'GetMethod', 'GetMethods')) {
+            return $true
+        }
+        if ($memberName -in @('InvokeScript', 'NewScriptBlock') -and
+            ((Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('InvokeCommand')) -or
+                (Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('SessionState', 'InvokeCommand')))) {
+            return $true
+        }
+        if ($memberName -eq 'InvokeProvider' -and
+            ((Test-ExecutionContextRoot -Node $Node.Expression) -or
+                (Test-ExecutionContextMemberChain -Node $Node.Expression -Members @('SessionState')))) {
+            return $true
+        }
+    }
+    if ($Node -is [System.Management.Automation.Language.CommandAst]) {
+        $name = $Node.GetCommandName()
+        $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
+        return $leafName -in @('Set-Alias', 'sal', 'New-Alias', 'nal', 'Remove-Alias', 'ral', 'Import-Alias', 'ipal', 'Import-Module', 'ipmo', 'Import-PSSession', 'Invoke-Expression', 'iex') -or
+            $Node.Extent.Text -match '(?i)(?:alias|function):'
+    }
+    if ($Node -is [System.Management.Automation.Language.AssignmentStatementAst]) {
+        return $Node.Left.Extent.Text -match '(?i)^\$(?:\{)?(?:global:|script:|local:|private:)?(?:alias|function):'
+    }
+    return $false
+}
+
+function Assert-CommandResolutionContract {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Context,
+        [string[]] $ExpectedDotSources = @(),
+        [string[]] $ExpectedAmpersandCommands = @()
+    )
+
+    $mutators = @($Ast.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true))
+    if ($mutators.Count -ne 0) { throw "Command resolution mutation is forbidden: $Context" }
+    $dotSources = @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.InvocationOperator -eq [System.Management.Automation.Language.TokenKind]::Dot
+    }, $true))
+    if ($dotSources.Count -ne $ExpectedDotSources.Count) { throw "Unexpected dot-source count: $Context" }
+    for ($i = 0; $i -lt $ExpectedDotSources.Count; $i++) {
+        if ($dotSources[$i].Extent.Text.Trim() -ne $ExpectedDotSources[$i]) {
+            throw "Unexpected dot-source command: $Context"
+        }
+    }
+    $ampersandCommands = @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.InvocationOperator -eq [System.Management.Automation.Language.TokenKind]::Ampersand
+    }, $true))
+    if ($ampersandCommands.Count -ne $ExpectedAmpersandCommands.Count) { throw "Unexpected call-operator count: $Context" }
+    for ($i = 0; $i -lt $ExpectedAmpersandCommands.Count; $i++) {
+        if ($ampersandCommands[$i].Extent.Text.Trim() -ne $ExpectedAmpersandCommands[$i]) {
+            throw "Unexpected call-operator command: $Context"
+        }
+    }
+}
+
+function Assert-NoProtectedFunctionDefinitions {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Context
+    )
+
+    $protectedNames = @('Get-InteractiveWin11MessageTimeoutMs', 'Assert-InteractiveWin11WindowOwner', 'Invoke-InteractiveWin11PostMessage', 'Invoke-StatefulPostedCommand')
+    $definitions = @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            (($node.Name -replace '^(?i)(?:global|script|local|private):', '') -in $protectedNames)
+    }, $true))
+    if ($definitions.Count -ne 0) { throw "Harness must not redefine protected interactive functions: $Context" }
+}
+
+$commandResolutionProbes = @(
+    [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock]::' + [Environment]::NewLine + '''Create''("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '[ System.Management.Automation.ScriptBlock, System.Management.Automation ]::Create("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '[PowerShell]::Create()' }
+    [pscustomobject]@{ Reject = $true; Text = '$ExecutionContext.' + [Environment]::NewLine + 'InvokeCommand.' + [Environment]::NewLine + 'InvokeScript("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '${ExecutionContext}.SessionState.InvokeCommand.''InvokeScript''("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$($ExecutionContext).InvokeCommand.InvokeScript("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$global:ExecutionContext.InvokeCommand.NewScriptBlock("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ec = $($ExecutionContext)' }
+    [pscustomobject]@{ Reject = $true; Text = '$factory = [ScriptBlock]' }
+    [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock].GetMethod("Create")' }
+    [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation.ScriptBlock")' }
+    [pscustomobject]@{ Reject = $true; Text = '$factory = [type]"System.Management.Automation.ScriptBlock"' }
+    [pscustomobject]@{ Reject = $false; Text = '[ScriptBlock]::CreateDelegate("x")' }
+    [pscustomobject]@{ Reject = $false; Text = '$ExecutionContext.InvokeCommand.InvokeScriptBlock("x")' }
+    [pscustomobject]@{ Reject = $false; Text = '$list.Add("[ScriptBlock]::Create")' }
+    [pscustomobject]@{ Reject = $false; Text = 'Write-Host "ScriptBlock"' }
+    [pscustomobject]@{ Reject = $false; Text = '$list.Add("System.Management.Automation.ScriptBlock")' }
+)
+foreach ($probe in $commandResolutionProbes) {
+    $probeTokens = $null
+    $probeErrors = $null
+    $probeAst = [System.Management.Automation.Language.Parser]::ParseInput($probe.Text, [ref] $probeTokens, [ref] $probeErrors)
+    if ($probeErrors.Count -ne 0) { throw "Command-resolution probe does not parse: $($probe.Text)" }
+    $probeRejected = @($probeAst.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true)).Count -ne 0
+    if ($probeRejected -ne $probe.Reject) { throw "Command-resolution probe contract failed: $($probe.Text)" }
+}
+
 $stepBoundaryProbe = @'
       - name: Target
         run: inside-step
@@ -217,13 +433,218 @@ $readinessWorkflow = Join-Path $repoRoot '.github\workflows\release-readiness.ym
 $testWorkflow = Join-Path $repoRoot '.github\workflows\test.yml'
 $accessibilityChecker = Join-Path $repoRoot 'scripts\check-accessibility-evidence.ps1'
 $runnerProvenanceChecker = Join-Path $repoRoot 'test\windows\assert-interactive-runner.ps1'
+$interactiveWin11Lib = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+$statefulWin11Lib = Join-Path $repoRoot 'test\windows\interactive-win11-stateful-lib.ps1'
 $sessionRestoreHarness = Join-Path $repoRoot 'test\windows\interactive-win11-session-restore.ps1'
+$paletteThemeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-palette-theme.ps1'
 $releaseCopyChecker = Join-Path $repoRoot 'scripts\check-release-copy.ps1'
 $releasePreflight = Join-Path $repoRoot 'scripts\release-preflight.ps1'
 $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
 $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
+$interactiveWin11LibText = Get-Content -LiteralPath $interactiveWin11Lib -Raw
+$statefulWin11LibText = Get-Content -LiteralPath $statefulWin11Lib -Raw
 $sessionRestoreHarnessText = Get-Content -LiteralPath $sessionRestoreHarness -Raw
+$paletteThemeHarnessText = Get-Content -LiteralPath $paletteThemeHarness -Raw
+$resolutionSourceAsts = foreach ($source in @(
+    [pscustomobject]@{ Path = $interactiveWin11Lib; Text = $interactiveWin11LibText },
+    [pscustomobject]@{ Path = $statefulWin11Lib; Text = $statefulWin11LibText }
+)) {
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($source.Text, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -ne 0) { throw "PowerShell resolution source does not parse: $($source.Path) ($($errors[0].Message))" }
+    [pscustomobject]@{ Path = $source.Path; Ast = $ast }
+}
+foreach ($source in $resolutionSourceAsts) {
+    $expectedAmpersands = if ($source.Path -eq $interactiveWin11Lib) {
+        @(
+            '& $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $LauncherPath @ArgumentList',
+            '& cmd /c $devWindowsCmd zig build -Demit-exe=true',
+            '& $Condition',
+            '& taskkill.exe /PID $Process.Id /T /F *> $null'
+        )
+    } else { @() }
+    Assert-CommandResolutionContract -Ast $source.Ast -Context $source.Path -ExpectedAmpersandCommands $expectedAmpersands
+    $definitions = @($source.Ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true))
+    foreach ($name in @('Get-InteractiveWin11MessageTimeoutMs', 'Assert-InteractiveWin11WindowOwner', 'Invoke-InteractiveWin11PostMessage', 'Invoke-StatefulPostedCommand')) {
+        $expected = if ($source.Path -eq $interactiveWin11Lib) {
+            if ($name -eq 'Invoke-StatefulPostedCommand') { 0 } else { 1 }
+        } else {
+            if ($name -eq 'Invoke-StatefulPostedCommand') { 1 } else { 0 }
+        }
+        if (@($definitions | Where-Object { ($_.Name -replace '^(?i)(?:global|script|local|private):', '') -eq $name }).Count -ne $expected) {
+            throw "Interactive library has the wrong ownership count for protected function $name`: $($source.Path)"
+        }
+    }
+}
+$timeoutFunctions = @($resolutionSourceAsts[0].Ast.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'Get-InteractiveWin11MessageTimeoutMs'
+}, $true))
+$timeoutParameters = @($timeoutFunctions[0].Body.ParamBlock.Parameters)
+$timeoutStatements = @($timeoutFunctions[0].Body.EndBlock.Statements)
+$timeoutTraps = @($timeoutFunctions[0].Body.FindAll({ param($node) $node -is [System.Management.Automation.Language.TrapStatementAst] }, $true))
+if ($timeoutFunctions.Count -ne 1 -or $timeoutParameters.Count -ne 2 -or
+    $timeoutParameters[0].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [DateTime] $Deadline' -or
+    $timeoutParameters[1].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [string] $Description' -or
+    $null -ne $timeoutFunctions[0].Body.DynamicParamBlock -or $null -ne $timeoutFunctions[0].Body.BeginBlock -or
+    $null -ne $timeoutFunctions[0].Body.ProcessBlock -or $null -ne $timeoutFunctions[0].Body.CleanBlock -or
+    $timeoutTraps.Count -ne 0 -or $timeoutStatements.Count -ne 3 -or
+    $timeoutStatements[0].Extent.Text.Trim() -ne '$remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds' -or
+    $timeoutStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$remainingMs -le 0\) \{\s*throw "Deadline elapsed before sending \$Description\."\s*\}$' -or
+    $timeoutStatements[2].Extent.Text.Trim() -ne 'return [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))') {
+    throw 'Message timeout helper must preserve its exact direct elapsed-deadline calculation and bounded return.'
+}
+$postMessageWrapperText = Get-PowerShellBlockText `
+    -Content $interactiveWin11LibText `
+    -HeaderPattern '^function Invoke-InteractiveWin11PostMessage'
+$statefulPostedCommandText = Get-PowerShellBlockText `
+    -Content $statefulWin11LibText `
+    -HeaderPattern '^function Invoke-StatefulPostedCommand'
+$postWrapperTokens = $null
+$postWrapperErrors = $null
+$postWrapperAst = [System.Management.Automation.Language.Parser]::ParseInput($postMessageWrapperText, [ref]$postWrapperTokens, [ref]$postWrapperErrors)
+$postWrapperFunctions = @($postWrapperAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true))
+if ($postWrapperErrors.Count -ne 0 -or $postWrapperFunctions.Count -ne 1 -or
+    $postWrapperFunctions[0].Name -ne 'Invoke-InteractiveWin11PostMessage') {
+    throw 'Posted-message wrapper contract does not parse to the exact named function.'
+}
+$postWrapperFunction = $postWrapperFunctions[0]
+$postWrapperParameters = @($postWrapperFunction.Body.ParamBlock.Parameters)
+$postWrapperStatements = @($postWrapperFunction.Body.EndBlock.Statements)
+$postWrapperTraps = @($postWrapperFunction.Body.FindAll({ param($node) $node -is [System.Management.Automation.Language.TrapStatementAst] }, $true))
+if ($postWrapperParameters.Count -ne 7 -or
+    $postWrapperParameters[0].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [IntPtr] $Hwnd' -or
+    $postWrapperParameters[1].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [uint32] $Message' -or
+    $postWrapperParameters[2].Extent.Text.Trim() -ne '[UIntPtr] $WParam = [UIntPtr]::Zero' -or
+    $postWrapperParameters[3].Extent.Text.Trim() -ne '[IntPtr] $LParam = [IntPtr]::Zero' -or
+    $postWrapperParameters[4].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [DateTime] $Deadline' -or
+    $postWrapperParameters[5].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [string] $Description' -or
+    $postWrapperParameters[6].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [System.Diagnostics.Process] $Process' -or
+    $null -ne $postWrapperFunction.Body.DynamicParamBlock -or $null -ne $postWrapperFunction.Body.BeginBlock -or
+    $null -ne $postWrapperFunction.Body.ProcessBlock -or $null -ne $postWrapperFunction.Body.CleanBlock -or
+    $postWrapperTraps.Count -ne 0 -or $postWrapperStatements.Count -ne 6 -or
+    $postWrapperStatements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
+    $postWrapperStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$Process\.HasExited\) \{\s*throw "Refusing to post \$Description because winghostty already exited \(exit code \$\(\$Process\.ExitCode\)\)\."\s*\}$' -or
+    $postWrapperStatements[2].Extent.Text.Trim() -ne '[void](Assert-InteractiveWin11WindowOwner -Hwnd $Hwnd -Process $Process -Description $Description -Verb ''post'')' -or
+    $postWrapperStatements[3].Extent.Text.Trim() -ne '$lastError = 0' -or
+    $postWrapperStatements[4].Extent.Text.Trim() -ne 'if ($Deadline -le [DateTime]::UtcNow) { throw "Timed out waiting for $Description." }' -or
+    $postWrapperStatements[5].Extent.Text.Trim() -notmatch '(?s)^if \(-not \[InteractiveWin11MessageNativeV2\]::PostMessageWithError\(\$Hwnd, \$Message, \$WParam, \$LParam, \[ref\] \$lastError\)\) \{\s*\$detail = if \(\$lastError -eq 0\) \{ ''without a Win32 error'' \} else \{ "with Win32 error \$lastError" \}\s*throw "PostMessageW failed for \$Description hwnd=\$Hwnd \$detail\."\s*\}$') {
+    throw 'Posted-message wrapper must preserve its exact direct process, ownership, deadline, and native-post sequence.'
+}
+$statefulPostTokens = $null
+$statefulPostErrors = $null
+$statefulPostAst = [System.Management.Automation.Language.Parser]::ParseInput($statefulPostedCommandText, [ref]$statefulPostTokens, [ref]$statefulPostErrors)
+$statefulPostFunctions = @($statefulPostAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true))
+if ($statefulPostErrors.Count -ne 0 -or $statefulPostFunctions.Count -ne 1 -or
+    $statefulPostFunctions[0].Name -ne 'Invoke-StatefulPostedCommand') {
+    throw 'Stateful posted-command contract does not parse to the exact named function.'
+}
+$statefulPostParameters = @($statefulPostFunctions[0].Parameters)
+$statefulPostStatements = @($statefulPostFunctions[0].Body.EndBlock.Statements)
+$statefulPostTraps = @($statefulPostFunctions[0].Body.FindAll({ param($node) $node -is [System.Management.Automation.Language.TrapStatementAst] }, $true))
+if ($statefulPostParameters.Count -ne 4 -or
+    $statefulPostParameters[0].Extent.Text.Trim() -ne '[IntPtr] $Hwnd' -or
+    $statefulPostParameters[1].Extent.Text.Trim() -ne '[int] $Id' -or
+    $statefulPostParameters[2].Extent.Text.Trim() -ne '[DateTime] $Deadline' -or
+    $statefulPostParameters[3].Extent.Text.Trim() -ne '[Parameter(Mandatory)] [System.Diagnostics.Process] $Process' -or
+    $null -ne $statefulPostFunctions[0].Body.DynamicParamBlock -or $null -ne $statefulPostFunctions[0].Body.BeginBlock -or
+    $null -ne $statefulPostFunctions[0].Body.ProcessBlock -or $null -ne $statefulPostFunctions[0].Body.CleanBlock -or
+    $statefulPostTraps.Count -ne 0 -or
+    $statefulPostStatements.Count -ne 1 -or
+    $statefulPostStatements[0].Extent.Text.Trim() -notmatch '(?s)^Invoke-InteractiveWin11PostMessage\s+`\s*-Hwnd \$Hwnd\s+`\s*-Message 0x0111\s+`\s*-WParam \(\[UIntPtr\]::new\(\[uint64\]\$Id\)\)\s+`\s*-Deadline \$Deadline\s+`\s*-Description "WM_COMMAND id=\$Id"\s+`\s*-Process \$Process$') {
+    throw 'Stateful posted-command wrapper must require and forward its exact deadline and process.'
+}
+$paletteThemeTokens = $null
+$paletteThemeErrors = $null
+$paletteThemeAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $paletteThemeHarnessText,
+    [ref]$paletteThemeTokens,
+    [ref]$paletteThemeErrors
+)
+if ($paletteThemeErrors.Count -ne 0) { throw "Palette theme harness does not parse: $($paletteThemeErrors[0].Message)" }
+Assert-CommandResolutionContract -Ast $paletteThemeAst -Context $paletteThemeHarness -ExpectedDotSources @(
+    ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')",
+    ". (Join-Path `$PSScriptRoot 'interactive-win11-stateful-lib.ps1')"
+)
+Assert-NoProtectedFunctionDefinitions -Ast $paletteThemeAst -Context $paletteThemeHarness
+$paletteThemeTraps = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.TrapStatementAst]
+}, $true))
+$paletteThemeFunctions = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+}, $true))
+$openThemeQueryFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Open-ThemeQuery')
+if ($paletteThemeFunctions.Count -ne 1 -or $openThemeQueryFunctions.Count -ne 1) {
+    throw 'Palette theme harness must define only the exact Open-ThemeQuery function.'
+}
+$openThemeQueryParameters = @($openThemeQueryFunctions[0].Parameters)
+if ($openThemeQueryParameters.Count -ne 4 -or
+    $openThemeQueryParameters[0].Extent.Text.Trim() -ne '[IntPtr]$HostHwnd' -or
+    $openThemeQueryParameters[1].Extent.Text.Trim() -ne '[string]$Query' -or
+    $openThemeQueryParameters[2].Extent.Text.Trim() -ne '[DateTime]$Deadline' -or
+    $openThemeQueryParameters[3].Extent.Text.Trim() -ne '$Process') {
+    throw 'Palette query opening must preserve its exact non-executable parameter contract.'
+}
+$openThemeQueryBody = $openThemeQueryFunctions[0].Body
+if ($null -ne $openThemeQueryBody.DynamicParamBlock -or $null -ne $openThemeQueryBody.BeginBlock -or
+    $null -ne $openThemeQueryBody.ProcessBlock -or
+    $null -ne $openThemeQueryBody.CleanBlock -or $paletteThemeTraps.Count -ne 0) {
+    throw 'Palette query opening must not use alternate named blocks or traps that can bypass fail-closed deadline errors.'
+}
+$openThemeQueryStatements = @($openThemeQueryBody.EndBlock.Statements)
+if ($openThemeQueryStatements.Count -ne 6 -or
+    $openThemeQueryStatements[0].Extent.Text.Trim() -ne 'Invoke-StatefulPostedCommand $HostHwnd 1901 $Deadline $Process' -or
+    $openThemeQueryStatements[1].Extent.Text.Trim() -ne '$script:PaletteThemeHost = $HostHwnd' -or
+    $openThemeQueryStatements[2].Extent.Text.Trim() -notmatch '(?s)^Wait-InteractiveWin11Until -Deadline \$Deadline -Description ''palette query edit'' -Process \$Process -Condition \{\s*@\(Get-StatefulChildren \$script:PaletteThemeHost \| Where-Object Id -eq 2002\)\.Count -gt 0\s*\}$' -or
+    $openThemeQueryStatements[3].Extent.Text.Trim() -ne '$edit = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2002 | Select-Object -First 1' -or
+    $openThemeQueryStatements[4].Extent.Text.Trim() -ne 'Set-StatefulEditText $HostHwnd $edit.Hwnd $Query $Deadline $Process' -or
+    $openThemeQueryStatements[5].Extent.Text.Trim() -ne 'return $edit.Hwnd') {
+    throw 'Palette query opening must preserve its complete fail-closed command, wait, edit, and return sequence.'
+}
+$paletteMainTries = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.TryStatementAst] -and
+        $node.Parent -is [System.Management.Automation.Language.NamedBlockAst]
+}, $true))
+$paletteOpenCalls = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Open-ThemeQuery'
+}, $true))
+$paletteNormalOpenCalls = @($paletteOpenCalls | Where-Object {
+    $_.Extent.Text.Trim() -eq "Open-ThemeQuery `$hostHwnd '0x96f' `$deadline `$run.Process"
+})
+$paletteHighContrastOpenCalls = @($paletteOpenCalls | Where-Object {
+    $_.Extent.Text.Trim() -eq "Open-ThemeQuery `$hcHost 'Dracula' `$deadline `$hcRun.Process"
+})
+if ($paletteMainTries.Count -ne 1 -or $paletteOpenCalls.Count -ne 3 -or
+    $paletteNormalOpenCalls.Count -ne 2 -or $paletteHighContrastOpenCalls.Count -ne 1) {
+    throw 'Palette theme harness must preserve its three exact Open-ThemeQuery calls.'
+}
+foreach ($call in $paletteNormalOpenCalls) {
+    if (-not (Test-DirectStatementBlockChild -Node $call -StatementBlock $paletteMainTries[0].Body)) {
+        throw 'Normal palette query calls must be direct statements in the main try body.'
+    }
+}
+$paletteHighContrastCallIf = $null
+foreach ($candidate in @($paletteThemeAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.IfStatementAst] }, $true))) {
+    foreach ($clause in $candidate.Clauses) {
+        if ($clause.Item1.Extent.Text.Trim() -eq '$ExerciseHighContrast' -and
+            (Test-DirectStatementBlockChild -Node $paletteHighContrastOpenCalls[0] -StatementBlock $clause.Item2)) {
+            if ($null -ne $paletteHighContrastCallIf) { throw 'High Contrast palette query call appears in multiple control-flow blocks.' }
+            $paletteHighContrastCallIf = $candidate
+        }
+    }
+}
+if ($null -eq $paletteHighContrastCallIf -or
+    -not (Test-DirectStatementBlockChild -Node $paletteHighContrastCallIf -StatementBlock $paletteMainTries[0].Body)) {
+    throw 'High Contrast palette query call must be direct in its main-try ExerciseHighContrast block.'
+}
 $sessionRestoreTabSeedLoop = Get-PowerShellBlockText `
     -Content $sessionRestoreHarnessText `
     -HeaderPattern '^foreach \(\$targetTabCount in 2\.\.3\)'
@@ -242,7 +663,7 @@ $sessionDeadlineNodes = @($sessionLoopNodes | Where-Object {
 })
 $sessionCommandNodes = @($sessionLoopNodes | Where-Object {
     $_ -is [System.Management.Automation.Language.CommandAst] -and
-    $_.Extent.Text.Trim() -eq 'Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process'
+    $_.Extent.Text.Trim() -eq 'Invoke-StatefulPostedCommand $hostHwnd 1904 $deadline $first.Process'
 })
 $sessionWaitNodes = @($sessionLoopNodes | Where-Object {
     $_ -is [System.Management.Automation.Language.CommandAst] -and
@@ -259,7 +680,7 @@ $sessionReadyNodes = @($sessionLoopNodes | Where-Object {
 if ($sessionDeadlineNodes.Count -ne 1 -or $sessionCommandNodes.Count -ne 1 -or
     $sessionWaitNodes.Count -ne 1 -or $sessionBarrierNodes.Count -ne 1 -or
     $sessionReadyNodes.Count -ne 1) {
-    throw 'Session restore tab-seed loop must contain one exact deadline, send, count wait, equality barrier, and pump-readiness barrier per iteration.'
+    throw 'Session restore tab-seed loop must contain one exact deadline, queued command, count wait, equality barrier, and pump-readiness barrier per iteration.'
 }
 $sessionParsedSeedLoops = @($sessionLoopNodes | Where-Object {
     $_ -is [System.Management.Automation.Language.ForEachStatementAst] -and
@@ -293,6 +714,13 @@ $sessionHarnessAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$sessionHarnessErrors
 )
 if ($sessionHarnessErrors.Count -ne 0) { throw "Session restore harness does not parse: $($sessionHarnessErrors[0].Message)" }
+Assert-CommandResolutionContract -Ast $sessionHarnessAst -Context $sessionRestoreHarness -ExpectedDotSources @(
+    ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')",
+    ". (Join-Path `$PSScriptRoot 'interactive-win11-stateful-lib.ps1')"
+)
+Assert-NoProtectedFunctionDefinitions -Ast $sessionHarnessAst -Context $sessionRestoreHarness
+$sessionTraps = @($sessionHarnessAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.TrapStatementAst] }, $true))
+if ($sessionTraps.Count -ne 0) { throw 'Session restore harness must not use traps that swallow validation failures.' }
 $sessionMainTries = @($sessionHarnessAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.TryStatementAst] -and
@@ -307,10 +735,50 @@ if ($sessionMainTries.Count -ne 1 -or $sessionSeedLoops.Count -ne 1 -or
     -not (Test-DirectStatementBlockChild -Node $sessionSeedLoops[0] -StatementBlock $sessionMainTries[0].Body)) {
     throw 'Session restore tab seeding must be one direct, executable loop in the main try body.'
 }
+$sessionInitialHostWaits = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$hostHwnd = Wait-StatefulHost $first $deadline'
+}, $true))
+$sessionInitialTabWaits = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Wait-InteractiveWin11Until -Deadline $deadline -Description ''initial session-save tab'' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 1 }'
+}, $true))
+$sessionInitialReadyBarriers = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$null = Invoke-InteractiveWin11Message -Hwnd $hostHwnd -Message 0 -Deadline $deadline -Description ''initial session-save host readiness barrier'' -Process $first.Process'
+}, $true))
+if ($sessionInitialHostWaits.Count -ne 1 -or $sessionInitialTabWaits.Count -ne 1 -or
+    $sessionInitialReadyBarriers.Count -ne 1) {
+    throw 'Session restore must contain one exact initial host wait, exact tab-count wait, and nonmutating pump-readiness barrier.'
+}
+foreach ($node in @($sessionInitialHostWaits[0], $sessionInitialTabWaits[0], $sessionInitialReadyBarriers[0])) {
+    if (-not (Test-DirectStatementBlockChild -Node $node -StatementBlock $sessionMainTries[0].Body)) {
+        throw 'Session restore initial host, tab-count, and readiness waits must be direct, executable statements in the main try body.'
+    }
+}
+$sessionInitialStatements = @($sessionMainTries[0].Body.Statements)
+$sessionInitialWaitIndex = -1
+$sessionInitialTabIndex = -1
+$sessionInitialReadyIndex = -1
+$sessionInitialSeedIndex = -1
+for ($i = 0; $i -lt $sessionInitialStatements.Count; $i++) {
+    if ([object]::ReferenceEquals($sessionInitialStatements[$i], $sessionInitialHostWaits[0])) { $sessionInitialWaitIndex = $i }
+    if ([object]::ReferenceEquals($sessionInitialStatements[$i], $sessionInitialTabWaits[0].Parent)) { $sessionInitialTabIndex = $i }
+    if ([object]::ReferenceEquals($sessionInitialStatements[$i], $sessionInitialReadyBarriers[0])) { $sessionInitialReadyIndex = $i }
+    if ([object]::ReferenceEquals($sessionInitialStatements[$i], $sessionSeedLoops[0])) { $sessionInitialSeedIndex = $i }
+}
+if ($sessionInitialTabIndex -ne ($sessionInitialWaitIndex + 1) -or
+    $sessionInitialReadyIndex -ne ($sessionInitialTabIndex + 1) -or
+    $sessionInitialSeedIndex -ne ($sessionInitialReadyIndex + 1)) {
+    throw 'Session restore must prove initial tab creation and host pump readiness on the startup deadline immediately before tab seeding.'
+}
 $sessionBurstCommands = @($sessionHarnessAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.CommandAst] -and
-        $node.Extent.Text.Trim() -eq 'Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process'
+        $node.Extent.Text.Trim() -eq 'Invoke-StatefulPostedCommand $explicitHost 1904 $deadline $explicit.Process'
 }, $true))
 $sessionExplicitStarts = @($sessionHarnessAst.FindAll({
     param($node)
@@ -321,6 +789,16 @@ $sessionBurstWaits = @($sessionHarnessAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.CommandAst] -and
         $node.Extent.Text.Trim() -eq "Wait-InteractiveWin11Until -Deadline `$deadline -Description 'asynchronous burst-created tabs' -Process `$explicit.Process -Condition { (Get-StatefulTabCount `$explicitHost) -eq 3 }"
+}, $true))
+$sessionExplicitTabWaits = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq "Wait-InteractiveWin11Until -Deadline `$deadline -Description 'fresh explicit-command tab' -Process `$explicit.Process -Condition { (Get-StatefulTabCount `$explicitHost) -eq 1 }"
+}, $true))
+$sessionExplicitHostWaits = @($sessionHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$explicitHost = Wait-StatefulHost $explicit $deadline'
 }, $true))
 $sessionBurstReady = @($sessionHarnessAst.FindAll({
     param($node)
@@ -343,15 +821,16 @@ $sessionInvariantLoops = @($sessionHarnessAst.FindAll({
         $node.Parent -is [System.Management.Automation.Language.NamedBlockAst] -and
         $node.Extent.Text.Trim() -match '(?s)^foreach \(\$run in \$runs\) \{\s*if \(Select-String -LiteralPath \$run\.Stderr -SimpleMatch ''shell/native invariant failed'' -Quiet\) \{\s*throw "Shell/native invariant failure reported by \$\(\$run\.Stderr\)\."\s*\}\s*\}$'
 }, $true))
-if ($sessionExplicitStarts.Count -ne 1 -or $sessionBurstCommands.Count -ne 2 -or
+if ($sessionExplicitStarts.Count -ne 1 -or $sessionExplicitHostWaits.Count -ne 1 -or
+    $sessionExplicitTabWaits.Count -ne 1 -or $sessionBurstCommands.Count -ne 2 -or
     $sessionBurstWaits.Count -ne 1 -or $sessionBurstReady.Count -ne 1 -or
     $sessionExplicitCloses.Count -ne 1 -or $sessionInvariantLoops.Count -ne 1) {
     throw 'Session restore validation must preserve the explicit-process burst phase, its exact-count/pump barriers, and invariant-log rejection.'
 }
 $sessionBurstDeadlines = @($sessionExactDeadlines | Where-Object {
     (Test-DirectStatementBlockChild -Node $_ -StatementBlock $sessionMainTries[0].Body) -and
-    $_.Extent.StartOffset -gt $sessionBurstCommands[1].Extent.EndOffset -and
-    $_.Extent.EndOffset -lt $sessionBurstWaits[0].Extent.StartOffset
+    $_.Extent.StartOffset -gt $sessionExplicitTabWaits[0].Extent.EndOffset -and
+    $_.Extent.EndOffset -lt $sessionBurstCommands[0].Extent.StartOffset
 })
 $sessionCloseDeadlines = @($sessionExactDeadlines | Where-Object {
     (Test-DirectStatementBlockChild -Node $_ -StatementBlock $sessionMainTries[0].Body) -and
@@ -363,9 +842,10 @@ if ($sessionBurstDeadlines.Count -ne 1 -or $sessionCloseDeadlines.Count -ne 1) {
 }
 $sessionDirectBurstNodes = @(
     $sessionExplicitStarts[0],
+    $sessionExplicitTabWaits[0],
+    $sessionBurstDeadlines[0],
     $sessionBurstCommands[0],
     $sessionBurstCommands[1],
-    $sessionBurstDeadlines[0],
     $sessionBurstWaits[0],
     $sessionBurstReady[0],
     $sessionCloseDeadlines[0],
@@ -594,6 +1074,24 @@ if ($sessionStartAssignments.Count -eq $sessionExpectedStartAssignments.Count -a
         if ($addIndex -ne ($startIndex + 1)) {
             throw 'Session restore must register each launched process immediately for cleanup and invariant scanning.'
         }
+        if ($i -eq 0 -and (
+            $startIndex -le 0 -or
+            $sessionMainTryStatements[$startIndex - 1].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+            $sessionInitialWaitIndex -ne ($addIndex + 1))) {
+            throw 'Session restore initial launch, evidence registration, and host wait must share one original startup deadline without intervening work.'
+        }
+        if ($i -eq 1) {
+            $explicitHostStatement = Get-DirectStatementBlockChild -Node $sessionExplicitHostWaits[0] -StatementBlock $sessionMainTries[0].Body
+            $explicitTabStatement = Get-DirectStatementBlockChild -Node $sessionExplicitTabWaits[0] -StatementBlock $sessionMainTries[0].Body
+            $burstDeadlineStatement = Get-DirectStatementBlockChild -Node $sessionBurstDeadlines[0] -StatementBlock $sessionMainTries[0].Body
+            $explicitHostIndex = [Array]::IndexOf($sessionMainTryStatements, $explicitHostStatement)
+            $explicitTabIndex = [Array]::IndexOf($sessionMainTryStatements, $explicitTabStatement)
+            $burstDeadlineIndex = [Array]::IndexOf($sessionMainTryStatements, $burstDeadlineStatement)
+            if ($explicitHostIndex -ne ($addIndex + 1) -or $explicitTabIndex -ne ($explicitHostIndex + 1) -or
+                $burstDeadlineIndex -ne ($explicitTabIndex + 1)) {
+                throw 'Session explicit launch must proceed directly through host/tab readiness into the fresh burst deadline.'
+            }
+        }
     }
 }
 if ($sessionInvariantIfs.Count -ne 1 -or $sessionInvariantThrows.Count -ne 1 -or
@@ -623,25 +1121,33 @@ if ($sessionInvariantIfs.Count -ne 1 -or $sessionInvariantThrows.Count -ne 1 -or
 }
 $sessionBurstOffsets = @(
     $sessionExplicitStarts[0].Extent.StartOffset,
-    $sessionBurstCommands[0].Extent.StartOffset,
-    $sessionBurstCommands[1].Extent.StartOffset,
-    $sessionBurstDeadlines[0].Extent.StartOffset,
-    $sessionBurstWaits[0].Extent.StartOffset,
-    $sessionBurstReady[0].Extent.StartOffset,
-    $sessionCloseDeadlines[0].Extent.StartOffset,
-    $sessionExplicitCloses[0].Extent.StartOffset
+    $sessionExplicitTabWaits[0].Extent.StartOffset,
+    $sessionBurstDeadlines[0].Extent.StartOffset
 )
 for ($i = 1; $i -lt $sessionBurstOffsets.Count; $i++) {
     if ($sessionBurstOffsets[$i - 1] -ge $sessionBurstOffsets[$i]) {
         throw 'Session restore asynchronous burst operations are not in fail-closed causal order.'
     }
 }
-$betweenBurstPosts = $sessionRestoreHarnessText.Substring(
-    $sessionBurstCommands[0].Extent.EndOffset,
-    $sessionBurstCommands[1].Extent.StartOffset - $sessionBurstCommands[0].Extent.EndOffset
+$sessionBurstSequenceNodes = @(
+    $sessionBurstDeadlines[0],
+    $sessionBurstCommands[0],
+    $sessionBurstCommands[1],
+    $sessionBurstWaits[0],
+    $sessionBurstReady[0],
+    $sessionCloseDeadlines[0],
+    $sessionExplicitCloses[0]
 )
-if ($betweenBurstPosts -notmatch '^\s*$') {
-    throw 'Session restore asynchronous new-tab posts must remain adjacent.'
+$sessionBurstMainStatements = @($sessionMainTries[0].Body.Statements)
+$sessionBurstStatementIndices = foreach ($node in $sessionBurstSequenceNodes) {
+    $statement = Get-DirectStatementBlockChild -Node $node -StatementBlock $sessionMainTries[0].Body
+    if ($null -eq $statement) { throw 'Session restore burst sequence contains a nested operation.' }
+    [Array]::IndexOf($sessionBurstMainStatements, $statement)
+}
+for ($i = 1; $i -lt $sessionBurstStatementIndices.Count; $i++) {
+    if ($sessionBurstStatementIndices[$i] -ne ($sessionBurstStatementIndices[$i - 1] + 1)) {
+        throw 'Session restore burst deadline, posts, proof barriers, and close must remain adjacent statements.'
+    }
 }
 Assert-TextContract `
     -Content (Get-YamlStepText -Content $releaseWorkflowText -Name 'Release preflight' -Source $releaseWorkflow) `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -223,12 +223,49 @@ Assert-TextContract `
     -Context "$testWorkflow :: Remote release copy checks"
 Assert-TextContract `
     -Content (Get-YamlStepText `
+        -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows' -Source $testWorkflow) `
+        -Name 'Setup Zig' `
+        -Source "$testWorkflow :: windows") `
+    -Pattern '(?ms)with:\s+version: 0\.15\.2\s+.*?use-cache: false' `
+    -Description 'hosted Windows tests cannot restore failed Zig build caches' `
+    -Context "$testWorkflow :: windows :: Setup Zig"
+Assert-TextContract `
+    -Content (Get-YamlStepText `
+        -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-portable-smoke' -Source $testWorkflow) `
+        -Name 'Setup Zig' `
+        -Source "$testWorkflow :: windows-portable-smoke") `
+    -Pattern '(?ms)with:\s+version: 0\.15\.2\s+.*?use-cache: false' `
+    -Description 'portable smoke cannot restore failed Zig build caches' `
+    -Context "$testWorkflow :: windows-portable-smoke :: Setup Zig"
+Assert-TextContract `
+    -Content (Get-YamlStepText `
+        -Content (Get-YamlJobText -Content $releaseWorkflowText -Name 'windows-release' -Source $releaseWorkflow) `
+        -Name 'Setup Zig' `
+        -Source "$releaseWorkflow :: windows-release") `
+    -Pattern '(?ms)with:\s+version: 0\.15\.2\s+.*?use-cache: false' `
+    -Description 'release builds cannot restore failed Zig build caches' `
+    -Context "$releaseWorkflow :: windows-release :: Setup Zig"
+Assert-TextContract `
+    -Content (Get-YamlStepText `
         -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
         -Name 'Setup Zig' `
         -Source "$testWorkflow :: windows-interactive") `
     -Pattern '(?ms)with:\s+version: 0\.15\.2\s+.*?use-cache: false' `
     -Description 'ephemeral interactive retries cannot restore failed Zig build caches' `
     -Context "$testWorkflow :: windows-interactive :: Setup Zig"
+Assert-TextContract `
+    -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
+    -Pattern '(?ms)env:\s+ZIG_GLOBAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-global-cache\s+ZIG_LOCAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-local-cache' `
+    -Description 'interactive builds use clean per-job Zig caches' `
+    -Context "$testWorkflow :: windows-interactive"
+Assert-WorkflowContract `
+    -Path (Join-Path $repoRoot 'scripts\dev-windows.cmd') `
+    -Pattern '(?s)if "%ZIG_GLOBAL_CACHE_DIR%"=="" set "ZIG_GLOBAL_CACHE_DIR=.*?if "%ZIG_LOCAL_CACHE_DIR%"=="" set "ZIG_LOCAL_CACHE_DIR=' `
+    -Description 'Windows bootstrap preserves caller-provided Zig cache isolation'
+Assert-WorkflowContract `
+    -Path (Join-Path $repoRoot 'scripts\dev-windows.ps1') `
+    -Pattern '(?s)IsNullOrWhiteSpace\(\$env:ZIG_GLOBAL_CACHE_DIR\).*?IsNullOrWhiteSpace\(\$env:ZIG_LOCAL_CACHE_DIR\)' `
+    -Description 'PowerShell Windows bootstrap preserves caller-provided Zig cache isolation'
 Assert-TextContract `
     -Content (Get-YamlStepText -Content $testWorkflowText -Name 'Upload interactive evidence' -Source $testWorkflow) `
     -Pattern '(?ms)include-hidden-files: true.*?github\.workspace.*?\.sandbox/win11/\*\*/logs/\*\*' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1564,6 +1564,8 @@ Assert-TextContract `
     -Description 'package-manager preflight invokes the WinGet architecture gate' `
     -Context "$releasePreflight :: RequirePackageManagers"
 
+& (Join-Path $root 'Test-WindowsX64Baseline.ps1')
+
 foreach ($baselinePath in Get-ChildItem -LiteralPath (Join-Path $root 'baselines') -Filter '*.json') {
     Assert-JsonDocument `
         -Path $baselinePath.FullName `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -440,6 +440,7 @@ $paletteThemeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-palet
 $interactivePrSmoke = Join-Path $repoRoot 'test\windows\interactive-win11-pr-smoke.ps1'
 $releaseCopyChecker = Join-Path $repoRoot 'scripts\check-release-copy.ps1'
 $releasePreflight = Join-Path $repoRoot 'scripts\release-preflight.ps1'
+$windowsPackager = Join-Path $repoRoot 'scripts\package-windows.ps1'
 $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
 $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
@@ -1558,6 +1559,14 @@ Assert-WorkflowContract `
     -Path $releasePreflight `
     -Pattern '\$minimumValidityDays -lt 180(?!\d)' `
     -Description 'signer-validity overrides cannot lower the 180-day floor'
+Assert-WorkflowContract `
+    -Path $windowsPackager `
+    -Pattern '(?ms)& zig build .*?\r?\n\s+if \(\$LASTEXITCODE -ne 0\) \{\s*throw "Zig build failed with exit code \$LASTEXITCODE\."' `
+    -Description 'Windows packaging fails closed when its native Zig build fails'
+Assert-WorkflowContract `
+    -Path $windowsPackager `
+    -Pattern '(?ms)foreach \(\$runtimeFile in \$runtimeFiles\).*?Assert-PeMachine.*?if \(\$Architecture -eq "x64"\).*?check-windows-x64-baseline\.ps1.*?-Path \$runtimePath' `
+    -Description 'Windows packaging checks every x64 runtime PE for baseline compatibility'
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content (Get-Content -LiteralPath $releasePreflight -Raw) -HeaderPattern '^function\s+Assert-WingetArchitectureCoverage(?=\s|\{)') `
     -Pattern '(?ms)Assert-WingetArchitectureCoverage.*?Architecture:.*?arm64,x64' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -172,12 +172,16 @@ function Get-MemberExpressionName {
 function Test-DynamicScriptTypeName {
     param([Parameter(Mandatory)] [AllowEmptyString()] [string] $TypeName)
 
-    $typeName = (($TypeName -split ',', 2)[0] -replace '\s', '')
+    $typeName = ((($TypeName -split ',', 2)[0] -replace '\s', '')).ToLowerInvariant()
     return $typeName -in @(
-        'ScriptBlock',
-        'System.Management.Automation.ScriptBlock',
-        'PowerShell',
-        'System.Management.Automation.PowerShell'
+        'scriptblock',
+        'system.management.automation.scriptblock',
+        'powershell',
+        'system.management.automation.powershell',
+        'runspace',
+        'runspacefactory',
+        'system.management.automation.runspaces.runspace',
+        'system.management.automation.runspaces.runspacefactory'
     )
 }
 
@@ -237,7 +241,9 @@ function Test-CommandResolutionMutationNode {
         $isGetTypeArgument = $Node.Parent -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
             (Get-MemberExpressionName -Node $Node.Parent) -eq 'GetType' -and
             @($Node.Parent.Arguments | Where-Object { [object]::ReferenceEquals($_, $Node) }).Count -eq 1
-        if ($isTypeConversion -or $isGetTypeArgument) { return $true }
+        $isAsTypeArgument = $Node.Parent -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+            $Node.Parent.Operator -eq [System.Management.Automation.Language.TokenKind]::As
+        if ($isTypeConversion -or $isGetTypeArgument -or $isAsTypeArgument) { return $true }
     }
     if ($Node -is [System.Management.Automation.Language.VariableExpressionAst] -and
         (($Node.VariablePath.UserPath -split ':')[-1] -eq 'ExecutionContext')) {
@@ -263,7 +269,11 @@ function Test-CommandResolutionMutationNode {
         $memberName = Get-MemberExpressionName -Node $Node
         if ($Node.Extent.Text -match '(?is)TypeAccelerators.*(?:Add|Remove)\b') { return $true }
         if ((Test-DynamicScriptTypeExpression -Node $Node.Expression) -and
-            $memberName -in @('Create', 'GetMethod', 'GetMethods')) {
+            $memberName -in @('Create', 'CreateRunspace', 'CreatePipeline', 'CreateNestedPipeline', 'GetMethod', 'GetMethods')) {
+            return $true
+        }
+        if ($memberName -eq 'SessionState' -and
+            (Test-ExecutionContextRoot -Node $Node.Expression)) {
             return $true
         }
         # Reject access to the InvokeCommand object itself so assigning it to
@@ -282,11 +292,11 @@ function Test-CommandResolutionMutationNode {
     if ($Node -is [System.Management.Automation.Language.CommandAst]) {
         $name = $Node.GetCommandName()
         $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
-        return $leafName -in @('Set-Alias', 'sal', 'New-Alias', 'nal', 'Remove-Alias', 'ral', 'Import-Alias', 'ipal', 'Import-Module', 'ipmo', 'Import-PSSession', 'Invoke-Expression', 'iex') -or
-            $Node.Extent.Text -match '(?i)(?:alias|function):'
+        return $leafName -in @('Set-Alias', 'sal', 'New-Alias', 'nal', 'Remove-Alias', 'ral', 'Import-Alias', 'ipal', 'Import-Module', 'ipmo', 'Import-PSSession', 'Invoke-Expression', 'iex', 'Get-Variable', 'gv') -or
+            $Node.Extent.Text -match '(?i)(?:alias|function|variable):'
     }
     if ($Node -is [System.Management.Automation.Language.AssignmentStatementAst]) {
-        return $Node.Left.Extent.Text -match '(?i)^\$(?:\{)?(?:global:|script:|local:|private:)?(?:alias|function):'
+        return $Node.Left.Extent.Text -match '(?i)^\$(?:\{)?(?:global:|script:|local:|private:)?(?:alias|function|variable):'
     }
     return $false
 }
@@ -350,6 +360,9 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '$global:ExecutionContext.InvokeCommand.NewScriptBlock("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ic = $ExecutionContext.InvokeCommand; $ic.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ic = ${ExecutionContext}.SessionState.InvokeCommand; $ic.NewScriptBlock("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ec = Get-Variable ExecutionContext -ValueOnly; $ec.InvokeCommand.InvokeScript("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$(Get-Item variable:ExecutionContext).Value.InvokeCommand.InvokeScript("1+1")' }
+    [pscustomobject]@{ Reject = $true; Text = '$ss = $ExecutionContext.SessionState; $ss.InvokeCommand.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$member = "Create"; [ScriptBlock]::$member("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$member = "InvokeCommand"; $ExecutionContext.$member.InvokeScript("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '$ec = $($ExecutionContext)' }
@@ -357,6 +370,9 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock].GetMethod("Create")' }
     [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation.ScriptBlock")' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [type]"System.Management.Automation.ScriptBlock"' }
+    [pscustomobject]@{ Reject = $true; Text = '$factory = "System.Management.Automation.ScriptBlock" -as [type]' }
+    [pscustomobject]@{ Reject = $true; Text = '[runspacefactory]::CreateRunspace()' }
+    [pscustomobject]@{ Reject = $true; Text = '[System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()' }
     [pscustomobject]@{ Reject = $false; Text = '[ScriptBlock]::CreateDelegate("x")' }
     [pscustomobject]@{ Reject = $true; Text = '$ExecutionContext.InvokeCommand.InvokeScriptBlock("x")' }
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("[ScriptBlock]::Create")' }

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1583,6 +1583,10 @@ Assert-WorkflowContract `
     -Description 'interactive PR smoke retries exactly the transient Zig cache hydration miss'
 Assert-WorkflowContract `
     -Path $interactivePrSmoke `
+    -Pattern "(?ms)\`$originalErrorActionPreference = \`$ErrorActionPreference\s*try \{\s*\`$ErrorActionPreference = 'Continue'\s*\`$buildOutput = @\(& \(Join-Path \`$repoRoot 'scripts\\dev-windows\.cmd'\) zig build -Demit-exe=true 2>&1\)\s*\`$buildExitCode = \`$LASTEXITCODE\s*\}\s*finally \{\s*\`$ErrorActionPreference = \`$originalErrorActionPreference\s*\}" `
+    -Description 'interactive PR smoke captures native build stderr without bypassing exit-code retry logic on PowerShell 7.0'
+Assert-WorkflowContract `
+    -Path $interactivePrSmoke `
     -Pattern "(?ms)if \(\`$attempt -eq 2 -and \`$env:RUNNER_TEMP\).*?zig-global-cache-pr-smoke-retry-\`$PID.*?zig-local-cache-pr-smoke-retry-\`$PID" `
     -Description 'interactive PR smoke moves the retry to fresh runner-temp Zig cache directories'
 Assert-WorkflowContract `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1606,6 +1606,22 @@ Assert-WorkflowContract `
     -Description 'accessibility evidence rejects unsupported runner provenance schemas'
 Assert-WorkflowContract `
     -Path $runnerProvenanceChecker `
+    -Pattern 'WINGHOSTTY_EXPECTED_CHECKOUT_SHA' `
+    -Description 'interactive provenance can verify an exact PR head checkout instead of only GITHUB_SHA'
+Assert-WorkflowContract `
+    -Path $runnerProvenanceChecker `
+    -Pattern 'commit = \$expectedCommit' `
+    -Description 'interactive provenance records the exact expected tested commit'
+Assert-WorkflowContract `
+    -Path $testWorkflow `
+    -Pattern "ref: \\\$\\{\\{ github\\.event_name == 'pull_request' && github\\.event\\.pull_request\\.head\\.sha \\|\\| github\\.sha \\}\\}" `
+    -Description 'Test workflow checkouts use the immutable PR head SHA for pull requests'
+Assert-WorkflowContract `
+    -Path (Join-Path $repoRoot '.github\workflows\windows-arm64.yml') `
+    -Pattern "ref: \\\$\\{\\{ github\\.event_name == 'pull_request' && github\\.event\\.pull_request\\.head\\.sha \\|\\| github\\.sha \\}\\}" `
+    -Description 'ARM64 workflow checkout uses the immutable PR head SHA for pull requests'
+Assert-WorkflowContract `
+    -Path $runnerProvenanceChecker `
     -Pattern '\$runnerVersion -lt \$minimumRunnerVersion' `
     -Description 'interactive evidence rejects outdated runners'
 Assert-WorkflowContract `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -506,6 +506,7 @@ $accessibilityChecker = Join-Path $repoRoot 'scripts\check-accessibility-evidenc
 $runnerProvenanceChecker = Join-Path $repoRoot 'test\windows\assert-interactive-runner.ps1'
 $interactiveWin11Lib = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
 $statefulWin11Lib = Join-Path $repoRoot 'test\windows\interactive-win11-stateful-lib.ps1'
+$accessibilityHarness = Join-Path $repoRoot 'test\windows\interactive-win11-accessibility.ps1'
 $sessionRestoreHarness = Join-Path $repoRoot 'test\windows\interactive-win11-session-restore.ps1'
 $paletteThemeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-palette-theme.ps1'
 $interactivePrSmoke = Join-Path $repoRoot 'test\windows\interactive-win11-pr-smoke.ps1'
@@ -517,6 +518,7 @@ $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
 $interactiveWin11LibText = Get-Content -LiteralPath $interactiveWin11Lib -Raw
 $statefulWin11LibText = Get-Content -LiteralPath $statefulWin11Lib -Raw
+$accessibilityHarnessText = Get-Content -LiteralPath $accessibilityHarness -Raw
 $sessionRestoreHarnessText = Get-Content -LiteralPath $sessionRestoreHarness -Raw
 $paletteThemeHarnessText = Get-Content -LiteralPath $paletteThemeHarness -Raw
 $resolutionSourceAsts = foreach ($source in @(
@@ -550,6 +552,21 @@ foreach ($source in $resolutionSourceAsts) {
             throw "Interactive library has the wrong ownership count for protected function $name`: $($source.Path)"
         }
     }
+}
+$accessibilityTokens = $null
+$accessibilityErrors = $null
+$accessibilityAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $accessibilityHarnessText,
+    [ref]$accessibilityTokens,
+    [ref]$accessibilityErrors
+)
+$accessibilityUIntPtrConversions = @($accessibilityAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ConvertExpressionAst] -and
+        $node.Type.TypeName.FullName -eq 'UIntPtr'
+}, $true))
+if ($accessibilityErrors.Count -ne 0 -or $accessibilityUIntPtrConversions.Count -ne 0) {
+    throw 'Accessibility harness must parse and construct nonzero WPARAM values through UIntPtr::new([uint64] ...).'
 }
 $timeoutFunctions = @($resolutionSourceAsts[0].Ast.FindAll({
     param($node)

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1490,6 +1490,18 @@ Assert-WorkflowContract `
     -Pattern "(?ms)if \(\`$harness -eq 'interactive-win11-undo\.ps1'\) \{\s*\`$harnessArgs \+= @\('-TimeoutSeconds', '35'\)\s*\}" `
     -Description 'interactive PR smoke preserves the documented undo harness timeout'
 Assert-WorkflowContract `
+    -Path $interactivePrSmoke `
+    -Pattern "(?ms)for \(\`$attempt = 1; \`$attempt -le 2; \`$attempt\+\+\).*?\`$cacheHydrationMiss = \`$buildText -match 'FileNotFound' -and \`$buildText -match 'zig-global-cache'.*?retrying once with fresh temp cache directories" `
+    -Description 'interactive PR smoke retries exactly the transient Zig cache hydration miss'
+Assert-WorkflowContract `
+    -Path $interactivePrSmoke `
+    -Pattern "(?ms)if \(\`$attempt -eq 2 -and \`$env:RUNNER_TEMP\).*?zig-global-cache-pr-smoke-retry-\`$PID.*?zig-local-cache-pr-smoke-retry-\`$PID" `
+    -Description 'interactive PR smoke moves the retry to fresh runner-temp Zig cache directories'
+Assert-WorkflowContract `
+    -Path $interactivePrSmoke `
+    -Pattern "(?ms)finally \{\s*\`$env:ZIG_GLOBAL_CACHE_DIR = \`$originalZigGlobalCache\s*\`$env:ZIG_LOCAL_CACHE_DIR = \`$originalZigLocalCache\s*\}" `
+    -Description 'interactive PR smoke restores caller-provided Zig cache directories after rebuild retry'
+Assert-WorkflowContract `
     -Path $accessibilityChecker `
     -Pattern '\[DateTimeOffset\]::TryParse\(' `
     -Description 'accessibility evidence timestamp is semantically validated'

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -153,6 +153,10 @@ function Get-DirectStatementBlockChild {
         [Parameter(Mandatory)] [System.Management.Automation.Language.StatementBlockAst] $StatementBlock
     )
 
+    if (-not (Test-DirectStatementBlockChild -Node $Node -StatementBlock $StatementBlock)) {
+        return $null
+    }
+
     $statement = $Node
     $ancestor = $Node.Parent
     while ($null -ne $ancestor -and $ancestor -isnot [System.Management.Automation.Language.StatementBlockAst]) {
@@ -268,6 +272,10 @@ function Test-CommandResolutionMutationNode {
         }
         $memberName = Get-MemberExpressionName -Node $Node
         if ($Node.Extent.Text -match '(?is)TypeAccelerators.*(?:Add|Remove)\b') { return $true }
+        if ($Node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $memberName -eq 'GetType' -and $Node.Arguments.Count -ne 0) {
+            return $true
+        }
         if ((Test-DynamicScriptTypeExpression -Node $Node.Expression) -and
             $memberName -in @('Create', 'CreateRunspace', 'CreatePipeline', 'CreateNestedPipeline', 'GetMethod', 'GetMethods')) {
             return $true
@@ -369,6 +377,8 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '$factory = [ScriptBlock]' }
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock].GetMethod("Create")' }
     [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation.ScriptBlock")' }
+    [pscustomobject]@{ Reject = $true; Text = '[PSObject].Assembly.GetType("System.Management.Automation." + "ScriptBlock")' }
+    [pscustomobject]@{ Reject = $true; Text = '$typeName = "System.Management.Automation.ScriptBlock"; [PSObject].Assembly.GetType($typeName)' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = [type]"System.Management.Automation.ScriptBlock"' }
     [pscustomobject]@{ Reject = $true; Text = '$factory = "System.Management.Automation.ScriptBlock" -as [type]' }
     [pscustomobject]@{ Reject = $true; Text = '[runspacefactory]::CreateRunspace()' }
@@ -386,6 +396,26 @@ foreach ($probe in $commandResolutionProbes) {
     if ($probeErrors.Count -ne 0) { throw "Command-resolution probe does not parse: $($probe.Text)" }
     $probeRejected = @($probeAst.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true)).Count -ne 0
     if ($probeRejected -ne $probe.Reject) { throw "Command-resolution probe contract failed: $($probe.Text)" }
+}
+
+$directStatementTokens = $null
+$directStatementErrors = $null
+$directStatementAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    'try { if ($(Invoke-StatefulPostedCommand 1 2 $deadline $process)) { } } finally { }',
+    [ref] $directStatementTokens,
+    [ref] $directStatementErrors
+)
+if ($directStatementErrors.Count -ne 0) {
+    throw "Direct-statement control-flow probe does not parse: $($directStatementErrors[0].Message)"
+}
+$directStatementTry = @($directStatementAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.TryStatementAst] }, $true))[0]
+$conditionalPostedCall = @($directStatementAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Invoke-StatefulPostedCommand'
+}, $true))[0]
+if ($null -ne (Get-DirectStatementBlockChild -Node $conditionalPostedCall -StatementBlock $directStatementTry.Body)) {
+    throw 'Direct-statement helper accepted a protected call nested in control flow.'
 }
 
 $stepBoundaryProbe = @'
@@ -1606,7 +1636,7 @@ Assert-WorkflowContract `
     -Description 'Windows packaging checks every x64 runtime PE for baseline compatibility'
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\check-windows-x64-baseline.ps1') `
-    -Pattern '(?ms)Get-Command llvm-objdump\.exe.*?\$objdumpTimeoutMs = 120000.*?\$streamCopyTimeoutMs = 30000.*?WaitForExit\(\$objdumpTimeoutMs\).*?\$objdumpProcess\.Kill\(\).*?WaitAll\(.*?\$streamCopyTimeoutMs.*?llvm-objdump stream cleanup timed out' `
+    -Pattern '(?ms)Get-Command llvm-objdump\.exe.*?\$objdumpTimeoutMs = 120000.*?\$objdumpKillTimeoutMs = 5000.*?\$streamCopyTimeoutMs = 30000.*?WaitForExit\(\$objdumpTimeoutMs\).*?\$objdumpProcess\.Kill\(\).*?WaitForExit\(\$objdumpKillTimeoutMs\).*?llvm-objdump did not exit after termination.*?WaitAll\(.*?\$streamCopyTimeoutMs.*?llvm-objdump stream cleanup timed out' `
     -Description 'Windows x64 baseline disassembly is time-bounded and kills a timed-out tool'
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content (Get-Content -LiteralPath $releasePreflight -Raw) -HeaderPattern '^function\s+Assert-WingetArchitectureCoverage(?=\s|\{)') `

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -1,0 +1,101 @@
+#requires -Version 7.3
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+$checker = Join-Path $repoRoot 'scripts/check-windows-x64-baseline.ps1'
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) "winghostty-x64-baseline-$([Guid]::NewGuid().ToString('N'))"
+
+function New-ProbePe {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [byte[]] $Text
+    )
+
+    $peOffset = 0x80
+    $sectionTable = $peOffset + 24
+    $rawPointer = 0x200
+    $rawSize = [Math]::Max(0x20, $Text.Length)
+    $bytes = [byte[]]::new($rawPointer + $rawSize)
+    $writer = [IO.BinaryWriter]::new([IO.MemoryStream]::new($bytes))
+    try {
+        $writer.Write([uint16]0x5A4D)
+        $writer.BaseStream.Position = 0x3C
+        $writer.Write([uint32]$peOffset)
+        $writer.BaseStream.Position = $peOffset
+        $writer.Write([uint32]0x00004550)
+        $writer.Write([uint16]0x8664)
+        $writer.Write([uint16]1)
+        $writer.BaseStream.Position = $peOffset + 20
+        $writer.Write([uint16]0)
+        $writer.BaseStream.Position = $sectionTable
+        $writer.Write([Text.Encoding]::ASCII.GetBytes(".text`0`0`0"))
+        $writer.Write([uint32]$Text.Length)
+        $writer.Write([uint32]0x1000)
+        $writer.Write([uint32]$rawSize)
+        $writer.Write([uint32]$rawPointer)
+        $writer.BaseStream.Position = $rawPointer
+        $writer.Write($Text)
+    }
+    finally {
+        $writer.Dispose()
+    }
+    [IO.File]::WriteAllBytes($Path, $bytes)
+}
+
+function Assert-BaselinePass {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [byte[]] $Text
+    )
+
+    $path = Join-Path $tempRoot "$Name.exe"
+    New-ProbePe -Path $path -Text $Text
+    & $checker -Path $path
+}
+
+function Assert-BaselineReject {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [byte[]] $Text
+    )
+
+    $path = Join-Path $tempRoot "$Name.exe"
+    New-ProbePe -Path $path -Text $Text
+    try {
+        & $checker -Path $path
+    }
+    catch {
+        if ($_.Exception.Message -notmatch 'AMD-only SSE4a EXTRQ/INSERTQ') {
+            throw
+        }
+        return
+    }
+    throw "CPU baseline checker accepted SSE4a probe '$Name'."
+}
+
+try {
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+    # Prefix bytes embedded in another instruction are not SSE4a opcodes.
+    Assert-BaselinePass -Name 'insertq-memory-form' -Text ([byte[]](0x90, 0xF2, 0x0F, 0x78, 0x00, 0x90, 0x90))
+    Assert-BaselinePass -Name 'extrq-wrong-extension' -Text ([byte[]](0x90, 0x66, 0x0F, 0x78, 0xC8, 0x01, 0x02))
+    Assert-BaselinePass -Name 'truncated-immediate' -Text ([byte[]](0x90, 0xF2, 0x0F, 0x78, 0xC1, 0x01))
+
+    Assert-BaselineReject -Name 'extrq-immediate' -Text ([byte[]](0x66, 0x0F, 0x78, 0xC0, 0x01, 0x02))
+    Assert-BaselineReject -Name 'extrq-register' -Text ([byte[]](0x66, 0x0F, 0x79, 0xC1))
+    Assert-BaselineReject -Name 'insertq-immediate-rex' -Text ([byte[]](0xF2, 0x41, 0x0F, 0x78, 0xC1, 0x01, 0x02))
+    Assert-BaselineReject -Name 'insertq-register' -Text ([byte[]](0xF2, 0x0F, 0x79, 0xC1))
+
+    Write-Host 'Windows x64 baseline checker probes: PASS'
+}
+finally {
+    $resolvedTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    $resolvedRoot = [IO.Path]::GetFullPath($tempRoot)
+    if ($resolvedRoot.StartsWith($resolvedTemp, [StringComparison]::OrdinalIgnoreCase) -and
+        (Test-Path -LiteralPath $resolvedRoot)) {
+        Remove-Item -LiteralPath $resolvedRoot -Recurse -Force
+    }
+}

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -109,6 +109,9 @@ function Assert-WindowsPowerShellObjdumpFailure {
 function Assert-ObjdumpTimeoutCleanupContract {
     $checkerText = Get-Content -LiteralPath $checker -Raw
     if ($checkerText -notmatch '\$objdumpProcess\.Kill\(\)' -or
+        $checkerText -notmatch '\$objdumpKillTimeoutMs\s*=\s*5000' -or
+        $checkerText -notmatch 'WaitForExit\(\$objdumpKillTimeoutMs\)' -or
+        $checkerText -notmatch 'llvm-objdump did not exit after termination' -or
         $checkerText -notmatch '\[System\.Threading\.Tasks\.Task\]::WaitAll\(' -or
         $checkerText -notmatch '\$streamCopyTimeoutMs' -or
         $checkerText -notmatch 'stream cleanup timed out') {

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -108,28 +108,37 @@ function Assert-WindowsPowerShellObjdumpFailure {
 
 try {
     New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
-    $fakeObjdump = Join-Path $tempRoot 'llvm-objdump.cmd'
-    [IO.File]::WriteAllText($fakeObjdump, @'
-@echo off
-:next_argument
-if "%~1"=="" goto arguments_done
-set "target=%~nx1"
-shift
-goto next_argument
-:arguments_done
-if /I "%target%"=="tool-failure.exe" (
-  echo synthetic llvm-objdump failure 1>&2
-  exit /b 7
-)
-for %%M in (extrq insertq movntsd movntss) do (
-  if /I "%target%"=="%%M.exe" (
-    echo 140001000:        %%M
-    exit /b 0
-  )
-)
-echo 140001000:        nop
-exit /b 0
+    $windowsPowerShell = Get-Command powershell.exe -CommandType Application -ErrorAction Stop |
+        Select-Object -First 1 -ExpandProperty Source
+    $fakeSource = Join-Path $tempRoot 'llvm-objdump.cs'
+    $fakeObjdump = Join-Path $tempRoot 'llvm-objdump.exe'
+    [IO.File]::WriteAllText($fakeSource, @'
+using System;
+using System.IO;
+
+public static class Program {
+    public static int Main(string[] args) {
+        string target = Path.GetFileName(args[args.Length - 1]);
+        if (target.Equals("tool-failure.exe", StringComparison.OrdinalIgnoreCase)) {
+            Console.Error.WriteLine("synthetic llvm-objdump failure");
+            return 7;
+        }
+        foreach (string mnemonic in new[] { "extrq", "insertq", "movntsd", "movntss" }) {
+            if (target.Equals(mnemonic + ".exe", StringComparison.OrdinalIgnoreCase)) {
+                Console.WriteLine("140001000:        " + mnemonic);
+                return 0;
+            }
+        }
+        Console.WriteLine("140001000:        nop");
+        return 0;
+    }
+}
 '@)
+    $compileCommand = "Add-Type -LiteralPath '$($fakeSource.Replace("'", "''"))' -OutputAssembly '$($fakeObjdump.Replace("'", "''"))' -OutputType ConsoleApplication"
+    & $windowsPowerShell -NoLogo -NoProfile -Command $compileCommand
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $fakeObjdump -PathType Leaf)) {
+        throw "Failed to compile the llvm-objdump fixture (exit=$LASTEXITCODE)."
+    }
     $env:PATH = "$tempRoot;$originalPath"
 
     Assert-BaselinePass -Name 'raw-sse4a-looking-data'

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -7,6 +7,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
 $checker = Join-Path $repoRoot 'scripts/check-windows-x64-baseline.ps1'
 $tempRoot = Join-Path ([IO.Path]::GetTempPath()) "winghostty-x64-baseline-$([Guid]::NewGuid().ToString('N'))"
+$originalPath = $env:PATH
 
 function New-ProbePe {
     param(
@@ -46,52 +47,81 @@ function New-ProbePe {
 }
 
 function Assert-BaselinePass {
-    param(
-        [Parameter(Mandatory)] [string] $Name,
-        [Parameter(Mandatory)] [byte[]] $Text
-    )
+    param([Parameter(Mandatory)] [string] $Name)
 
     $path = Join-Path $tempRoot "$Name.exe"
-    New-ProbePe -Path $path -Text $Text
-    & $checker -Path $path
+    # These bytes resemble EXTRQ inside .text. The fake disassembler reports
+    # only a decoded NOP, proving raw data is not treated as an instruction.
+    New-ProbePe -Path $path -Text ([byte[]](0x66, 0x0F, 0x78, 0xC0, 0x01, 0x02))
+    $output = @(& $checker -Path $path 6>&1)
+    if (($output -join "`n") -notmatch 'CPU baseline check: passed') {
+        throw "CPU baseline checker did not report its PASS sentinel for '$Name'."
+    }
 }
 
 function Assert-BaselineReject {
-    param(
-        [Parameter(Mandatory)] [string] $Name,
-        [Parameter(Mandatory)] [byte[]] $Text
-    )
+    param([Parameter(Mandatory)] [string] $Name)
 
     $path = Join-Path $tempRoot "$Name.exe"
-    New-ProbePe -Path $path -Text $Text
+    New-ProbePe -Path $path -Text ([byte[]](0x90))
     try {
         & $checker -Path $path
     }
     catch {
-        if ($_.Exception.Message -notmatch 'AMD-only SSE4a EXTRQ/INSERTQ') {
+        if ($_.Exception.Message -notmatch 'AMD-only SSE4a instructions') {
             throw
         }
         return
     }
-    throw "CPU baseline checker accepted SSE4a probe '$Name'."
+    throw "CPU baseline checker accepted decoded SSE4a probe '$Name'."
+}
+
+function Assert-ObjdumpFailure {
+    $path = Join-Path $tempRoot 'tool-failure.exe'
+    New-ProbePe -Path $path -Text ([byte[]](0x90))
+    try {
+        & $checker -Path $path
+    }
+    catch {
+        if ($_.Exception.Message -notmatch 'llvm-objdump failed with exit code 7') {
+            throw
+        }
+        return
+    }
+    throw 'CPU baseline checker ignored an llvm-objdump failure.'
 }
 
 try {
     New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    $fakeObjdump = Join-Path $tempRoot 'llvm-objdump.cmd'
+    [IO.File]::WriteAllText($fakeObjdump, @'
+@echo off
+set "target=%~nx3"
+if /I "%target%"=="tool-failure.exe" (
+  echo synthetic llvm-objdump failure 1>&2
+  exit /b 7
+)
+for %%M in (extrq insertq movntsd movntss) do (
+  if /I "%target%"=="%%M.exe" (
+    echo 140001000:        %%M
+    exit /b 0
+  )
+)
+echo 140001000:        nop
+exit /b 0
+'@)
+    $env:PATH = "$tempRoot;$originalPath"
 
-    # Prefix bytes embedded in another instruction are not SSE4a opcodes.
-    Assert-BaselinePass -Name 'insertq-memory-form' -Text ([byte[]](0x90, 0xF2, 0x0F, 0x78, 0x00, 0x90, 0x90))
-    Assert-BaselinePass -Name 'extrq-wrong-extension' -Text ([byte[]](0x90, 0x66, 0x0F, 0x78, 0xC8, 0x01, 0x02))
-    Assert-BaselinePass -Name 'truncated-immediate' -Text ([byte[]](0x90, 0xF2, 0x0F, 0x78, 0xC1, 0x01))
-
-    Assert-BaselineReject -Name 'extrq-immediate' -Text ([byte[]](0x66, 0x0F, 0x78, 0xC0, 0x01, 0x02))
-    Assert-BaselineReject -Name 'extrq-register' -Text ([byte[]](0x66, 0x0F, 0x79, 0xC1))
-    Assert-BaselineReject -Name 'insertq-immediate-rex' -Text ([byte[]](0xF2, 0x41, 0x0F, 0x78, 0xC1, 0x01, 0x02))
-    Assert-BaselineReject -Name 'insertq-register' -Text ([byte[]](0xF2, 0x0F, 0x79, 0xC1))
+    Assert-BaselinePass -Name 'raw-sse4a-looking-data'
+    foreach ($mnemonic in @('extrq', 'insertq', 'movntsd', 'movntss')) {
+        Assert-BaselineReject -Name $mnemonic
+    }
+    Assert-ObjdumpFailure
 
     Write-Host 'Windows x64 baseline checker probes: PASS'
 }
 finally {
+    $env:PATH = $originalPath
     $resolvedTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
     $resolvedRoot = [IO.Path]::GetFullPath($tempRoot)
     if ($resolvedRoot.StartsWith($resolvedTemp, [StringComparison]::OrdinalIgnoreCase) -and

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -91,12 +91,32 @@ function Assert-ObjdumpFailure {
     throw 'CPU baseline checker ignored an llvm-objdump failure.'
 }
 
+function Assert-WindowsPowerShellObjdumpFailure {
+    $windowsPowerShell = Get-Command powershell.exe -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty Source
+    if (-not $windowsPowerShell) { return }
+
+    $path = Join-Path $tempRoot 'tool-failure.exe'
+    $outputPath = Join-Path $tempRoot 'windows-powershell-failure.log'
+    & $windowsPowerShell -NoLogo -NoProfile -ExecutionPolicy Bypass -File $checker -Path $path *> $outputPath
+    $exitCode = $LASTEXITCODE
+    $output = Get-Content -LiteralPath $outputPath -Raw
+    if ($exitCode -eq 0 -or $output -notmatch 'llvm-objdump failed with exit code 7') {
+        throw "Windows PowerShell did not preserve the llvm-objdump failure (exit=$exitCode):$([Environment]::NewLine)$output"
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
     $fakeObjdump = Join-Path $tempRoot 'llvm-objdump.cmd'
     [IO.File]::WriteAllText($fakeObjdump, @'
 @echo off
-set "target=%~nx3"
+:next_argument
+if "%~1"=="" goto arguments_done
+set "target=%~nx1"
+shift
+goto next_argument
+:arguments_done
 if /I "%target%"=="tool-failure.exe" (
   echo synthetic llvm-objdump failure 1>&2
   exit /b 7
@@ -117,6 +137,7 @@ exit /b 0
         Assert-BaselineReject -Name $mnemonic
     }
     Assert-ObjdumpFailure
+    Assert-WindowsPowerShellObjdumpFailure
 
     Write-Host 'Windows x64 baseline checker probes: PASS'
 }

--- a/test/windows/flagship/Test-WindowsX64Baseline.ps1
+++ b/test/windows/flagship/Test-WindowsX64Baseline.ps1
@@ -106,6 +106,16 @@ function Assert-WindowsPowerShellObjdumpFailure {
     }
 }
 
+function Assert-ObjdumpTimeoutCleanupContract {
+    $checkerText = Get-Content -LiteralPath $checker -Raw
+    if ($checkerText -notmatch '\$objdumpProcess\.Kill\(\)' -or
+        $checkerText -notmatch '\[System\.Threading\.Tasks\.Task\]::WaitAll\(' -or
+        $checkerText -notmatch '\$streamCopyTimeoutMs' -or
+        $checkerText -notmatch 'stream cleanup timed out') {
+        throw 'CPU baseline checker must bound stream cleanup after killing a timed-out objdump process.'
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
     $windowsPowerShell = Get-Command powershell.exe -CommandType Application -ErrorAction Stop |
@@ -147,6 +157,7 @@ public static class Program {
     }
     Assert-ObjdumpFailure
     Assert-WindowsPowerShellObjdumpFailure
+    Assert-ObjdumpTimeoutCleanupContract
 
     Write-Host 'Windows x64 baseline checker probes: PASS'
 }

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -29,6 +29,9 @@ if (-not ('WinghosttyAccessibilityNative' -as [type])) {
 using System;
 using System.Runtime.InteropServices;
 public static class WinghosttyAccessibilityNative {
+    [StructLayout(LayoutKind.Sequential)] public struct POINT {
+        public int x; public int y;
+    }
     [StructLayout(LayoutKind.Sequential)] public struct HIGHCONTRAST {
         public uint cbSize; public uint dwFlags; public IntPtr lpszDefaultScheme;
     }
@@ -38,12 +41,12 @@ public static class WinghosttyAccessibilityNative {
     public static extern bool SetForegroundWindow(IntPtr hwnd);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool SetWindowPos(IntPtr hwnd, IntPtr insertAfter, int x, int y, int width, int height, uint flags);
-    [DllImport("user32.dll", SetLastError=true)]
-    public static extern bool SetCursorPos(int x, int y);
     [DllImport("user32.dll")]
-    public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extraInfo);
+    public static extern IntPtr WindowFromPoint(POINT point);
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
     [DllImport("user32.dll", SetLastError=true)]
-    public static extern bool PostMessage(IntPtr hwnd, uint message, UIntPtr wParam, IntPtr lParam);
+    public static extern bool ScreenToClient(IntPtr hwnd, ref POINT point);
 }
 '@
 }
@@ -130,20 +133,49 @@ try {
                 )
                 $x = [int][Math]::Round($bounds.Left + ($bounds.Width / 2))
                 $y = [int][Math]::Round($bounds.Top + ($bounds.Height / 2))
-                if ([WinghosttyAccessibilityNative]::SetCursorPos($x, $y)) {
-                    [WinghosttyAccessibilityNative]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
-                    [WinghosttyAccessibilityNative]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
-                    [void][WinghosttyAccessibilityNative]::SetWindowPos(
-                        $process.MainWindowHandle,
-                        [IntPtr](-2),
-                        0,
-                        0,
-                        0,
-                        0,
-                        $noMoveNoSizeShow
-                    )
-                    $clickedDocument = $true
+                $point = [WinghosttyAccessibilityNative+POINT]::new()
+                $point.x = $x
+                $point.y = $y
+                $targetHwnd = [WinghosttyAccessibilityNative]::WindowFromPoint($point)
+                [uint32] $targetProcessId = 0
+                $targetThreadId = [WinghosttyAccessibilityNative]::GetWindowThreadProcessId(
+                    $targetHwnd,
+                    [ref] $targetProcessId
+                )
+                if ($targetHwnd -eq [IntPtr]::Zero -or $targetThreadId -eq 0 -or $targetProcessId -ne [uint32]$process.Id) {
+                    throw "Refusing accessibility click outside winghostty (hwnd=$targetHwnd, owner=$targetProcessId, expected=$($process.Id))."
                 }
+                $clientPoint = $point
+                if (-not [WinghosttyAccessibilityNative]::ScreenToClient($targetHwnd, [ref] $clientPoint)) {
+                    throw "ScreenToClient failed for accessibility click hwnd=${targetHwnd}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+                }
+                [int32] $clickCoordinates = ($clientPoint.x -band 0xffff) -bor (($clientPoint.y -band 0xffff) -shl 16)
+                [void](Invoke-InteractiveWin11Message `
+                    -Hwnd $targetHwnd `
+                    -Message 0x0201 `
+                    -WParam ([UIntPtr]1) `
+                    -LParam ([IntPtr]$clickCoordinates) `
+                    -Deadline $focusDeadline `
+                    -Process $process `
+                    -Description 'accessibility document mouse-down')
+                [void](Invoke-InteractiveWin11Message `
+                    -Hwnd $targetHwnd `
+                    -Message 0x0202 `
+                    -WParam ([UIntPtr]::Zero) `
+                    -LParam ([IntPtr]$clickCoordinates) `
+                    -Deadline $focusDeadline `
+                    -Process $process `
+                    -Description 'accessibility document mouse-up')
+                [void][WinghosttyAccessibilityNative]::SetWindowPos(
+                    $process.MainWindowHandle,
+                    [IntPtr](-2),
+                    0,
+                    0,
+                    0,
+                    0,
+                    $noMoveNoSizeShow
+                )
+                $clickedDocument = $true
             }
         }
         Start-Sleep -Milliseconds 100
@@ -156,10 +188,15 @@ try {
         }
         throw "UIA focus did not resolve to an element owned by winghostty (focused=$focusedSummary, document_set_focus_error='$documentFocusError', clicked_document=$clickedDocument)."
     }
-    if (-not [WinghosttyAccessibilityNative]::PostMessage($process.MainWindowHandle, 0x0111, [UIntPtr]([uint64]1901), [IntPtr]::Zero)) {
-        throw "Failed to open command palette: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
-    }
     $paletteDeadline = [DateTime]::UtcNow.AddSeconds(5)
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $process.MainWindowHandle `
+        -Message 0x0111 `
+        -WParam ([UIntPtr]([uint64]1901)) `
+        -LParam ([IntPtr]::Zero) `
+        -Deadline $paletteDeadline `
+        -Process $process `
+        -Description 'open accessibility command palette')
     $palette = $null
     do {
         Start-Sleep -Milliseconds 100
@@ -195,7 +232,14 @@ try {
         $selectedBounds.Right -gt $paletteBounds.Right -or $selectedBounds.Bottom -gt $paletteBounds.Bottom) {
         throw 'Selected command palette row bounds escape the List bounds.'
     }
-    [void][WinghosttyAccessibilityNative]::PostMessage($process.MainWindowHandle, 0x0111, [UIntPtr]([uint64]2004), [IntPtr]::Zero)
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $process.MainWindowHandle `
+        -Message 0x0111 `
+        -WParam ([UIntPtr]([uint64]2004)) `
+        -LParam ([IntPtr]::Zero) `
+        -Deadline ([DateTime]::UtcNow.AddSeconds(5)) `
+        -Process $process `
+        -Description 'dismiss accessibility command palette')
     $hc = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
     $hc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($hc)
     if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(0x42, $hc.cbSize, [ref]$hc, 0)) {

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -153,7 +153,7 @@ try {
                 [void](Invoke-InteractiveWin11Message `
                     -Hwnd $targetHwnd `
                     -Message 0x0201 `
-                    -WParam ([UIntPtr]1) `
+                    -WParam ([UIntPtr]::new([uint64]1)) `
                     -LParam ([IntPtr]$clickCoordinates) `
                     -Deadline $focusDeadline `
                     -Process $process `
@@ -192,7 +192,7 @@ try {
     [void](Invoke-InteractiveWin11Message `
         -Hwnd $process.MainWindowHandle `
         -Message 0x0111 `
-        -WParam ([UIntPtr]([uint64]1901)) `
+        -WParam ([UIntPtr]::new([uint64]1901)) `
         -LParam ([IntPtr]::Zero) `
         -Deadline $paletteDeadline `
         -Process $process `
@@ -235,7 +235,7 @@ try {
     [void](Invoke-InteractiveWin11Message `
         -Hwnd $process.MainWindowHandle `
         -Message 0x0111 `
-        -WParam ([UIntPtr]([uint64]2004)) `
+        -WParam ([UIntPtr]::new([uint64]2004)) `
         -LParam ([IntPtr]::Zero) `
         -Deadline ([DateTime]::UtcNow.AddSeconds(5)) `
         -Process $process `

--- a/test/windows/interactive-win11-boo-multitab.ps1
+++ b/test/windows/interactive-win11-boo-multitab.ps1
@@ -98,8 +98,6 @@ public static class InteractiveWin11BooMultiTabNative {
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool SetForegroundWindow(IntPtr hWnd);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr SendMessageW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
 }
 
 public sealed class InteractiveWin11BooMultiTabChildControl {
@@ -277,16 +275,20 @@ function Get-VisibleTabCount {
 function Invoke-HostCommand {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $CommandId
+        [Parameter(Mandatory)] [int] $CommandId,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW($HostHwnd, 0x0111, (New-WParam -Low $CommandId), [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
 }
 
 function Activate-TabButton {
     param(
         [Parameter(Mandatory)] [InteractiveWin11BooMultiTabChildControl] $Tab,
-        [Parameter(Mandatory)] [IntPtr] $ExpectedParent
+        [Parameter(Mandatory)] [IntPtr] $ExpectedParent,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
     if (
@@ -305,8 +307,8 @@ function Activate-TabButton {
     $x = [Math]::Max(1, [int] (($rect.Right - $rect.Left) / 2))
     $y = [Math]::Max(1, [int] (($rect.Bottom - $rect.Top) / 2))
     $lParam = New-LParam -X $x -Y $y
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW($Tab.Hwnd, 0x0201, [UIntPtr]::Zero, $lParam)
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW($Tab.Hwnd, 0x0202, [UIntPtr]::Zero, $lParam)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Tab.Hwnd -Message 0x0201 -LParam $lParam -Deadline $Deadline -Description "tab button mouse down control=$($Tab.Id)" -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Tab.Hwnd -Message 0x0202 -LParam $lParam -Deadline $Deadline -Description "tab button mouse up control=$($Tab.Id)" -Process $Process)
 }
 
 function Send-TextKeyMessage {
@@ -314,48 +316,27 @@ function Send-TextKeyMessage {
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
         [Parameter(Mandatory)] [uint16] $VirtualKey,
         [Parameter(Mandatory)] [uint16] $CharCode,
-        [uint16] $ScanCode = 0x1E
+        [uint16] $ScanCode = 0x1E,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW(
-        $Hwnd,
-        0x0100,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode $ScanCode)
-    )
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW(
-        $Hwnd,
-        0x0102,
-        [UIntPtr]([uint64] $CharCode),
-        (New-KeyLParam -ScanCode $ScanCode)
-    )
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW(
-        $Hwnd,
-        0x0101,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode $ScanCode -KeyUp)
-    )
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0100 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode) -Deadline $Deadline -Description "WM_KEYDOWN vk=$VirtualKey" -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0102 -WParam ([UIntPtr]([uint64] $CharCode)) -LParam (New-KeyLParam -ScanCode $ScanCode) -Deadline $Deadline -Description "WM_CHAR char=$CharCode" -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0101 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode -KeyUp) -Deadline $Deadline -Description "WM_KEYUP vk=$VirtualKey" -Process $Process)
 }
 
 function Send-KeyPressMessage {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
         [Parameter(Mandatory)] [uint16] $VirtualKey,
-        [Parameter(Mandatory)] [uint16] $ScanCode
+        [Parameter(Mandatory)] [uint16] $ScanCode,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW(
-        $Hwnd,
-        0x0100,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode $ScanCode)
-    )
-    [void] [InteractiveWin11BooMultiTabNative]::SendMessageW(
-        $Hwnd,
-        0x0101,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode $ScanCode -KeyUp)
-    )
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0100 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode) -Deadline $Deadline -Description "WM_KEYDOWN vk=$VirtualKey" -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0101 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode -KeyUp) -Deadline $Deadline -Description "WM_KEYUP vk=$VirtualKey" -Process $Process)
 }
 
 $harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'boo-multitab' -ResetState:$ResetState
@@ -497,13 +478,13 @@ try {
 
     while ((Get-VisibleTabCount -Parent $hostHwnd) -lt $SeedTabs) {
         $targetTabCount = (Get-VisibleTabCount -Parent $hostHwnd) + 1
-        Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904
+        Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904 -Deadline $deadline -Process $process
         Wait-InteractiveWin11Until -Deadline $deadline -Description "seed tabs ($targetTabCount/$SeedTabs)" -Process $process -Condition {
             (Get-VisibleTabCount -Parent $hostHwnd) -ge $targetTabCount
         }
     }
 
-    Activate-TabButton -Tab $initialTabButton -ExpectedParent $hostHwnd
+    Activate-TabButton -Tab $initialTabButton -ExpectedParent $hostHwnd -Deadline $deadline -Process $process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'initial surface reactivation' -Process $process -Condition {
         Test-SurfaceWindow -Hwnd $initialSurfaceHwnd -ExpectedParent $hostHwnd
     }
@@ -521,7 +502,7 @@ try {
     }
 
     Start-Sleep -Milliseconds $EscapeAfterMs
-    Send-KeyPressMessage -Hwnd $surfaceHwnd -VirtualKey 0x1B -ScanCode 0x01
+    Send-KeyPressMessage -Hwnd $surfaceHwnd -VirtualKey 0x1B -ScanCode 0x01 -Deadline $deadline -Process $process
 
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'post-boo state file' -Process $process -Condition {
         if (-not (Test-Path -LiteralPath $statePath)) {
@@ -553,7 +534,7 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         throw 'initial surface disappeared or became hidden after +boo'
     }
 
-    Send-TextKeyMessage -Hwnd $initialSurfaceHwnd -VirtualKey 0x41 -CharCode 97
+    Send-TextKeyMessage -Hwnd $initialSurfaceHwnd -VirtualKey 0x41 -CharCode 97 -Deadline $deadline -Process $process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'post-boo key result file' -Process $process -Condition {
         Test-Path -LiteralPath $resultPath
     }

--- a/test/windows/interactive-win11-boo-multitab.ps1
+++ b/test/windows/interactive-win11-boo-multitab.ps1
@@ -44,8 +44,6 @@ if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_BOO_MULTITAB_BOOTSTRAPPED) {
     exit $bootstrapExitCode
 }
 
-Add-Type -AssemblyName Microsoft.VisualBasic
-
 if (-not ('InteractiveWin11BooMultiTabNative' -as [type])) {
     Add-Type @"
 using System;
@@ -497,8 +495,13 @@ try {
         if (-not (Test-Path -LiteralPath $booTracePath)) {
             return $false
         }
-        $booTraceProbe = Get-Content -LiteralPath $booTracePath -Raw | ConvertFrom-Json
-        return $booTraceProbe.phase -eq 'before_app_run'
+        try {
+            $booTraceProbe = Get-Content -LiteralPath $booTracePath -Raw | ConvertFrom-Json
+            return $booTraceProbe.phase -eq 'before_app_run'
+        }
+        catch {
+            return $false
+        }
     }
 
     Start-Sleep -Milliseconds $EscapeAfterMs
@@ -508,8 +511,13 @@ try {
         if (-not (Test-Path -LiteralPath $statePath)) {
             return $false
         }
-        $stateProbe = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
-        return $stateProbe.phase -eq 'after-boo'
+        try {
+            $stateProbe = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+            return $stateProbe.phase -eq 'after-boo'
+        }
+        catch {
+            return $false
+        }
     }
 
     $state = Get-InteractiveWin11RequiredJsonFile -Path $statePath

--- a/test/windows/interactive-win11-boo-multitab.ps1
+++ b/test/windows/interactive-win11-boo-multitab.ps1
@@ -277,18 +277,18 @@ function Invoke-HostCommand {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [int] $CommandId,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
 }
 
-function Activate-TabButton {
+function Invoke-TabButtonActivation {
     param(
         [Parameter(Mandatory)] [InteractiveWin11BooMultiTabChildControl] $Tab,
         [Parameter(Mandatory)] [IntPtr] $ExpectedParent,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     if (
@@ -318,7 +318,7 @@ function Send-TextKeyMessage {
         [Parameter(Mandatory)] [uint16] $CharCode,
         [uint16] $ScanCode = 0x1E,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0100 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode) -Deadline $Deadline -Description "WM_KEYDOWN vk=$VirtualKey" -Process $Process)
@@ -332,7 +332,7 @@ function Send-KeyPressMessage {
         [Parameter(Mandatory)] [uint16] $VirtualKey,
         [Parameter(Mandatory)] [uint16] $ScanCode,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message 0x0100 -WParam ([UIntPtr]([uint64] $VirtualKey)) -LParam (New-KeyLParam -ScanCode $ScanCode) -Deadline $Deadline -Description "WM_KEYDOWN vk=$VirtualKey" -Process $Process)
@@ -484,7 +484,7 @@ try {
         }
     }
 
-    Activate-TabButton -Tab $initialTabButton -ExpectedParent $hostHwnd -Deadline $deadline -Process $process
+    Invoke-TabButtonActivation -Tab $initialTabButton -ExpectedParent $hostHwnd -Deadline $deadline -Process $process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'initial surface reactivation' -Process $process -Condition {
         Test-SurfaceWindow -Hwnd $initialSurfaceHwnd -ExpectedParent $hostHwnd
     }

--- a/test/windows/interactive-win11-boo-multitab.ps1
+++ b/test/windows/interactive-win11-boo-multitab.ps1
@@ -457,7 +457,7 @@ try {
     }
 
     $hostHwnd = Find-HostWindow -ProcessId $process.Id
-    Show-InteractiveWin11Window -Hwnd $hostHwnd -NativeTypeName 'InteractiveWin11BooMultiTabNative' -SetForeground
+    Show-InteractiveWin11Window -Hwnd $hostHwnd -NativeType ([InteractiveWin11BooMultiTabNative]) -SetForeground
 
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
         (Find-SurfaceWindow -Parent $hostHwnd) -ne [IntPtr]::Zero

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -141,6 +141,7 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
     }
     $requiredRenderTraceFields = @(
         'startup_window_ms',
+        'startup_paint_gap_ceiling_ms',
         'paint_gap_limit_ms',
         'paint_gap_over_limit_count',
         'max_paint_gap_ms',
@@ -161,12 +162,15 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
     if ($startupWindowMs -le 0) {
         throw "Render trace startup window must be positive (got $startupWindowMs)"
     }
+    $startupPaintGapLimitMs = [long]$renderTrace.startup_paint_gap_ceiling_ms
+    if ($startupPaintGapLimitMs -lt $startupWindowMs) {
+        throw "Render trace startup paint ceiling must cover the startup window (window=$startupWindowMs, ceiling=$startupPaintGapLimitMs)"
+    }
     $paintGapLimitMs = [long]$renderTrace.paint_gap_limit_ms
     if ($paintGapLimitMs -le 0) {
         throw "Render trace paint gap limit must be positive (got $paintGapLimitMs)"
     }
     $startupDrawLeadMs = 500
-    $startupPaintGapLimitMs = $startupWindowMs
     $startupMatchToleranceMs = 16
     $startupPaintStartMs = $renderTrace.max_paint_gap_ended_at_ms - $renderTrace.max_paint_gap_ms
     $startupDurationDeltaMs = [Math]::Abs(

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -141,6 +141,8 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
     }
     $requiredRenderTraceFields = @(
         'startup_window_ms',
+        'paint_gap_limit_ms',
+        'paint_gap_over_limit_count',
         'max_paint_gap_ms',
         'max_paint_gap_ended_at_ms',
         'max_sustained_paint_gap_ms',
@@ -159,8 +161,12 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
     if ($startupWindowMs -le 0) {
         throw "Render trace startup window must be positive (got $startupWindowMs)"
     }
+    $paintGapLimitMs = [long]$renderTrace.paint_gap_limit_ms
+    if ($paintGapLimitMs -le 0) {
+        throw "Render trace paint gap limit must be positive (got $paintGapLimitMs)"
+    }
     $startupDrawLeadMs = 500
-    $startupPaintGapLimitMs = 1000
+    $startupPaintGapLimitMs = $startupWindowMs
     $startupMatchToleranceMs = 16
     $startupPaintStartMs = $renderTrace.max_paint_gap_ended_at_ms - $renderTrace.max_paint_gap_ms
     $startupDurationDeltaMs = [Math]::Abs(
@@ -175,17 +181,25 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         $startupEndDeltaMs -le $startupMatchToleranceMs -and
         $startupPaintStartMs -ge $renderTrace.first_paint_at_ms -and
         $startupPaintStartMs - $renderTrace.first_paint_at_ms -le $startupDrawLeadMs
-    if ($renderTrace.max_paint_gap_ms -gt 300 -and -not $startupPaintGap) {
-        throw "Expected visible paint gaps to stay below the prior choppy path (expected <= 300, got $($renderTrace.max_paint_gap_ms))"
+    if ($renderTrace.max_paint_gap_ms -gt $paintGapLimitMs -and -not $startupPaintGap) {
+        throw "Expected visible paint gaps to stay below the prior choppy path (expected <= $paintGapLimitMs, got $($renderTrace.max_paint_gap_ms))"
     }
     if ($startupPaintGap -and $renderTrace.max_paint_gap_ms -gt $startupPaintGapLimitMs) {
         throw "Startup paint initialization gap exceeded the hard ceiling (expected <= $startupPaintGapLimitMs, got $($renderTrace.max_paint_gap_ms))"
     }
-    if ($renderTrace.max_paint_gap_ms -gt 300 -and $startupPaintGap) {
-        Write-Warning "Ignoring startup paint initialization gap ($($renderTrace.max_paint_gap_ms) ms at $($renderTrace.max_paint_gap_ended_at_ms) ms); enforcing sustained paint gap <= 300 ms after $startupWindowMs ms."
+    $hasOverLimitMaximum = $renderTrace.max_paint_gap_ms -gt $paintGapLimitMs
+    $hasOverLimitCount = $renderTrace.paint_gap_over_limit_count -gt 0
+    if ($hasOverLimitMaximum -ne $hasOverLimitCount) {
+        throw "Render trace paint gap maximum and over-limit count are inconsistent"
     }
-    if ($renderTrace.max_sustained_paint_gap_ms -gt 300) {
-        throw "Expected sustained visible paint gaps after startup to stay below the prior choppy path (expected <= 300, got $($renderTrace.max_sustained_paint_gap_ms) at $($renderTrace.max_sustained_paint_gap_ended_at_ms) ms)"
+    if ($startupPaintGap -and $renderTrace.paint_gap_over_limit_count -gt 1) {
+        throw "Expected at most one startup initialization paint gap above $paintGapLimitMs ms (got $($renderTrace.paint_gap_over_limit_count))"
+    }
+    if ($renderTrace.max_paint_gap_ms -gt $paintGapLimitMs -and $startupPaintGap) {
+        Write-Warning "Accepted one startup paint initialization gap ($($renderTrace.max_paint_gap_ms) ms at $($renderTrace.max_paint_gap_ended_at_ms) ms); enforcing every other paint gap <= $paintGapLimitMs ms and the startup ceiling <= $startupPaintGapLimitMs ms."
+    }
+    if ($renderTrace.max_sustained_paint_gap_ms -gt $paintGapLimitMs) {
+        throw "Expected sustained visible paint gaps after startup to stay below the prior choppy path (expected <= $paintGapLimitMs, got $($renderTrace.max_sustained_paint_gap_ms) at $($renderTrace.max_sustained_paint_gap_ended_at_ms) ms)"
     }
     if ($termioTrace.process_output_count -lt 140) {
         throw "Expected steady PTY output batches for +boo (expected >= 140, got $($termioTrace.process_output_count))"

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -110,7 +110,7 @@ try {
     $processHandle = $process.Handle
     Show-InteractiveWin11ProcessMainWindow `
         -Process $process `
-        -NativeTypeName 'InteractiveWin11BooPerfNative' `
+        -NativeType ([InteractiveWin11BooPerfNative]) `
         -SetForeground
 
     if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -160,7 +160,7 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         throw "Render trace startup window must be positive (got $startupWindowMs)"
     }
     $startupDrawLeadMs = 500
-    $startupPaintGapLimitMs = 750
+    $startupPaintGapLimitMs = 1000
     $startupMatchToleranceMs = 16
     $startupPaintStartMs = $renderTrace.max_paint_gap_ended_at_ms - $renderTrace.max_paint_gap_ms
     $startupDurationDeltaMs = [Math]::Abs(

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -70,15 +70,11 @@ public static class Win11ImeCandidateNative {
     [DllImport("user32.dll", SetLastError = true)]
     public static extern IntPtr SetFocus(IntPtr hWnd);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr SendMessageTimeoutW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
-
 }
 '@
 
 $CFS_POINT = 0x0002
 $CFS_EXCLUDE = 0x0080
-$SMTO_ABORTIFHUNG = 0x0002
 $SW_RESTORE = 9
 $WM_MOUSEMOVE = 0x0200
 $WM_IME_STARTCOMPOSITION = 0x010D
@@ -183,23 +179,19 @@ function Send-WindowMessage {
         [Parameter(Mandatory)] [uint32] $Message,
         [UIntPtr] $WParam = [UIntPtr]::Zero,
         [IntPtr] $LParam = [IntPtr]::Zero,
-        [string] $Description = 'window message'
+        [string] $Description = 'window message',
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
-    $result = [UIntPtr]::Zero
-    $status = [Win11ImeCandidateNative]::SendMessageTimeoutW(
-        $Hwnd,
-        $Message,
-        $WParam,
-        $LParam,
-        [uint32] $SMTO_ABORTIFHUNG,
-        [uint32] 1000,
-        [ref] $result
-    )
-    if ($status -eq [IntPtr]::Zero) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendMessageTimeoutW failed for $Description (hwnd=$Hwnd msg=$Message error=$lastError)"
-    }
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $Hwnd `
+        -Message $Message `
+        -WParam $WParam `
+        -LParam $LParam `
+        -Deadline $Deadline `
+        -Process $Process `
+        -Description $Description)
 }
 
 function Read-ImeFormTrace {
@@ -404,11 +396,15 @@ try {
         -Hwnd $surfaceHwnd `
         -Message $WM_MOUSEMOVE `
         -LParam (New-LParam -X $poisonX -Y $poisonY) `
+        -Deadline $deadline `
+        -Process $process `
         -Description "poison WM_MOUSEMOVE at $poisonX,$poisonY"
 
     Send-WindowMessage `
         -Hwnd $surfaceHwnd `
         -Message $WM_IME_STARTCOMPOSITION `
+        -Deadline $deadline `
+        -Process $process `
         -Description 'WM_IME_STARTCOMPOSITION'
 
     $script:Win11ImeCandidateTrace = $null
@@ -482,6 +478,8 @@ finally {
                 Send-WindowMessage `
                     -Hwnd $surfaceHwnd `
                     -Message $WM_IME_ENDCOMPOSITION `
+                    -Deadline ([DateTime]::UtcNow.AddSeconds(3)) `
+                    -Process $process `
                     -Description 'WM_IME_ENDCOMPOSITION'
             }
         }

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -43,27 +43,6 @@ public static class Win11KeyInputNative {
     public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct INPUT {
-        public uint type;
-        public InputUnion U;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    public struct InputUnion {
-        [FieldOffset(0)]
-        public KEYBDINPUT ki;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct KEYBDINPUT {
-        public ushort wVk;
-        public ushort wScan;
-        public uint dwFlags;
-        public uint time;
-        public IntPtr dwExtraInfo;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
     public struct RECT {
         public int Left;
         public int Top;
@@ -108,17 +87,12 @@ public static class Win11KeyInputNative {
     [DllImport("user32.dll")]
     public static extern IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll", SetLastError = true)]
-    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
-
     [DllImport("user32.dll")]
     public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
 }
 '@
 Add-Type -AssemblyName Microsoft.VisualBasic
 
-$INPUT_KEYBOARD = 1
-$KEYEVENTF_KEYUP = 0x0002
 $MAPVK_VK_TO_VSC = 0
 $SW_RESTORE = 9
 $VK_A = 0x41
@@ -224,39 +198,6 @@ function New-KeyLParam {
     }
 
     return [IntPtr] $bits
-}
-
-function Send-VirtualKey {
-    param(
-        [Parameter(Mandatory)] [UInt16] $VirtualKey
-    )
-
-    $scanCode = [Win11KeyInputNative]::MapVirtualKeyW([uint32] $VirtualKey, [uint32] $MAPVK_VK_TO_VSC)
-    if ($scanCode -eq 0) {
-        throw "MapVirtualKeyW returned 0 for VK=$VirtualKey"
-    }
-
-    $inputs = [Win11KeyInputNative+INPUT[]]::new(2)
-
-    $inputs[0].type = $INPUT_KEYBOARD
-    $inputs[0].U.ki.wVk = $VirtualKey
-    $inputs[0].U.ki.wScan = [uint16] $scanCode
-    $inputs[0].U.ki.dwFlags = 0
-
-    $inputs[1].type = $INPUT_KEYBOARD
-    $inputs[1].U.ki.wVk = $VirtualKey
-    $inputs[1].U.ki.wScan = [uint16] $scanCode
-    $inputs[1].U.ki.dwFlags = $KEYEVENTF_KEYUP
-
-    $sent = [Win11KeyInputNative]::SendInput(
-        [uint32] $inputs.Length,
-        $inputs,
-        [Runtime.InteropServices.Marshal]::SizeOf([type] [Win11KeyInputNative+INPUT])
-    )
-    if ($sent -ne $inputs.Length) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendInput sent $sent/$($inputs.Length) events (Win32 error $lastError)"
-    }
 }
 
 function Send-VirtualKeyMessage {

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -335,6 +335,7 @@ $process = Start-Process -FilePath $exePath `
     -RedirectStandardOutput $stdoutPath `
     -RedirectStandardError $stderrPath `
     -PassThru
+$keyInputProcessHandle = $process.Handle
 
 try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
@@ -390,11 +391,42 @@ try {
 
     Send-VirtualKeyMessage -Hwnd $messageTargetHwnd -VirtualKey $virtualKey -CharCode ([uint16] $charCode) -Deadline $deadline -Process $process
 
-    Wait-InteractiveWin11Until -Deadline $deadline -Description 'key input result file' -Process $process -Condition {
-        Test-Path -LiteralPath $resultPath
+    $resultRef = [ref]$null
+    $lastResultReadError = [ref]'result file has not appeared'
+    $lastResultContent = [ref]'<missing>'
+    $keyInputProcess = $process
+    try {
+        Wait-InteractiveWin11Until -Deadline $deadline -Description 'key input result file' -Condition {
+            if (Test-Path -LiteralPath $resultPath) {
+                try {
+                    $content = Get-Content -LiteralPath $resultPath -Raw
+                    $contentText = if ($null -eq $content) { '' } else { [string]$content }
+                    $contentText = $contentText -replace '\s+', ' '
+                    $lastResultContent.Value = if ($contentText.Length -gt 240) { $contentText.Substring(0, 240) + '...' } elseif ($contentText.Length -eq 0) { '<empty>' } else { $contentText }
+                    $parsed = $content | ConvertFrom-Json
+                    if ($null -ne $parsed) {
+                        $resultRef.Value = $parsed
+                        return $true
+                    }
+                    $lastResultReadError.Value = 'JSON parsed to null'
+                }
+                catch {
+                    $lastResultReadError.Value = $_.Exception.Message
+                }
+            }
+            $keyInputProcess.Refresh()
+            if ($keyInputProcess.HasExited) {
+                $exitCode = Get-InteractiveWin11ProcessExitCode -Process $keyInputProcess -ProcessHandle $keyInputProcessHandle
+                throw "winghostty exited while waiting for key input result file (exit code $exitCode)"
+            }
+            return $false
+        }
+    }
+    catch {
+        throw "$($_.Exception.Message) (last result read error='$($lastResultReadError.Value)', content='$($lastResultContent.Value)')"
     }
 
-    $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+    $result = $resultRef.Value
     if ($result.keyCharCode -ne $expectedKeyCharCode -or $result.key -ne $expectedKeyName) {
         throw "unexpected key input result (mode=$deliveryMode): $($result | ConvertTo-Json -Compress)"
     }

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -91,7 +91,6 @@ public static class Win11KeyInputNative {
     public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
 }
 '@
-Add-Type -AssemblyName Microsoft.VisualBasic
 
 $MAPVK_VK_TO_VSC = 0
 $SW_RESTORE = 9

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -108,9 +108,6 @@ public static class Win11KeyInputNative {
     [DllImport("user32.dll")]
     public static extern IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr SendMessageTimeoutW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
-
     [DllImport("user32.dll", SetLastError = true)]
     public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
@@ -123,7 +120,6 @@ Add-Type -AssemblyName Microsoft.VisualBasic
 $INPUT_KEYBOARD = 1
 $KEYEVENTF_KEYUP = 0x0002
 $MAPVK_VK_TO_VSC = 0
-$SMTO_ABORTIFHUNG = 0x0002
 $SW_RESTORE = 9
 $VK_A = 0x41
 $VK_ESCAPE = 0x1B
@@ -189,29 +185,6 @@ function Find-SurfaceWindow {
 
     [void] [Win11KeyInputNative]::EnumChildWindows($Parent, $callback, [IntPtr]::Zero)
     return $script:Win11KeyInputFoundSurface
-}
-
-function Wait-Until {
-    param(
-        [Parameter(Mandatory)] [scriptblock] $Condition,
-        [Parameter(Mandatory)] [string] $Description,
-        [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
-    )
-
-    while ([DateTime]::UtcNow -lt $Deadline) {
-        if ($null -ne $Process -and $Process.HasExited) {
-            throw "winghostty exited while waiting for ${Description} (exit code $($Process.ExitCode))"
-        }
-
-        if (& $Condition) {
-            return
-        }
-
-        Start-Sleep -Milliseconds 100
-    }
-
-    throw "Timed out waiting for $Description"
 }
 
 function Get-GuiThreadInfo {
@@ -290,7 +263,9 @@ function Send-VirtualKeyMessage {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
         [Parameter(Mandatory)] [UInt16] $VirtualKey,
-        [UInt16] $CharCode = 0
+        [UInt16] $CharCode = 0,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $scanCode = [Win11KeyInputNative]::MapVirtualKeyW([uint32] $VirtualKey, [uint32] $MAPVK_VK_TO_VSC)
@@ -298,51 +273,32 @@ function Send-VirtualKeyMessage {
         throw "MapVirtualKeyW returned 0 for VK=$VirtualKey"
     }
 
-    $sendTimeoutMs = 1000
-    $sendResult = [UIntPtr]::Zero
-    $sendStatus = [Win11KeyInputNative]::SendMessageTimeoutW(
-        $Hwnd,
-        $WM_KEYDOWN,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode ([uint16] $scanCode)),
-        [uint32] $SMTO_ABORTIFHUNG,
-        [uint32] $sendTimeoutMs,
-        [ref] $sendResult
-    )
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendMessageTimeoutW failed for WM_KEYDOWN (hwnd=$Hwnd, vk=$VirtualKey, error=$lastError)"
-    }
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $Hwnd `
+        -Message $WM_KEYDOWN `
+        -WParam ([UIntPtr]([uint64] $VirtualKey)) `
+        -LParam (New-KeyLParam -ScanCode ([uint16] $scanCode)) `
+        -Deadline $Deadline `
+        -Process $Process `
+        -Description "WM_KEYDOWN vk=$VirtualKey")
     if ($CharCode -ne 0) {
-        $sendResult = [UIntPtr]::Zero
-        $sendStatus = [Win11KeyInputNative]::SendMessageTimeoutW(
-            $Hwnd,
-            $WM_CHAR,
-            [UIntPtr]([uint64] $CharCode),
-            (New-KeyLParam -ScanCode ([uint16] $scanCode)),
-            [uint32] $SMTO_ABORTIFHUNG,
-            [uint32] $sendTimeoutMs,
-            [ref] $sendResult
-        )
-        if ($sendStatus -eq [IntPtr]::Zero) {
-            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-            throw "SendMessageTimeoutW failed for WM_CHAR (hwnd=$Hwnd, char=$CharCode, error=$lastError)"
-        }
+        [void](Invoke-InteractiveWin11Message `
+            -Hwnd $Hwnd `
+            -Message $WM_CHAR `
+            -WParam ([UIntPtr]([uint64] $CharCode)) `
+            -LParam (New-KeyLParam -ScanCode ([uint16] $scanCode)) `
+            -Deadline $Deadline `
+            -Process $Process `
+            -Description "WM_CHAR char=$CharCode")
     }
-    $sendResult = [UIntPtr]::Zero
-    $sendStatus = [Win11KeyInputNative]::SendMessageTimeoutW(
-        $Hwnd,
-        $WM_KEYUP,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode ([uint16] $scanCode) -KeyUp),
-        [uint32] $SMTO_ABORTIFHUNG,
-        [uint32] $sendTimeoutMs,
-        [ref] $sendResult
-    )
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendMessageTimeoutW failed for WM_KEYUP (hwnd=$Hwnd, vk=$VirtualKey, error=$lastError)"
-    }
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $Hwnd `
+        -Message $WM_KEYUP `
+        -WParam ([UIntPtr]([uint64] $VirtualKey)) `
+        -LParam (New-KeyLParam -ScanCode ([uint16] $scanCode) -KeyUp) `
+        -Deadline $Deadline `
+        -Process $Process `
+        -Description "WM_KEYUP vk=$VirtualKey")
 }
 
 $harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'key-input' -ResetState:$ResetState -IncludeResourcesDir
@@ -442,7 +398,7 @@ $process = Start-Process -FilePath $exePath `
 
 try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-    Wait-Until -Deadline $deadline -Description 'host window' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'host window' -Process $process -Condition {
         (Find-HostWindow -ProcessId $process.Id) -ne [IntPtr]::Zero
     }
 
@@ -450,7 +406,7 @@ try {
     [void] [Win11KeyInputNative]::ShowWindow($hostHwnd, $SW_RESTORE)
     [void] [Win11KeyInputNative]::SetForegroundWindow($hostHwnd)
 
-    Wait-Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
         (Find-SurfaceWindow -Parent $hostHwnd) -ne [IntPtr]::Zero
     }
 
@@ -461,7 +417,7 @@ try {
 
     if ($RunBooFirst) {
         try {
-            Wait-Until -Deadline $deadline -Description 'post-boo readiness file' -Process $process -Condition {
+            Wait-InteractiveWin11Until -Deadline $deadline -Description 'post-boo readiness file' -Process $process -Condition {
                 Test-Path -LiteralPath $preReadKeyReadyPath
             }
         }
@@ -492,9 +448,9 @@ try {
         Start-Sleep -Milliseconds 300
     }
 
-    Send-VirtualKeyMessage -Hwnd $messageTargetHwnd -VirtualKey $virtualKey -CharCode ([uint16] $charCode)
+    Send-VirtualKeyMessage -Hwnd $messageTargetHwnd -VirtualKey $virtualKey -CharCode ([uint16] $charCode) -Deadline $deadline -Process $process
 
-    Wait-Until -Deadline $deadline -Description 'key input result file' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'key input result file' -Process $process -Condition {
         Test-Path -LiteralPath $resultPath
     }
 

--- a/test/windows/interactive-win11-new-tab.ps1
+++ b/test/windows/interactive-win11-new-tab.ps1
@@ -244,7 +244,7 @@ function Invoke-HostCommand {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [int] $CommandId,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
@@ -255,7 +255,7 @@ function Invoke-CommandPaletteAction {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [string] $Action,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901 -Deadline $Deadline -Process $Process

--- a/test/windows/interactive-win11-new-tab.ps1
+++ b/test/windows/interactive-win11-new-tab.ps1
@@ -92,8 +92,6 @@ public static class Win11NewTabNative {
     [DllImport("user32.dll", SetLastError = true)]
     public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr SendMessageW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
 }
 
 public sealed class Win11NewTabChildControl {
@@ -244,10 +242,12 @@ function Get-VisibleTabCount {
 function Invoke-HostCommand {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $CommandId
+        [Parameter(Mandatory)] [int] $CommandId,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [Win11NewTabNative]::SendMessageW($HostHwnd, 0x0111, (New-WParam -Low $CommandId), [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
 }
 
 function Invoke-CommandPaletteAction {
@@ -258,7 +258,7 @@ function Invoke-CommandPaletteAction {
         [System.Diagnostics.Process] $Process
     )
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901 -Deadline $Deadline -Process $Process
     $script:Win11NewTabPaletteHostHwnd = $HostHwnd
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'command palette edit control' -Process $Process -Condition {
         @(Get-VisibleChildControls -Parent $script:Win11NewTabPaletteHostHwnd |
@@ -270,15 +270,10 @@ function Invoke-CommandPaletteAction {
         Select-Object -First 1
 
     foreach ($ch in $Action.ToCharArray()) {
-        [void] [Win11NewTabNative]::SendMessageW(
-            $edit.Hwnd,
-            0x0102,
-            ([UIntPtr]([uint64]([int][char]$ch))),
-            [IntPtr]::Zero
-        )
+        [void] (Invoke-InteractiveWin11Message -Hwnd $edit.Hwnd -Message 0x0102 -WParam ([UIntPtr]([uint64]([int][char]$ch))) -Deadline $Deadline -Description "palette WM_CHAR '$ch'" -Process $Process)
     }
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 2003
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 2003 -Deadline $Deadline -Process $Process
 }
 
 function Invoke-NewTabScenario {
@@ -322,7 +317,7 @@ function Invoke-NewTabScenario {
 
         while ((Get-VisibleTabCount -Parent $hostHwnd) -lt $SeedTabs) {
             $targetTabCount = (Get-VisibleTabCount -Parent $hostHwnd) + 1
-            Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904
+            Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904 -Deadline $deadline -Process $process
             Wait-InteractiveWin11Until -Deadline $deadline -Description "seed tabs ($Name)" -Process $process -Condition {
                 (Get-VisibleTabCount -Parent $hostHwnd) -ge $targetTabCount
             }
@@ -382,12 +377,7 @@ function Invoke-NewTabScenario {
             throw "$Name new-tab path changed WINDOWPLACEMENT restore target while maximized. before=$($normalPlacementBeforeMaximize.NormalPosition | ConvertTo-Json -Compress) after=$($maximizedPlacementAfterNewTab.NormalPosition | ConvertTo-Json -Compress)"
         }
 
-        [void] [Win11NewTabNative]::SendMessageW(
-            $hostHwnd,
-            0x0112,
-            (New-WParam -Low 0xF120),
-            [IntPtr]::Zero
-        )
+        [void] (Invoke-InteractiveWin11Message -Hwnd $hostHwnd -Message 0x0112 -WParam (New-WParam -Low 0xF120) -Deadline $deadline -Description 'SC_RESTORE' -Process $process)
         Wait-InteractiveWin11Until -Deadline $deadline -Description "restored host ($Name)" -Process $process -Condition {
             -not [Win11NewTabNative]::IsZoomed($hostHwnd)
         }
@@ -450,7 +440,7 @@ function Invoke-NewTabScenarioRun {
 
 $titlebarRun = Invoke-NewTabScenarioRun -Name 'titlebar' -OpenAction {
     param($HostHwnd, $Deadline, $Process)
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1904
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1904 -Deadline $Deadline -Process $Process
 }
 
 $commandRun = Invoke-NewTabScenarioRun -Name 'command-palette' -OpenAction {

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -92,8 +92,9 @@ try {
     }
 }
 finally {
-    if ($hcChanged -and -not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)) { Write-Error 'Failed to restore the original High Contrast setting.' }
+    $hcRestoreFailed = $hcChanged -and -not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)
     if ($null -ne $hcMutex) { try { $hcMutex.ReleaseMutex() } catch { }; $hcMutex.Dispose() }
     foreach ($run in $runs) { if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process } }
+    if ($hcRestoreFailed) { throw 'Failed to restore the original High Contrast setting.' }
 }
 Write-Host "interactive-win11 palette-theme validation: PASS (config=$configPath)"

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -34,6 +34,48 @@ function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline,
     return $edit.Hwnd
 }
 
+function Invoke-PostHighContrastPresentationCanary([string]$Name, [int]$ExpectedRgb) {
+    $lastError = $null
+    foreach ($attempt in 1..2) {
+        $canary = $null
+        try {
+            $canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"
+            $runs.Add($canary)
+            $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+            $canaryHost = Wait-StatefulHost $canary $deadline
+            Wait-InteractiveWin11Until -Deadline $deadline -Description 'post-High-Contrast canary tab' -Process $canary.Process -Condition {
+                (Get-StatefulTabCount $canaryHost) -eq 1
+            }
+            $canarySurface = Wait-StatefulSurface $canaryHost $canary $deadline
+            Show-StatefulHost $canaryHost
+            $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+            $stablePresentation = [Diagnostics.Stopwatch]::new()
+            Wait-InteractiveWin11Until -Deadline $deadline -Description 'post-High-Contrast canary framebuffer' -Process $canary.Process -Condition {
+                if (((Get-StatefulPixel $canarySurface.Hwnd) -band 0xFFFFFF) -ne $ExpectedRgb) {
+                    $stablePresentation.Reset()
+                    return $false
+                }
+                if (-not $stablePresentation.IsRunning) { $stablePresentation.Start() }
+                return $stablePresentation.Elapsed -ge [TimeSpan]::FromSeconds(2)
+            }
+            $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+            Close-StatefulHost $canaryHost $canary $deadline
+            return
+        }
+        catch {
+            $lastError = $_
+            if ($null -ne $canary -and -not $canary.Process.HasExited) {
+                try { Stop-InteractiveWin11Process -Process $canary.Process }
+                catch {
+                    throw "Post-High-Contrast presentation attempt $attempt failed: $($lastError.Exception.Message); process cleanup also failed: $($_.Exception.Message)"
+                }
+            }
+            if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }
+        }
+    }
+    throw "Post-High-Contrast presentation did not recover after two fresh processes: $($lastError.Exception.Message)"
+}
+
 $originalHc = $null
 $hcChanged = $false
 $hcMutex = $null
@@ -66,6 +108,7 @@ try {
             $recoveryReadback = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $recoveryReadback.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($recoveryReadback)
             if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $recoveryReadback.cbSize, [ref]$recoveryReadback, 0)) { throw 'SPI_GETHIGHCONTRAST recovery verification failed.' }
             if (($recoveryReadback.dwFlags -band 1) -ne 0) { throw 'High Contrast remained enabled after interrupted-run recovery.' }
+            Invoke-PostHighContrastPresentationCanary 'palette-theme-recovery-canary' $draculaRgb
             Remove-Item -LiteralPath $hcRecoveryPath -Force -ErrorAction Stop
             Write-Warning 'Restored High Contrast state left behind by an interrupted harness run.'
         }
@@ -78,6 +121,7 @@ try {
     $surface = Wait-StatefulSurface $hostHwnd $run $deadline
     Show-StatefulHost $hostHwnd
     Write-Host ('theme initial framebuffer rgb={0:x6}' -f ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF))
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'Dracula background render' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $draculaRgb }
     $edit = Open-ThemeQuery $hostHwnd '0x96f' $deadline $run.Process
     Start-Sleep -Milliseconds 750
@@ -124,6 +168,7 @@ catch {
 finally {
     $cleanupErrors = [Collections.Generic.List[string]]::new()
     $hcRestored = $false
+    $hcPresentationReady = $false
     if ($hcChanged) {
         try {
             if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)) {
@@ -148,6 +193,15 @@ finally {
         }
     }
     if ($hcRestored) {
+        try {
+            Invoke-PostHighContrastPresentationCanary 'palette-theme-restore-canary' $themeRgb
+            $hcPresentationReady = $true
+        }
+        catch {
+            [void]$cleanupErrors.Add("High Contrast post-restore presentation failed: $($_.Exception.Message)")
+        }
+    }
+    if ($hcPresentationReady) {
         try { Remove-Item -LiteralPath $hcRecoveryPath -Force -ErrorAction Stop } catch { [void]$cleanupErrors.Add("High Contrast recovery marker cleanup failed: $($_.Exception.Message)") }
     }
     if ($null -ne $hcMutex) {

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -92,9 +92,29 @@ try {
     }
 }
 finally {
-    $hcRestoreFailed = $hcChanged -and -not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)
-    if ($null -ne $hcMutex) { try { $hcMutex.ReleaseMutex() } catch { }; $hcMutex.Dispose() }
-    foreach ($run in $runs) { if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process } }
-    if ($hcRestoreFailed) { throw 'Failed to restore the original High Contrast setting.' }
+    $cleanupErrors = [Collections.Generic.List[string]]::new()
+    if ($hcChanged) {
+        try {
+            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)) {
+                [void]$cleanupErrors.Add('Failed to restore the original High Contrast setting.')
+            }
+        }
+        catch {
+            [void]$cleanupErrors.Add("High Contrast restoration threw: $($_.Exception.Message)")
+        }
+    }
+    if ($null -ne $hcMutex) {
+        try { $hcMutex.ReleaseMutex() } catch { [void]$cleanupErrors.Add("High Contrast mutex release failed: $($_.Exception.Message)") }
+        try { $hcMutex.Dispose() } catch { [void]$cleanupErrors.Add("High Contrast mutex disposal failed: $($_.Exception.Message)") }
+    }
+    foreach ($run in $runs) {
+        try {
+            if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process }
+        }
+        catch {
+            [void]$cleanupErrors.Add("winghostty process cleanup failed: $($_.Exception.Message)")
+        }
+    }
+    if ($cleanupErrors.Count -gt 0) { throw "Palette/theme cleanup failed: $($cleanupErrors -join '; ')" }
 }
 Write-Host "interactive-win11 palette-theme validation: PASS (config=$configPath)"

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -38,21 +38,34 @@ $originalHc = $null
 $hcChanged = $false
 $hcMutex = $null
 $hcMutexAcquired = $false
+$hcRecoveryPath = $null
 $primaryError = $null
 $runs = [Collections.Generic.List[object]]::new()
 $draculaRgb = [Convert]::ToInt32('282a36', 16)
 $themeRgb = [Convert]::ToInt32('262427', 16)
 try {
     if ($ExerciseHighContrast) {
-        $hcMutex = [Threading.Mutex]::new($false, 'Global\WinghosttyHighContrastHarness')
+        $currentUserSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        $hcMutex = [Threading.Mutex]::new($false, "Global\WinghosttyHighContrastHarness-$currentUserSid")
+        $hostLocalAppData = [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)
+        if ([string]::IsNullOrWhiteSpace($hostLocalAppData)) { throw 'Unable to resolve the host LocalAppData directory for High Contrast recovery.' }
+        $hcRecoveryPath = Join-Path $hostLocalAppData 'winghostty\harness-state\high-contrast-restore-off.marker'
         try {
             $hcMutexAcquired = $hcMutex.WaitOne([TimeSpan]::FromSeconds(10))
         }
         catch [Threading.AbandonedMutexException] {
             $hcMutexAcquired = $true
-            throw
+            Write-Warning 'Recovered ownership of an abandoned High Contrast harness mutex.'
         }
         if (-not $hcMutexAcquired) { throw 'Timed out waiting for the High Contrast harness mutex.' }
+        if (Test-Path -LiteralPath $hcRecoveryPath) {
+            $recoveryHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $recoveryHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($recoveryHc)
+            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $recoveryHc.cbSize, [ref]$recoveryHc, 0)) { throw 'SPI_GETHIGHCONTRAST recovery failed.' }
+            $recoveryHc.dwFlags = $recoveryHc.dwFlags -band (-bnot 1)
+            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $recoveryHc.cbSize, [ref]$recoveryHc, 2)) { throw 'SPI_SETHIGHCONTRAST recovery failed.' }
+            Remove-Item -LiteralPath $hcRecoveryPath -Force
+            Write-Warning 'Restored High Contrast state left behind by an interrupted harness run.'
+        }
         $originalHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $originalHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($originalHc)
         if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $originalHc.cbSize, [ref]$originalHc, 0)) { throw 'SPI_GETHIGHCONTRAST failed.' }
     }
@@ -85,8 +98,10 @@ try {
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         if (($originalHc.dwFlags -band 1) -eq 0) {
             $enabled = $originalHc; $enabled.dwFlags = $enabled.dwFlags -bor 1
-            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $enabled.cbSize, [ref]$enabled, 2)) { throw 'SPI_SETHIGHCONTRAST enable failed.' }
+            [IO.Directory]::CreateDirectory((Split-Path -Parent $hcRecoveryPath)) | Out-Null
+            [IO.File]::WriteAllText($hcRecoveryPath, 'restore-high-contrast-off', [Text.UTF8Encoding]::new($false))
             $hcChanged = $true
+            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $enabled.cbSize, [ref]$enabled, 2)) { throw 'SPI_SETHIGHCONTRAST enable failed.' }
         }
         $hcRun = Start-StatefulApp $layout $exe $repoRoot 'palette-theme-high-contrast'; $runs.Add($hcRun)
         $hcHost = Wait-StatefulHost $hcRun $deadline
@@ -105,15 +120,22 @@ catch {
 }
 finally {
     $cleanupErrors = [Collections.Generic.List[string]]::new()
+    $hcRestored = $false
     if ($hcChanged) {
         try {
             if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $originalHc.cbSize, [ref]$originalHc, 2)) {
                 [void]$cleanupErrors.Add('Failed to restore the original High Contrast setting.')
             }
+            else {
+                $hcRestored = $true
+            }
         }
         catch {
             [void]$cleanupErrors.Add("High Contrast restoration threw: $($_.Exception.Message)")
         }
+    }
+    if ($hcRestored) {
+        try { Remove-Item -LiteralPath $hcRecoveryPath -Force -ErrorAction Stop } catch { [void]$cleanupErrors.Add("High Contrast recovery marker cleanup failed: $($_.Exception.Message)") }
     }
     if ($null -ne $hcMutex) {
         if ($hcMutexAcquired) {

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -24,13 +24,13 @@ $configPath = Join-Path $configDir 'config.ghostty'
 [IO.File]::WriteAllText($configPath, "theme = Dracula`r`nwindow-save-state = never`r`n", [Text.UTF8Encoding]::new($false))
 
 function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline, $Process) {
-    Invoke-StatefulCommand $HostHwnd 1901
+    Invoke-StatefulCommand $HostHwnd 1901 $Deadline
     $script:PaletteThemeHost = $HostHwnd
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'palette query edit' -Process $Process -Condition {
         @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2002).Count -gt 0
     }
     $edit = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2002 | Select-Object -First 1
-    Set-StatefulEditText $HostHwnd $edit.Hwnd $Query
+    Set-StatefulEditText $HostHwnd $edit.Hwnd $Query $Deadline
     return $edit.Hwnd
 }
 
@@ -59,7 +59,7 @@ try {
     Write-Host ('theme preview framebuffer rgb={0:x6}' -f ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF))
     Wait-InteractiveWin11Until -Deadline $deadline -Description '0x96f preview render' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $themeRgb }
     if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*Dracula') { throw 'Preview mutated config before commit.' }
-    Invoke-StatefulCommand $hostHwnd 2004
+    Invoke-StatefulCommand $hostHwnd 2004 $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'Dracula preview rollback' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $draculaRgb }
     $edit = Open-ThemeQuery $hostHwnd '0x96f' $deadline $run.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description '0x96f commit preview' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $themeRgb }
@@ -67,8 +67,9 @@ try {
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'theme palette result list' -Process $run.Process -Condition {
         @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2006).Count -gt 0
     }
-    Invoke-StatefulPaletteFirstRow $hostHwnd
+    Invoke-StatefulPaletteFirstRow $hostHwnd $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'theme config persistence' -Process $run.Process -Condition { (Get-Content $configPath -Raw) -match 'theme\s*=\s*0x96f' }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $run $deadline
 
     if ($ExerciseHighContrast) {
@@ -85,7 +86,8 @@ try {
         Start-Sleep -Milliseconds 500
         if ((Get-StatefulPixel $hcSurface.Hwnd) -ne $hcPixel) { throw 'Theme preview changed terminal colors while High Contrast was active.' }
         if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
-        Invoke-StatefulCommand $hcHost 2004
+        Invoke-StatefulCommand $hcHost 2004 $deadline
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         Close-StatefulHost $hcHost $hcRun $deadline
     }
 }

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -37,13 +37,22 @@ function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline,
 $originalHc = $null
 $hcChanged = $false
 $hcMutex = $null
+$hcMutexAcquired = $false
+$primaryError = $null
 $runs = [Collections.Generic.List[object]]::new()
 $draculaRgb = [Convert]::ToInt32('282a36', 16)
 $themeRgb = [Convert]::ToInt32('262427', 16)
 try {
     if ($ExerciseHighContrast) {
         $hcMutex = [Threading.Mutex]::new($false, 'Global\WinghosttyHighContrastHarness')
-        if (-not $hcMutex.WaitOne([TimeSpan]::FromSeconds(10))) { throw 'Timed out waiting for the High Contrast harness mutex.' }
+        try {
+            $hcMutexAcquired = $hcMutex.WaitOne([TimeSpan]::FromSeconds(10))
+        }
+        catch [Threading.AbandonedMutexException] {
+            $hcMutexAcquired = $true
+            throw
+        }
+        if (-not $hcMutexAcquired) { throw 'Timed out waiting for the High Contrast harness mutex.' }
         $originalHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $originalHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($originalHc)
         if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $originalHc.cbSize, [ref]$originalHc, 0)) { throw 'SPI_GETHIGHCONTRAST failed.' }
     }
@@ -91,6 +100,9 @@ try {
         Close-StatefulHost $hcHost $hcRun $deadline
     }
 }
+catch {
+    $primaryError = $_
+}
 finally {
     $cleanupErrors = [Collections.Generic.List[string]]::new()
     if ($hcChanged) {
@@ -104,7 +116,9 @@ finally {
         }
     }
     if ($null -ne $hcMutex) {
-        try { $hcMutex.ReleaseMutex() } catch { [void]$cleanupErrors.Add("High Contrast mutex release failed: $($_.Exception.Message)") }
+        if ($hcMutexAcquired) {
+            try { $hcMutex.ReleaseMutex() } catch { [void]$cleanupErrors.Add("High Contrast mutex release failed: $($_.Exception.Message)") }
+        }
         try { $hcMutex.Dispose() } catch { [void]$cleanupErrors.Add("High Contrast mutex disposal failed: $($_.Exception.Message)") }
     }
     foreach ($run in $runs) {
@@ -115,6 +129,16 @@ finally {
             [void]$cleanupErrors.Add("winghostty process cleanup failed: $($_.Exception.Message)")
         }
     }
-    if ($cleanupErrors.Count -gt 0) { throw "Palette/theme cleanup failed: $($cleanupErrors -join '; ')" }
+    if ($cleanupErrors.Count -gt 0) {
+        $cleanupMessage = "Palette/theme cleanup failed: $($cleanupErrors -join '; ')"
+        if ($null -ne $primaryError) {
+            $primaryError.Exception.Data['WinghosttyCleanupErrors'] = $cleanupMessage
+            Write-Error $cleanupMessage -ErrorAction Continue
+        }
+        else {
+            throw $cleanupMessage
+        }
+    }
 }
+if ($null -ne $primaryError) { throw $primaryError }
 Write-Host "interactive-win11 palette-theme validation: PASS (config=$configPath)"

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -24,13 +24,13 @@ $configPath = Join-Path $configDir 'config.ghostty'
 [IO.File]::WriteAllText($configPath, "theme = Dracula`r`nwindow-save-state = never`r`n", [Text.UTF8Encoding]::new($false))
 
 function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline, $Process) {
-    Invoke-StatefulCommand $HostHwnd 1901 $Deadline
+    Invoke-StatefulCommand $HostHwnd 1901 $Deadline $Process
     $script:PaletteThemeHost = $HostHwnd
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'palette query edit' -Process $Process -Condition {
         @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2002).Count -gt 0
     }
     $edit = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2002 | Select-Object -First 1
-    Set-StatefulEditText $HostHwnd $edit.Hwnd $Query $Deadline
+    Set-StatefulEditText $HostHwnd $edit.Hwnd $Query $Deadline $Process
     return $edit.Hwnd
 }
 
@@ -59,7 +59,7 @@ try {
     Write-Host ('theme preview framebuffer rgb={0:x6}' -f ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF))
     Wait-InteractiveWin11Until -Deadline $deadline -Description '0x96f preview render' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $themeRgb }
     if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*Dracula') { throw 'Preview mutated config before commit.' }
-    Invoke-StatefulCommand $hostHwnd 2004 $deadline
+    Invoke-StatefulCommand $hostHwnd 2004 $deadline $run.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'Dracula preview rollback' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $draculaRgb }
     $edit = Open-ThemeQuery $hostHwnd '0x96f' $deadline $run.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description '0x96f commit preview' -Process $run.Process -Condition { ((Get-StatefulPixel $surface.Hwnd) -band 0xFFFFFF) -eq $themeRgb }
@@ -67,7 +67,7 @@ try {
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'theme palette result list' -Process $run.Process -Condition {
         @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2006).Count -gt 0
     }
-    Invoke-StatefulPaletteFirstRow $hostHwnd $deadline
+    Invoke-StatefulPaletteFirstRow $hostHwnd $deadline $run.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'theme config persistence' -Process $run.Process -Condition { (Get-Content $configPath -Raw) -match 'theme\s*=\s*0x96f' }
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $run $deadline
@@ -86,7 +86,7 @@ try {
         Start-Sleep -Milliseconds 500
         if ((Get-StatefulPixel $hcSurface.Hwnd) -ne $hcPixel) { throw 'Theme preview changed terminal colors while High Contrast was active.' }
         if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
-        Invoke-StatefulCommand $hcHost 2004 $deadline
+        Invoke-StatefulCommand $hcHost 2004 $deadline $hcRun.Process
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         Close-StatefulHost $hcHost $hcRun $deadline
     }

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -24,7 +24,7 @@ $configPath = Join-Path $configDir 'config.ghostty'
 [IO.File]::WriteAllText($configPath, "theme = Dracula`r`nwindow-save-state = never`r`n", [Text.UTF8Encoding]::new($false))
 
 function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline, $Process) {
-    Invoke-StatefulCommand $HostHwnd 1901 $Deadline $Process
+    Invoke-StatefulPostedCommand $HostHwnd 1901 $Deadline $Process
     $script:PaletteThemeHost = $HostHwnd
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'palette query edit' -Process $Process -Condition {
         @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2002).Count -gt 0
@@ -63,7 +63,10 @@ try {
             if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $recoveryHc.cbSize, [ref]$recoveryHc, 0)) { throw 'SPI_GETHIGHCONTRAST recovery failed.' }
             $recoveryHc.dwFlags = $recoveryHc.dwFlags -band (-bnot 1)
             if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x43, $recoveryHc.cbSize, [ref]$recoveryHc, 2)) { throw 'SPI_SETHIGHCONTRAST recovery failed.' }
-            Remove-Item -LiteralPath $hcRecoveryPath -Force
+            $recoveryReadback = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $recoveryReadback.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($recoveryReadback)
+            if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $recoveryReadback.cbSize, [ref]$recoveryReadback, 0)) { throw 'SPI_GETHIGHCONTRAST recovery verification failed.' }
+            if (($recoveryReadback.dwFlags -band 1) -ne 0) { throw 'High Contrast remained enabled after interrupted-run recovery.' }
+            Remove-Item -LiteralPath $hcRecoveryPath -Force -ErrorAction Stop
             Write-Warning 'Restored High Contrast state left behind by an interrupted harness run.'
         }
         $originalHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new(); $originalHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($originalHc)
@@ -127,7 +130,17 @@ finally {
                 [void]$cleanupErrors.Add('Failed to restore the original High Contrast setting.')
             }
             else {
-                $hcRestored = $true
+                $restoredHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new()
+                $restoredHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($restoredHc)
+                if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $restoredHc.cbSize, [ref]$restoredHc, 0)) {
+                    [void]$cleanupErrors.Add('Failed to verify the restored High Contrast setting.')
+                }
+                elseif (($restoredHc.dwFlags -band 1) -ne ($originalHc.dwFlags -band 1)) {
+                    [void]$cleanupErrors.Add('High Contrast remained enabled after restoration.')
+                }
+                else {
+                    $hcRestored = $true
+                }
             }
         }
         catch {

--- a/test/windows/interactive-win11-pr-smoke.ps1
+++ b/test/windows/interactive-win11-pr-smoke.ps1
@@ -7,8 +7,32 @@ param(
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ($Rebuild) {
-    & (Join-Path $repoRoot 'scripts\dev-windows.cmd') zig build -Demit-exe=true
-    if ($LASTEXITCODE -ne 0) { throw "PR smoke build failed with exit code $LASTEXITCODE." }
+    $originalZigGlobalCache = $env:ZIG_GLOBAL_CACHE_DIR
+    $originalZigLocalCache = $env:ZIG_LOCAL_CACHE_DIR
+    try {
+        for ($attempt = 1; $attempt -le 2; $attempt++) {
+            if ($attempt -eq 2 -and $env:RUNNER_TEMP) {
+                $env:ZIG_GLOBAL_CACHE_DIR = Join-Path $env:RUNNER_TEMP "zig-global-cache-pr-smoke-retry-$PID"
+                $env:ZIG_LOCAL_CACHE_DIR = Join-Path $env:RUNNER_TEMP "zig-local-cache-pr-smoke-retry-$PID"
+            }
+
+            $buildOutput = @(& (Join-Path $repoRoot 'scripts\dev-windows.cmd') zig build -Demit-exe=true 2>&1)
+            $buildExitCode = $LASTEXITCODE
+            $buildOutput | ForEach-Object { Write-Host $_ }
+            if ($buildExitCode -eq 0) { break }
+
+            $buildText = $buildOutput -join "`n"
+            $cacheHydrationMiss = $buildText -match 'FileNotFound' -and $buildText -match 'zig-global-cache'
+            if ($attempt -eq 2 -or -not $cacheHydrationMiss) {
+                throw "PR smoke build failed with exit code $buildExitCode."
+            }
+            Write-Warning 'PR smoke build hit a transient Zig package-cache miss; retrying once with fresh temp cache directories.'
+        }
+    }
+    finally {
+        $env:ZIG_GLOBAL_CACHE_DIR = $originalZigGlobalCache
+        $env:ZIG_LOCAL_CACHE_DIR = $originalZigLocalCache
+    }
 }
 
 $childPowerShell = Get-Command pwsh.exe -CommandType Application -ErrorAction SilentlyContinue |

--- a/test/windows/interactive-win11-pr-smoke.ps1
+++ b/test/windows/interactive-win11-pr-smoke.ps1
@@ -1,3 +1,5 @@
+#requires -Version 7.0
+
 [CmdletBinding()]
 param(
     [switch] $Rebuild,

--- a/test/windows/interactive-win11-pr-smoke.ps1
+++ b/test/windows/interactive-win11-pr-smoke.ps1
@@ -34,6 +34,9 @@ foreach ($harness in @(
         (Join-Path $PSScriptRoot $harness)
     )
     if ($ResetState) { $harnessArgs += '-ResetState' }
+    if ($harness -eq 'interactive-win11-undo.ps1') {
+        $harnessArgs += @('-TimeoutSeconds', '35')
+    }
 
     & $childPowerShell @harnessArgs
     if ($LASTEXITCODE -ne 0) { throw "$harness failed with exit code $LASTEXITCODE." }

--- a/test/windows/interactive-win11-pr-smoke.ps1
+++ b/test/windows/interactive-win11-pr-smoke.ps1
@@ -18,8 +18,15 @@ if ($Rebuild) {
                 $env:ZIG_LOCAL_CACHE_DIR = Join-Path $env:RUNNER_TEMP "zig-local-cache-pr-smoke-retry-$PID"
             }
 
-            $buildOutput = @(& (Join-Path $repoRoot 'scripts\dev-windows.cmd') zig build -Demit-exe=true 2>&1)
-            $buildExitCode = $LASTEXITCODE
+            $originalErrorActionPreference = $ErrorActionPreference
+            try {
+                $ErrorActionPreference = 'Continue'
+                $buildOutput = @(& (Join-Path $repoRoot 'scripts\dev-windows.cmd') zig build -Demit-exe=true 2>&1)
+                $buildExitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $originalErrorActionPreference
+            }
             $buildOutput | ForEach-Object { Write-Host $_ }
             if ($buildExitCode -eq 0) { break }
 

--- a/test/windows/interactive-win11-resize.ps1
+++ b/test/windows/interactive-win11-resize.ps1
@@ -226,7 +226,7 @@ function Invoke-HostCommand {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [int] $CommandId,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message $wmCommand -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
@@ -237,7 +237,7 @@ function Invoke-CommandPaletteAction {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [string] $Action,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     Invoke-HostCommand -HostHwnd $HostHwnd -CommandId $hostCommandPaletteCommandId -Deadline $Deadline -Process $Process

--- a/test/windows/interactive-win11-resize.ps1
+++ b/test/windows/interactive-win11-resize.ps1
@@ -81,9 +81,6 @@ public static class WinghosttyResizeWin32 {
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     public static extern IntPtr FindWindowExW(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr SendMessageW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
-
 }
 '@
 
@@ -227,10 +224,12 @@ function New-WParam {
 function Invoke-HostCommand {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $CommandId
+        [Parameter(Mandatory)] [int] $CommandId,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [WinghosttyResizeWin32]::SendMessageW($HostHwnd, $wmCommand, (New-WParam -Low $CommandId), [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message $wmCommand -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
 }
 
 function Invoke-CommandPaletteAction {
@@ -241,22 +240,17 @@ function Invoke-CommandPaletteAction {
         [System.Diagnostics.Process] $Process
     )
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId $hostCommandPaletteCommandId
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId $hostCommandPaletteCommandId -Deadline $Deadline -Process $Process
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'command palette edit control' -Process $Process -Condition {
         $null -ne (Get-VisibleChildById -Parent $HostHwnd -Id $paletteEditControlId)
     }
 
     $edit = Get-VisibleChildById -Parent $HostHwnd -Id $paletteEditControlId
     foreach ($ch in $Action.ToCharArray()) {
-        [void] [WinghosttyResizeWin32]::SendMessageW(
-            $edit.Hwnd,
-            $wmChar,
-            ([UIntPtr]([uint64]([int][char]$ch))),
-            [IntPtr]::Zero
-        )
+        [void] (Invoke-InteractiveWin11Message -Hwnd $edit.Hwnd -Message $wmChar -WParam ([UIntPtr]([uint64]([int][char]$ch))) -Deadline $Deadline -Description "palette WM_CHAR '$ch'" -Process $Process)
     }
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId $paletteConfirmCommandId
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId $paletteConfirmCommandId -Deadline $Deadline -Process $Process
 }
 
 function Show-ResizeHarnessWindow {
@@ -585,7 +579,7 @@ try {
     Start-Sleep -Milliseconds 600
 
     $scenarioDeadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-    Invoke-HostCommand -HostHwnd $process.MainWindowHandle -CommandId $hostNewTabCommandId
+    Invoke-HostCommand -HostHwnd $process.MainWindowHandle -CommandId $hostNewTabCommandId -Deadline $scenarioDeadline -Process $process
     Wait-InteractiveWin11Until -Deadline $scenarioDeadline -Description 'second tab for resize repro' -Process $process -Condition {
         (Get-VisibleTabCount -Parent $process.MainWindowHandle) -ge 2
     }
@@ -595,7 +589,7 @@ try {
     }
     $initialUnion = Assert-VisibleSurfaceUnionFillsHostContent -HostHwnd $process.MainWindowHandle -ExpectedSurfaceCount 2 -Label 'initial split layout'
 
-    [void] [WinghosttyResizeWin32]::SendMessageW($process.MainWindowHandle, $wmEnterSizeMove, [UIntPtr]::Zero, [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $process.MainWindowHandle -Message $wmEnterSizeMove -Deadline $scenarioDeadline -Description 'WM_ENTERSIZEMOVE' -Flags $script:InteractiveWin11SmtoBlock -Process $process)
     $enteredSizeMove = $true
     Assert-Win32CallSucceeded `
         -Succeeded ([WinghosttyResizeWin32]::MoveWindow($process.MainWindowHandle, $x, $y, $grownWidth, $grownHeight, $true)) `
@@ -608,7 +602,7 @@ try {
     [void] [WinghosttyResizeWin32]::UpdateWindow($process.MainWindowHandle)
     Start-Sleep -Milliseconds 700
 
-    [void] [WinghosttyResizeWin32]::SendMessageW($process.MainWindowHandle, $wmExitSizeMove, [UIntPtr]::Zero, [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $process.MainWindowHandle -Message $wmExitSizeMove -Deadline $scenarioDeadline -Description 'WM_EXITSIZEMOVE' -Flags $script:InteractiveWin11SmtoBlock -Process $process)
     $enteredSizeMove = $false
     [void] [WinghosttyResizeWin32]::UpdateWindow($process.MainWindowHandle)
     Start-Sleep -Milliseconds 700
@@ -632,7 +626,12 @@ try {
 }
 finally {
     if ($enteredSizeMove -and $process.MainWindowHandle -ne 0) {
-        [void] [WinghosttyResizeWin32]::SendMessageW($process.MainWindowHandle, $wmExitSizeMove, [UIntPtr]::Zero, [IntPtr]::Zero)
+        try {
+            [void] (Invoke-InteractiveWin11Message -Hwnd $process.MainWindowHandle -Message $wmExitSizeMove -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'cleanup WM_EXITSIZEMOVE' -Flags $script:InteractiveWin11SmtoBlock -Process $process)
+        }
+        catch {
+            Write-Warning "cleanup WM_EXITSIZEMOVE failed: $($_.Exception.Message)"
+        }
     }
     Stop-InteractiveWin11Process -Process $process
 }

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -50,8 +50,15 @@ try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     $first = Start-StatefulApp $layout $exe $repoRoot 'session-save' @('--single-instance=true'); $runs.Add($first)
     $hostHwnd = Wait-StatefulHost $first $deadline
-    Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process; Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process
-    Wait-InteractiveWin11Until -Deadline $deadline -Description 'three live tabs' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 3 }
+    foreach ($targetTabCount in 2..3) {
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process
+        Wait-InteractiveWin11Until -Deadline $deadline -Description "live tab count $targetTabCount" -Process $first.Process -Condition {
+            (Get-StatefulTabCount $hostHwnd) -eq $targetTabCount
+        }
+        $null = Invoke-InteractiveWin11Message -Hwnd $hostHwnd -Message 0 -Deadline $deadline -Description "live tab $targetTabCount readiness barrier" -Process $first.Process
+    }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Invoke-StatefulButton $hostHwnd 1001 $deadline $first.Process
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $first $deadline
@@ -65,6 +72,11 @@ try {
     $explicit = Start-StatefulApp $layout $exe $repoRoot 'session-explicit-command' @('-e', 'cmd.exe', '/k'); $runs.Add($explicit)
     $explicitHost = Wait-StatefulHost $explicit $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'fresh explicit-command tab' -Process $explicit.Process -Condition { (Get-StatefulTabCount $explicitHost) -eq 1 }
+    Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process
+    Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'asynchronous burst-created tabs' -Process $explicit.Process -Condition { (Get-StatefulTabCount $explicitHost) -eq 3 }
+    $null = Invoke-InteractiveWin11Message -Hwnd $explicitHost -Message 0 -Deadline $deadline -Description 'asynchronous tab burst readiness barrier' -Process $explicit.Process
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $explicitHost $explicit $deadline
     if ((Get-Content $statePath -Raw) -ne $savedRaw) { throw 'Explicit -e launch read or replaced the saved workspace.' }
@@ -97,5 +109,10 @@ try {
 }
 finally {
     foreach ($run in $runs) { if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process } }
+}
+foreach ($run in $runs) {
+    if (Select-String -LiteralPath $run.Stderr -SimpleMatch 'shell/native invariant failed' -Quiet) {
+        throw "Shell/native invariant failure reported by $($run.Stderr)."
+    }
 }
 Write-Host "interactive-win11 session-restore validation: PASS (state=$statePath)"

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -50,9 +50,11 @@ try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     $first = Start-StatefulApp $layout $exe $repoRoot 'session-save' @('--single-instance=true'); $runs.Add($first)
     $hostHwnd = Wait-StatefulHost $first $deadline
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'initial session-save tab' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 1 }
+    $null = Invoke-InteractiveWin11Message -Hwnd $hostHwnd -Message 0 -Deadline $deadline -Description 'initial session-save host readiness barrier' -Process $first.Process
     foreach ($targetTabCount in 2..3) {
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-        Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process
+        Invoke-StatefulPostedCommand $hostHwnd 1904 $deadline $first.Process
         Wait-InteractiveWin11Until -Deadline $deadline -Description "live tab count $targetTabCount" -Process $first.Process -Condition {
             (Get-StatefulTabCount $hostHwnd) -eq $targetTabCount
         }
@@ -72,9 +74,9 @@ try {
     $explicit = Start-StatefulApp $layout $exe $repoRoot 'session-explicit-command' @('-e', 'cmd.exe', '/k'); $runs.Add($explicit)
     $explicitHost = Wait-StatefulHost $explicit $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'fresh explicit-command tab' -Process $explicit.Process -Condition { (Get-StatefulTabCount $explicitHost) -eq 1 }
-    Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process
-    Invoke-StatefulPostedCommand $explicitHost 1904 $explicit.Process
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Invoke-StatefulPostedCommand $explicitHost 1904 $deadline $explicit.Process
+    Invoke-StatefulPostedCommand $explicitHost 1904 $deadline $explicit.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'asynchronous burst-created tabs' -Process $explicit.Process -Condition { (Get-StatefulTabCount $explicitHost) -eq 3 }
     $null = Invoke-InteractiveWin11Message -Hwnd $explicitHost -Message 0 -Deadline $deadline -Description 'asynchronous tab burst readiness barrier' -Process $explicit.Process
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -50,9 +50,9 @@ try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     $first = Start-StatefulApp $layout $exe $repoRoot 'session-save' @('--single-instance=true'); $runs.Add($first)
     $hostHwnd = Wait-StatefulHost $first $deadline
-    Invoke-StatefulCommand $hostHwnd 1904; Invoke-StatefulCommand $hostHwnd 1904
+    Invoke-StatefulCommand $hostHwnd 1904 $deadline; Invoke-StatefulCommand $hostHwnd 1904 $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'three live tabs' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 3 }
-    Invoke-StatefulButton $hostHwnd 1001
+    Invoke-StatefulButton $hostHwnd 1001 $deadline
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $first $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'session-state file' -Condition { Test-Path $statePath }

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -53,6 +53,7 @@ try {
     Invoke-StatefulCommand $hostHwnd 1904; Invoke-StatefulCommand $hostHwnd 1904
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'three live tabs' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 3 }
     Invoke-StatefulButton $hostHwnd 1001
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $first $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'session-state file' -Condition { Test-Path $statePath }
     $saved = Get-Content $statePath -Raw | ConvertFrom-Json
@@ -63,6 +64,7 @@ try {
     $explicit = Start-StatefulApp $layout $exe $repoRoot 'session-explicit-command' @('-e', 'cmd.exe', '/k'); $runs.Add($explicit)
     $explicitHost = Wait-StatefulHost $explicit $deadline
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'fresh explicit-command tab' -Process $explicit.Process -Condition { (Get-StatefulTabCount $explicitHost) -eq 1 }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $explicitHost $explicit $deadline
     if ((Get-Content $statePath -Raw) -ne $savedRaw) { throw 'Explicit -e launch read or replaced the saved workspace.' }
 
@@ -76,6 +78,7 @@ try {
     if ($activeTabs.Count -ne 1 -or $snapshot.windows[0].tabs[1].tab_id -ne $snapshot.windows[0].active_tab_id -or -not $snapshot.windows[0].tabs[1].active) {
         throw "Restored selected tab mismatch: $($snapshot | ConvertTo-Json -Depth 8 -Compress)"
     }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $restoredHost $second $deadline
 
     [IO.File]::WriteAllText($statePath, '{not valid json', [Text.UTF8Encoding]::new($false))
@@ -88,6 +91,7 @@ try {
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'fresh tab after corrupt state' -Process $third.Process -Condition {
         (Get-StatefulTabCount $freshHost) -eq 1
     }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $freshHost $third $deadline
 }
 finally {

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -55,6 +55,7 @@ try {
     Invoke-StatefulButton $hostHwnd 1001 $deadline
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $first $deadline
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'session-state file' -Condition { Test-Path $statePath }
     $saved = Get-Content $statePath -Raw | ConvertFrom-Json
     if ($saved.windows[0].tabs.Count -ne 3 -or $saved.windows[0].selected_tab -ne 1) { throw "Saved session mismatch: $($saved | ConvertTo-Json -Depth 8 -Compress)" }

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -50,9 +50,9 @@ try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     $first = Start-StatefulApp $layout $exe $repoRoot 'session-save' @('--single-instance=true'); $runs.Add($first)
     $hostHwnd = Wait-StatefulHost $first $deadline
-    Invoke-StatefulCommand $hostHwnd 1904 $deadline; Invoke-StatefulCommand $hostHwnd 1904 $deadline
+    Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process; Invoke-StatefulCommand $hostHwnd 1904 $deadline $first.Process
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'three live tabs' -Process $first.Process -Condition { (Get-StatefulTabCount $hostHwnd) -eq 3 }
-    Invoke-StatefulButton $hostHwnd 1001 $deadline
+    Invoke-StatefulButton $hostHwnd 1001 $deadline $first.Process
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     Close-StatefulHost $hostHwnd $first $deadline
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -33,6 +33,7 @@ function Get-SessionAutomationSnapshot([string]$Name, [DateTime]$Deadline) {
         $out = Join-Path $layout.Logs "$Name-$attempt.json"
         $err = Join-Path $layout.Logs "$Name-$attempt.stderr.log"
         $query = Start-Process -FilePath $cli -ArgumentList @('+list-windows', "--class=$instanceClass") -WorkingDirectory $repoRoot -RedirectStandardOutput $out -RedirectStandardError $err -PassThru
+        $queryHandle = $query.Handle
         $remainingMs = [Math]::Max(0, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)
         if (-not $query.WaitForExit($remainingMs)) {
             Stop-InteractiveWin11Process -Process $query
@@ -40,8 +41,14 @@ function Get-SessionAutomationSnapshot([string]$Name, [DateTime]$Deadline) {
             continue
         }
         $query.Refresh()
+        $queryExitCode = Get-InteractiveWin11ProcessExitCode -Process $query -ProcessHandle $queryHandle
+        if ($queryExitCode -ne 0) {
+            $lastError = if ((Test-Path $err) -and (Get-Item $err).Length -gt 0) { "exit ${queryExitCode}: $(Get-Content $err -Raw)" } else { "exit $queryExitCode" }
+            Start-Sleep -Milliseconds 250
+            continue
+        }
         if ((Test-Path $out) -and (Get-Item $out).Length -gt 0) { return Get-Content $out -Raw | ConvertFrom-Json }
-        $lastError = if (Test-Path $err) { Get-Content $err -Raw } else { "exit $($query.ExitCode)" }
+        $lastError = if ((Test-Path $err) -and (Get-Item $err).Length -gt 0) { Get-Content $err -Raw } else { 'empty stdout' }
         Start-Sleep -Milliseconds 250
     }
     throw "Session automation query failed after three attempts: $lastError"

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -35,7 +35,7 @@ function Get-SessionAutomationSnapshot([string]$Name, [DateTime]$Deadline) {
         $query = Start-Process -FilePath $cli -ArgumentList @('+list-windows', "--class=$instanceClass") -WorkingDirectory $repoRoot -RedirectStandardOutput $out -RedirectStandardError $err -PassThru
         $remainingMs = [Math]::Max(0, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)
         if (-not $query.WaitForExit($remainingMs)) {
-            $query.Kill($true); $query.WaitForExit()
+            Stop-InteractiveWin11Process -Process $query
             $lastError = "automation query process did not exit before the story deadline"
             continue
         }

--- a/test/windows/interactive-win11-shell-command-live.ps1
+++ b/test/windows/interactive-win11-shell-command-live.ps1
@@ -323,7 +323,7 @@ function Invoke-SendMessageTimeoutOrThrow {
         -Description $Description)
 }
 
-function Activate-TabIndex {
+function Invoke-TabIndexActivation {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [int] $TabIndex,
@@ -661,7 +661,7 @@ try {
         }
     }
 
-    Activate-TabIndex -HostHwnd $hostHwnd -TabIndex 0 -Deadline $deadline -Process $process
+    Invoke-TabIndexActivation -HostHwnd $hostHwnd -TabIndex 0 -Deadline $deadline -Process $process
 
     Wait-InteractiveWin11Until -Deadline $deadline -Description 'shell ready file' -Process $process -Condition {
         Test-Path -LiteralPath $readyPath

--- a/test/windows/interactive-win11-shell-command-live.ps1
+++ b/test/windows/interactive-win11-shell-command-live.ps1
@@ -110,9 +110,6 @@ public static class Win11ShellCommandLiveNative {
     [DllImport("user32.dll", SetLastError = true)]
     public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr SendMessageTimeoutW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
-
     [DllImport("user32.dll")]
     public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
 
@@ -127,7 +124,6 @@ if (-not ('System.Drawing.Bitmap' -as [type])) {
 }
 
 $MAPVK_VK_TO_VSC = 0
-$SMTO_ABORTIFHUNG = 0x0002
 $SW_RESTORE = 9
 $SWP_NOMOVE = 0x0002
 $SWP_NOSIZE = 0x0001
@@ -135,7 +131,6 @@ $SWP_SHOWWINDOW = 0x0040
 $VISIBLE_TAB_MIN_ID = 1000
 $VISIBLE_TAB_MAX_ID_EXCLUSIVE = 1900
 $HOST_COMMAND_NEW_TAB_ID = 1904
-$SEND_TIMEOUT_MS = 1000
 $BOO_AUTO_EXIT_MS = 1000
 $KEY_STROKE_DELAY_MS = 15
 $CAPTURE_PROMOTION_DELAY_MS = 150
@@ -292,7 +287,9 @@ function Get-VisibleTabCount {
 function Invoke-HostCommand {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $CommandId
+        [Parameter(Mandatory)] [int] $CommandId,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     Invoke-SendMessageTimeoutOrThrow `
@@ -300,6 +297,8 @@ function Invoke-HostCommand {
         -Message 0x0111 `
         -WParam (New-WParam -Low $CommandId) `
         -LParam ([IntPtr]::Zero) `
+        -Deadline $Deadline `
+        -Process $Process `
         -Description "host command $CommandId"
 }
 
@@ -309,29 +308,27 @@ function Invoke-SendMessageTimeoutOrThrow {
         [Parameter(Mandatory)] [uint32] $Message,
         [Parameter(Mandatory)] [UIntPtr] $WParam,
         [Parameter(Mandatory)] [IntPtr] $LParam,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
         [Parameter(Mandatory)] [string] $Description
     )
 
-    $sendResult = [UIntPtr]::Zero
-    $sendStatus = [Win11ShellCommandLiveNative]::SendMessageTimeoutW(
-        $Hwnd,
-        $Message,
-        $WParam,
-        $LParam,
-        [uint32] $SMTO_ABORTIFHUNG,
-        [uint32] $SEND_TIMEOUT_MS,
-        [ref] $sendResult
-    )
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendMessageTimeoutW failed for $Description hwnd=$Hwnd error=$lastError"
-    }
+    [void](Invoke-InteractiveWin11Message `
+        -Hwnd $Hwnd `
+        -Message $Message `
+        -WParam $WParam `
+        -LParam $LParam `
+        -Deadline $Deadline `
+        -Process $Process `
+        -Description $Description)
 }
 
 function Activate-TabIndex {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $TabIndex
+        [Parameter(Mandatory)] [int] $TabIndex,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $tab = Get-VisibleTabButtons -Parent $HostHwnd | Select-Object -Index $TabIndex
@@ -344,36 +341,17 @@ function Activate-TabIndex {
         -Message 0x0201 `
         -WParam ([UIntPtr]::Zero) `
         -LParam ([IntPtr]::Zero) `
+        -Deadline $Deadline `
+        -Process $Process `
         -Description "activate tab index $TabIndex mouse down"
     Invoke-SendMessageTimeoutOrThrow `
         -Hwnd $tab.Hwnd `
         -Message 0x0202 `
         -WParam ([UIntPtr]::Zero) `
         -LParam ([IntPtr]::Zero) `
+        -Deadline $Deadline `
+        -Process $Process `
         -Description "activate tab index $TabIndex mouse up"
-}
-
-function Wait-Until {
-    param(
-        [Parameter(Mandatory)] [scriptblock] $Condition,
-        [Parameter(Mandatory)] [string] $Description,
-        [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
-    )
-
-    while ([DateTime]::UtcNow -lt $Deadline) {
-        if ($null -ne $Process -and $Process.HasExited) {
-            throw "winghostty exited while waiting for ${Description} (exit code $($Process.ExitCode))"
-        }
-
-        if (& $Condition) {
-            return
-        }
-
-        Start-Sleep -Milliseconds 100
-    }
-
-    throw "Timed out waiting for $Description"
 }
 
 function New-KeyLParam {
@@ -395,7 +373,9 @@ function Send-KeyMessage {
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
         [Parameter(Mandatory)] [UInt16] $VirtualKey,
         [UInt16] $CharCode = 0,
-        [switch] $KeyUp
+        [switch] $KeyUp,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $scanCode = [Win11ShellCommandLiveNative]::MapVirtualKeyW([uint32] $VirtualKey, [uint32] $MAPVK_VK_TO_VSC)
@@ -404,43 +384,33 @@ function Send-KeyMessage {
     }
 
     $message = if ($KeyUp) { $WM_KEYUP } else { $WM_KEYDOWN }
-    $sendResult = [UIntPtr]::Zero
-    $sendStatus = [Win11ShellCommandLiveNative]::SendMessageTimeoutW(
-        $Hwnd,
-        [uint32] $message,
-        [UIntPtr]([uint64] $VirtualKey),
-        (New-KeyLParam -ScanCode ([uint16] $scanCode) -KeyUp:$KeyUp),
-        [uint32] $SMTO_ABORTIFHUNG,
-        [uint32] $SEND_TIMEOUT_MS,
-        [ref] $sendResult
-    )
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "SendMessageTimeoutW failed for message=$message hwnd=$Hwnd vk=$VirtualKey error=$lastError"
-    }
+    Invoke-SendMessageTimeoutOrThrow `
+        -Hwnd $Hwnd `
+        -Message ([uint32] $message) `
+        -WParam ([UIntPtr]([uint64] $VirtualKey)) `
+        -LParam (New-KeyLParam -ScanCode ([uint16] $scanCode) -KeyUp:$KeyUp) `
+        -Deadline $Deadline `
+        -Process $Process `
+        -Description "message=$message vk=$VirtualKey"
 
     if (-not $KeyUp -and $CharCode -ne 0) {
-        $sendResult = [UIntPtr]::Zero
-        $sendStatus = [Win11ShellCommandLiveNative]::SendMessageTimeoutW(
-            $Hwnd,
-            [uint32] $WM_CHAR,
-            [UIntPtr]([uint64] $CharCode),
-            (New-KeyLParam -ScanCode ([uint16] $scanCode)),
-            [uint32] $SMTO_ABORTIFHUNG,
-            [uint32] $SEND_TIMEOUT_MS,
-            [ref] $sendResult
-        )
-        if ($sendStatus -eq [IntPtr]::Zero) {
-            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-            throw "SendMessageTimeoutW failed for WM_CHAR hwnd=$Hwnd char=$CharCode error=$lastError"
-        }
+        Invoke-SendMessageTimeoutOrThrow `
+            -Hwnd $Hwnd `
+            -Message ([uint32] $WM_CHAR) `
+            -WParam ([UIntPtr]([uint64] $CharCode)) `
+            -LParam (New-KeyLParam -ScanCode ([uint16] $scanCode)) `
+            -Deadline $Deadline `
+            -Process $Process `
+            -Description "WM_CHAR char=$CharCode"
     }
 }
 
 function Send-ModifiedChar {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
-        [Parameter(Mandatory)] [char] $Character
+        [Parameter(Mandatory)] [char] $Character,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $vkScan = [Win11ShellCommandLiveNative]::VkKeyScanW($Character)
@@ -456,17 +426,17 @@ function Send-ModifiedChar {
     if ($modifierMask -band 0x01) { $modifiers += [uint16] $VK_SHIFT }
 
     foreach ($modifier in $modifiers) {
-        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $modifier
+        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $modifier -Deadline $Deadline -Process $Process
     }
 
     try {
-        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $virtualKey -CharCode ([uint16] [int] $Character)
-        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $virtualKey -KeyUp
+        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $virtualKey -CharCode ([uint16] [int] $Character) -Deadline $Deadline -Process $Process
+        Send-KeyMessage -Hwnd $Hwnd -VirtualKey $virtualKey -KeyUp -Deadline $Deadline -Process $Process
     }
     finally {
         for ($i = $modifiers.Count - 1; $i -ge 0; $i -= 1) {
             $modifier = $modifiers[$i]
-            Send-KeyMessage -Hwnd $Hwnd -VirtualKey $modifier -KeyUp
+            Send-KeyMessage -Hwnd $Hwnd -VirtualKey $modifier -KeyUp -Deadline $Deadline -Process $Process
         }
     }
 }
@@ -474,16 +444,18 @@ function Send-ModifiedChar {
 function Send-Line {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
-        [Parameter(Mandatory)] [string] $Text
+        [Parameter(Mandatory)] [string] $Text,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     foreach ($character in $Text.ToCharArray()) {
-        Send-ModifiedChar -Hwnd $Hwnd -Character $character
+        Send-ModifiedChar -Hwnd $Hwnd -Character $character -Deadline $Deadline -Process $Process
         Start-Sleep -Milliseconds $KEY_STROKE_DELAY_MS
     }
 
-    Send-KeyMessage -Hwnd $Hwnd -VirtualKey ([uint16] $VK_RETURN) -CharCode 13
-    Send-KeyMessage -Hwnd $Hwnd -VirtualKey ([uint16] $VK_RETURN) -KeyUp
+    Send-KeyMessage -Hwnd $Hwnd -VirtualKey ([uint16] $VK_RETURN) -CharCode 13 -Deadline $Deadline -Process $Process
+    Send-KeyMessage -Hwnd $Hwnd -VirtualKey ([uint16] $VK_RETURN) -KeyUp -Deadline $Deadline -Process $Process
 }
 
 function Save-WindowCapture {
@@ -670,28 +642,28 @@ $hostHwnd = [IntPtr]::Zero
 try {
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
 
-    Wait-Until -Deadline $deadline -Description 'host window' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'host window' -Process $process -Condition {
         (Find-HostWindow -ProcessId $process.Id) -ne [IntPtr]::Zero
     }
 
     $hostHwnd = Find-HostWindow -ProcessId $process.Id
     Promote-WindowForCapture -Hwnd $hostHwnd
 
-    Wait-Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'surface child window' -Process $process -Condition {
         (Find-SurfaceWindow -Parent $hostHwnd) -ne [IntPtr]::Zero
     }
 
     while ((Get-VisibleTabCount -Parent $hostHwnd) -lt $SeedTabs) {
         $targetTabCount = (Get-VisibleTabCount -Parent $hostHwnd) + 1
-        Invoke-HostCommand -HostHwnd $hostHwnd -CommandId $HOST_COMMAND_NEW_TAB_ID
-        Wait-Until -Deadline $deadline -Description "seed tabs ($targetTabCount/$SeedTabs)" -Process $process -Condition {
+        Invoke-HostCommand -HostHwnd $hostHwnd -CommandId $HOST_COMMAND_NEW_TAB_ID -Deadline $deadline -Process $process
+        Wait-InteractiveWin11Until -Deadline $deadline -Description "seed tabs ($targetTabCount/$SeedTabs)" -Process $process -Condition {
             (Get-VisibleTabCount -Parent $hostHwnd) -ge $targetTabCount
         }
     }
 
-    Activate-TabIndex -HostHwnd $hostHwnd -TabIndex 0
+    Activate-TabIndex -HostHwnd $hostHwnd -TabIndex 0 -Deadline $deadline -Process $process
 
-    Wait-Until -Deadline $deadline -Description 'shell ready file' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'shell ready file' -Process $process -Condition {
         Test-Path -LiteralPath $readyPath
     }
 
@@ -700,14 +672,14 @@ try {
     Promote-WindowForCapture -Hwnd $hostHwnd
     Save-WindowCapture -Hwnd $surfaceHwnd -Path $beforeCapturePath
 
-    Send-Line -Hwnd $surfaceHwnd -Text 'echo READY>interactive-win11-shell-command-live-control.txt'
-    Wait-Until -Deadline $deadline -Description 'control output file' -Process $process -Condition {
+    Send-Line -Hwnd $surfaceHwnd -Text 'echo READY>interactive-win11-shell-command-live-control.txt' -Deadline $deadline -Process $process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'control output file' -Process $process -Condition {
         Test-Path -LiteralPath $controlPath
     }
     Start-Sleep -Milliseconds $CAPTURE_SETTLE_MS
 
-    Send-Line -Hwnd $surfaceHwnd -Text 'where winghostty>interactive-win11-shell-command-live-resolved.txt'
-    Wait-Until -Deadline $deadline -Description 'command resolution file' -Process $process -Condition {
+    Send-Line -Hwnd $surfaceHwnd -Text 'where winghostty>interactive-win11-shell-command-live-resolved.txt' -Deadline $deadline -Process $process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'command resolution file' -Process $process -Condition {
         Test-Path -LiteralPath $resolvedPath
     }
     Start-Sleep -Milliseconds $CAPTURE_SETTLE_MS
@@ -726,7 +698,7 @@ try {
         throw "live shell resolved unexpected first winghostty command: $($resolved[0]) (expected same install dir as $exePath)"
     }
 
-    Send-Line -Hwnd $surfaceHwnd -Text ("{0} & echo POST>interactive-win11-shell-command-live-post.txt" -f $typedCommandText)
+    Send-Line -Hwnd $surfaceHwnd -Text ("{0} & echo POST>interactive-win11-shell-command-live-post.txt" -f $typedCommandText) -Deadline $deadline -Process $process
     Start-Sleep -Milliseconds $POST_COMMAND_CAPTURE_SETTLE_MS
     Promote-WindowForCapture -Hwnd $hostHwnd
     Save-WindowCapture -Hwnd $surfaceHwnd -Path $afterCapturePath
@@ -735,7 +707,7 @@ try {
         throw "live shell command '$typedCommandText' produced too little visible change (changed=$($imageDelta.ChangedPixels), sampled=$($imageDelta.SampledPixels))"
     }
 
-    Wait-Until -Deadline $deadline -Description 'post output file' -Process $process -Condition {
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'post output file' -Process $process -Condition {
         Test-Path -LiteralPath $postPath
     }
 

--- a/test/windows/interactive-win11-smoke.ps1
+++ b/test/windows/interactive-win11-smoke.ps1
@@ -38,17 +38,6 @@ $exePath = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
 $buildInputs = Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot
 $launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -BuildInputs $buildInputs
 
-if (-not ('InteractiveWin11SmokeNative' -as [type])) {
-    Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-public static class InteractiveWin11SmokeNative {
-    [DllImport("user32.dll", SetLastError=true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool PostMessageW(IntPtr hwnd, uint msg, UIntPtr wParam, IntPtr lParam);
-}
-"@
-}
 $launchArgs = @(Get-InteractiveWin11LaunchArguments -Layout $layout)
 $stdoutPath = Join-Path $layout.Logs 'interactive-win11-smoke-stdout.log'
 $stderrPath = Join-Path $layout.Logs 'interactive-win11-smoke-stderr.log'
@@ -100,7 +89,6 @@ try {
 
     if ($smokePassed) {
         $closeTimeoutSeconds = [Math]::Max(5, $TimeoutSeconds)
-        $closeTimeoutMs = $closeTimeoutSeconds * 1000
         $closeDeadline = [DateTime]::UtcNow.AddSeconds($closeTimeoutSeconds)
         while ([DateTime]::UtcNow -lt $closeDeadline) {
             $process.Refresh()
@@ -119,18 +107,28 @@ try {
         }
         elseif (-not $failureReason) {
             $processHandle = $process.Handle
-            if (-not [InteractiveWin11SmokeNative]::PostMessageW(
-                $process.MainWindowHandle,
-                0x0010,
-                [UIntPtr]::Zero,
-                [IntPtr]::Zero
-            )) {
-                $failureReason = "winghostty could not be sent WM_CLOSE: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
-            }
-            elseif (-not $process.WaitForExit($closeTimeoutMs)) {
-                $failureReason = 'winghostty did not exit cleanly after WM_CLOSE'
-            }
-            else {
+            try {
+                try {
+                    [void](Invoke-InteractiveWin11Message `
+                        -Hwnd $process.MainWindowHandle `
+                        -Message 0x0010 `
+                        -Deadline $closeDeadline `
+                        -Description 'WM_CLOSE smoke validation' `
+                        -Flags $script:InteractiveWin11SmtoBlock `
+                        -Process $process)
+                }
+                catch {
+                    $sendError = $_
+                    $process.Refresh()
+                    if (-not $process.HasExited) {
+                        throw $sendError
+                    }
+                }
+                $closeProcess = $process
+                Wait-InteractiveWin11Until -Deadline $closeDeadline -Description 'winghostty smoke graceful exit' -Condition {
+                    $closeProcess.Refresh()
+                    $closeProcess.HasExited
+                }
                 $process.Refresh()
                 $exitCode = $process.ExitCode
 
@@ -150,6 +148,9 @@ try {
                 elseif (-not $failureReason) {
                     $closePassed = $true
                 }
+            }
+            catch {
+                $failureReason = "winghostty graceful-close validation failed: $($_.Exception.Message)"
             }
         }
     }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -22,14 +22,25 @@ public static class WinghosttyStatefulNative {
     [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hwnd);
     [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hwnd, IntPtr insertAfter, int x, int y, int width, int height, uint flags);
     [DllImport("user32.dll", SetLastError=true)] public static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
-    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
     [DllImport("user32.dll", SetLastError=true)] public static extern bool SystemParametersInfo(uint action, uint parameter, ref HIGHCONTRAST value, uint flags);
 }
 '@
 }
 
+if (-not ('WinghosttyStatefulMessageNative' -as [type])) {
+    Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class WinghosttyStatefulMessageNative {
+    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
+    [DllImport("kernel32.dll")] public static extern void SetLastError(uint errorCode);
+}
+'@
+}
+
 $script:SmtoNormal = [uint32]0
-$script:SmtoAbortIfHung = [uint32]0x0002
+$script:SmtoBlock = [uint32]0x0001
+$script:ErrorSuccess = 0
 $script:ErrorInvalidWindowHandle = 1400
 $script:ErrorTimeout = 1460
 
@@ -49,7 +60,8 @@ function Send-StatefulMessage(
 ) {
     $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline "$Description to hwnd=$Hwnd"
     $sendResult = [UIntPtr]::Zero
-    $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
+    [WinghosttyStatefulMessageNative]::SetLastError($script:ErrorSuccess)
+    $sendStatus = [WinghosttyStatefulMessageNative]::SendMessageTimeoutW(
         $Hwnd,
         $Message,
         $WParam,
@@ -220,30 +232,41 @@ function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
 
 function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
-    $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline 'WM_CLOSE to winghostty'
-    $sendResult = [UIntPtr]::Zero
-    $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
-        $HostHwnd,
-        0x0010,
-        [UIntPtr]::Zero,
-        [IntPtr]::Zero,
-        $script:SmtoAbortIfHung,
-        $sendTimeoutMs,
-        [ref] $sendResult
-    )
-    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        $Run.Process.Refresh()
-        if (-not $Run.Process.HasExited) {
-            if ($lastError -eq $script:ErrorTimeout) {
-                throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+    $Run.Process.Refresh()
+    if (-not $Run.Process.HasExited) {
+        $windowProcessId = [uint32]0
+        $windowThreadId = [WinghosttyStatefulNative]::GetWindowThreadProcessId($HostHwnd, [ref]$windowProcessId)
+        if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Run.Process.Id) {
+            throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
+        }
+
+        $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline 'WM_CLOSE to winghostty'
+        $sendResult = [UIntPtr]::Zero
+        [WinghosttyStatefulMessageNative]::SetLastError($script:ErrorSuccess)
+        $sendStatus = [WinghosttyStatefulMessageNative]::SendMessageTimeoutW(
+            $HostHwnd,
+            0x0010,
+            [UIntPtr]::Zero,
+            [IntPtr]::Zero,
+            $script:SmtoBlock,
+            $sendTimeoutMs,
+            [ref] $sendResult
+        )
+        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        if ($sendStatus -eq [IntPtr]::Zero) {
+            $Run.Process.Refresh()
+            if (-not $Run.Process.HasExited) {
+                if ($lastError -eq $script:ErrorTimeout) {
+                    throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+                }
+                if ($lastError -ne $script:ErrorInvalidWindowHandle) {
+                    $detail = if ($lastError -eq $script:ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
+                    throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd ($detail)."
+                }
+                # A destroyed host HWND can race process teardown; the bounded exit
+                # wait and mandatory zero exit-code check below still fail closed.
+                Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
             }
-            if ($lastError -ne $script:ErrorInvalidWindowHandle) {
-                throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
-            }
-            # A destroyed host HWND can race process teardown; the bounded exit
-            # wait and mandatory zero exit-code check below still fail closed.
-            Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
         }
     }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -28,6 +28,17 @@ public static class WinghosttyStatefulNative {
 '@
 }
 
+$script:SmtoNormal = [uint32]0
+$script:SmtoAbortIfHung = [uint32]0x0002
+$script:ErrorInvalidWindowHandle = 1400
+$script:ErrorTimeout = 1460
+
+function Get-StatefulMessageTimeoutMs([DateTime] $Deadline, [string] $Description) {
+    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
+    if ($remainingMs -le 0) { throw "Deadline elapsed before sending $Description." }
+    return [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
+}
+
 function Send-StatefulMessage(
     [IntPtr] $Hwnd,
     [uint32] $Message,
@@ -36,16 +47,14 @@ function Send-StatefulMessage(
     [DateTime] $Deadline,
     [string] $Description
 ) {
-    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
-    if ($remainingMs -le 0) { throw "Deadline elapsed before sending $Description to hwnd=$Hwnd." }
-    $sendTimeoutMs = [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
+    $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline "$Description to hwnd=$Hwnd"
     $sendResult = [UIntPtr]::Zero
     $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
         $Hwnd,
         $Message,
         $WParam,
         $LParam,
-        0,
+        $script:SmtoNormal,
         $sendTimeoutMs,
         [ref] $sendResult
     )
@@ -211,29 +220,30 @@ function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
 
 function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
-    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
-    if ($remainingMs -le 0) { throw 'Deadline elapsed before sending WM_CLOSE to winghostty.' }
-    $sendTimeoutMs = [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
+    $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline 'WM_CLOSE to winghostty'
     $sendResult = [UIntPtr]::Zero
     $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
         $HostHwnd,
         0x0010,
         [UIntPtr]::Zero,
         [IntPtr]::Zero,
-        0x0002,
+        $script:SmtoAbortIfHung,
         $sendTimeoutMs,
         [ref] $sendResult
     )
     $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
     if ($sendStatus -eq [IntPtr]::Zero) {
         $Run.Process.Refresh()
-        # Timeout/abort and destroyed-window races still converge on the same
-        # deadline-bounded exit wait and mandatory zero exit-code check below.
-        if (-not $Run.Process.HasExited -and $lastError -notin @(0, 1400, 1460)) {
-            throw "SendMessageTimeoutW timed out or failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
-        }
         if (-not $Run.Process.HasExited) {
-            Write-Warning "WM_CLOSE delivery returned status=0 error=$lastError; waiting for winghostty to exit."
+            if ($lastError -eq $script:ErrorTimeout) {
+                throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+            }
+            if ($lastError -ne $script:ErrorInvalidWindowHandle) {
+                throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+            }
+            # A destroyed host HWND can race process teardown; the bounded exit
+            # wait and mandatory zero exit-code check below still fail closed.
+            Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
         }
     }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -33,16 +33,20 @@ function Send-StatefulMessage(
     [uint32] $Message,
     [UIntPtr] $WParam,
     [IntPtr] $LParam,
+    [DateTime] $Deadline,
     [string] $Description
 ) {
+    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
+    if ($remainingMs -le 0) { throw "Deadline elapsed before sending $Description to hwnd=$Hwnd." }
+    $sendTimeoutMs = [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
     $sendResult = [UIntPtr]::Zero
     $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
         $Hwnd,
         $Message,
         $WParam,
         $LParam,
-        0x0002,
-        5000,
+        0,
+        $sendTimeoutMs,
         [ref] $sendResult
     )
     $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
@@ -106,14 +110,14 @@ function Get-StatefulWindowRect([IntPtr] $Hwnd) {
     return $rect
 }
 
-function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId) {
-    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) "WM_COMMAND id=$CommandId")
+function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId, [DateTime] $Deadline) {
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) $Deadline "WM_COMMAND id=$CommandId")
 }
 
-function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text) {
+function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text, [DateTime] $Deadline) {
     $textPointer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni($Text)
     try {
-        $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer 'WM_SETTEXT'
+        $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer $Deadline 'WM_SETTEXT'
         if ($result -eq [UIntPtr]::Zero) { throw "WM_SETTEXT failed for hwnd=$Hwnd" }
     }
     finally {
@@ -122,7 +126,7 @@ function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text
     $enChange = 0x0300
     $controlId = [WinghosttyStatefulNative]::GetDlgCtrlID($Hwnd)
     $command = [uint64]([uint32]$controlId -bor ([uint32]$enChange -shl 16))
-    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]$command) $Hwnd "WM_COMMAND EN_CHANGE id=$controlId")
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]$command) $Hwnd $Deadline "WM_COMMAND EN_CHANGE id=$controlId")
 }
 
 function Show-StatefulHost([IntPtr] $HostHwnd) {
@@ -181,17 +185,17 @@ function Wait-StatefulHost($Run, [DateTime] $Deadline) {
     return Find-StatefulHost $Run.Process.Id
 }
 
-function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId) {
+function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] $Deadline) {
     $button = Get-StatefulChildren $HostHwnd | Where-Object Id -eq $ControlId | Select-Object -First 1
     if ($null -eq $button) { throw "No visible button with control ID $ControlId." }
-    [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) "BM_CLICK id=$ControlId")
+    [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline "BM_CLICK id=$ControlId")
 }
 
-function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd) {
+function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline) {
     $list = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2006 | Select-Object -First 1
     if ($null -eq $list) { throw 'No visible command-palette list.' }
     $coordinates = [IntPtr](4 -bor (4 -shl 16))
-    [void](Send-StatefulMessage $list.Hwnd 0x0201 ([UIntPtr]::Zero) $coordinates 'WM_LBUTTONDOWN command-palette first row')
+    [void](Send-StatefulMessage $list.Hwnd 0x0201 ([UIntPtr]::Zero) $coordinates $Deadline 'WM_LBUTTONDOWN command-palette first row')
 }
 
 function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
@@ -223,6 +227,8 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
     if ($sendStatus -eq [IntPtr]::Zero) {
         $Run.Process.Refresh()
+        # Timeout/abort and destroyed-window races still converge on the same
+        # deadline-bounded exit wait and mandatory zero exit-code check below.
         if (-not $Run.Process.HasExited -and $lastError -notin @(0, 1400, 1460)) {
             throw "SendMessageTimeoutW timed out or failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
         }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -15,7 +15,6 @@ public static class WinghosttyStatefulNative {
     [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc callback, IntPtr data);
     [DllImport("user32.dll")] public static extern bool EnumChildWindows(IntPtr parent, EnumProc callback, IntPtr data);
     [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassNameW(IntPtr hwnd, StringBuilder value, int capacity);
-    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
     [DllImport("user32.dll")] public static extern int GetDlgCtrlID(IntPtr hwnd);
     [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hwnd);
     [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hwnd, int command);
@@ -27,15 +26,13 @@ public static class WinghosttyStatefulNative {
 '@
 }
 
-$script:ErrorInvalidWindowHandle = 1400
-
 function Send-StatefulMessage(
     [IntPtr] $Hwnd,
     [uint32] $Message,
     [UIntPtr] $WParam,
     [IntPtr] $LParam,
     [DateTime] $Deadline,
-    [System.Diagnostics.Process] $Process,
+    [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
     [string] $Description
 ) {
     return Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message $Message -WParam $WParam -LParam $LParam -Deadline $Deadline -Process $Process -Description $Description
@@ -53,7 +50,7 @@ function Find-StatefulHost([int] $ProcessId) {
     $callback = [WinghosttyStatefulNative+EnumProc] {
         param([IntPtr]$hwnd, [IntPtr]$data)
         $windowProcessId = [uint32]0
-        [void][WinghosttyStatefulNative]::GetWindowThreadProcessId($hwnd, [ref]$windowProcessId)
+        [void][InteractiveWin11MessageNative]::GetWindowThreadProcessId($hwnd, [ref]$windowProcessId)
         if ($windowProcessId -eq $script:StatefulPid -and (Get-StatefulClassName $hwnd) -eq 'winghostty.win32.host') {
             $script:StatefulHost = $hwnd
             return $false
@@ -95,11 +92,11 @@ function Get-StatefulWindowRect([IntPtr] $Hwnd) {
     return $rect
 }
 
-function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
+function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId, [DateTime] $Deadline, [Parameter(Mandatory)] [System.Diagnostics.Process] $Process) {
     [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) $Deadline $Process "WM_COMMAND id=$CommandId")
 }
 
-function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
+function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text, [DateTime] $Deadline, [Parameter(Mandatory)] [System.Diagnostics.Process] $Process) {
     $textPointer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni($Text)
     try {
         $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer $Deadline $Process 'WM_SETTEXT'
@@ -170,13 +167,13 @@ function Wait-StatefulHost($Run, [DateTime] $Deadline) {
     return Find-StatefulHost $Run.Process.Id
 }
 
-function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
+function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] $Deadline, [Parameter(Mandatory)] [System.Diagnostics.Process] $Process) {
     $button = Get-StatefulChildren $HostHwnd | Where-Object Id -eq $ControlId | Select-Object -First 1
     if ($null -eq $button) { throw "No visible button with control ID $ControlId." }
     [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline $Process "BM_CLICK id=$ControlId")
 }
 
-function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
+function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline, [Parameter(Mandatory)] [System.Diagnostics.Process] $Process) {
     $list = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2006 | Select-Object -First 1
     if ($null -eq $list) { throw 'No visible command-palette list.' }
     $coordinates = [IntPtr](4 -bor (4 -shl 16))
@@ -196,45 +193,23 @@ function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
 
 function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
-    $Run.Process.Refresh()
-    if (-not $Run.Process.HasExited) {
-        $windowProcessId = [uint32]0
-        $windowThreadId = [WinghosttyStatefulNative]::GetWindowThreadProcessId($HostHwnd, [ref]$windowProcessId)
-        if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Run.Process.Id) {
-            $Run.Process.Refresh()
-            if (-not $Run.Process.HasExited) {
-                throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
-            }
-        } else {
-            $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description 'WM_CLOSE to winghostty'
-            $sendResult = [UIntPtr]::Zero
-            $lastError = 0
-            $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutWithError(
-                $HostHwnd,
-                0x0010,
-                [UIntPtr]::Zero,
-                [IntPtr]::Zero,
-                $script:InteractiveWin11SmtoBlock,
-                $sendTimeoutMs,
-                [ref] $sendResult,
-                [ref] $lastError
-            )
-            if ($sendStatus -eq [IntPtr]::Zero) {
-                $Run.Process.Refresh()
-                if (-not $Run.Process.HasExited) {
-                    if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
-                        throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
-                    }
-                    if ($lastError -ne $script:ErrorInvalidWindowHandle) {
-                        $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
-                        throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd ($detail)."
-                    }
-                    # A destroyed host HWND can race process teardown; the bounded exit
-                    # wait and mandatory zero exit-code check below still fail closed.
-                    Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
-                }
-            }
+    try {
+        [void](Invoke-InteractiveWin11Message `
+            -Hwnd $HostHwnd `
+            -Message 0x0010 `
+            -Deadline $Deadline `
+            -Description 'WM_CLOSE to winghostty' `
+            -Flags $script:InteractiveWin11SmtoBlock `
+            -ToleratedErrors @($script:InteractiveWin11ErrorInvalidWindowHandle) `
+            -Process $Run.Process)
+    }
+    catch {
+        $sendError = $_
+        $Run.Process.Refresh()
+        if (-not $Run.Process.HasExited) {
+            throw $sendError
         }
+        Write-Warning "WM_CLOSE send raced winghostty exit: $sendError"
     }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
     $exitCode = Get-InteractiveWin11ProcessExitCode -Process $Run.Process -ProcessHandle $processHandle

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -50,7 +50,7 @@ function Find-StatefulHost([int] $ProcessId) {
     $callback = [WinghosttyStatefulNative+EnumProc] {
         param([IntPtr]$hwnd, [IntPtr]$data)
         $windowProcessId = [uint32]0
-        [void][InteractiveWin11MessageNative]::GetWindowThreadProcessId($hwnd, [ref]$windowProcessId)
+        [void][InteractiveWin11MessageNativeV2]::GetWindowThreadProcessId($hwnd, [ref]$windowProcessId)
         if ($windowProcessId -eq $script:StatefulPid -and (Get-StatefulClassName $hwnd) -eq 'winghostty.win32.host') {
             $script:StatefulHost = $hwnd
             return $false

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -202,33 +202,37 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
         $windowProcessId = [uint32]0
         $windowThreadId = [WinghosttyStatefulNative]::GetWindowThreadProcessId($HostHwnd, [ref]$windowProcessId)
         if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Run.Process.Id) {
-            throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
-        }
-        $sendResult = [UIntPtr]::Zero
-        [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
-        $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
-            $HostHwnd,
-            0x0010,
-            [UIntPtr]::Zero,
-            [IntPtr]::Zero,
-            $script:InteractiveWin11SmtoBlock,
-            $sendTimeoutMs,
-            [ref] $sendResult
-        )
-        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        if ($sendStatus -eq [IntPtr]::Zero) {
             $Run.Process.Refresh()
             if (-not $Run.Process.HasExited) {
-                if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
-                    throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+                throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
+            }
+        } else {
+            $sendResult = [UIntPtr]::Zero
+            [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
+            $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
+                $HostHwnd,
+                0x0010,
+                [UIntPtr]::Zero,
+                [IntPtr]::Zero,
+                $script:InteractiveWin11SmtoBlock,
+                $sendTimeoutMs,
+                [ref] $sendResult
+            )
+            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            if ($sendStatus -eq [IntPtr]::Zero) {
+                $Run.Process.Refresh()
+                if (-not $Run.Process.HasExited) {
+                    if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
+                        throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+                    }
+                    if ($lastError -ne $script:ErrorInvalidWindowHandle) {
+                        $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
+                        throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd ($detail)."
+                    }
+                    # A destroyed host HWND can race process teardown; the bounded exit
+                    # wait and mandatory zero exit-code check below still fail closed.
+                    Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
                 }
-                if ($lastError -ne $script:ErrorInvalidWindowHandle) {
-                    $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
-                    throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd ($detail)."
-                }
-                # A destroyed host HWND can race process teardown; the bounded exit
-                # wait and mandatory zero exit-code check below still fail closed.
-                Write-Warning "WM_CLOSE raced a destroyed hwnd=$HostHwnd; waiting for winghostty to exit."
             }
         }
     }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -173,11 +173,17 @@ function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] 
     [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline $Process "BM_CLICK id=$ControlId")
 }
 
-function Invoke-StatefulPostedCommand([IntPtr]$Hwnd, [int]$Id, [System.Diagnostics.Process]$Process) {
+function Invoke-StatefulPostedCommand(
+    [IntPtr] $Hwnd,
+    [int] $Id,
+    [DateTime] $Deadline,
+    [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
+) {
     Invoke-InteractiveWin11PostMessage `
         -Hwnd $Hwnd `
         -Message 0x0111 `
         -WParam ([UIntPtr]::new([uint64]$Id)) `
+        -Deadline $Deadline `
         -Description "WM_COMMAND id=$Id" `
         -Process $Process
 }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -22,10 +22,34 @@ public static class WinghosttyStatefulNative {
     [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hwnd);
     [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hwnd, IntPtr insertAfter, int x, int y, int width, int height, uint flags);
     [DllImport("user32.dll", SetLastError=true)] public static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
-    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern IntPtr SendMessageW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
     [DllImport("user32.dll", SetLastError=true)] public static extern bool SystemParametersInfo(uint action, uint parameter, ref HIGHCONTRAST value, uint flags);
 }
 '@
+}
+
+function Send-StatefulMessage(
+    [IntPtr] $Hwnd,
+    [uint32] $Message,
+    [UIntPtr] $WParam,
+    [IntPtr] $LParam,
+    [string] $Description
+) {
+    $sendResult = [UIntPtr]::Zero
+    $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
+        $Hwnd,
+        $Message,
+        $WParam,
+        $LParam,
+        0x0002,
+        5000,
+        [ref] $sendResult
+    )
+    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($sendStatus -eq [IntPtr]::Zero) {
+        throw "SendMessageTimeoutW timed out or failed for $Description hwnd=$Hwnd error=$lastError"
+    }
+    return $sendResult
 }
 
 function Get-StatefulClassName([IntPtr] $Hwnd) {
@@ -83,14 +107,14 @@ function Get-StatefulWindowRect([IntPtr] $Hwnd) {
 }
 
 function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId) {
-    [void][WinghosttyStatefulNative]::SendMessageW($HostHwnd, 0x0111, [UIntPtr]([uint64]$CommandId), [IntPtr]::Zero)
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) "WM_COMMAND id=$CommandId")
 }
 
 function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text) {
     $textPointer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni($Text)
     try {
-        $result = [WinghosttyStatefulNative]::SendMessageW($Hwnd, 0x000C, [UIntPtr]::Zero, $textPointer)
-        if ($result -eq [IntPtr]::Zero) { throw "WM_SETTEXT failed for hwnd=$Hwnd" }
+        $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer 'WM_SETTEXT'
+        if ($result -eq [UIntPtr]::Zero) { throw "WM_SETTEXT failed for hwnd=$Hwnd" }
     }
     finally {
         [Runtime.InteropServices.Marshal]::FreeHGlobal($textPointer)
@@ -98,7 +122,7 @@ function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text
     $enChange = 0x0300
     $controlId = [WinghosttyStatefulNative]::GetDlgCtrlID($Hwnd)
     $command = [uint64]([uint32]$controlId -bor ([uint32]$enChange -shl 16))
-    [void][WinghosttyStatefulNative]::SendMessageW($HostHwnd, 0x0111, [UIntPtr]$command, $Hwnd)
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]$command) $Hwnd "WM_COMMAND EN_CHANGE id=$controlId")
 }
 
 function Show-StatefulHost([IntPtr] $HostHwnd) {
@@ -160,14 +184,14 @@ function Wait-StatefulHost($Run, [DateTime] $Deadline) {
 function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId) {
     $button = Get-StatefulChildren $HostHwnd | Where-Object Id -eq $ControlId | Select-Object -First 1
     if ($null -eq $button) { throw "No visible button with control ID $ControlId." }
-    [void][WinghosttyStatefulNative]::SendMessageW($button.Hwnd, 0x00F5, [UIntPtr]::Zero, [IntPtr]::Zero)
+    [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) "BM_CLICK id=$ControlId")
 }
 
 function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd) {
     $list = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2006 | Select-Object -First 1
     if ($null -eq $list) { throw 'No visible command-palette list.' }
     $coordinates = [IntPtr](4 -bor (4 -shl 16))
-    [void][WinghosttyStatefulNative]::SendMessageW($list.Hwnd, 0x0201, [UIntPtr]::Zero, $coordinates)
+    [void](Send-StatefulMessage $list.Hwnd 0x0201 ([UIntPtr]::Zero) $coordinates 'WM_LBUTTONDOWN command-palette first row')
 }
 
 function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
@@ -182,6 +206,28 @@ function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
 }
 
 function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
-    [void][WinghosttyStatefulNative]::SendMessageW($HostHwnd, 0x0010, [UIntPtr]::Zero, [IntPtr]::Zero)
+    $processHandle = $Run.Process.Handle
+    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
+    if ($remainingMs -le 0) { throw 'Deadline elapsed before sending WM_CLOSE to winghostty.' }
+    $sendTimeoutMs = [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
+    $sendResult = [UIntPtr]::Zero
+    $sendStatus = [WinghosttyStatefulNative]::SendMessageTimeoutW(
+        $HostHwnd,
+        0x0010,
+        [UIntPtr]::Zero,
+        [IntPtr]::Zero,
+        0x0002,
+        $sendTimeoutMs,
+        [ref] $sendResult
+    )
+    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($sendStatus -eq [IntPtr]::Zero) {
+        $Run.Process.Refresh()
+        if (-not $Run.Process.HasExited -and $lastError -notin @(0, 1400, 1460)) {
+            throw "SendMessageTimeoutW timed out or failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
+        }
+    }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
+    $exitCode = Get-InteractiveWin11ProcessExitCode -Process $Run.Process -ProcessHandle $processHandle
+    if ($exitCode -ne 0) { throw "winghostty exited after WM_CLOSE with exit code $exitCode" }
 }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -198,7 +198,6 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
     $Run.Process.Refresh()
     if (-not $Run.Process.HasExited) {
-        $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description 'WM_CLOSE to winghostty'
         $windowProcessId = [uint32]0
         $windowThreadId = [WinghosttyStatefulNative]::GetWindowThreadProcessId($HostHwnd, [ref]$windowProcessId)
         if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Run.Process.Id) {
@@ -207,6 +206,7 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
                 throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
             }
         } else {
+            $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description 'WM_CLOSE to winghostty'
             $sendResult = [UIntPtr]::Zero
             [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
             $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -193,6 +193,8 @@ function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
 
 function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
+    $toleratedCloseError = [ref]0
+    $closeSkipDetail = $null
     try {
         [void](Invoke-InteractiveWin11Message `
             -Hwnd $HostHwnd `
@@ -201,7 +203,11 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
             -Description 'WM_CLOSE to winghostty' `
             -Flags $script:InteractiveWin11SmtoBlock `
             -ToleratedErrors @($script:InteractiveWin11ErrorInvalidWindowHandle) `
+            -ObservedToleratedError $toleratedCloseError `
             -Process $Run.Process)
+        if ($toleratedCloseError.Value -ne 0) {
+            $closeSkipDetail = "WM_CLOSE was skipped after tolerated Win32 error $($toleratedCloseError.Value) for hwnd=$HostHwnd"
+        }
     }
     catch {
         $sendError = $_
@@ -211,7 +217,16 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
         }
         Write-Warning "WM_CLOSE send raced winghostty exit: $sendError"
     }
-    Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
+    try {
+        Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
+    }
+    catch {
+        if ($null -ne $closeSkipDetail) { throw "$($_.Exception.Message) ($closeSkipDetail)" }
+        throw
+    }
     $exitCode = Get-InteractiveWin11ProcessExitCode -Process $Run.Process -ProcessHandle $processHandle
-    if ($exitCode -ne 0) { throw "winghostty exited with code $exitCode during graceful-close validation" }
+    if ($exitCode -ne 0) {
+        $suffix = if ($null -ne $closeSkipDetail) { " ($closeSkipDetail)" } else { '' }
+        throw "winghostty exited with code $exitCode during graceful-close validation$suffix"
+    }
 }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -232,6 +232,9 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
         if (-not $Run.Process.HasExited -and $lastError -notin @(0, 1400, 1460)) {
             throw "SendMessageTimeoutW timed out or failed for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
         }
+        if (-not $Run.Process.HasExited) {
+            Write-Warning "WM_CLOSE delivery returned status=0 error=$lastError; waiting for winghostty to exit."
+        }
     }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
     $exitCode = Get-InteractiveWin11ProcessExitCode -Process $Run.Process -ProcessHandle $processHandle

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -173,6 +173,15 @@ function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] 
     [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline $Process "BM_CLICK id=$ControlId")
 }
 
+function Invoke-StatefulPostedCommand([IntPtr]$Hwnd, [int]$Id, [System.Diagnostics.Process]$Process) {
+    Invoke-InteractiveWin11PostMessage `
+        -Hwnd $Hwnd `
+        -Message 0x0111 `
+        -WParam ([UIntPtr]::new([uint64]$Id)) `
+        -Description "WM_COMMAND id=$Id" `
+        -Process $Process
+}
+
 function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline, [Parameter(Mandatory)] [System.Diagnostics.Process] $Process) {
     $list = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2006 | Select-Object -First 1
     if ($null -eq $list) { throw 'No visible command-palette list.' }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -27,28 +27,7 @@ public static class WinghosttyStatefulNative {
 '@
 }
 
-if (-not ('WinghosttyStatefulMessageNative' -as [type])) {
-    Add-Type @'
-using System;
-using System.Runtime.InteropServices;
-public static class WinghosttyStatefulMessageNative {
-    [DllImport("user32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint message, UIntPtr wparam, IntPtr lparam, uint flags, uint timeout, out UIntPtr result);
-    [DllImport("kernel32.dll")] public static extern void SetLastError(uint errorCode);
-}
-'@
-}
-
-$script:SmtoNormal = [uint32]0
-$script:SmtoBlock = [uint32]0x0001
-$script:ErrorSuccess = 0
 $script:ErrorInvalidWindowHandle = 1400
-$script:ErrorTimeout = 1460
-
-function Get-StatefulMessageTimeoutMs([DateTime] $Deadline, [string] $Description) {
-    $remainingMs = ($Deadline - [DateTime]::UtcNow).TotalMilliseconds
-    if ($remainingMs -le 0) { throw "Deadline elapsed before sending $Description." }
-    return [uint32][Math]::Min([double][uint32]::MaxValue, [Math]::Ceiling($remainingMs))
-}
 
 function Send-StatefulMessage(
     [IntPtr] $Hwnd,
@@ -56,25 +35,10 @@ function Send-StatefulMessage(
     [UIntPtr] $WParam,
     [IntPtr] $LParam,
     [DateTime] $Deadline,
+    [System.Diagnostics.Process] $Process,
     [string] $Description
 ) {
-    $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline "$Description to hwnd=$Hwnd"
-    $sendResult = [UIntPtr]::Zero
-    [WinghosttyStatefulMessageNative]::SetLastError($script:ErrorSuccess)
-    $sendStatus = [WinghosttyStatefulMessageNative]::SendMessageTimeoutW(
-        $Hwnd,
-        $Message,
-        $WParam,
-        $LParam,
-        $script:SmtoNormal,
-        $sendTimeoutMs,
-        [ref] $sendResult
-    )
-    $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    if ($sendStatus -eq [IntPtr]::Zero) {
-        throw "SendMessageTimeoutW timed out or failed for $Description hwnd=$Hwnd error=$lastError"
-    }
-    return $sendResult
+    return Invoke-InteractiveWin11Message -Hwnd $Hwnd -Message $Message -WParam $WParam -LParam $LParam -Deadline $Deadline -Process $Process -Description $Description
 }
 
 function Get-StatefulClassName([IntPtr] $Hwnd) {
@@ -131,14 +95,14 @@ function Get-StatefulWindowRect([IntPtr] $Hwnd) {
     return $rect
 }
 
-function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId, [DateTime] $Deadline) {
-    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) $Deadline "WM_COMMAND id=$CommandId")
+function Invoke-StatefulCommand([IntPtr] $HostHwnd, [int] $CommandId, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]([uint64]$CommandId)) ([IntPtr]::Zero) $Deadline $Process "WM_COMMAND id=$CommandId")
 }
 
-function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text, [DateTime] $Deadline) {
+function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
     $textPointer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni($Text)
     try {
-        $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer $Deadline 'WM_SETTEXT'
+        $result = Send-StatefulMessage $Hwnd 0x000C ([UIntPtr]::Zero) $textPointer $Deadline $Process 'WM_SETTEXT'
         if ($result -eq [UIntPtr]::Zero) { throw "WM_SETTEXT failed for hwnd=$Hwnd" }
     }
     finally {
@@ -147,7 +111,7 @@ function Set-StatefulEditText([IntPtr] $HostHwnd, [IntPtr] $Hwnd, [string] $Text
     $enChange = 0x0300
     $controlId = [WinghosttyStatefulNative]::GetDlgCtrlID($Hwnd)
     $command = [uint64]([uint32]$controlId -bor ([uint32]$enChange -shl 16))
-    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]$command) $Hwnd $Deadline "WM_COMMAND EN_CHANGE id=$controlId")
+    [void](Send-StatefulMessage $HostHwnd 0x0111 ([UIntPtr]$command) $Hwnd $Deadline $Process "WM_COMMAND EN_CHANGE id=$controlId")
 }
 
 function Show-StatefulHost([IntPtr] $HostHwnd) {
@@ -206,17 +170,17 @@ function Wait-StatefulHost($Run, [DateTime] $Deadline) {
     return Find-StatefulHost $Run.Process.Id
 }
 
-function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] $Deadline) {
+function Invoke-StatefulButton([IntPtr] $HostHwnd, [int] $ControlId, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
     $button = Get-StatefulChildren $HostHwnd | Where-Object Id -eq $ControlId | Select-Object -First 1
     if ($null -eq $button) { throw "No visible button with control ID $ControlId." }
-    [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline "BM_CLICK id=$ControlId")
+    [void](Send-StatefulMessage $button.Hwnd 0x00F5 ([UIntPtr]::Zero) ([IntPtr]::Zero) $Deadline $Process "BM_CLICK id=$ControlId")
 }
 
-function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline) {
+function Invoke-StatefulPaletteFirstRow([IntPtr] $HostHwnd, [DateTime] $Deadline, [System.Diagnostics.Process] $Process) {
     $list = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2006 | Select-Object -First 1
     if ($null -eq $list) { throw 'No visible command-palette list.' }
     $coordinates = [IntPtr](4 -bor (4 -shl 16))
-    [void](Send-StatefulMessage $list.Hwnd 0x0201 ([UIntPtr]::Zero) $coordinates $Deadline 'WM_LBUTTONDOWN command-palette first row')
+    [void](Send-StatefulMessage $list.Hwnd 0x0201 ([UIntPtr]::Zero) $coordinates $Deadline $Process 'WM_LBUTTONDOWN command-palette first row')
 }
 
 function Wait-StatefulSurface([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
@@ -234,21 +198,20 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     $processHandle = $Run.Process.Handle
     $Run.Process.Refresh()
     if (-not $Run.Process.HasExited) {
+        $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description 'WM_CLOSE to winghostty'
         $windowProcessId = [uint32]0
         $windowThreadId = [WinghosttyStatefulNative]::GetWindowThreadProcessId($HostHwnd, [ref]$windowProcessId)
         if ($windowThreadId -eq 0 -or $windowProcessId -ne [uint32]$Run.Process.Id) {
             throw "Refusing WM_CLOSE for hwnd=$HostHwnd because owner pid=$windowProcessId does not match winghostty pid=$($Run.Process.Id)."
         }
-
-        $sendTimeoutMs = Get-StatefulMessageTimeoutMs $Deadline 'WM_CLOSE to winghostty'
         $sendResult = [UIntPtr]::Zero
-        [WinghosttyStatefulMessageNative]::SetLastError($script:ErrorSuccess)
-        $sendStatus = [WinghosttyStatefulMessageNative]::SendMessageTimeoutW(
+        [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
+        $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
             $HostHwnd,
             0x0010,
             [UIntPtr]::Zero,
             [IntPtr]::Zero,
-            $script:SmtoBlock,
+            $script:InteractiveWin11SmtoBlock,
             $sendTimeoutMs,
             [ref] $sendResult
         )
@@ -256,11 +219,11 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
         if ($sendStatus -eq [IntPtr]::Zero) {
             $Run.Process.Refresh()
             if (-not $Run.Process.HasExited) {
-                if ($lastError -eq $script:ErrorTimeout) {
+                if ($lastError -eq $script:InteractiveWin11ErrorTimeout) {
                     throw "SendMessageTimeoutW timed out for winghostty WM_CLOSE hwnd=$HostHwnd error=$lastError"
                 }
                 if ($lastError -ne $script:ErrorInvalidWindowHandle) {
-                    $detail = if ($lastError -eq $script:ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
+                    $detail = if ($lastError -eq $script:InteractiveWin11ErrorSuccess) { 'generic failure without a Win32 error' } else { "Win32 error $lastError" }
                     throw "SendMessageTimeoutW failed for winghostty WM_CLOSE hwnd=$HostHwnd ($detail)."
                 }
                 # A destroyed host HWND can race process teardown; the bounded exit
@@ -271,5 +234,5 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
     }
     Wait-InteractiveWin11Until -Deadline $Deadline -Description 'winghostty graceful exit' -Condition { $Run.Process.Refresh(); $Run.Process.HasExited }
     $exitCode = Get-InteractiveWin11ProcessExitCode -Process $Run.Process -ProcessHandle $processHandle
-    if ($exitCode -ne 0) { throw "winghostty exited after WM_CLOSE with exit code $exitCode" }
+    if ($exitCode -ne 0) { throw "winghostty exited with code $exitCode during graceful-close validation" }
 }

--- a/test/windows/interactive-win11-stateful-lib.ps1
+++ b/test/windows/interactive-win11-stateful-lib.ps1
@@ -208,17 +208,17 @@ function Close-StatefulHost([IntPtr] $HostHwnd, $Run, [DateTime] $Deadline) {
         } else {
             $sendTimeoutMs = Get-InteractiveWin11MessageTimeoutMs -Deadline $Deadline -Description 'WM_CLOSE to winghostty'
             $sendResult = [UIntPtr]::Zero
-            [InteractiveWin11MessageNative]::SetLastError($script:InteractiveWin11ErrorSuccess)
-            $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutW(
+            $lastError = 0
+            $sendStatus = [InteractiveWin11MessageNative]::SendMessageTimeoutWithError(
                 $HostHwnd,
                 0x0010,
                 [UIntPtr]::Zero,
                 [IntPtr]::Zero,
                 $script:InteractiveWin11SmtoBlock,
                 $sendTimeoutMs,
-                [ref] $sendResult
+                [ref] $sendResult,
+                [ref] $lastError
             )
-            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             if ($sendStatus -eq [IntPtr]::Zero) {
                 $Run.Process.Refresh()
                 if (-not $Run.Process.HasExited) {

--- a/test/windows/interactive-win11-undo.ps1
+++ b/test/windows/interactive-win11-undo.ps1
@@ -246,19 +246,7 @@ function Wait-Until {
         [System.Diagnostics.Process] $Process
     )
 
-    while ([DateTime]::UtcNow -lt $Deadline) {
-        if ($null -ne $Process -and $Process.HasExited) {
-            throw "winghostty exited while waiting for ${Description} (exit code $($Process.ExitCode))"
-        }
-
-        if (& $Condition) {
-            return
-        }
-
-        Start-Sleep -Milliseconds 100
-    }
-
-    throw "Timed out waiting for $Description"
+    Wait-InteractiveWin11Until @PSBoundParameters
 }
 
 function Invoke-HostCommand {

--- a/test/windows/interactive-win11-undo.ps1
+++ b/test/windows/interactive-win11-undo.ps1
@@ -70,8 +70,6 @@ public static class Win11UndoNative {
     [DllImport("user32.dll")]
     public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
-    [DllImport("user32.dll")]
-    public static extern IntPtr SendMessageW(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
 }
 
 public sealed class Win11UndoChildControl {
@@ -266,10 +264,12 @@ function Wait-Until {
 function Invoke-HostCommand {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
-        [Parameter(Mandatory)] [int] $CommandId
+        [Parameter(Mandatory)] [int] $CommandId,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
-    [void] [Win11UndoNative]::SendMessageW($HostHwnd, 0x0111, (New-WParam -Low $CommandId), [IntPtr]::Zero)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
 }
 
 function Invoke-CommandPaletteAction {
@@ -280,7 +280,7 @@ function Invoke-CommandPaletteAction {
         [System.Diagnostics.Process] $Process
     )
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901 -Deadline $Deadline -Process $Process
     $script:Win11UndoPaletteHostHwnd = $HostHwnd
     Wait-Until -Deadline $Deadline -Description 'command palette edit control' -Process $Process -Condition {
         $null -ne (Get-VisibleChildById -Parent $script:Win11UndoPaletteHostHwnd -Id 2002)
@@ -294,20 +294,17 @@ function Invoke-CommandPaletteAction {
         ([Win11UndoPaletteAction]::CloseTabThis) { 'close_tab:this' }
     }
     foreach ($ch in $actionText.ToCharArray()) {
-        [void] [Win11UndoNative]::SendMessageW(
-            $edit.Hwnd,
-            0x0102,
-            ([UIntPtr]([uint64]([int][char]$ch))),
-            [IntPtr]::Zero
-        )
+        [void] (Invoke-InteractiveWin11Message -Hwnd $edit.Hwnd -Message 0x0102 -WParam ([UIntPtr]([uint64]([int][char]$ch))) -Deadline $Deadline -Description "palette WM_CHAR '$ch'" -Process $Process)
     }
 
-    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 2003
+    Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 2003 -Deadline $Deadline -Process $Process
 }
 
 function Invoke-CloseSecondTab {
     param(
-        [Parameter(Mandatory)] [IntPtr] $HostHwnd
+        [Parameter(Mandatory)] [IntPtr] $HostHwnd,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
     $tab = Get-VisibleTabButtons -Parent $HostHwnd |
@@ -325,13 +322,15 @@ function Invoke-CloseSecondTab {
     $x = [Math]::Max(0, $rect.Right - 4)
     $y = [Math]::Max(0, [int] (($rect.Bottom - $rect.Top) / 2))
     $lParam = New-LParam -X $x -Y $y
-    [void] [Win11UndoNative]::SendMessageW($tab.Hwnd, 0x0201, [UIntPtr]::Zero, $lParam)
-    [void] [Win11UndoNative]::SendMessageW($tab.Hwnd, 0x0202, [UIntPtr]::Zero, $lParam)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $tab.Hwnd -Message 0x0201 -LParam $lParam -Deadline $Deadline -Description 'second tab mouse down' -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $tab.Hwnd -Message 0x0202 -LParam $lParam -Deadline $Deadline -Description 'second tab mouse up' -Process $Process)
 }
 
 function Invoke-DragFirstTabIntoActiveSurface {
     param(
-        [Parameter(Mandatory)] [IntPtr] $HostHwnd
+        [Parameter(Mandatory)] [IntPtr] $HostHwnd,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [System.Diagnostics.Process] $Process
     )
 
     $sourceTab = Get-VisibleTabButtons -Parent $HostHwnd |
@@ -360,24 +359,9 @@ function Invoke-DragFirstTabIntoActiveSurface {
     $moveX = $targetScreenX - $tabScreen.Left
     $moveY = $targetScreenY - $tabScreen.Top
 
-    [void] [Win11UndoNative]::SendMessageW(
-        $sourceTab.Hwnd,
-        0x0201,
-        [UIntPtr]::Zero,
-        (New-LParam -X $downX -Y $downY)
-    )
-    [void] [Win11UndoNative]::SendMessageW(
-        $sourceTab.Hwnd,
-        0x0200,
-        (New-WParam -Low 1),
-        (New-LParam -X $moveX -Y $moveY)
-    )
-    [void] [Win11UndoNative]::SendMessageW(
-        $sourceTab.Hwnd,
-        0x0202,
-        [UIntPtr]::Zero,
-        (New-LParam -X $moveX -Y $moveY)
-    )
+    [void] (Invoke-InteractiveWin11Message -Hwnd $sourceTab.Hwnd -Message 0x0201 -LParam (New-LParam -X $downX -Y $downY) -Deadline $Deadline -Description 'tab drag mouse down' -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $sourceTab.Hwnd -Message 0x0200 -WParam (New-WParam -Low 1) -LParam (New-LParam -X $moveX -Y $moveY) -Deadline $Deadline -Description 'tab drag mouse move' -Process $Process)
+    [void] (Invoke-InteractiveWin11Message -Hwnd $sourceTab.Hwnd -Message 0x0202 -LParam (New-LParam -X $moveX -Y $moveY) -Deadline $Deadline -Description 'tab drag mouse up' -Process $Process)
 }
 
 $harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'undo' -ResetState:$ResetState
@@ -471,7 +455,7 @@ try {
     }
     Assert-Equal (Get-VisibleSurfaceCount -Parent $hostHwnd) 1 'visible surface count after second split undo'
 
-    Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904
+    Invoke-HostCommand -HostHwnd $hostHwnd -CommandId 1904 -Deadline $deadline -Process $process
     Wait-Until -Deadline $deadline -Description 'second tab button' -Process $process -Condition {
         (Get-VisibleTabCount -Parent $hostHwnd) -eq 2
     }
@@ -480,7 +464,7 @@ try {
     }
     Assert-Equal (Get-VisibleTabCount -Parent $hostHwnd) 2 'tab count after new_tab'
 
-    Invoke-DragFirstTabIntoActiveSurface -HostHwnd $hostHwnd
+    Invoke-DragFirstTabIntoActiveSurface -HostHwnd $hostHwnd -Deadline $deadline -Process $process
     Wait-Until -Deadline $deadline -Description 'tab drag split transfer' -Process $process -Condition {
         (Get-VisibleTabCount -Parent $hostHwnd) -eq 1 -and
         (Get-VisibleSurfaceCount -Parent $hostHwnd) -eq 2
@@ -506,7 +490,7 @@ try {
         (Get-VisibleSurfaceCount -Parent $hostHwnd) -eq 1
     }
 
-    Invoke-CloseSecondTab -HostHwnd $hostHwnd
+    Invoke-CloseSecondTab -HostHwnd $hostHwnd -Deadline $deadline -Process $process
     Wait-Until -Deadline $deadline -Description 'second tab close' -Process $process -Condition {
         (Get-VisibleTabCount -Parent $hostHwnd) -eq 1
     }

--- a/test/windows/interactive-win11-undo.ps1
+++ b/test/windows/interactive-win11-undo.ps1
@@ -254,7 +254,7 @@ function Invoke-HostCommand {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [int] $CommandId,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     [void] (Invoke-InteractiveWin11Message -Hwnd $HostHwnd -Message 0x0111 -WParam (New-WParam -Low $CommandId) -Deadline $Deadline -Description "WM_COMMAND $CommandId" -Process $Process)
@@ -265,7 +265,7 @@ function Invoke-CommandPaletteAction {
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [Win11UndoPaletteAction] $Action,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     Invoke-HostCommand -HostHwnd $HostHwnd -CommandId 1901 -Deadline $Deadline -Process $Process
@@ -292,7 +292,7 @@ function Invoke-CloseSecondTab {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $tab = Get-VisibleTabButtons -Parent $HostHwnd |
@@ -318,7 +318,7 @@ function Invoke-DragFirstTabIntoActiveSurface {
     param(
         [Parameter(Mandatory)] [IntPtr] $HostHwnd,
         [Parameter(Mandatory)] [DateTime] $Deadline,
-        [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
     $sourceTab = Get-VisibleTabButtons -Parent $HostHwnd |


### PR DESCRIPTION
## Summary

- give every stateful Win11 close a fresh phase deadline
- bound cross-process harness messages and exit races with deadline-aware Win32 probes
- make `+boo` paint validation trace-owned and fail closed: a separate one-time startup ceiling, strict 300 ms steady-state ceiling, and exactly one classified initialization exemption
- isolate Zig caches per CI run and preserve caller-provided cache paths in Windows wrappers
- add fail-closed verification contracts for cache isolation, command-resolution integrity, baseline scanning, provenance, and paint-gap policy

## Root cause

Exact-main Test run `29251512053` passed the flagship composite, accessibility check, and palette/theme check, then failed session restore with `Timed out waiting for winghostty graceful exit`. Cold setup and tab creation had consumed the shared 30-second story deadline before `Close-StatefulHost` began. Later exact-head review and reruns exposed independent harness risks: an arbitrary startup-paint allowance, cross-run Zig cache corruption, unbounded native-tool cleanup, PowerShell AST-contract bypasses, and PowerShell 7.0/7.1 native-stderr behavior. Each repository-mitigable finding is fixed and mechanically covered.

## Exact-head validation

Exact PR head: `f8ba1da66fc07b6595f0a8582705066f0e86e0c0`.

- PowerShell 7 and Windows PowerShell 5.1 parsers: PASS
- source formatting, `zig fmt`, and `git diff --check`: PASS
- flagship verification contracts, including mutation probes: PASS
- Windows x64 baseline synthetic probes and real-binary scan: PASS
- native stderr/exit-code compatibility probe: PASS
- hosted Windows build/tests: PASS (`29299141329`)
- Windows x64 portable package smoke: PASS (`29299141329`)
- native Windows ARM64 tests: PASS (`29299141306`)
- Greptile exact-head review: PASS, 30 files reviewed, 0 comments
- CodeRabbit exact-head review: no actionable findings or residuals ([record](https://github.com/amanthanvi/winghostty/pull/88#issuecomment-4964587619))
- Codex exact-head review: no major issues ([record](https://github.com/amanthanvi/winghostty/pull/88#issuecomment-4964616499))
- review threads: 26 total, 0 unresolved

Sourcery's exact-head run was skipped by its fixed 150,000-diff-character service limit. Earlier completed Sourcery coverage produced no unresolved findings. Independent GPT audit was clean at `e956cfa`; Sol's completed audit was clean at `d28d16a`; the complete Claude Fable High audit at `48130293a` reported SAFE and all of its residuals were subsequently fixed. A final later-head Claude retry followed Anthropic's structured/XML prompting guidance and completed 18 read-only audit turns before Anthropic stopped it at the account's monthly spend limit, so it is not represented as a final exact-head SAFE verdict.

## Interactive evidence

The exact-head Windows 11 Interactive Composite passed on workflow run `29299141329`, attempt `6`, after temporarily stopping the machine's `GameInputSvc` foreground owner under explicit approval. The service was restored immediately after the job; its start mode remained Manual throughout. The repository-scoped ephemeral runner self-deregistered and its guarded local installation was removed.

- conclusion: PASS
- repository: `amanthanvi/winghostty`
- checked-out commit: `f8ba1da66fc07b6595f0a8582705066f0e86e0c0`
- workflow run/attempt: `29299141329` / `6`
- runner: `winghostty-interactive-29299141329-a7`
- labels/environment: repository-scoped ephemeral Windows/X64/`winghostty-interactive`, Default desktop, active console session 1
- synthetic PR merge SHA recorded separately: `43fbaad1a459d8276741c42f261be6af945554b1`
- artifact: `flagship-interactive-win11-29299141329`, ID `8299028368`
- artifact digest: `sha256:d7283f14d073a8ba09041c0857823eba5761e0470ddf1a83d38d35b114490bfa`
- evidence: 31 files; all three JSON records parse; local SHA-256 inventory captured
- successful coverage includes smoke, key input, new-tab/maximize, resize, undo, UI Automation/TextPattern/palette accessibility, palette/theme, and session restore
- post-run machine state: `GameInputSvc` Running, start mode Manual; no runner registration, runner process, runner directory, or restore watchdog remains

## Scope
Fork-local follow-up to #87. Runtime changes are limited to diagnostic paint-gap telemetry consumed by the Win11 harness; user-facing application behavior is unchanged. CI, packaging, verification contracts, runner provenance, and Windows harness reliability are hardened fail closed.

## Merge status

All required exact-head checks and immutable interactive evidence are complete. No repository finding or review thread remains open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows interactive Win11 messaging with deadline-aware sends/posts, stronger last-error handling, and safer HWND ownership validation.
- **Reliability Improvements**
  - Improved timeout/exit-code handling and tighter lifecycle checks across interactive scenarios, including more robust graceful shutdown/rollback and aggregated cleanup failure reporting.
- **Performance / Diagnostics**
  - Extended render-trace paint-gap instrumentation (startup ceiling, limits, over-limit counter) and updated paint-gap pass/fail rules.
- **CI / Packaging**
  - Disabled Zig caching for Windows jobs with cache isolation, added LLVM objdump-based x64 baseline verification, strengthened packaging gates, and enforced verification contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->