### PR TITLE
test/windows: report launcher timeouts accurately

### DIFF
--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -633,7 +633,7 @@ function Stop-InteractiveWin11Process {
     $taskkillTerminationVerified = $true
     try {
         $taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
-        $taskkillStartInfo.FileName = Join-Path $env:SystemRoot 'System32\taskkill.exe'
+        $taskkillStartInfo.FileName = Join-Path ([Environment]::SystemDirectory) 'taskkill.exe'
         $taskkillStartInfo.UseShellExecute = $false
         $taskkillStartInfo.CreateNoWindow = $true
         $taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -602,31 +602,72 @@ function Stop-InteractiveWin11Process {
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
     )
 
-    if (-not $Process.HasExited) {
-        $taskkillError = $null
-        try {
-            & taskkill.exe /PID $Process.Id /T /F *> $null
+    $rootProcessId = $Process.Id
+    $rootStartedAt = $Process.StartTime
+    $rootIsLive = $false
+    try {
+        $Process.Refresh()
+        $rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt
+    }
+    catch [System.InvalidOperationException] {
+        # The root exited while its identity was being checked.
+    }
+    if (-not $rootIsLive) {
+        throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."
+    }
+
+    $taskkillError = $null
+    $taskkill = $null
+    $taskkillTerminationVerified = $true
+    try {
+        $taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $taskkillStartInfo.FileName = Join-Path $env:SystemRoot 'System32\taskkill.exe'
+        $taskkillStartInfo.UseShellExecute = $false
+        $taskkillStartInfo.CreateNoWindow = $true
+        foreach ($argument in @('/PID', "$rootProcessId", '/T', '/F')) {
+            [void] $taskkillStartInfo.ArgumentList.Add($argument)
         }
-        catch {
-            $taskkillError = $_.Exception.Message
-        }
-        try {
-            $Process.Refresh()
-        }
-        catch {
-            Write-Warning "Process refresh failed during interactive Win11 cleanup: $($_.Exception.Message)"
-        }
-        if (-not $Process.HasExited) {
-            try {
-                Stop-Process -Id $Process.Id -Force -ErrorAction Stop
+        $taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)
+        $taskkillTerminationVerified = $false
+        $taskkillTerminationVerified = $taskkill.WaitForExit(10000)
+        if (-not $taskkillTerminationVerified) {
+            $taskkill.Kill()
+            $taskkillTerminationVerified = $taskkill.WaitForExit(5000)
+            if (-not $taskkillTerminationVerified) {
+                throw 'taskkill could not be stopped within 5 seconds'
             }
-            catch {
-                throw "Failed to stop interactive Win11 process $($Process.Id) (taskkill='$taskkillError', Stop-Process='$($_.Exception.Message)')."
-            }
+            $taskkillError = 'taskkill exceeded 10 seconds'
+        } elseif ($taskkill.ExitCode -ne 0) {
+            $taskkillError = "taskkill exited with code $($taskkill.ExitCode)"
+        }
+        if ($null -eq $taskkillError -and $Process.WaitForExit(5000)) {
+            return
         }
     }
-    if (-not $Process.WaitForExit(5000)) {
-        throw "Interactive Win11 process $($Process.Id) did not exit within 5 seconds."
+    catch {
+        if (-not $taskkillTerminationVerified) {
+            throw
+        }
+        $taskkillError = $_.Exception.Message
+    }
+    finally {
+        if ($null -ne $taskkill) {
+            $taskkill.Dispose()
+        }
+    }
+
+    try {
+        $Process.Refresh()
+        if ($Process.HasExited -or $Process.StartTime -ne $rootStartedAt) {
+            throw 'the root exited before fallback tree cleanup could be verified'
+        }
+        $Process.Kill($true)
+        if (-not $Process.WaitForExit(5000)) {
+            throw 'managed tree kill did not stop the root within 5 seconds'
+        }
+    }
+    catch {
+        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', managed='$($_.Exception.Message)')."
     }
 }
 

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -612,7 +612,9 @@ function Stop-InteractiveWin11Process {
     }
     catch [System.InvalidOperationException] {
         # The root exited while its identity was being checked.
-        Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"
+        if ($VerbosePreference -eq 'Continue') {
+            Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"
+        }
     }
     if (-not $rootIsLive) {
         if (-not $RequireLiveRoot) {

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -599,7 +599,8 @@ function Wait-InteractiveWin11Until {
 
 function Stop-InteractiveWin11Process {
     param(
-        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
+        [switch] $RequireLiveRoot
     )
 
     $rootProcessId = $Process.Id
@@ -613,6 +614,9 @@ function Stop-InteractiveWin11Process {
         # The root exited while its identity was being checked.
     }
     if (-not $rootIsLive) {
+        if (-not $RequireLiveRoot) {
+            return
+        }
         throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."
     }
 
@@ -624,9 +628,7 @@ function Stop-InteractiveWin11Process {
         $taskkillStartInfo.FileName = Join-Path $env:SystemRoot 'System32\taskkill.exe'
         $taskkillStartInfo.UseShellExecute = $false
         $taskkillStartInfo.CreateNoWindow = $true
-        foreach ($argument in @('/PID', "$rootProcessId", '/T', '/F')) {
-            [void] $taskkillStartInfo.ArgumentList.Add($argument)
-        }
+        $taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"
         $taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)
         $taskkillTerminationVerified = $false
         $taskkillTerminationVerified = $taskkill.WaitForExit(10000)
@@ -659,15 +661,16 @@ function Stop-InteractiveWin11Process {
     try {
         $Process.Refresh()
         if ($Process.HasExited -or $Process.StartTime -ne $rootStartedAt) {
-            throw 'the root exited before fallback tree cleanup could be verified'
+            throw 'the root exited before fallback cleanup could verify the process tree'
         }
-        $Process.Kill($true)
+        $Process.Kill()
         if (-not $Process.WaitForExit(5000)) {
-            throw 'managed tree kill did not stop the root within 5 seconds'
+            throw 'root fallback did not stop the process within 5 seconds'
         }
+        throw 'root fallback stopped the process but could not verify descendant cleanup'
     }
     catch {
-        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', managed='$($_.Exception.Message)')."
+        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', fallback='$($_.Exception.Message)')."
     }
 }
 

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -661,6 +661,9 @@ function Stop-InteractiveWin11Process {
     try {
         $Process.Refresh()
         if ($Process.HasExited -or $Process.StartTime -ne $rootStartedAt) {
+            if (-not $RequireLiveRoot) {
+                return
+            }
             throw 'the root exited before fallback cleanup could verify the process tree'
         }
         $Process.Kill()

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -604,11 +604,16 @@ function Stop-InteractiveWin11Process {
     )
 
     $rootProcessId = $Process.Id
-    $rootStartedAt = $Process.StartTime
+    $rootProcessHandle = [IntPtr]::Zero
+    $rootStartedAt = $null
     $rootIsLive = $false
     try {
         $Process.Refresh()
-        $rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt
+        if (-not $Process.HasExited) {
+            $rootProcessHandle = $Process.Handle
+            $rootStartedAt = $Process.StartTime
+            $rootIsLive = $true
+        }
     }
     catch [System.InvalidOperationException] {
         # The root exited while its identity was being checked.
@@ -669,8 +674,20 @@ function Stop-InteractiveWin11Process {
             }
             throw 'the root exited before fallback cleanup could verify the process tree'
         }
-        $Process.Kill()
-        if (-not $Process.WaitForExit(5000)) {
+        Initialize-InteractiveWin11ProcessNative
+        $rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)
+        $terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        $rootExited = $Process.WaitForExit(5000)
+        if (-not $rootTerminationRequested) {
+            if ($rootExited) {
+                if (-not $RequireLiveRoot) {
+                    return
+                }
+                throw 'the root exited before fallback cleanup could verify the process tree'
+            }
+            throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
+        }
+        if (-not $rootExited) {
             throw 'root fallback did not stop the process within 5 seconds'
         }
         throw 'root fallback stopped the process but could not verify descendant cleanup'
@@ -767,6 +784,10 @@ public static class InteractiveWin11ProcessNative {
     [DllImport("kernel32.dll", SetLastError=true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+    [DllImport("kernel32.dll", SetLastError=true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
 }
 "@
     }

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -612,6 +612,7 @@ function Stop-InteractiveWin11Process {
     }
     catch [System.InvalidOperationException] {
         # The root exited while its identity was being checked.
+        Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"
     }
     if (-not $rootIsLive) {
         if (-not $RequireLiveRoot) {

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -48,15 +48,16 @@ function Format-PowerShellLiteral {
     return "'" + $Argument.Replace("'", "''") + "'"
 }
 
-$binDir = if ($BinDir) { $BinDir } else { Join-Path $repoRoot 'zig-out\bin' }
+$binDir = [System.IO.Path]::GetFullPath($(if ($BinDir) { $BinDir } else { Join-Path $repoRoot 'zig-out\bin' }))
 $guiExe = Join-Path $binDir 'winghostty.exe'
 $commandExe = Join-Path $binDir 'winghostty.com'
+$cmdExe = Join-Path ([Environment]::SystemDirectory) 'cmd.exe'
+$powershellExe = Join-Path ([Environment]::SystemDirectory) 'WindowsPowerShell\v1.0\powershell.exe'
 
-if (-not (Test-Path $guiExe)) {
-    throw "Missing built executable: $guiExe. Run `zig build -Demit-exe=true` first."
-}
-if (-not (Test-Path $commandExe)) {
-    throw "Missing shell launcher: $commandExe. Run `zig build -Demit-exe=true` first."
+foreach ($requiredExecutable in @($guiExe, $commandExe, $cmdExe, $powershellExe)) {
+    if (-not (Test-Path -LiteralPath $requiredExecutable -PathType Leaf)) {
+        throw "Missing required executable: $requiredExecutable. Run `zig build -Demit-exe=true` if the winghostty binaries are absent."
+    }
 }
 
 $envPath = "$binDir;$env:PATH"
@@ -65,12 +66,13 @@ $shellLauncherTimeoutSeconds = 30
 
 switch ($Shell) {
     'cmd' {
-        $resolved = & cmd /d /c "set ""PATH=$envPath""&& where winghostty"
+        $resolved = & $cmdExe /d /c "set ""PATH=$envPath""&& where winghostty"
         if ($LASTEXITCODE -ne 0) {
             throw "cmd could not resolve winghostty from PATH."
         }
-        if (-not ($resolved | Select-Object -First 1 | ForEach-Object { $_.ToLowerInvariant().EndsWith('winghostty.com') })) {
-            throw "cmd resolved winghostty to the wrong artifact: $($resolved | Select-Object -First 1)"
+        $resolvedPath = [System.IO.Path]::GetFullPath(($resolved | Select-Object -First 1))
+        if (-not [string]::Equals($resolvedPath, $commandExe, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "cmd resolved winghostty to the wrong artifact: $resolvedPath"
         }
 
         $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
@@ -83,7 +85,7 @@ switch ($Shell) {
                 $cmdCommand
             ) | Set-Content -LiteralPath $payloadPath -Encoding ASCII
 
-            $output = & cmd /d /c $payloadPath 2>&1 | Out-String
+            $output = & $cmdExe /d /c $payloadPath 2>&1 | Out-String
             $exitCode = $LASTEXITCODE
         }
         finally {
@@ -95,18 +97,20 @@ switch ($Shell) {
         $oldPath = $env:PATH
         $env:PATH = $envPath
         try {
-            $resolved = & powershell.exe -NoProfile -Command "(Get-Command winghostty).Source"
+            $resolved = & $powershellExe -NoProfile -Command "(Get-Command winghostty).Source"
             if ($LASTEXITCODE -ne 0) {
                 throw "PowerShell could not resolve winghostty from PATH."
             }
-            if (-not $resolved.ToLowerInvariant().EndsWith('winghostty.com')) {
-                throw "PowerShell resolved winghostty to the wrong artifact: $resolved"
+            $resolvedPath = [System.IO.Path]::GetFullPath($resolved)
+            if (-not [string]::Equals($resolvedPath, $commandExe, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "PowerShell resolved winghostty to the wrong artifact: $resolvedPath"
             }
 
             $stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")
             $stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")
             $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".ps1")
             try {
+                $env:PATH = $envPath
                 $argLiterals = [string]::Join(', ', ($Arguments | ForEach-Object { Format-PowerShellLiteral $_ }))
                 @(
                     '$argsList = @(' + $argLiterals + ')'
@@ -117,7 +121,7 @@ switch ($Shell) {
                 ) | Set-Content -LiteralPath $payloadPath -Encoding UTF8
 
                 $process = Start-Process `
-                    -FilePath powershell.exe `
+                    -FilePath $powershellExe `
                     -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $payloadPath) `
                     -RedirectStandardOutput $stdoutPath `
                     -RedirectStandardError $stderrPath `

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -125,10 +125,7 @@ switch ($Shell) {
                     -PassThru
                 $processHandle = $process.Handle
                 if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
-                    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-                    if (-not $process.WaitForExit(1000)) {
-                        throw "Timed out waiting for shell launcher process to exit after termination."
-                    }
+                    Stop-InteractiveWin11Process -Process $process
                     throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
                 }
 

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -125,7 +125,7 @@ switch ($Shell) {
                     -PassThru
                 $processHandle = $process.Handle
                 if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
-                    Stop-InteractiveWin11Process -Process $process
+                    Stop-InteractiveWin11Process -Process $process -RequireLiveRoot
                     throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
                 }
 

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -75,6 +75,8 @@ switch ($Shell) {
             throw "cmd resolved winghostty to the wrong artifact: $resolvedPath"
         }
 
+        $stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")
+        $stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")
         $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
         try {
             $cmdArgs = [string]::Join(' ', ($Arguments | ForEach-Object { Format-CmdArgument $_ }))
@@ -85,11 +87,34 @@ switch ($Shell) {
                 $cmdCommand
             ) | Set-Content -LiteralPath $payloadPath -Encoding ASCII
 
-            $output = & $cmdExe /d /c $payloadPath 2>&1 | Out-String
-            $exitCode = $LASTEXITCODE
+            $process = Start-Process `
+                -FilePath $cmdExe `
+                -ArgumentList "/d /c `"$payloadPath`"" `
+                -RedirectStandardOutput $stdoutPath `
+                -RedirectStandardError $stderrPath `
+                -WindowStyle Hidden `
+                -PassThru
+            $processHandle = $process.Handle
+            if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
+                Stop-InteractiveWin11Process -Process $process -RequireLiveRoot
+                throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
+            }
+
+            $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
+            $stdoutText = if (Test-Path -LiteralPath $stdoutPath) {
+                Get-Content -LiteralPath $stdoutPath -Raw
+            } else {
+                ''
+            }
+            $stderrText = if (Test-Path -LiteralPath $stderrPath) {
+                Get-Content -LiteralPath $stderrPath -Raw
+            } else {
+                ''
+            }
+            $output = $stdoutText + $stderrText
         }
         finally {
-            Remove-Item -LiteralPath $payloadPath -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath -ErrorAction SilentlyContinue
         }
     }
 

--- a/test/windows/cli-shell-command.ps1
+++ b/test/windows/cli-shell-command.ps1
@@ -61,6 +61,7 @@ if (-not (Test-Path $commandExe)) {
 
 $envPath = "$binDir;$env:PATH"
 $argsDisplay = [string]::Join(' ', $Arguments)
+$shellLauncherTimeoutSeconds = 30
 
 switch ($Shell) {
     'cmd' {
@@ -123,11 +124,12 @@ switch ($Shell) {
                     -WindowStyle Hidden `
                     -PassThru
                 $processHandle = $process.Handle
-                if (-not $process.WaitForExit(5000)) {
+                if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
                     Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
                     if (-not $process.WaitForExit(1000)) {
-                        throw "Timed out waiting for shell launcher process to exit."
+                        throw "Timed out waiting for shell launcher process to exit after termination."
                     }
+                    throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
                 }
 
                 $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -538,8 +538,7 @@ foreach ($source in $resolutionSourceAsts) {
         @(
             '& $bootstrapCmd powershell.exe -ExecutionPolicy Bypass -File $LauncherPath @ArgumentList',
             '& cmd /c $devWindowsCmd zig build -Demit-exe=true',
-            '& $Condition',
-            '& taskkill.exe /PID $Process.Id /T /F *> $null'
+            '& $Condition'
         )
     } else { @() }
     Assert-CommandResolutionContract -Ast $source.Ast -Context $source.Path -ExpectedAmpersandCommands $expectedAmpersands
@@ -554,6 +553,127 @@ foreach ($source in $resolutionSourceAsts) {
             throw "Interactive library has the wrong ownership count for protected function $name`: $($source.Path)"
         }
     }
+}
+$interactiveWin11LibAst = @($resolutionSourceAsts | Where-Object { $_.Path -eq $interactiveWin11Lib })[0].Ast
+$stopProcessFunctions = @($interactiveWin11LibAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'Stop-InteractiveWin11Process'
+}, $true))
+$stopProcessStatements = if ($stopProcessFunctions.Count -eq 1) {
+    @($stopProcessFunctions[0].Body.EndBlock.Statements)
+} else { @() }
+$stopIdentityTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[3] } else { $null }
+$stopTaskkillTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[8] } else { $null }
+$stopManagedTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[9] } else { $null }
+if ($stopProcessFunctions.Count -ne 1 -or
+    -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    $null -ne $stopProcessFunctions[0].Body.BeginBlock -or
+    $null -ne $stopProcessFunctions[0].Body.ProcessBlock -or
+    $null -ne $stopProcessFunctions[0].Body.DynamicParamBlock -or
+    $null -ne $stopProcessFunctions[0].Body.CleanBlock -or
+    $null -eq $stopProcessFunctions[0].Body.ParamBlock -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters.Count -ne 1 -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Name.VariablePath.UserPath -ne 'Process' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes.Count -ne 2 -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes[0].Extent.Text.Trim() -ne '[Parameter(Mandatory)]' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes[1].Extent.Text.Trim() -ne '[System.Diagnostics.Process]' -or
+    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].DefaultValue -or
+    $stopProcessStatements.Count -ne 10 -or
+    $stopProcessStatements[0].Extent.Text.Trim() -ne '$rootProcessId = $Process.Id' -or
+    $stopProcessStatements[1].Extent.Text.Trim() -ne '$rootStartedAt = $Process.StartTime' -or
+    $stopProcessStatements[2].Extent.Text.Trim() -ne '$rootIsLive = $false' -or
+    $stopIdentityTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $stopIdentityTry.Body.Statements.Count -ne 2 -or
+    $stopIdentityTry.CatchClauses.Count -ne 1 -or
+    $null -ne $stopIdentityTry.Finally -or
+    $stopIdentityTry.CatchClauses[0].CatchTypes.Count -ne 1 -or
+    $stopIdentityTry.CatchClauses[0].CatchTypes[0].TypeName.FullName -ne 'System.InvalidOperationException' -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements.Count -ne 0 -or
+    $stopIdentityTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
+    $stopIdentityTry.Body.Statements[1].Extent.Text.Trim() -ne '$rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt' -or
+    $stopProcessStatements[4] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopProcessStatements[4].Clauses.Count -ne 1 -or
+    $null -ne $stopProcessStatements[4].ElseClause -or
+    $stopProcessStatements[4].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootIsLive' -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopProcessStatements[5].Extent.Text.Trim() -ne '$taskkillError = $null' -or
+    $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkill = $null' -or
+    $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
+    $stopTaskkillTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $stopTaskkillTry.Body.Statements.Count -ne 10 -or
+    $stopTaskkillTry.CatchClauses.Count -ne 1 -or
+    $null -eq $stopTaskkillTry.Finally -or
+    $stopTaskkillTry.Body.Statements[0].Extent.Text.Trim() -ne '$taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()' -or
+    $stopTaskkillTry.Body.Statements[1].Extent.Text.Trim() -ne '$taskkillStartInfo.FileName = Join-Path $env:SystemRoot ''System32\taskkill.exe''' -or
+    $stopTaskkillTry.Body.Statements[2].Extent.Text.Trim() -ne '$taskkillStartInfo.UseShellExecute = $false' -or
+    $stopTaskkillTry.Body.Statements[3].Extent.Text.Trim() -ne '$taskkillStartInfo.CreateNoWindow = $true' -or
+    $stopTaskkillTry.Body.Statements[4].Extent.Text.Trim() -notmatch '^foreach \(\$argument in @\(''/PID'', "\$rootProcessId", ''/T'', ''/F''\)\)' -or
+    $stopTaskkillTry.Body.Statements[4].Body.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Body.Statements[4].Body.Statements[0].Extent.Text.Trim() -ne '[void] $taskkillStartInfo.ArgumentList.Add($argument)' -or
+    $stopTaskkillTry.Body.Statements[5].Extent.Text.Trim() -ne '$taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)' -or
+    $stopTaskkillTry.Body.Statements[6].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $false' -or
+    $stopTaskkillTry.Body.Statements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $taskkill.WaitForExit(10000)' -or
+    $stopTaskkillTry.Body.Statements[8] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopTaskkillTry.Body.Statements[8].Clauses.Count -ne 2 -or
+    $null -ne $stopTaskkillTry.Body.Statements[8].ElseClause -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements.Count -ne 4 -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Kill()' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $taskkill.WaitForExit(5000)' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses.Count -ne 1 -or
+    $null -ne $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].ElseClause -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[3].Extent.Text.Trim() -ne '$taskkillError = ''taskkill exceeded 10 seconds''' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item1.Extent.Text.Trim() -ne '$taskkill.ExitCode -ne 0' -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item2.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkillError = "taskkill exited with code $($taskkill.ExitCode)"' -or
+    $stopTaskkillTry.Body.Statements[9] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopTaskkillTry.Body.Statements[9].Clauses.Count -ne 1 -or
+    $null -ne $stopTaskkillTry.Body.Statements[9].ElseClause -or
+    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item1.Extent.Text.Trim() -ne '$null -eq $taskkillError -and $Process.WaitForExit(5000)' -or
+    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements.Count -ne 2 -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopTaskkillTry.CatchClauses[0].Body.Statements[0].ElseClause -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[1].Extent.Text.Trim() -ne '$taskkillError = $_.Exception.Message' -or
+    $stopTaskkillTry.Finally.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Finally.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopTaskkillTry.Finally.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopTaskkillTry.Finally.Statements[0].ElseClause -or
+    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$null -ne $taskkill' -or
+    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Dispose()' -or
+    $stopManagedTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $stopManagedTry.Body.Statements.Count -ne 4 -or
+    $stopManagedTry.CatchClauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Finally -or
+    $stopManagedTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
+    $stopManagedTry.Body.Statements[1] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[1].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[1].ElseClause -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '$Process.HasExited -or $Process.StartTime -ne $rootStartedAt' -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill($true)' -or
+    $stopManagedTry.Body.Statements[3] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[3].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[3].ElseClause -or
+    $stopManagedTry.Body.Statements[3].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.WaitForExit(5000)' -or
+    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
+    $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst]) {
+    throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around both tree-kill mechanisms.'
 }
 $cliShellTokens = $null
 $cliShellErrors = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -608,6 +608,22 @@ $cliShellTimeoutIfs = if ($cliShellPowerShellClauseIndex -ge 0) {
 $cliShellTimeoutStatements = if ($cliShellTimeoutIfs.Count -eq 1) {
     @($cliShellTimeoutIfs[0].Clauses[0].Item2.Statements)
 } else { @() }
+$cliShellLauncherBlockShared = $cliShellStartProcessAssignments.Count -eq 1 -and
+    $cliShellTimeoutIfs.Count -eq 1 -and
+    [Object]::ReferenceEquals($cliShellStartProcessAssignments[0].Parent, $cliShellTimeoutIfs[0].Parent)
+$cliShellLauncherStatements = if ($cliShellLauncherBlockShared) {
+    @($cliShellStartProcessAssignments[0].Parent.Statements)
+} else { @() }
+$cliShellStartProcessIndex = -1
+$cliShellTimeoutIndex = -1
+for ($i = 0; $i -lt $cliShellLauncherStatements.Count; $i++) {
+    if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellStartProcessAssignments[0])) {
+        $cliShellStartProcessIndex = $i
+    }
+    if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellTimeoutIfs[0])) {
+        $cliShellTimeoutIndex = $i
+    }
+}
 if ($cliShellErrors.Count -ne 0 -or
     $cliShellTimeoutAssignments.Count -ne 1 -or
     $cliShellSwitches.Count -ne 1 -or
@@ -615,6 +631,19 @@ if ($cliShellErrors.Count -ne 0 -or
     $cliShellStartProcessAssignments.Count -ne 1 -or
     $cliShellWaitForExitCalls.Count -ne 1 -or
     $cliShellTimeoutIfs.Count -ne 1 -or
+    -not $cliShellLauncherBlockShared -or
+    $cliShellStartProcessAssignments[0].Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
+    $cliShellStartProcessAssignments[0].Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $cliShellStartProcessAssignments[0].Parent.Parent.Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
+    $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    -not [Object]::ReferenceEquals(
+        $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Parent,
+        $cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2
+    ) -or
+    $cliShellStartProcessIndex -lt 0 -or
+    $cliShellTimeoutIndex -ne ($cliShellStartProcessIndex + 2) -or
+    $cliShellLauncherStatements[$cliShellStartProcessIndex + 1].Extent.Text.Trim() -ne '$processHandle = $process.Handle' -or
+    $cliShellLauncherStatements[$cliShellTimeoutIndex + 1].Extent.Text.Trim() -ne '$exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle' -or
     $cliShellTimeoutStatements.Count -ne 2 -or
     $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-InteractiveWin11Process -Process $process' -or
     $cliShellTimeoutStatements[1].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -312,7 +312,7 @@ function Test-CommandResolutionMutationNode {
     if ($Node -is [System.Management.Automation.Language.CommandAst]) {
         $name = $Node.GetCommandName()
         $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
-        return $leafName -in @('Set-Alias', 'sal', 'New-Alias', 'nal', 'Remove-Alias', 'ral', 'Import-Alias', 'ipal', 'Import-Module', 'ipmo', 'Import-PSSession', 'Invoke-Expression', 'iex', 'Get-Variable', 'gv') -or
+        return $leafName -in @('Set-Alias', 'sal', 'New-Alias', 'nal', 'Remove-Alias', 'ral', 'Import-Alias', 'ipal', 'Import-Module', 'ipmo', 'Import-PSSession', 'Add-PSSnapin', 'asnp', 'Remove-PSSnapin', 'rsnp', 'Invoke-Expression', 'iex', 'Get-Variable', 'gv') -or
             $Node.Extent.Text -match '(?i)(?:alias|function|variable):'
     }
     if ($Node -is [System.Management.Automation.Language.AssignmentStatementAst]) {
@@ -370,6 +370,7 @@ function Assert-NoProtectedFunctionDefinitions {
     if ($definitions.Count -ne 0) { throw "Harness must not redefine protected interactive functions: $Context" }
 }
 
+$psSnapinRequirementPattern = '(?im)^[ \t]*#requires\b[^\r\n]*[ \t]-PSSnapin(?::|[ \t]|$)'
 $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock]::' + [Environment]::NewLine + '''Create''("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '[ System.Management.Automation.ScriptBlock, System.Management.Automation ]::Create("1+1")' }
@@ -404,6 +405,8 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("[ScriptBlock]::Create")' }
     [pscustomobject]@{ Reject = $false; Text = 'Write-Host "ScriptBlock"' }
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("System.Management.Automation.ScriptBlock")' }
+    [pscustomobject]@{ Reject = $true; Text = 'Add-PSSnapin Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = 'asnp Example.SnapIn' }
 )
 foreach ($probe in $commandResolutionProbes) {
     $probeTokens = $null
@@ -412,6 +415,18 @@ foreach ($probe in $commandResolutionProbes) {
     if ($probeErrors.Count -ne 0) { throw "Command-resolution probe does not parse: $($probe.Text)" }
     $probeRejected = @($probeAst.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true)).Count -ne 0
     if ($probeRejected -ne $probe.Reject) { throw "Command-resolution probe contract failed: $($probe.Text)" }
+}
+$psSnapinRequirementProbes = @(
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin:Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#ReQuIrEs -Version 5.1 -PsSnApIn Example.SnapIn' }
+    [pscustomobject]@{ Reject = $false; Text = '#requires -Modules Example.Module' }
+    [pscustomobject]@{ Reject = $false; Text = 'Write-Host ''#requires -PSSnapin Example.SnapIn''' }
+)
+foreach ($probe in $psSnapinRequirementProbes) {
+    if (($probe.Text -match $psSnapinRequirementPattern) -ne $probe.Reject) {
+        throw "PSSnapin requirement probe contract failed: $($probe.Text)"
+    }
 }
 
 $directStatementTokens = $null
@@ -748,6 +763,53 @@ $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$cliShellTokens,
     [ref]$cliShellErrors
 )
+$cliShellFunctionDefinitions = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+}, $true))
+$cliShellUsingModules = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.UsingStatementAst] -and
+        $node.UsingStatementKind.ToString() -eq 'Module'
+}, $true))
+$cliShellRequiredModules = if ($null -eq $cliShellAst.ScriptRequirements) {
+    @()
+} else {
+    @($cliShellAst.ScriptRequirements.RequiredModules)
+}
+$cliShellPathAssignments = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $node.Left.VariablePath.UserPath -in @('envPath', 'oldPath', 'env:PATH')
+}, $true))
+$cliShellTemporaryPathAssignments = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $node.Left.VariablePath.UserPath -in @('payloadPath', 'stdoutPath', 'stderrPath')
+}, $true))
+$cliShellForbiddenProviderCommands = @($cliShellAst.FindAll({
+    param($node)
+    if ($node -isnot [System.Management.Automation.Language.CommandAst]) { return $false }
+    $name = $node.GetCommandName()
+    $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
+    return $leafName -in @(
+        'Set-Item', 'si', 'New-Item', 'ni', 'Move-Item', 'mi', 'mv',
+        'Copy-Item', 'cpi', 'cp', 'Rename-Item', 'rni', 'Clear-Item', 'cli',
+        'Set-Variable', 'sv', 'New-Variable', 'nv', 'Remove-Variable', 'rv',
+        'Clear-Variable', 'clv', 'Add-Content', 'ac', 'Clear-Content', 'clc',
+        'Out-File', 'Tee-Object', 'tee', 'sc', 'rm', 'ri', 'del', 'erase',
+        'rd', 'rmdir'
+    )
+}, $true))
+$cliShellAllowedProviderCommands = @($cliShellAst.FindAll({
+    param($node)
+    if ($node -isnot [System.Management.Automation.Language.CommandAst]) { return $false }
+    $name = $node.GetCommandName()
+    $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
+    return $leafName -in @('Set-Content', 'Remove-Item')
+}, $true))
 $cliShellTimeoutAssignments = @($cliShellAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
@@ -832,6 +894,28 @@ if ($cliShellErrors.Count -ne 0 -or
         param($node)
         $node -is [System.Management.Automation.Language.TrapStatementAst]
     }, $true)).Count -ne 0 -or
+    $cliShellFunctionDefinitions.Count -ne 2 -or
+    $cliShellFunctionDefinitions[0].Name -ne 'Format-CmdArgument' -or
+    $cliShellFunctionDefinitions[1].Name -ne 'Format-PowerShellLiteral' -or
+    $cliShellUsingModules.Count -ne 0 -or
+    $cliShellRequiredModules.Count -ne 0 -or
+    $cliShellHarnessText -match $psSnapinRequirementPattern -or
+    $cliShellPathAssignments.Count -ne 4 -or
+    $cliShellPathAssignments[0].Extent.Text.Trim() -ne '$envPath = "$binDir;$env:PATH"' -or
+    $cliShellPathAssignments[1].Extent.Text.Trim() -ne '$oldPath = $env:PATH' -or
+    $cliShellPathAssignments[2].Extent.Text.Trim() -ne '$env:PATH = $envPath' -or
+    $cliShellPathAssignments[3].Extent.Text.Trim() -ne '$env:PATH = $oldPath' -or
+    $cliShellTemporaryPathAssignments.Count -ne 4 -or
+    $cliShellTemporaryPathAssignments[0].Extent.Text.Trim() -ne '$payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")' -or
+    $cliShellTemporaryPathAssignments[1].Extent.Text.Trim() -ne '$stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")' -or
+    $cliShellTemporaryPathAssignments[2].Extent.Text.Trim() -ne '$stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")' -or
+    $cliShellTemporaryPathAssignments[3].Extent.Text.Trim() -ne '$payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".ps1")' -or
+    $cliShellForbiddenProviderCommands.Count -ne 0 -or
+    $cliShellAllowedProviderCommands.Count -ne 4 -or
+    $cliShellAllowedProviderCommands[0].Extent.Text.Trim() -ne 'Set-Content -LiteralPath $payloadPath -Encoding ASCII' -or
+    $cliShellAllowedProviderCommands[1].Extent.Text.Trim() -ne 'Remove-Item -LiteralPath $payloadPath -ErrorAction SilentlyContinue' -or
+    $cliShellAllowedProviderCommands[2].Extent.Text.Trim() -ne 'Set-Content -LiteralPath $payloadPath -Encoding UTF8' -or
+    $cliShellAllowedProviderCommands[3].Extent.Text.Trim() -ne 'Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath -ErrorAction SilentlyContinue' -or
     $cliShellTimeoutAssignments.Count -ne 1 -or
     $cliShellTimeoutAssignments[0].Right.Extent.Text.Trim() -ne '30' -or
     $cliShellSwitches.Count -ne 1 -or
@@ -876,6 +960,13 @@ if ($cliShellErrors.Count -ne 0 -or
     $cliShellTimeoutStatements[1].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
     throw 'The live PowerShell shell launcher must use one hosted-cold-start timeout and fail explicitly after bounded process-tree cleanup.'
 }
+Assert-CommandResolutionContract -Ast $cliShellAst -Context $cliShellHarness -ExpectedDotSources @(
+    ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')"
+) -ExpectedAmpersandCommands @(
+    '& cmd /d /c "set ""PATH=$envPath""&& where winghostty"'
+    '& cmd /d /c $payloadPath 2>&1'
+    '& powershell.exe -NoProfile -Command "(Get-Command winghostty).Source"'
+)
 $accessibilityTokens = $null
 $accessibilityErrors = $null
 $accessibilityAst = [System.Management.Automation.Language.Parser]::ParseInput(

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -594,7 +594,12 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopIdentityTry.CatchClauses[0].CatchTypes.Count -ne 1 -or
     $stopIdentityTry.CatchClauses[0].CatchTypes[0].TypeName.FullName -ne 'System.InvalidOperationException' -or
     $stopIdentityTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne 'Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"' -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopIdentityTry.CatchClauses[0].Body.Statements[0].ElseClause -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$VerbosePreference -eq ''Continue''' -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"' -or
     $stopIdentityTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
     $stopIdentityTry.Body.Statements[1].Extent.Text.Trim() -ne '$rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt' -or
     $stopProcessStatements[4] -isnot [System.Management.Automation.Language.IfStatementAst] -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -324,6 +324,7 @@ function Test-CommandResolutionMutationNode {
 function Assert-CommandResolutionContract {
     param(
         [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Token[]] $Tokens,
         [Parameter(Mandatory)] [string] $Context,
         [string[]] $ExpectedDotSources = @(),
         [string[]] $ExpectedAmpersandCommands = @()
@@ -331,6 +332,9 @@ function Assert-CommandResolutionContract {
 
     $mutators = @($Ast.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true))
     if ($mutators.Count -ne 0) { throw "Command resolution mutation is forbidden: $Context" }
+    if (Test-CommandLoadingRequirement -Ast $Ast -Tokens $Tokens) {
+        throw "Command-loading #requires directive is forbidden: $Context"
+    }
     $dotSources = @($Ast.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.CommandAst] -and
@@ -355,6 +359,23 @@ function Assert-CommandResolutionContract {
     }
 }
 
+function Test-CommandLoadingRequirement {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Token[]] $Tokens
+    )
+
+    if ($null -ne $Ast.ScriptRequirements -and
+        @($Ast.ScriptRequirements.RequiredModules).Count -ne 0) {
+        return $true
+    }
+
+    return @($Tokens | Where-Object {
+        $_.Kind -eq [System.Management.Automation.Language.TokenKind]::Comment -and
+            $_.Text -match '(?i)^#requires\b[^\r\n]*[ \t]-(?:M(?:o(?:d(?:u(?:l(?:e(?:s)?)?)?)?)?)?|P(?:S(?:S(?:n(?:a(?:p(?:i(?:n)?)?)?)?)?)?)?)(?::|[ \t]|$)'
+    }).Count -ne 0
+}
+
 function Assert-NoProtectedFunctionDefinitions {
     param(
         [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
@@ -370,7 +391,6 @@ function Assert-NoProtectedFunctionDefinitions {
     if ($definitions.Count -ne 0) { throw "Harness must not redefine protected interactive functions: $Context" }
 }
 
-$psSnapinRequirementPattern = '(?im)^[ \t]*#requires\b[^\r\n]*[ \t]-PSSnapin(?::|[ \t]|$)'
 $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = '[ScriptBlock]::' + [Environment]::NewLine + '''Create''("1+1")' }
     [pscustomobject]@{ Reject = $true; Text = '[ System.Management.Automation.ScriptBlock, System.Management.Automation ]::Create("1+1")' }
@@ -409,25 +429,34 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $true; Text = 'iex ''Write-Host bypass''' }
     [pscustomobject]@{ Reject = $true; Text = 'Add-PSSnapin Example.SnapIn' }
     [pscustomobject]@{ Reject = $true; Text = 'asnp Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin:Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -P Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PS Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSn Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#ReQuIrEs -Version 5.1 -PsSnApIn Example.SnapIn' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -Modules Example.Module' }
+    [pscustomobject]@{ Reject = $true; Text = '#requires -M Example.Module' }
+    [pscustomobject]@{ Reject = $false; Text = '#requires -Version 5.1' }
+    [pscustomobject]@{ Reject = $false; Text = '#requires -PSEdition Desktop' }
+    [pscustomobject]@{ Reject = $false; Text = 'Write-Host ''#requires -PSSnapin Example.SnapIn''' }
+    [pscustomobject]@{ Reject = $false; Text = ("@'" + [Environment]::NewLine + '#requires -Modules Example.Module' + [Environment]::NewLine + "'@") }
 )
 foreach ($probe in $commandResolutionProbes) {
     $probeTokens = $null
     $probeErrors = $null
     $probeAst = [System.Management.Automation.Language.Parser]::ParseInput($probe.Text, [ref] $probeTokens, [ref] $probeErrors)
     if ($probeErrors.Count -ne 0) { throw "Command-resolution probe does not parse: $($probe.Text)" }
-    $probeRejected = @($probeAst.FindAll({ param($node) Test-CommandResolutionMutationNode -Node $node }, $true)).Count -ne 0
-    if ($probeRejected -ne $probe.Reject) { throw "Command-resolution probe contract failed: $($probe.Text)" }
-}
-$psSnapinRequirementProbes = @(
-    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin Example.SnapIn' }
-    [pscustomobject]@{ Reject = $true; Text = '#requires -PSSnapin:Example.SnapIn' }
-    [pscustomobject]@{ Reject = $true; Text = '#ReQuIrEs -Version 5.1 -PsSnApIn Example.SnapIn' }
-    [pscustomobject]@{ Reject = $false; Text = '#requires -Modules Example.Module' }
-    [pscustomobject]@{ Reject = $false; Text = 'Write-Host ''#requires -PSSnapin Example.SnapIn''' }
-)
-foreach ($probe in $psSnapinRequirementProbes) {
-    if (($probe.Text -match $psSnapinRequirementPattern) -ne $probe.Reject) {
-        throw "PSSnapin requirement probe contract failed: $($probe.Text)"
+    $probeRejected = $false
+    $probeFailure = $null
+    try {
+        Assert-CommandResolutionContract -Ast $probeAst -Tokens $probeTokens -Context "probe: $($probe.Text)"
+    } catch {
+        $probeRejected = $true
+        $probeFailure = $_.Exception.Message
+    }
+    if ($probeRejected -ne $probe.Reject) {
+        throw "Command-resolution probe contract failed: $($probe.Text) (contract result: $probeFailure)"
     }
 }
 
@@ -548,7 +577,7 @@ $resolutionSourceAsts = foreach ($source in @(
     $errors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseInput($source.Text, [ref]$tokens, [ref]$errors)
     if ($errors.Count -ne 0) { throw "PowerShell resolution source does not parse: $($source.Path) ($($errors[0].Message))" }
-    [pscustomobject]@{ Path = $source.Path; Ast = $ast }
+    [pscustomobject]@{ Path = $source.Path; Ast = $ast; Tokens = $tokens }
 }
 foreach ($source in $resolutionSourceAsts) {
     $expectedAmpersands = if ($source.Path -eq $interactiveWin11Lib) {
@@ -558,7 +587,7 @@ foreach ($source in $resolutionSourceAsts) {
             '& $Condition'
         )
     } else { @() }
-    Assert-CommandResolutionContract -Ast $source.Ast -Context $source.Path -ExpectedAmpersandCommands $expectedAmpersands
+    Assert-CommandResolutionContract -Ast $source.Ast -Tokens $source.Tokens -Context $source.Path -ExpectedAmpersandCommands $expectedAmpersands
     $definitions = @($source.Ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true))
     foreach ($name in @('Get-InteractiveWin11MessageTimeoutMs', 'Assert-InteractiveWin11WindowOwner', 'Invoke-InteractiveWin11PostMessage', 'Invoke-StatefulPostedCommand')) {
         $expected = if ($source.Path -eq $interactiveWin11Lib) {
@@ -652,7 +681,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.CatchClauses.Count -ne 1 -or
     $null -eq $stopTaskkillTry.Finally -or
     $stopTaskkillTry.Body.Statements[0].Extent.Text.Trim() -ne '$taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()' -or
-    $stopTaskkillTry.Body.Statements[1].Extent.Text.Trim() -ne '$taskkillStartInfo.FileName = Join-Path $env:SystemRoot ''System32\taskkill.exe''' -or
+    $stopTaskkillTry.Body.Statements[1].Extent.Text.Trim() -ne '$taskkillStartInfo.FileName = Join-Path ([Environment]::SystemDirectory) ''taskkill.exe''' -or
     $stopTaskkillTry.Body.Statements[2].Extent.Text.Trim() -ne '$taskkillStartInfo.UseShellExecute = $false' -or
     $stopTaskkillTry.Body.Statements[3].Extent.Text.Trim() -ne '$taskkillStartInfo.CreateNoWindow = $true' -or
     $stopTaskkillTry.Body.Statements[4].Extent.Text.Trim() -ne '$taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"' -or
@@ -836,6 +865,8 @@ switch ($Shell) {
             throw "cmd resolved winghostty to the wrong artifact: $resolvedPath"
         }
 
+        $stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")
+        $stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")
         $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
         try {
             $cmdArgs = [string]::Join(' ', ($Arguments | ForEach-Object { Format-CmdArgument $_ }))
@@ -846,11 +877,34 @@ switch ($Shell) {
                 $cmdCommand
             ) | Set-Content -LiteralPath $payloadPath -Encoding ASCII
 
-            $output = & $cmdExe /d /c $payloadPath 2>&1 | Out-String
-            $exitCode = $LASTEXITCODE
+            $process = Start-Process `
+                -FilePath $cmdExe `
+                -ArgumentList "/d /c `"$payloadPath`"" `
+                -RedirectStandardOutput $stdoutPath `
+                -RedirectStandardError $stderrPath `
+                -WindowStyle Hidden `
+                -PassThru
+            $processHandle = $process.Handle
+            if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
+                Stop-InteractiveWin11Process -Process $process -RequireLiveRoot
+                throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
+            }
+
+            $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
+            $stdoutText = if (Test-Path -LiteralPath $stdoutPath) {
+                Get-Content -LiteralPath $stdoutPath -Raw
+            } else {
+                ''
+            }
+            $stderrText = if (Test-Path -LiteralPath $stderrPath) {
+                Get-Content -LiteralPath $stderrPath -Raw
+            } else {
+                ''
+            }
+            $output = $stdoutText + $stderrText
         }
         finally {
-            Remove-Item -LiteralPath $payloadPath -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath -ErrorAction SilentlyContinue
         }
     }
 
@@ -940,11 +994,10 @@ $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$cliShellErrors
 )
 if ($cliShellErrors.Count -ne 0) { throw 'CLI shell harness must parse without errors.' }
-Assert-CommandResolutionContract -Ast $cliShellAst -Context $cliShellHarness -ExpectedDotSources @(
+Assert-CommandResolutionContract -Ast $cliShellAst -Tokens $cliShellTokens -Context $cliShellHarness -ExpectedDotSources @(
     ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')"
 ) -ExpectedAmpersandCommands @(
     '& $cmdExe /d /c "set ""PATH=$envPath""&& where winghostty"'
-    '& $cmdExe /d /c $payloadPath 2>&1'
     '& $powershellExe -NoProfile -Command "(Get-Command winghostty).Source"'
 )
 $accessibilityTokens = $null
@@ -1049,7 +1102,7 @@ $paletteThemeAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$paletteThemeErrors
 )
 if ($paletteThemeErrors.Count -ne 0) { throw "Palette theme harness does not parse: $($paletteThemeErrors[0].Message)" }
-Assert-CommandResolutionContract -Ast $paletteThemeAst -Context $paletteThemeHarness -ExpectedDotSources @(
+Assert-CommandResolutionContract -Ast $paletteThemeAst -Tokens $paletteThemeTokens -Context $paletteThemeHarness -ExpectedDotSources @(
     ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')",
     ". (Join-Path `$PSScriptRoot 'interactive-win11-stateful-lib.ps1')"
 )
@@ -1441,7 +1494,7 @@ $sessionHarnessAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$sessionHarnessErrors
 )
 if ($sessionHarnessErrors.Count -ne 0) { throw "Session restore harness does not parse: $($sessionHarnessErrors[0].Message)" }
-Assert-CommandResolutionContract -Ast $sessionHarnessAst -Context $sessionRestoreHarness -ExpectedDotSources @(
+Assert-CommandResolutionContract -Ast $sessionHarnessAst -Tokens $sessionHarnessTokens -Context $sessionRestoreHarness -ExpectedDotSources @(
     ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')",
     ". (Join-Path `$PSScriptRoot 'interactive-win11-stateful-lib.ps1')"
 )

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -593,7 +593,8 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $null -ne $stopIdentityTry.Finally -or
     $stopIdentityTry.CatchClauses[0].CatchTypes.Count -ne 1 -or
     $stopIdentityTry.CatchClauses[0].CatchTypes[0].TypeName.FullName -ne 'System.InvalidOperationException' -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements.Count -ne 0 -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
+    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne 'Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"' -or
     $stopIdentityTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
     $stopIdentityTry.Body.Statements[1].Extent.Text.Trim() -ne '$rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt' -or
     $stopProcessStatements[4] -isnot [System.Management.Automation.Language.IfStatementAst] -or
@@ -608,6 +609,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
     $stopProcessStatements[4].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."' -or
     $stopProcessStatements[5].Extent.Text.Trim() -ne '$taskkillError = $null' -or
     $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkill = $null' -or
     $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
@@ -636,6 +638,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
     $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''taskkill could not be stopped within 5 seconds''' -or
     $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[3].Extent.Text.Trim() -ne '$taskkillError = ''taskkill exceeded 10 seconds''' -or
     $stopTaskkillTry.Body.Statements[8].Clauses[1].Item1.Extent.Text.Trim() -ne '$taskkill.ExitCode -ne 0' -or
     $stopTaskkillTry.Body.Statements[8].Clauses[1].Item2.Statements.Count -ne 1 -or
@@ -653,6 +656,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
     $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw' -or
     $stopTaskkillTry.CatchClauses[0].Body.Statements[1].Extent.Text.Trim() -ne '$taskkillError = $_.Exception.Message' -or
     $stopTaskkillTry.Finally.Statements.Count -ne 1 -or
     $stopTaskkillTry.Finally.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
@@ -678,6 +682,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw ''the root exited before fallback cleanup could verify the process tree''' -or
     $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill()' -or
     $stopManagedTry.Body.Statements[3] -isnot [System.Management.Automation.Language.IfStatementAst] -or
     $stopManagedTry.Body.Statements[3].Clauses.Count -ne 1 -or
@@ -685,9 +690,12 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.WaitForExit(5000)' -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''root fallback did not stop the process within 5 seconds''' -or
     $stopManagedTry.Body.Statements[4] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[4].Extent.Text.Trim() -ne 'throw ''root fallback stopped the process but could not verify descendant cleanup''' -or
     $stopManagedTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
-    $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst]) {
+    $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne 'throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill=''$taskkillError'', fallback=''$($_.Exception.Message)'')."') {
     throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
 }
 $cliShellTokens = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -758,6 +758,180 @@ Assert-TextContract `
     -Pattern ([regex]::Escape('public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);')) `
     -Description 'native root fallback termination declaration' `
     -Context $interactiveWin11Lib
+$expectedCliShellHarnessText = @'
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('cmd', 'powershell')]
+    [string] $Shell,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $Arguments,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ExpectedText,
+
+    [int] $ExpectedExitCode = 0,
+
+    [string] $BinDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
+
+function Format-CmdArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Argument
+    )
+
+    if ($Argument.Length -eq 0) {
+        return '""'
+    }
+
+    $escaped = $Argument.Replace('%', '%%').Replace('"', '""')
+    if ($escaped -match '[\s"&|<>()^!]') {
+        return '"' + $escaped + '"'
+    }
+
+    return $escaped
+}
+
+function Format-PowerShellLiteral {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Argument
+    )
+
+    return "'" + $Argument.Replace("'", "''") + "'"
+}
+
+$binDir = [System.IO.Path]::GetFullPath($(if ($BinDir) { $BinDir } else { Join-Path $repoRoot 'zig-out\bin' }))
+$guiExe = Join-Path $binDir 'winghostty.exe'
+$commandExe = Join-Path $binDir 'winghostty.com'
+$cmdExe = Join-Path ([Environment]::SystemDirectory) 'cmd.exe'
+$powershellExe = Join-Path ([Environment]::SystemDirectory) 'WindowsPowerShell\v1.0\powershell.exe'
+
+foreach ($requiredExecutable in @($guiExe, $commandExe, $cmdExe, $powershellExe)) {
+    if (-not (Test-Path -LiteralPath $requiredExecutable -PathType Leaf)) {
+        throw "Missing required executable: $requiredExecutable. Run `zig build -Demit-exe=true` if the winghostty binaries are absent."
+    }
+}
+
+$envPath = "$binDir;$env:PATH"
+$argsDisplay = [string]::Join(' ', $Arguments)
+$shellLauncherTimeoutSeconds = 30
+
+switch ($Shell) {
+    'cmd' {
+        $resolved = & $cmdExe /d /c "set ""PATH=$envPath""&& where winghostty"
+        if ($LASTEXITCODE -ne 0) {
+            throw "cmd could not resolve winghostty from PATH."
+        }
+        $resolvedPath = [System.IO.Path]::GetFullPath(($resolved | Select-Object -First 1))
+        if (-not [string]::Equals($resolvedPath, $commandExe, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "cmd resolved winghostty to the wrong artifact: $resolvedPath"
+        }
+
+        $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
+        try {
+            $cmdArgs = [string]::Join(' ', ($Arguments | ForEach-Object { Format-CmdArgument $_ }))
+            $cmdCommand = if ([string]::IsNullOrEmpty($cmdArgs)) { 'winghostty' } else { "winghostty $cmdArgs" }
+            @(
+                '@echo off'
+                "set `"PATH=$envPath`""
+                $cmdCommand
+            ) | Set-Content -LiteralPath $payloadPath -Encoding ASCII
+
+            $output = & $cmdExe /d /c $payloadPath 2>&1 | Out-String
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            Remove-Item -LiteralPath $payloadPath -ErrorAction SilentlyContinue
+        }
+    }
+
+    'powershell' {
+        $oldPath = $env:PATH
+        $env:PATH = $envPath
+        try {
+            $resolved = & $powershellExe -NoProfile -Command "(Get-Command winghostty).Source"
+            if ($LASTEXITCODE -ne 0) {
+                throw "PowerShell could not resolve winghostty from PATH."
+            }
+            $resolvedPath = [System.IO.Path]::GetFullPath($resolved)
+            if (-not [string]::Equals($resolvedPath, $commandExe, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "PowerShell resolved winghostty to the wrong artifact: $resolvedPath"
+            }
+
+            $stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")
+            $stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")
+            $payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".ps1")
+            try {
+                $env:PATH = $envPath
+                $argLiterals = [string]::Join(', ', ($Arguments | ForEach-Object { Format-PowerShellLiteral $_ }))
+                @(
+                    '$argsList = @(' + $argLiterals + ')'
+                    '$output = & winghostty @argsList | Out-String'
+                    '$exitCode = $LASTEXITCODE'
+                    '[Console]::Out.Write($output)'
+                    'exit $exitCode'
+                ) | Set-Content -LiteralPath $payloadPath -Encoding UTF8
+
+                $process = Start-Process `
+                    -FilePath $powershellExe `
+                    -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $payloadPath) `
+                    -RedirectStandardOutput $stdoutPath `
+                    -RedirectStandardError $stderrPath `
+                    -WindowStyle Hidden `
+                    -PassThru
+                $processHandle = $process.Handle
+                if (-not $process.WaitForExit($shellLauncherTimeoutSeconds * 1000)) {
+                    Stop-InteractiveWin11Process -Process $process -RequireLiveRoot
+                    throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."
+                }
+
+                $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
+                $stdoutText = if (Test-Path -LiteralPath $stdoutPath) {
+                    Get-Content -LiteralPath $stdoutPath -Raw
+                } else {
+                    ''
+                }
+                $stderrText = if (Test-Path -LiteralPath $stderrPath) {
+                    Get-Content -LiteralPath $stderrPath -Raw
+                } else {
+                    ''
+                }
+                $output = $stdoutText + $stderrText
+            }
+            finally {
+                Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath -ErrorAction SilentlyContinue
+            }
+        }
+        finally {
+            $env:PATH = $oldPath
+        }
+    }
+}
+
+if ($exitCode -ne $ExpectedExitCode) {
+    throw "$Shell shell launcher should exit with code $ExpectedExitCode, got $exitCode."
+}
+
+$outputText = if ($output -is [string]) { $output } else { ($output | Out-String) }
+if (-not $outputText.Contains($ExpectedText)) {
+    throw "$Shell shell launcher output did not contain expected text '$ExpectedText'."
+}
+
+Write-Host "shell launcher validation: PASS (shell=$Shell, args=$argsDisplay)"
+'@
+if ((($cliShellHarnessText -replace "\r\n?", "`n") -replace '\n+\z', '') -cne
+    (($expectedCliShellHarnessText -replace "\r\n?", "`n") -replace '\n+\z', '')) {
+    throw 'CLI shell harness must match its complete reviewed source snapshot.'
+}
 $cliShellTokens = $null
 $cliShellErrors = $null
 $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
