### PR TITLE
ci: propagate interactive harness failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,11 +166,16 @@ jobs:
           $quick = '${{ github.event_name }}' -eq 'pull_request'
           if ($quick) {
             ./test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           } else {
             ./test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             ./test/windows/interactive-win11-accessibility.ps1 -ResetState
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             ./test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             ./test/windows/interactive-win11-session-restore.ps1 -ResetState
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
       - name: Upload interactive evidence

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
           ZIG_GLOBAL_CACHE_DIR: ${{ runner.temp }}\zig-global-cache
           ZIG_LOCAL_CACHE_DIR: ${{ runner.temp }}\zig-local-cache
         run: |
+          $ErrorActionPreference = 'Stop'
           $quick = '${{ github.event_name }}' -eq 'pull_request'
           if ($quick) {
             ./test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -2013,13 +2013,33 @@ Assert-TextContract `
     -Pattern "(?m)^[ \t]*\`$ErrorActionPreference = 'Stop'[ \t]*\r?\n[ \t]*\`$quick = " `
     -Description 'interactive workflow treats parent PowerShell errors as terminating before branch selection' `
     -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
-$interactiveHarnessCommands = @(
+$requiredInteractiveHarnessCommands = @(
     './test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState',
     './test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness',
     './test/windows/interactive-win11-accessibility.ps1 -ResetState',
     './test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast',
     './test/windows/interactive-win11-session-restore.ps1 -ResetState'
 )
+$interactiveHarnessLinePattern = [regex]::new(
+    '(?m)^[ \t]*(?<command>\./test/windows/[^\r\n]*?\.ps1(?:[ \t]+[^\r\n]*)?)[ \t]*(?=\r?$)'
+)
+$interactiveHarnessCommands = @(
+    foreach ($match in $interactiveHarnessLinePattern.Matches($interactiveRunStep)) {
+        $match.Groups['command'].Value.TrimEnd()
+    }
+)
+$allExecutablePs1Lines = [regex]::Matches(
+    $interactiveRunStep,
+    '(?m)^(?![ \t]*#)[ \t]*[^\r\n]*\.ps1(?:[ \t]+[^\r\n]*)?[ \t]*\r?$'
+)
+$missingInteractiveHarnesses = @(
+    $requiredInteractiveHarnessCommands | Where-Object { $_ -notin $interactiveHarnessCommands }
+)
+if ($interactiveHarnessCommands.Count -ne $allExecutablePs1Lines.Count -or
+    $interactiveHarnessCommands.Count -ne @($interactiveHarnessCommands | Sort-Object -Unique).Count -or
+    $missingInteractiveHarnesses.Count -gt 0) {
+    throw 'Interactive workflow harness discovery found an unsupported, duplicate, or missing PowerShell invocation.'
+}
 foreach ($command in $interactiveHarnessCommands) {
     $commandGuardPattern = '(?m)^[ \t]*' + [regex]::Escape($command) +
         '[ \t]*\r?\n[ \t]*if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}[ \t]*\r?$'
@@ -2028,14 +2048,22 @@ foreach ($command in $interactiveHarnessCommands) {
         -Pattern $commandGuardPattern `
         -Description "interactive workflow propagates the exit code from $command" `
         -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
-    $commentedCommandStep = [regex]::Replace(
+    $commandLinePattern = [regex]::new(
+        '(?m)^([ \t]*)' + [regex]::Escape($command) + '[ \t]*(?=\r?$)'
+    )
+    $commentedCommandStep = $commandLinePattern.Replace(
         $interactiveRunStep,
-        '(?m)^([ \t]*)' + [regex]::Escape($command) + '[ \t]*(?=\r?$)',
         '$1# ' + $command,
         1)
+    $separatedCommandStep = $commandLinePattern.Replace(
+        $interactiveRunStep,
+        '$0' + [Environment]::NewLine,
+        1)
     if ($commentedCommandStep -eq $interactiveRunStep -or
-        [regex]::IsMatch($commentedCommandStep, $commandGuardPattern)) {
-        throw "Interactive workflow contract accepted a commented-out harness command: $command"
+        $separatedCommandStep -eq $interactiveRunStep -or
+        [regex]::IsMatch($commentedCommandStep, $commandGuardPattern) -or
+        [regex]::IsMatch($separatedCommandStep, $commandGuardPattern)) {
+        throw "Interactive workflow contract accepted a commented-out or non-adjacent harness command: $command"
     }
 }
 Assert-WorkflowContract `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -104,6 +104,26 @@ function Get-YamlStepText {
     $match.Value
 }
 
+function Get-YamlLiteralRunScript {
+    param(
+        [Parameter(Mandatory)] [string] $Content,
+        [Parameter(Mandatory)] [string] $Source
+    )
+
+    $match = [regex]::Match($Content, '(?ms)^        run:[ \t]*\|[ \t]*\r?\n(?<body>.*)\z')
+    if (-not $match.Success) { throw "Literal workflow run block not found: $Source" }
+    $scriptLines = @(
+        foreach ($line in ($match.Groups['body'].Value -split '\r?\n')) {
+            if ($line.Length -eq 0) { ''; continue }
+            if (-not $line.StartsWith('          ', [StringComparison]::Ordinal)) {
+                throw "Literal workflow run block has unexpected indentation: $Source"
+            }
+            $line.Substring(10)
+        }
+    )
+    ($scriptLines -join "`n").TrimEnd([char[]]"`n")
+}
+
 function Get-PowerShellBlockText {
     param(
         [Parameter(Mandatory)] [string] $Content,
@@ -2008,63 +2028,29 @@ Assert-TextContract `
     -Pattern '(?ms)env:\s+ZIG_GLOBAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-global-cache\s+ZIG_LOCAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-local-cache' `
     -Description 'interactive builds use clean per-job Zig caches' `
     -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
-Assert-TextContract `
+$interactiveRunScript = Get-YamlLiteralRunScript `
     -Content $interactiveRunStep `
-    -Pattern "(?m)^[ \t]*\`$ErrorActionPreference = 'Stop'[ \t]*\r?\n[ \t]*\`$quick = " `
-    -Description 'interactive workflow treats parent PowerShell errors as terminating before branch selection' `
-    -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
-$requiredInteractiveHarnessCommands = @(
-    './test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState',
-    './test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness',
-    './test/windows/interactive-win11-accessibility.ps1 -ResetState',
-    './test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast',
-    './test/windows/interactive-win11-session-restore.ps1 -ResetState'
-)
-$interactiveHarnessLinePattern = [regex]::new(
-    '(?m)^[ \t]*(?<command>\./test/windows/[^\r\n]*?\.ps1(?:[ \t]+[^\r\n]*)?)[ \t]*(?=\r?$)'
-)
-$interactiveHarnessCommands = @(
-    foreach ($match in $interactiveHarnessLinePattern.Matches($interactiveRunStep)) {
-        $match.Groups['command'].Value.TrimEnd()
-    }
-)
-$allExecutablePs1Lines = [regex]::Matches(
-    $interactiveRunStep,
-    '(?m)^(?![ \t]*#)[ \t]*[^\r\n]*\.ps1(?:[ \t]+[^\r\n]*)?[ \t]*\r?$'
-)
-$missingInteractiveHarnesses = @(
-    $requiredInteractiveHarnessCommands | Where-Object { $_ -notin $interactiveHarnessCommands }
-)
-if ($interactiveHarnessCommands.Count -ne $allExecutablePs1Lines.Count -or
-    $interactiveHarnessCommands.Count -ne @($interactiveHarnessCommands | Sort-Object -Unique).Count -or
-    $missingInteractiveHarnesses.Count -gt 0) {
-    throw 'Interactive workflow harness discovery found an unsupported, duplicate, or missing PowerShell invocation.'
+    -Source "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
+$expectedInteractiveRunScript = @'
+$ErrorActionPreference = 'Stop'
+$quick = '${{ github.event_name }}' -eq 'pull_request'
+if ($quick) {
+  ./test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+} else {
+  ./test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  ./test/windows/interactive-win11-accessibility.ps1 -ResetState
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  ./test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  ./test/windows/interactive-win11-session-restore.ps1 -ResetState
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }
-foreach ($command in $interactiveHarnessCommands) {
-    $commandGuardPattern = '(?m)^[ \t]*' + [regex]::Escape($command) +
-        '[ \t]*\r?\n[ \t]*if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}[ \t]*\r?$'
-    Assert-TextContract `
-        -Content $interactiveRunStep `
-        -Pattern $commandGuardPattern `
-        -Description "interactive workflow propagates the exit code from $command" `
-        -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
-    $commandLinePattern = [regex]::new(
-        '(?m)^([ \t]*)' + [regex]::Escape($command) + '[ \t]*(?=\r?$)'
-    )
-    $commentedCommandStep = $commandLinePattern.Replace(
-        $interactiveRunStep,
-        '$1# ' + $command,
-        1)
-    $separatedCommandStep = $commandLinePattern.Replace(
-        $interactiveRunStep,
-        '$0' + [Environment]::NewLine,
-        1)
-    if ($commentedCommandStep -eq $interactiveRunStep -or
-        $separatedCommandStep -eq $interactiveRunStep -or
-        [regex]::IsMatch($commentedCommandStep, $commandGuardPattern) -or
-        [regex]::IsMatch($separatedCommandStep, $commandGuardPattern)) {
-        throw "Interactive workflow contract accepted a commented-out or non-adjacent harness command: $command"
-    }
+'@
+$expectedInteractiveRunScript = ($expectedInteractiveRunScript -replace '\r\n?', "`n").TrimEnd([char[]]"`n")
+if ($interactiveRunScript -cne $expectedInteractiveRunScript) {
+    throw 'Interactive workflow run script drifted from its exact fail-closed source snapshot.'
 }
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\dev-windows.cmd') `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -1999,14 +1999,29 @@ Assert-TextContract `
     -Pattern '(?ms)with:\s+version: 0\.15\.2\s+.*?use-cache: false' `
     -Description 'ephemeral interactive retries cannot restore failed Zig build caches' `
     -Context "$testWorkflow :: windows-interactive :: Setup Zig"
+$interactiveRunStep = Get-YamlStepText `
+    -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
+    -Name 'Run interactive Win11 composite' `
+    -Source "$testWorkflow :: windows-interactive"
 Assert-TextContract `
-    -Content (Get-YamlStepText `
-        -Content (Get-YamlJobText -Content $testWorkflowText -Name 'windows-interactive' -Source $testWorkflow) `
-        -Name 'Run interactive Win11 composite' `
-        -Source "$testWorkflow :: windows-interactive") `
+    -Content $interactiveRunStep `
     -Pattern '(?ms)env:\s+ZIG_GLOBAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-global-cache\s+ZIG_LOCAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-local-cache' `
     -Description 'interactive builds use clean per-job Zig caches' `
     -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
+$interactiveHarnessCommands = @(
+    './test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState',
+    './test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness',
+    './test/windows/interactive-win11-accessibility.ps1 -ResetState',
+    './test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast',
+    './test/windows/interactive-win11-session-restore.ps1 -ResetState'
+)
+foreach ($command in $interactiveHarnessCommands) {
+    Assert-TextContract `
+        -Content $interactiveRunStep `
+        -Pattern ([regex]::Escape($command) + '\s*\r?\n\s*if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}') `
+        -Description "interactive workflow propagates the exit code from $command" `
+        -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
+}
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\dev-windows.cmd') `
     -Pattern '(?s)if "%ZIG_GLOBAL_CACHE_DIR%"=="" set "ZIG_GLOBAL_CACHE_DIR=.*?if "%ZIG_LOCAL_CACHE_DIR%"=="" set "ZIG_LOCAL_CACHE_DIR=' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -2016,11 +2016,22 @@ $interactiveHarnessCommands = @(
     './test/windows/interactive-win11-session-restore.ps1 -ResetState'
 )
 foreach ($command in $interactiveHarnessCommands) {
+    $commandGuardPattern = '(?m)^[ \t]*' + [regex]::Escape($command) +
+        '[ \t]*\r?\n[ \t]*if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}[ \t]*\r?$'
     Assert-TextContract `
         -Content $interactiveRunStep `
-        -Pattern ([regex]::Escape($command) + '\s*\r?\n\s*if \(\$LASTEXITCODE -ne 0\) \{ exit \$LASTEXITCODE \}') `
+        -Pattern $commandGuardPattern `
         -Description "interactive workflow propagates the exit code from $command" `
         -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
+    $commentedCommandStep = [regex]::Replace(
+        $interactiveRunStep,
+        '(?m)^([ \t]*)' + [regex]::Escape($command) + '[ \t]*(?=\r?$)',
+        '$1# ' + $command,
+        1)
+    if ($commentedCommandStep -eq $interactiveRunStep -or
+        [regex]::IsMatch($commentedCommandStep, $commandGuardPattern)) {
+        throw "Interactive workflow contract accepted a commented-out harness command: $command"
+    }
 }
 Assert-WorkflowContract `
     -Path (Join-Path $repoRoot 'scripts\dev-windows.cmd') `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -2008,6 +2008,11 @@ Assert-TextContract `
     -Pattern '(?ms)env:\s+ZIG_GLOBAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-global-cache\s+ZIG_LOCAL_CACHE_DIR: \$\{\{ runner\.temp \}\}\\zig-local-cache' `
     -Description 'interactive builds use clean per-job Zig caches' `
     -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
+Assert-TextContract `
+    -Content $interactiveRunStep `
+    -Pattern "(?m)^[ \t]*\`$ErrorActionPreference = 'Stop'[ \t]*\r?\n[ \t]*\`$quick = " `
+    -Description 'interactive workflow treats parent PowerShell errors as terminating before branch selection' `
+    -Context "$testWorkflow :: windows-interactive :: Run interactive Win11 composite"
 $interactiveHarnessCommands = @(
     './test/windows/interactive-win11-pr-smoke.ps1 -Rebuild -ResetState',
     './test/windows/flagship/Invoke-InteractiveWin11.ps1 -Rebuild -ResetState -IncludeForegroundHarness',


### PR DESCRIPTION
## Summary
- make the Windows interactive workflow fail immediately after any nested harness exits nonzero
- add a verification contract test that snapshots the literal interactive workflow script
- prove the guard catches commented/reordered/unguarded harness drift before CI can false-green again

## Validation
- [x] `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- [x] PowerShell parser pass for `.github/workflows/test.yml` interactive run block
- [x] `git diff --check`
- [x] disposable exit-code probe: guarded parent PowerShell preserved nested exit code `23`
- [x] disposable adversarial contract mutations rejected: missing `$ErrorActionPreference`, wrong event branch, commented harness, unguarded added harness
- [x] local serial high-contrast palette recovery pass: `interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast -TimeoutSeconds 45`
- [ ] exact-head PR CI / self-hosted interactive runner

## Risk / follow-up
- Prior exact-main Test run `d65a6008` was invalid as release evidence: palette/high-contrast cleanup failed, then a later script overwrote `$LASTEXITCODE` and the job went green.
- This PR fixes that class of false-green. After merge, release gating still needs a fresh exact-main full interactive Test run, not the earlier green run.
- Sourcery is quota-limited on this PR. Greptile, CodeRabbit, Codex review threads, independent audit, local contracts, and CI are the merge gates here.