@@ -765,209 +939,13 @@ $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$cliShellTokens,
     [ref]$cliShellErrors
 )
-$cliShellFunctionDefinitions = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
-}, $true))
-$cliShellUsingModules = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.UsingStatementAst] -and
-        $node.UsingStatementKind.ToString() -eq 'Module'
-}, $true))
-$cliShellRequiredModules = if ($null -eq $cliShellAst.ScriptRequirements) {
-    @()
-} else {
-    @($cliShellAst.ScriptRequirements.RequiredModules)
-}
-$cliShellPathAssignments = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
-        $node.Left.VariablePath.UserPath -in @('envPath', 'oldPath', 'env:PATH')
-}, $true))
-$cliShellTemporaryPathAssignments = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
-        $node.Left.VariablePath.UserPath -in @('payloadPath', 'stdoutPath', 'stderrPath')
-}, $true))
-$cliShellForbiddenProviderCommands = @($cliShellAst.FindAll({
-    param($node)
-    if ($node -isnot [System.Management.Automation.Language.CommandAst]) { return $false }
-    $name = $node.GetCommandName()
-    $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
-    return $leafName -in @(
-        'Set-Item', 'si', 'New-Item', 'ni', 'Move-Item', 'mi', 'mv',
-        'Copy-Item', 'cpi', 'cp', 'Rename-Item', 'rni', 'Clear-Item', 'cli',
-        'Set-Variable', 'sv', 'New-Variable', 'nv', 'Remove-Variable', 'rv',
-        'Clear-Variable', 'clv', 'Add-Content', 'ac', 'Clear-Content', 'clc',
-        'Out-File', 'Tee-Object', 'tee', 'sc', 'rm', 'ri', 'del', 'erase',
-        'rd', 'rmdir'
-    )
-}, $true))
-$cliShellAllowedProviderCommands = @($cliShellAst.FindAll({
-    param($node)
-    if ($node -isnot [System.Management.Automation.Language.CommandAst]) { return $false }
-    $name = $node.GetCommandName()
-    $leafName = if ($null -eq $name) { '' } else { ($name -split '\\')[-1] }
-    return $leafName -in @('Set-Content', 'Remove-Item')
-}, $true))
-$cliShellTimeoutAssignments = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-        $node.Left.Extent.Text.Trim() -eq '$shellLauncherTimeoutSeconds'
-}, $true))
-$cliShellSwitches = @($cliShellAst.FindAll({
-    param($node)
-    $node -is [System.Management.Automation.Language.SwitchStatementAst] -and
-        $node.Condition.Extent.Text.Trim() -eq '$Shell'
-}, $true))
-$cliShellPowerShellClauseIndexes = if ($cliShellSwitches.Count -eq 1) {
-    @(for ($i = 0; $i -lt $cliShellSwitches[0].Clauses.Count; $i++) {
-        if ($cliShellSwitches[0].Clauses[$i].Item1.Extent.Text.Trim() -eq "'powershell'") { $i }
-    })
-} else { @() }
-$cliShellPowerShellClauseIndex = if ($cliShellPowerShellClauseIndexes.Count -eq 1) {
-    [int] $cliShellPowerShellClauseIndexes[0]
-} else { -1 }
-$cliShellStartProcessAssignments = if ($cliShellPowerShellClauseIndex -ge 0) {
-    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
-        param($node)
-            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-            $node.Left.Extent.Text.Trim() -eq '$process' -and
-            $node.Right -is [System.Management.Automation.Language.PipelineAst] -and
-            $node.Right.PipelineElements.Count -eq 1 -and
-            $node.Right.PipelineElements[0] -is [System.Management.Automation.Language.CommandAst] -and
-            $node.Right.PipelineElements[0].GetCommandName() -eq 'Start-Process'
-    }, $true))
-} else { @() }
-$cliShellWaitForExitCalls = if ($cliShellPowerShellClauseIndex -ge 0) {
-    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
-        param($node)
-        $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
-            $node.Member.Extent.Text.Trim() -eq 'WaitForExit'
-    }, $true))
-} else { @() }
-$cliShellTimeoutIfs = if ($cliShellPowerShellClauseIndex -ge 0) {
-    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
-        param($node)
-        $node -is [System.Management.Automation.Language.IfStatementAst] -and
-        $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(\$shellLauncherTimeoutSeconds \* 1000\)\)'
-    }, $true))
-} else { @() }
-$cliShellTimeoutStatements = if ($cliShellTimeoutIfs.Count -eq 1) {
-    @($cliShellTimeoutIfs[0].Clauses[0].Item2.Statements)
-} else { @() }
-$cliShellLauncherBlockShared = $cliShellStartProcessAssignments.Count -eq 1 -and
-    $cliShellTimeoutIfs.Count -eq 1 -and
-    [Object]::ReferenceEquals($cliShellStartProcessAssignments[0].Parent, $cliShellTimeoutIfs[0].Parent)
-$cliShellLauncherStatements = if ($cliShellLauncherBlockShared) {
-    @($cliShellStartProcessAssignments[0].Parent.Statements)
-} else { @() }
-$cliShellTopLevelShared = $cliShellTimeoutAssignments.Count -eq 1 -and
-    $cliShellSwitches.Count -eq 1 -and
-    [Object]::ReferenceEquals($cliShellTimeoutAssignments[0].Parent, $cliShellSwitches[0].Parent) -and
-    [Object]::ReferenceEquals($cliShellTimeoutAssignments[0].Parent, $cliShellAst.EndBlock)
-$cliShellTopLevelStatements = if ($cliShellTopLevelShared) {
-    @($cliShellAst.EndBlock.Statements)
-} else { @() }
-$cliShellStartProcessIndex = -1
-$cliShellTimeoutIndex = -1
-$cliShellTimeoutAssignmentIndex = -1
-$cliShellSwitchIndex = -1
-for ($i = 0; $i -lt $cliShellLauncherStatements.Count; $i++) {
-    if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellStartProcessAssignments[0])) {
-        $cliShellStartProcessIndex = $i
-    }
-    if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellTimeoutIfs[0])) {
-        $cliShellTimeoutIndex = $i
-    }
-}
-for ($i = 0; $i -lt $cliShellTopLevelStatements.Count; $i++) {
-    if ([Object]::ReferenceEquals($cliShellTopLevelStatements[$i], $cliShellTimeoutAssignments[0])) {
-        $cliShellTimeoutAssignmentIndex = $i
-    }
-    if ([Object]::ReferenceEquals($cliShellTopLevelStatements[$i], $cliShellSwitches[0])) {
-        $cliShellSwitchIndex = $i
-    }
-}
-if ($cliShellErrors.Count -ne 0 -or
-    @($cliShellAst.FindAll({
-        param($node)
-        $node -is [System.Management.Automation.Language.TrapStatementAst]
-    }, $true)).Count -ne 0 -or
-    $cliShellFunctionDefinitions.Count -ne 2 -or
-    $cliShellFunctionDefinitions[0].Name -ne 'Format-CmdArgument' -or
-    $cliShellFunctionDefinitions[1].Name -ne 'Format-PowerShellLiteral' -or
-    $cliShellUsingModules.Count -ne 0 -or
-    $cliShellRequiredModules.Count -ne 0 -or
-    $cliShellHarnessText -match $psSnapinRequirementPattern -or
-    $cliShellPathAssignments.Count -ne 4 -or
-    $cliShellPathAssignments[0].Extent.Text.Trim() -ne '$envPath = "$binDir;$env:PATH"' -or
-    $cliShellPathAssignments[1].Extent.Text.Trim() -ne '$oldPath = $env:PATH' -or
-    $cliShellPathAssignments[2].Extent.Text.Trim() -ne '$env:PATH = $envPath' -or
-    $cliShellPathAssignments[3].Extent.Text.Trim() -ne '$env:PATH = $oldPath' -or
-    $cliShellTemporaryPathAssignments.Count -ne 4 -or
-    $cliShellTemporaryPathAssignments[0].Extent.Text.Trim() -ne '$payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")' -or
-    $cliShellTemporaryPathAssignments[1].Extent.Text.Trim() -ne '$stdoutPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stdout.txt")' -or
-    $cliShellTemporaryPathAssignments[2].Extent.Text.Trim() -ne '$stderrPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + "-stderr.txt")' -or
-    $cliShellTemporaryPathAssignments[3].Extent.Text.Trim() -ne '$payloadPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winghostty-cli-shell-" + [System.Guid]::NewGuid().ToString("N") + ".ps1")' -or
-    $cliShellForbiddenProviderCommands.Count -ne 0 -or
-    $cliShellAllowedProviderCommands.Count -ne 4 -or
-    $cliShellAllowedProviderCommands[0].Extent.Text.Trim() -ne 'Set-Content -LiteralPath $payloadPath -Encoding ASCII' -or
-    $cliShellAllowedProviderCommands[1].Extent.Text.Trim() -ne 'Remove-Item -LiteralPath $payloadPath -ErrorAction SilentlyContinue' -or
-    $cliShellAllowedProviderCommands[2].Extent.Text.Trim() -ne 'Set-Content -LiteralPath $payloadPath -Encoding UTF8' -or
-    $cliShellAllowedProviderCommands[3].Extent.Text.Trim() -ne 'Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath -ErrorAction SilentlyContinue' -or
-    $cliShellTimeoutAssignments.Count -ne 1 -or
-    $cliShellTimeoutAssignments[0].Right.Extent.Text.Trim() -ne '30' -or
-    $cliShellSwitches.Count -ne 1 -or
-    $cliShellPowerShellClauseIndexes.Count -ne 1 -or
-    $cliShellStartProcessAssignments.Count -ne 1 -or
-    $cliShellWaitForExitCalls.Count -ne 1 -or
-    $cliShellTimeoutIfs.Count -ne 1 -or
-    $cliShellTimeoutIfs[0].Clauses.Count -ne 1 -or
-    $null -ne $cliShellTimeoutIfs[0].ElseClause -or
-    -not $cliShellTopLevelShared -or
-    $cliShellTimeoutAssignmentIndex -lt 0 -or
-    $cliShellSwitchIndex -ne ($cliShellTimeoutAssignmentIndex + 1) -or
-    -not $cliShellLauncherBlockShared -or
-    $cliShellStartProcessAssignments[0].Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
-    $cliShellStartProcessAssignments[0].Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    -not [Object]::ReferenceEquals(
-        $cliShellStartProcessAssignments[0].Parent,
-        $cliShellStartProcessAssignments[0].Parent.Parent.Body
-    ) -or
-    $cliShellStartProcessAssignments[0].Parent.Parent.CatchClauses.Count -ne 0 -or
-    $null -eq $cliShellStartProcessAssignments[0].Parent.Parent.Finally -or
-    $cliShellStartProcessAssignments[0].Parent.Parent.Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
-    $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    -not [Object]::ReferenceEquals(
-        $cliShellStartProcessAssignments[0].Parent.Parent.Parent,
-        $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Body
-    ) -or
-    $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.CatchClauses.Count -ne 0 -or
-    $null -eq $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Finally -or
-    -not [Object]::ReferenceEquals(
-        $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Parent,
-        $cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2
-    ) -or
-    $cliShellStartProcessIndex -lt 0 -or
-    $cliShellTimeoutIndex -ne ($cliShellStartProcessIndex + 2) -or
-    ($cliShellStartProcessIndex + 1) -ge $cliShellLauncherStatements.Count -or
-    ($cliShellTimeoutIndex + 1) -ge $cliShellLauncherStatements.Count -or
-    $cliShellLauncherStatements[$cliShellStartProcessIndex + 1].Extent.Text.Trim() -ne '$processHandle = $process.Handle' -or
-    $cliShellLauncherStatements[$cliShellTimeoutIndex + 1].Extent.Text.Trim() -ne '$exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle' -or
-    $cliShellTimeoutStatements.Count -ne 2 -or
-    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-InteractiveWin11Process -Process $process -RequireLiveRoot' -or
-    $cliShellTimeoutStatements[1].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
-    throw 'The live PowerShell shell launcher must use one hosted-cold-start timeout and fail explicitly after bounded process-tree cleanup.'
-}
+if ($cliShellErrors.Count -ne 0) { throw 'CLI shell harness must parse without errors.' }
 Assert-CommandResolutionContract -Ast $cliShellAst -Context $cliShellHarness -ExpectedDotSources @(
     ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')"
 ) -ExpectedAmpersandCommands @(
-    '& cmd /d /c "set ""PATH=$envPath""&& where winghostty"'
-    '& cmd /d /c $payloadPath 2>&1'
-    '& powershell.exe -NoProfile -Command "(Get-Command winghostty).Source"'
+    '& $cmdExe /d /c "set ""PATH=$envPath""&& where winghostty"'
+    '& $cmdExe /d /c $payloadPath 2>&1'
+    '& $powershellExe -NoProfile -Command "(Get-Command winghostty).Source"'
 )
 $accessibilityTokens = $null
 $accessibilityErrors = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -567,31 +567,58 @@ $cliShellTimeoutAssignments = @($cliShellAst.FindAll({
     $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
         $node.Extent.Text.Trim() -eq '$shellLauncherTimeoutSeconds = 30'
 }, $true))
-$cliShellTimeoutIfs = @($cliShellAst.FindAll({
+$cliShellSwitches = @($cliShellAst.FindAll({
     param($node)
-    $node -is [System.Management.Automation.Language.IfStatementAst] -and
-        $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(\$shellLauncherTimeoutSeconds \* 1000\)\)'
+    $node -is [System.Management.Automation.Language.SwitchStatementAst] -and
+        $node.Condition.Extent.Text.Trim() -eq '$Shell'
 }, $true))
+$cliShellPowerShellClauseIndexes = if ($cliShellSwitches.Count -eq 1) {
+    @(for ($i = 0; $i -lt $cliShellSwitches[0].Clauses.Count; $i++) {
+        if ($cliShellSwitches[0].Clauses[$i].Item1.Extent.Text.Trim() -eq "'powershell'") { $i }
+    })
+} else { @() }
+$cliShellPowerShellClauseIndex = if ($cliShellPowerShellClauseIndexes.Count -eq 1) {
+    [int] $cliShellPowerShellClauseIndexes[0]
+} else { -1 }
+$cliShellStartProcessAssignments = if ($cliShellPowerShellClauseIndex -ge 0) {
+    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
+        param($node)
+            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left.Extent.Text.Trim() -eq '$process' -and
+            $node.Right -is [System.Management.Automation.Language.PipelineAst] -and
+            $node.Right.PipelineElements.Count -eq 1 -and
+            $node.Right.PipelineElements[0] -is [System.Management.Automation.Language.CommandAst] -and
+            $node.Right.PipelineElements[0].GetCommandName() -eq 'Start-Process'
+    }, $true))
+} else { @() }
+$cliShellWaitForExitCalls = if ($cliShellPowerShellClauseIndex -ge 0) {
+    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $node.Member.Extent.Text.Trim() -eq 'WaitForExit'
+    }, $true))
+} else { @() }
+$cliShellTimeoutIfs = if ($cliShellPowerShellClauseIndex -ge 0) {
+    @($cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(\$shellLauncherTimeoutSeconds \* 1000\)\)'
+    }, $true))
+} else { @() }
 $cliShellTimeoutStatements = if ($cliShellTimeoutIfs.Count -eq 1) {
     @($cliShellTimeoutIfs[0].Clauses[0].Item2.Statements)
 } else { @() }
-$cliShellCleanupIfs = if ($cliShellTimeoutStatements.Count -ge 2) {
-    @($cliShellTimeoutStatements[1].FindAll({
-        param($node)
-        $node -is [System.Management.Automation.Language.IfStatementAst] -and
-            $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(1000\)\)'
-    }, $true))
-} else { @() }
 if ($cliShellErrors.Count -ne 0 -or
     $cliShellTimeoutAssignments.Count -ne 1 -or
+    $cliShellSwitches.Count -ne 1 -or
+    $cliShellPowerShellClauseIndexes.Count -ne 1 -or
+    $cliShellStartProcessAssignments.Count -ne 1 -or
+    $cliShellWaitForExitCalls.Count -ne 1 -or
     $cliShellTimeoutIfs.Count -ne 1 -or
-    $cliShellTimeoutStatements.Count -ne 3 -or
-    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue' -or
-    $cliShellCleanupIfs.Count -ne 1 -or
-    $cliShellCleanupIfs[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $cliShellCleanupIfs[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw "Timed out waiting for shell launcher process to exit after termination."' -or
-    $cliShellTimeoutStatements[2].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
-    throw 'PowerShell shell launcher timeout must allow hosted cold starts and fail explicitly after bounded cleanup.'
+    $cliShellTimeoutStatements.Count -ne 2 -or
+    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-InteractiveWin11Process -Process $process' -or
+    $cliShellTimeoutStatements[1].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
+    throw 'The live PowerShell shell launcher must use one hosted-cold-start timeout and fail explicitly after bounded process-tree cleanup.'
 }
 $accessibilityTokens = $null
 $accessibilityErrors = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -573,12 +573,16 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $null -ne $stopProcessFunctions[0].Body.DynamicParamBlock -or
     $null -ne $stopProcessFunctions[0].Body.CleanBlock -or
     $null -eq $stopProcessFunctions[0].Body.ParamBlock -or
-    $stopProcessFunctions[0].Body.ParamBlock.Parameters.Count -ne 1 -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters.Count -ne 2 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Name.VariablePath.UserPath -ne 'Process' -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes.Count -ne 2 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes[0].Extent.Text.Trim() -ne '[Parameter(Mandatory)]' -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes[1].Extent.Text.Trim() -ne '[System.Diagnostics.Process]' -or
     $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].DefaultValue -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Name.VariablePath.UserPath -ne 'RequireLiveRoot' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes.Count -ne 1 -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes[0].Extent.Text.Trim() -ne '[switch]' -or
+    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue -or
     $stopProcessStatements.Count -ne 10 -or
     $stopProcessStatements[0].Extent.Text.Trim() -ne '$rootProcessId = $Process.Id' -or
     $stopProcessStatements[1].Extent.Text.Trim() -ne '$rootStartedAt = $Process.StartTime' -or
@@ -596,8 +600,14 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopProcessStatements[4].Clauses.Count -ne 1 -or
     $null -ne $stopProcessStatements[4].ElseClause -or
     $stopProcessStatements[4].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootIsLive' -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements.Count -ne 2 -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopProcessStatements[4].Clauses[0].Item2.Statements[0].ElseClause -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
+    $stopProcessStatements[4].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
     $stopProcessStatements[5].Extent.Text.Trim() -ne '$taskkillError = $null' -or
     $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkill = $null' -or
     $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
@@ -609,9 +619,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.Body.Statements[1].Extent.Text.Trim() -ne '$taskkillStartInfo.FileName = Join-Path $env:SystemRoot ''System32\taskkill.exe''' -or
     $stopTaskkillTry.Body.Statements[2].Extent.Text.Trim() -ne '$taskkillStartInfo.UseShellExecute = $false' -or
     $stopTaskkillTry.Body.Statements[3].Extent.Text.Trim() -ne '$taskkillStartInfo.CreateNoWindow = $true' -or
-    $stopTaskkillTry.Body.Statements[4].Extent.Text.Trim() -notmatch '^foreach \(\$argument in @\(''/PID'', "\$rootProcessId", ''/T'', ''/F''\)\)' -or
-    $stopTaskkillTry.Body.Statements[4].Body.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Body.Statements[4].Body.Statements[0].Extent.Text.Trim() -ne '[void] $taskkillStartInfo.ArgumentList.Add($argument)' -or
+    $stopTaskkillTry.Body.Statements[4].Extent.Text.Trim() -ne '$taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"' -or
     $stopTaskkillTry.Body.Statements[5].Extent.Text.Trim() -ne '$taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)' -or
     $stopTaskkillTry.Body.Statements[6].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $false' -or
     $stopTaskkillTry.Body.Statements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $taskkill.WaitForExit(10000)' -or
@@ -654,7 +662,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Dispose()' -or
     $stopManagedTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    $stopManagedTry.Body.Statements.Count -ne 4 -or
+    $stopManagedTry.Body.Statements.Count -ne 5 -or
     $stopManagedTry.CatchClauses.Count -ne 1 -or
     $null -ne $stopManagedTry.Finally -or
     $stopManagedTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
@@ -664,16 +672,17 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '$Process.HasExited -or $Process.StartTime -ne $rootStartedAt' -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill($true)' -or
+    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill()' -or
     $stopManagedTry.Body.Statements[3] -isnot [System.Management.Automation.Language.IfStatementAst] -or
     $stopManagedTry.Body.Statements[3].Clauses.Count -ne 1 -or
     $null -ne $stopManagedTry.Body.Statements[3].ElseClause -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.WaitForExit(5000)' -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[4] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
     $stopManagedTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
     $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst]) {
-    throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around both tree-kill mechanisms.'
+    throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
 }
 $cliShellTokens = $null
 $cliShellErrors = $null
@@ -802,7 +811,7 @@ if ($cliShellErrors.Count -ne 0 -or
     $cliShellLauncherStatements[$cliShellStartProcessIndex + 1].Extent.Text.Trim() -ne '$processHandle = $process.Handle' -or
     $cliShellLauncherStatements[$cliShellTimeoutIndex + 1].Extent.Text.Trim() -ne '$exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle' -or
     $cliShellTimeoutStatements.Count -ne 2 -or
-    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-InteractiveWin11Process -Process $process' -or
+    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-InteractiveWin11Process -Process $process -RequireLiveRoot' -or
     $cliShellTimeoutStatements[1].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
     throw 'The live PowerShell shell launcher must use one hosted-cold-start timeout and fail explicitly after bounded process-tree cleanup.'
 }

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -614,14 +614,31 @@ $cliShellLauncherBlockShared = $cliShellStartProcessAssignments.Count -eq 1 -and
 $cliShellLauncherStatements = if ($cliShellLauncherBlockShared) {
     @($cliShellStartProcessAssignments[0].Parent.Statements)
 } else { @() }
+$cliShellTopLevelShared = $cliShellTimeoutAssignments.Count -eq 1 -and
+    $cliShellSwitches.Count -eq 1 -and
+    [Object]::ReferenceEquals($cliShellTimeoutAssignments[0].Parent, $cliShellSwitches[0].Parent) -and
+    [Object]::ReferenceEquals($cliShellTimeoutAssignments[0].Parent, $cliShellAst.EndBlock)
+$cliShellTopLevelStatements = if ($cliShellTopLevelShared) {
+    @($cliShellAst.EndBlock.Statements)
+} else { @() }
 $cliShellStartProcessIndex = -1
 $cliShellTimeoutIndex = -1
+$cliShellTimeoutAssignmentIndex = -1
+$cliShellSwitchIndex = -1
 for ($i = 0; $i -lt $cliShellLauncherStatements.Count; $i++) {
     if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellStartProcessAssignments[0])) {
         $cliShellStartProcessIndex = $i
     }
     if ([Object]::ReferenceEquals($cliShellLauncherStatements[$i], $cliShellTimeoutIfs[0])) {
         $cliShellTimeoutIndex = $i
+    }
+}
+for ($i = 0; $i -lt $cliShellTopLevelStatements.Count; $i++) {
+    if ([Object]::ReferenceEquals($cliShellTopLevelStatements[$i], $cliShellTimeoutAssignments[0])) {
+        $cliShellTimeoutAssignmentIndex = $i
+    }
+    if ([Object]::ReferenceEquals($cliShellTopLevelStatements[$i], $cliShellSwitches[0])) {
+        $cliShellSwitchIndex = $i
     }
 }
 if ($cliShellErrors.Count -ne 0 -or
@@ -631,6 +648,9 @@ if ($cliShellErrors.Count -ne 0 -or
     $cliShellStartProcessAssignments.Count -ne 1 -or
     $cliShellWaitForExitCalls.Count -ne 1 -or
     $cliShellTimeoutIfs.Count -ne 1 -or
+    -not $cliShellTopLevelShared -or
+    $cliShellTimeoutAssignmentIndex -lt 0 -or
+    $cliShellSwitchIndex -ne ($cliShellTimeoutAssignmentIndex + 1) -or
     -not $cliShellLauncherBlockShared -or
     $cliShellStartProcessAssignments[0].Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
     $cliShellStartProcessAssignments[0].Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -568,6 +568,10 @@ $stopTaskkillTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatem
 $stopManagedTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[10] } else { $null }
 if ($stopProcessFunctions.Count -ne 1 -or
     -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    @($stopProcessFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.TrapStatementAst]
+    }, $true)).Count -ne 0 -or
     $null -ne $stopProcessFunctions[0].Body.BeginBlock -or
     $null -ne $stopProcessFunctions[0].Body.ProcessBlock -or
     $null -ne $stopProcessFunctions[0].Body.DynamicParamBlock -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -505,6 +505,7 @@ $testWorkflow = Join-Path $repoRoot '.github\workflows\test.yml'
 $accessibilityChecker = Join-Path $repoRoot 'scripts\check-accessibility-evidence.ps1'
 $runnerProvenanceChecker = Join-Path $repoRoot 'test\windows\assert-interactive-runner.ps1'
 $interactiveWin11Lib = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
+$cliShellHarness = Join-Path $repoRoot 'test\windows\cli-shell-command.ps1'
 $statefulWin11Lib = Join-Path $repoRoot 'test\windows\interactive-win11-stateful-lib.ps1'
 $accessibilityHarness = Join-Path $repoRoot 'test\windows\interactive-win11-accessibility.ps1'
 $sessionRestoreHarness = Join-Path $repoRoot 'test\windows\interactive-win11-session-restore.ps1'
@@ -517,6 +518,7 @@ $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
 $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
 $interactiveWin11LibText = Get-Content -LiteralPath $interactiveWin11Lib -Raw
+$cliShellHarnessText = Get-Content -LiteralPath $cliShellHarness -Raw
 $statefulWin11LibText = Get-Content -LiteralPath $statefulWin11Lib -Raw
 $accessibilityHarnessText = Get-Content -LiteralPath $accessibilityHarness -Raw
 $sessionRestoreHarnessText = Get-Content -LiteralPath $sessionRestoreHarness -Raw
@@ -552,6 +554,44 @@ foreach ($source in $resolutionSourceAsts) {
             throw "Interactive library has the wrong ownership count for protected function $name`: $($source.Path)"
         }
     }
+}
+$cliShellTokens = $null
+$cliShellErrors = $null
+$cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $cliShellHarnessText,
+    [ref]$cliShellTokens,
+    [ref]$cliShellErrors
+)
+$cliShellTimeoutAssignments = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Extent.Text.Trim() -eq '$shellLauncherTimeoutSeconds = 30'
+}, $true))
+$cliShellTimeoutIfs = @($cliShellAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(\$shellLauncherTimeoutSeconds \* 1000\)\)'
+}, $true))
+$cliShellTimeoutStatements = if ($cliShellTimeoutIfs.Count -eq 1) {
+    @($cliShellTimeoutIfs[0].Clauses[0].Item2.Statements)
+} else { @() }
+$cliShellCleanupIfs = if ($cliShellTimeoutStatements.Count -ge 2) {
+    @($cliShellTimeoutStatements[1].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.IfStatementAst] -and
+            $node.Extent.Text -match '^if \(-not \$process\.WaitForExit\(1000\)\)'
+    }, $true))
+} else { @() }
+if ($cliShellErrors.Count -ne 0 -or
+    $cliShellTimeoutAssignments.Count -ne 1 -or
+    $cliShellTimeoutIfs.Count -ne 1 -or
+    $cliShellTimeoutStatements.Count -ne 3 -or
+    $cliShellTimeoutStatements[0].Extent.Text.Trim() -ne 'Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue' -or
+    $cliShellCleanupIfs.Count -ne 1 -or
+    $cliShellCleanupIfs[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $cliShellCleanupIfs[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw "Timed out waiting for shell launcher process to exit after termination."' -or
+    $cliShellTimeoutStatements[2].Extent.Text.Trim() -ne 'throw "Timed out waiting $shellLauncherTimeoutSeconds seconds for shell launcher process to exit."') {
+    throw 'PowerShell shell launcher timeout must allow hosted cold starts and fail explicitly after bounded cleanup.'
 }
 $accessibilityTokens = $null
 $accessibilityErrors = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -565,7 +565,7 @@ $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(
 $cliShellTimeoutAssignments = @($cliShellAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-        $node.Extent.Text.Trim() -eq '$shellLauncherTimeoutSeconds = 30'
+        $node.Left.Extent.Text.Trim() -eq '$shellLauncherTimeoutSeconds'
 }, $true))
 $cliShellSwitches = @($cliShellAst.FindAll({
     param($node)
@@ -643,25 +643,42 @@ for ($i = 0; $i -lt $cliShellTopLevelStatements.Count; $i++) {
 }
 if ($cliShellErrors.Count -ne 0 -or
     $cliShellTimeoutAssignments.Count -ne 1 -or
+    $cliShellTimeoutAssignments[0].Right.Extent.Text.Trim() -ne '30' -or
     $cliShellSwitches.Count -ne 1 -or
     $cliShellPowerShellClauseIndexes.Count -ne 1 -or
     $cliShellStartProcessAssignments.Count -ne 1 -or
     $cliShellWaitForExitCalls.Count -ne 1 -or
     $cliShellTimeoutIfs.Count -ne 1 -or
+    $cliShellTimeoutIfs[0].Clauses.Count -ne 1 -or
+    $null -ne $cliShellTimeoutIfs[0].ElseClause -or
     -not $cliShellTopLevelShared -or
     $cliShellTimeoutAssignmentIndex -lt 0 -or
     $cliShellSwitchIndex -ne ($cliShellTimeoutAssignmentIndex + 1) -or
     -not $cliShellLauncherBlockShared -or
     $cliShellStartProcessAssignments[0].Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
     $cliShellStartProcessAssignments[0].Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    -not [Object]::ReferenceEquals(
+        $cliShellStartProcessAssignments[0].Parent,
+        $cliShellStartProcessAssignments[0].Parent.Parent.Body
+    ) -or
+    $cliShellStartProcessAssignments[0].Parent.Parent.CatchClauses.Count -ne 0 -or
+    $null -eq $cliShellStartProcessAssignments[0].Parent.Parent.Finally -or
     $cliShellStartProcessAssignments[0].Parent.Parent.Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
     $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    -not [Object]::ReferenceEquals(
+        $cliShellStartProcessAssignments[0].Parent.Parent.Parent,
+        $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Body
+    ) -or
+    $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.CatchClauses.Count -ne 0 -or
+    $null -eq $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Finally -or
     -not [Object]::ReferenceEquals(
         $cliShellStartProcessAssignments[0].Parent.Parent.Parent.Parent.Parent,
         $cliShellSwitches[0].Clauses[$cliShellPowerShellClauseIndex].Item2
     ) -or
     $cliShellStartProcessIndex -lt 0 -or
     $cliShellTimeoutIndex -ne ($cliShellStartProcessIndex + 2) -or
+    ($cliShellStartProcessIndex + 1) -ge $cliShellLauncherStatements.Count -or
+    ($cliShellTimeoutIndex + 1) -ge $cliShellLauncherStatements.Count -or
     $cliShellLauncherStatements[$cliShellStartProcessIndex + 1].Extent.Text.Trim() -ne '$processHandle = $process.Handle' -or
     $cliShellLauncherStatements[$cliShellTimeoutIndex + 1].Extent.Text.Trim() -ne '$exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle' -or
     $cliShellTimeoutStatements.Count -ne 2 -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -568,7 +568,7 @@ $stopTaskkillTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatem
 $stopManagedTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[10] } else { $null }
 if ($stopProcessFunctions.Count -ne 1 -or
     -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
-    @($stopProcessFunctions[0].FindAll({
+    @($interactiveWin11LibAst.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.TrapStatementAst]
     }, $true)).Count -ne 0 -or
@@ -828,6 +828,10 @@ for ($i = 0; $i -lt $cliShellTopLevelStatements.Count; $i++) {
     }
 }
 if ($cliShellErrors.Count -ne 0 -or
+    @($cliShellAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.TrapStatementAst]
+    }, $true)).Count -ne 0 -or
     $cliShellTimeoutAssignments.Count -ne 1 -or
     $cliShellTimeoutAssignments[0].Right.Extent.Text.Trim() -ne '30' -or
     $cliShellSwitches.Count -ne 1 -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -670,8 +670,14 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses.Count -ne 1 -or
     $null -ne $stopManagedTry.Body.Statements[1].ElseClause -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '$Process.HasExited -or $Process.StartTime -ne $rootStartedAt' -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 2 -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].ElseClause -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
+    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
     $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill()' -or
     $stopManagedTry.Body.Statements[3] -isnot [System.Management.Automation.Language.IfStatementAst] -or
     $stopManagedTry.Body.Statements[3].Clauses.Count -ne 1 -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -563,9 +563,9 @@ $stopProcessFunctions = @($interactiveWin11LibAst.FindAll({
 $stopProcessStatements = if ($stopProcessFunctions.Count -eq 1) {
     @($stopProcessFunctions[0].Body.EndBlock.Statements)
 } else { @() }
-$stopIdentityTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[3] } else { $null }
-$stopTaskkillTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[8] } else { $null }
-$stopManagedTry = if ($stopProcessStatements.Count -eq 10) { $stopProcessStatements[9] } else { $null }
+$stopIdentityTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[4] } else { $null }
+$stopTaskkillTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[9] } else { $null }
+$stopManagedTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[10] } else { $null }
 if ($stopProcessFunctions.Count -ne 1 -or
     -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
     $null -ne $stopProcessFunctions[0].Body.BeginBlock -or
@@ -583,10 +583,11 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes[0].Extent.Text.Trim() -ne '[switch]' -or
     $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue -or
-    $stopProcessStatements.Count -ne 10 -or
+    $stopProcessStatements.Count -ne 11 -or
     $stopProcessStatements[0].Extent.Text.Trim() -ne '$rootProcessId = $Process.Id' -or
-    $stopProcessStatements[1].Extent.Text.Trim() -ne '$rootStartedAt = $Process.StartTime' -or
-    $stopProcessStatements[2].Extent.Text.Trim() -ne '$rootIsLive = $false' -or
+    $stopProcessStatements[1].Extent.Text.Trim() -ne '$rootProcessHandle = [IntPtr]::Zero' -or
+    $stopProcessStatements[2].Extent.Text.Trim() -ne '$rootStartedAt = $null' -or
+    $stopProcessStatements[3].Extent.Text.Trim() -ne '$rootIsLive = $false' -or
     $stopIdentityTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
     $stopIdentityTry.Body.Statements.Count -ne 2 -or
     $stopIdentityTry.CatchClauses.Count -ne 1 -or
@@ -601,23 +602,30 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"' -or
     $stopIdentityTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
-    $stopIdentityTry.Body.Statements[1].Extent.Text.Trim() -ne '$rootIsLive = -not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt' -or
-    $stopProcessStatements[4] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopProcessStatements[4].Clauses.Count -ne 1 -or
-    $null -ne $stopProcessStatements[4].ElseClause -or
-    $stopProcessStatements[4].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootIsLive' -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements.Count -ne 2 -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopProcessStatements[4].Clauses[0].Item2.Statements[0].ElseClause -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopProcessStatements[4].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."' -or
-    $stopProcessStatements[5].Extent.Text.Trim() -ne '$taskkillError = $null' -or
-    $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkill = $null' -or
-    $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
+    $stopIdentityTry.Body.Statements[1] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopIdentityTry.Body.Statements[1].Clauses.Count -ne 1 -or
+    $null -ne $stopIdentityTry.Body.Statements[1].ElseClause -or
+    $stopIdentityTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.HasExited' -or
+    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 3 -or
+    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$rootProcessHandle = $Process.Handle' -or
+    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne '$rootStartedAt = $Process.StartTime' -or
+    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[2].Extent.Text.Trim() -ne '$rootIsLive = $true' -or
+    $stopProcessStatements[5] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopProcessStatements[5].Clauses.Count -ne 1 -or
+    $null -ne $stopProcessStatements[5].ElseClause -or
+    $stopProcessStatements[5].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootIsLive' -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements.Count -ne 2 -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopProcessStatements[5].Clauses[0].Item2.Statements[0].ElseClause -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopProcessStatements[5].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."' -or
+    $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkillError = $null' -or
+    $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkill = $null' -or
+    $stopProcessStatements[8].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
     $stopTaskkillTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
     $stopTaskkillTry.Body.Statements.Count -ne 10 -or
     $stopTaskkillTry.CatchClauses.Count -ne 1 -or
@@ -671,7 +679,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
     $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Dispose()' -or
     $stopManagedTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    $stopManagedTry.Body.Statements.Count -ne 5 -or
+    $stopManagedTry.Body.Statements.Count -ne 9 -or
     $stopManagedTry.CatchClauses.Count -ne 1 -or
     $null -ne $stopManagedTry.Finally -or
     $stopManagedTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
@@ -688,21 +696,47 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
     $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw ''the root exited before fallback cleanup could verify the process tree''' -or
-    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne '$Process.Kill()' -or
-    $stopManagedTry.Body.Statements[3] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[3].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[3].ElseClause -or
-    $stopManagedTry.Body.Statements[3].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.WaitForExit(5000)' -or
-    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[3].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''root fallback did not stop the process within 5 seconds''' -or
-    $stopManagedTry.Body.Statements[4] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[4].Extent.Text.Trim() -ne 'throw ''root fallback stopped the process but could not verify descendant cleanup''' -or
+    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne 'Initialize-InteractiveWin11ProcessNative' -or
+    $stopManagedTry.Body.Statements[3].Extent.Text.Trim() -ne '$rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)' -or
+    $stopManagedTry.Body.Statements[4].Extent.Text.Trim() -ne '$terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()' -or
+    $stopManagedTry.Body.Statements[5].Extent.Text.Trim() -ne '$rootExited = $Process.WaitForExit(5000)' -or
+    $stopManagedTry.Body.Statements[6] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[6].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[6].ElseClause -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootTerminationRequested' -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements.Count -ne 2 -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].ElseClause -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$rootExited' -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 2 -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].ElseClause -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw ''the root exited before fallback cleanup could verify the process tree''' -or
+    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"' -or
+    $stopManagedTry.Body.Statements[7] -isnot [System.Management.Automation.Language.IfStatementAst] -or
+    $stopManagedTry.Body.Statements[7].Clauses.Count -ne 1 -or
+    $null -ne $stopManagedTry.Body.Statements[7].ElseClause -or
+    $stopManagedTry.Body.Statements[7].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootExited' -or
+    $stopManagedTry.Body.Statements[7].Clauses[0].Item2.Statements.Count -ne 1 -or
+    $stopManagedTry.Body.Statements[7].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''root fallback did not stop the process within 5 seconds''' -or
+    $stopManagedTry.Body.Statements[8] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
+    $stopManagedTry.Body.Statements[8].Extent.Text.Trim() -ne 'throw ''root fallback stopped the process but could not verify descendant cleanup''' -or
     $stopManagedTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
     $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
     $stopManagedTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne 'throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill=''$taskkillError'', fallback=''$($_.Exception.Message)'')."') {
     throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
 }
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);')) `
+    -Description 'native root fallback termination declaration' `
+    -Context $interactiveWin11Lib
 $cliShellTokens = $null
 $cliShellErrors = $null
 $cliShellAst = [System.Management.Automation.Language.Parser]::ParseInput(

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -405,6 +405,8 @@ $commandResolutionProbes = @(
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("[ScriptBlock]::Create")' }
     [pscustomobject]@{ Reject = $false; Text = 'Write-Host "ScriptBlock"' }
     [pscustomobject]@{ Reject = $false; Text = '$list.Add("System.Management.Automation.ScriptBlock")' }
+    [pscustomobject]@{ Reject = $true; Text = 'Invoke-Expression ''Write-Host bypass''' }
+    [pscustomobject]@{ Reject = $true; Text = 'iex ''Write-Host bypass''' }
     [pscustomobject]@{ Reject = $true; Text = 'Add-PSSnapin Example.SnapIn' }
     [pscustomobject]@{ Reject = $true; Text = 'asnp Example.SnapIn' }
 )


### PR DESCRIPTION
## Summary

- give packaged PowerShell CLI probes a 30-second cold-start deadline
- throw an explicit timeout after bounded force-stop cleanup instead of reporting exit `-1`
- add an AST verification contract for the timeout/cleanup sequence

## Root cause

Exact-main Test run `29303516583` passed packaging and five CLI probes, then `+list-themes` crossed the fixed five-second wait under hosted-runner load. The harness force-killed the wrapper and fell through, so native termination status `0xffffffff` appeared as signed `-1`.

## Validation

- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- packaged PowerShell launcher matrix: `+version`, `+list-keybinds`, `+list-themes`
- exact failed `+list-themes` artifact probe repeated 10/10 successfully
- PowerShell syntax checks for both changed files
- `git diff --check`

## Scope

Test-harness-only. No runtime, packaging, signing, release-copy, or product behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows “cli-shell” launcher robustness with consistent validation of required shell binaries and clearer 30-second timeout handling.
  * Enhanced interactive process cleanup by adding a `-RequireLiveRoot` option, introducing pre-cleanup liveness verification, and using more reliable bounded shutdown with fallback termination and verification.

* **Tests**
  * Updated AST-based verification for the revised cli-shell timeout and the updated interactive stop/contract behavior.
  * Strengthened command-resolution mutation checks to treat `Invoke-Expression`/`iex` as forbidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->