### PR TITLE
fix: contain interactive Win11 cleanup

### DIFF
--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -602,6 +602,26 @@ function Get-InteractiveWin11ProcessTreeSnapshot {
         [Parameter(Mandatory)] [int] $RootProcessId
     )
 
+    $processes = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+    if ($processes.Count -eq 0) {
+        throw 'Win32_Process returned no processes while snapshotting interactive cleanup.'
+    }
+
+    $processById = @{}
+    $childrenByParent = @{}
+    foreach ($process in $processes) {
+        $processId = [int]$process.ProcessId
+        $parentProcessId = [int]$process.ParentProcessId
+        $processById[$processId] = $process
+        if (-not $childrenByParent.ContainsKey($parentProcessId)) {
+            $childrenByParent[$parentProcessId] = [Collections.Generic.List[object]]::new()
+        }
+        [void]$childrenByParent[$parentProcessId].Add($process)
+    }
+    if (-not $processById.ContainsKey($RootProcessId)) {
+        throw "Interactive Win11 root process $RootProcessId was absent from the process-table snapshot."
+    }
+
     $snapshot = [Collections.Generic.List[object]]::new()
     $queue = [Collections.Generic.Queue[int]]::new()
     $seen = [Collections.Generic.HashSet[int]]::new()
@@ -610,31 +630,17 @@ function Get-InteractiveWin11ProcessTreeSnapshot {
 
     while ($queue.Count -gt 0) {
         $processId = $queue.Dequeue()
-        try {
-            $process = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $processId" -ErrorAction Stop
-        }
-        catch {
-            if ($VerbosePreference -eq 'Continue') {
-                Write-Verbose "Unable to snapshot Win32 process ${processId}: $($_.Exception.Message)"
-            }
-            continue
-        }
-        if ($null -eq $process) { continue }
+        $process = $processById[$processId]
         [void]$snapshot.Add([pscustomobject]@{
                 ProcessId    = [int]$process.ProcessId
                 CreationDate = $process.CreationDate
             })
-        try {
-            Get-CimInstance -ClassName Win32_Process -Filter "ParentProcessId = $processId" -ErrorAction Stop | ForEach-Object {
-                $childProcessId = [int]$_.ProcessId
+        if ($childrenByParent.ContainsKey($processId)) {
+            foreach ($child in $childrenByParent[$processId]) {
+                $childProcessId = [int]$child.ProcessId
                 if ($seen.Add($childProcessId)) {
                     $queue.Enqueue($childProcessId)
                 }
-            }
-        }
-        catch {
-            if ($VerbosePreference -eq 'Continue') {
-                Write-Verbose "Unable to enumerate children for Win32 process ${processId}: $($_.Exception.Message)"
             }
         }
     }
@@ -647,14 +653,35 @@ function Test-InteractiveWin11ProcessTreeSnapshotExited {
         [Parameter(Mandatory)] [object[]] $Snapshot
     )
 
+    if ($Snapshot.Count -eq 0) {
+        throw 'Interactive Win11 process-tree verification requires a non-empty snapshot.'
+    }
+
+    $processes = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+    if ($processes.Count -eq 0) {
+        throw 'Win32_Process returned no processes while verifying interactive cleanup.'
+    }
+
+    $liveById = @{}
+    foreach ($process in $processes) {
+        $liveById[[int]$process.ProcessId] = $process
+    }
+
+    $capturedProcessIds = [Collections.Generic.HashSet[int]]::new()
     foreach ($entry in $Snapshot) {
-        try {
-            $live = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $($entry.ProcessId)" -ErrorAction Stop
-        }
-        catch {
-            continue
-        }
+        $processId = [int]$entry.ProcessId
+        [void]$capturedProcessIds.Add($processId)
+        $live = $liveById[$processId]
         if ($null -ne $live -and $live.CreationDate -eq $entry.CreationDate) {
+            return $false
+        }
+    }
+
+    # Fail closed if a child appeared after the last snapshot. ParentProcessId
+    # remains useful after its parent exits; PID reuse can only cause a safe
+    # false positive during this short verification window.
+    foreach ($process in $processes) {
+        if ($capturedProcessIds.Contains([int]$process.ParentProcessId)) {
             return $false
         }
     }
@@ -717,12 +744,6 @@ function Stop-InteractiveWin11Process {
         } elseif ($taskkill.ExitCode -ne 0) {
             $taskkillError = "taskkill exited with code $($taskkill.ExitCode)"
         }
-        if ($Process.WaitForExit(5000)) {
-            if ($null -eq $taskkillError -or (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot)) {
-                return
-            }
-            $taskkillError = "$taskkillError; root exited but captured descendants remained live"
-        }
     }
     catch {
         if (-not $taskkillTerminationVerified) {
@@ -737,25 +758,37 @@ function Stop-InteractiveWin11Process {
     }
 
     try {
+        [void]$Process.WaitForExit(5000)
+        if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
+            return
+        }
+        if ($null -eq $taskkillError) {
+            $taskkillError = 'taskkill exited successfully but the captured process tree remained live'
+        }
+
         $Process.Refresh()
         if ($Process.HasExited -or $Process.StartTime -ne $rootStartedAt) {
-            if (-not $RequireLiveRoot) {
+            if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
                 return
             }
-            throw 'the root exited before fallback cleanup could verify the process tree'
+            throw 'the root exited before fallback cleanup, but captured descendants remained live'
         }
+
+        $latestProcessTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId
+        $snapshotByIdentity = @{}
+        foreach ($entry in @($processTreeSnapshot) + @($latestProcessTreeSnapshot)) {
+            $snapshotByIdentity["$($entry.ProcessId)|$($entry.CreationDate)"] = $entry
+        }
+        $processTreeSnapshot = @($snapshotByIdentity.Values)
+
         Initialize-InteractiveWin11ProcessNative
         $rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)
         $terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         $rootExited = $Process.WaitForExit(5000)
         if (-not $rootTerminationRequested) {
-            if ($rootExited) {
-                if (-not $RequireLiveRoot) {
-                    return
-                }
-                throw 'the root exited before fallback cleanup could verify the process tree'
+            if (-not $rootExited) {
+                throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
             }
-            throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
         }
         if (-not $rootExited) {
             throw 'root fallback did not stop the process within 5 seconds'

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -597,6 +597,71 @@ function Wait-InteractiveWin11Until {
     throw "Timed out waiting for $Description"
 }
 
+function Get-InteractiveWin11ProcessTreeSnapshot {
+    param(
+        [Parameter(Mandatory)] [int] $RootProcessId
+    )
+
+    $snapshot = [Collections.Generic.List[object]]::new()
+    $queue = [Collections.Generic.Queue[int]]::new()
+    $seen = [Collections.Generic.HashSet[int]]::new()
+    $queue.Enqueue($RootProcessId)
+    [void]$seen.Add($RootProcessId)
+
+    while ($queue.Count -gt 0) {
+        $processId = $queue.Dequeue()
+        try {
+            $process = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $processId" -ErrorAction Stop
+        }
+        catch {
+            if ($VerbosePreference -eq 'Continue') {
+                Write-Verbose "Unable to snapshot Win32 process ${processId}: $($_.Exception.Message)"
+            }
+            continue
+        }
+        if ($null -eq $process) { continue }
+        [void]$snapshot.Add([pscustomobject]@{
+                ProcessId    = [int]$process.ProcessId
+                CreationDate = $process.CreationDate
+            })
+        try {
+            Get-CimInstance -ClassName Win32_Process -Filter "ParentProcessId = $processId" -ErrorAction Stop | ForEach-Object {
+                $childProcessId = [int]$_.ProcessId
+                if ($seen.Add($childProcessId)) {
+                    $queue.Enqueue($childProcessId)
+                }
+            }
+        }
+        catch {
+            if ($VerbosePreference -eq 'Continue') {
+                Write-Verbose "Unable to enumerate children for Win32 process ${processId}: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    return @($snapshot)
+}
+
+function Test-InteractiveWin11ProcessTreeSnapshotExited {
+    param(
+        [Parameter(Mandatory)] [object[]] $Snapshot
+    )
+
+    foreach ($entry in $Snapshot) {
+        try {
+            $live = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $($entry.ProcessId)" -ErrorAction Stop
+        }
+        catch {
+            continue
+        }
+        if ($null -ne $live -and $live.CreationDate -eq $entry.CreationDate) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Stop-InteractiveWin11Process {
     param(
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
@@ -607,12 +672,14 @@ function Stop-InteractiveWin11Process {
     $rootProcessHandle = [IntPtr]::Zero
     $rootStartedAt = $null
     $rootIsLive = $false
+    $processTreeSnapshot = @()
     try {
         $Process.Refresh()
         if (-not $Process.HasExited) {
             $rootProcessHandle = $Process.Handle
             $rootStartedAt = $Process.StartTime
             $rootIsLive = $true
+            $processTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId
         }
     }
     catch [System.InvalidOperationException] {
@@ -650,8 +717,11 @@ function Stop-InteractiveWin11Process {
         } elseif ($taskkill.ExitCode -ne 0) {
             $taskkillError = "taskkill exited with code $($taskkill.ExitCode)"
         }
-        if ($null -eq $taskkillError -and $Process.WaitForExit(5000)) {
-            return
+        if ($Process.WaitForExit(5000)) {
+            if ($null -eq $taskkillError -or (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot)) {
+                return
+            }
+            $taskkillError = "$taskkillError; root exited but captured descendants remained live"
         }
     }
     catch {
@@ -690,7 +760,10 @@ function Stop-InteractiveWin11Process {
         if (-not $rootExited) {
             throw 'root fallback did not stop the process within 5 seconds'
         }
-        throw 'root fallback stopped the process but could not verify descendant cleanup'
+        if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
+            return
+        }
+        throw 'root fallback stopped the process but captured descendants remained live'
     }
     catch {
         throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', fallback='$($_.Exception.Message)')."

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -298,12 +298,21 @@ function Invoke-InteractiveWin11PostMessage {
     }
 }
 
+function Get-InteractiveWin11ContainmentArguments {
+    return @(
+        '--linux-cgroup=always'
+        '--linux-cgroup-hard-fail=true'
+        '--windows-job-object-kill-on-close=true'
+    )
+}
+
 function Get-InteractiveWin11LaunchArguments {
     param(
         [Parameter(Mandatory)] [System.Collections.IDictionary] $Layout
     )
 
     return @(
+        Get-InteractiveWin11ContainmentArguments
         '--single-instance=false'
         "--class=winghostty-interactive-$($Layout.SandboxId)"
     )
@@ -599,10 +608,11 @@ function Wait-InteractiveWin11Until {
 
 function Get-InteractiveWin11ProcessTreeSnapshot {
     param(
-        [Parameter(Mandatory)] [int] $RootProcessId
+        [Parameter(Mandatory)] [int] $RootProcessId,
+        [Parameter(Mandatory)] [datetime] $RootStartedAt
     )
 
-    $processes = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+    $processes = @(Get-CimInstance -ClassName Win32_Process -OperationTimeoutSec 5 -ErrorAction Stop)
     if ($processes.Count -eq 0) {
         throw 'Win32_Process returned no processes while snapshotting interactive cleanup.'
     }
@@ -621,6 +631,11 @@ function Get-InteractiveWin11ProcessTreeSnapshot {
     if (-not $processById.ContainsKey($RootProcessId)) {
         throw "Interactive Win11 root process $RootProcessId was absent from the process-table snapshot."
     }
+    $observedRootStartedAt = ([datetime]$processById[$RootProcessId].CreationDate).ToUniversalTime()
+    $expectedRootStartedAt = $RootStartedAt.ToUniversalTime()
+    if ([math]::Abs(($observedRootStartedAt - $expectedRootStartedAt).TotalMilliseconds) -gt 10) {
+        throw "Interactive Win11 root process $RootProcessId identity changed before process-tree cleanup."
+    }
 
     $snapshot = [Collections.Generic.List[object]]::new()
     $queue = [Collections.Generic.Queue[int]]::new()
@@ -631,13 +646,18 @@ function Get-InteractiveWin11ProcessTreeSnapshot {
     while ($queue.Count -gt 0) {
         $processId = $queue.Dequeue()
         $process = $processById[$processId]
+        $processStartedAt = ([datetime]$process.CreationDate).ToUniversalTime()
         [void]$snapshot.Add([pscustomobject]@{
-                ProcessId    = [int]$process.ProcessId
-                CreationDate = $process.CreationDate
-            })
+            ProcessId    = [int]$process.ProcessId
+            CreationDate = $processStartedAt
+        })
         if ($childrenByParent.ContainsKey($processId)) {
             foreach ($child in $childrenByParent[$processId]) {
                 $childProcessId = [int]$child.ProcessId
+                $childStartedAt = ([datetime]$child.CreationDate).ToUniversalTime()
+                if ($childStartedAt -lt $processStartedAt) {
+                    continue
+                }
                 if ($seen.Add($childProcessId)) {
                     $queue.Enqueue($childProcessId)
                 }
@@ -650,14 +670,18 @@ function Get-InteractiveWin11ProcessTreeSnapshot {
 
 function Test-InteractiveWin11ProcessTreeSnapshotExited {
     param(
-        [Parameter(Mandatory)] [object[]] $Snapshot
+        [Parameter(Mandatory)] [object[]] $Snapshot,
+        [ValidateRange(1, 5)] [uint32] $OperationTimeoutSec = 5
     )
 
     if ($Snapshot.Count -eq 0) {
         throw 'Interactive Win11 process-tree verification requires a non-empty snapshot.'
     }
 
-    $processes = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+    $processes = @(Get-CimInstance `
+            -ClassName Win32_Process `
+            -OperationTimeoutSec $OperationTimeoutSec `
+            -ErrorAction Stop)
     if ($processes.Count -eq 0) {
         throw 'Win32_Process returned no processes while verifying interactive cleanup.'
     }
@@ -668,20 +692,26 @@ function Test-InteractiveWin11ProcessTreeSnapshotExited {
     }
 
     $capturedProcessIds = [Collections.Generic.HashSet[int]]::new()
+    $capturedStartedAtById = @{}
     foreach ($entry in $Snapshot) {
         $processId = [int]$entry.ProcessId
         [void]$capturedProcessIds.Add($processId)
+        $capturedStartedAtById[$processId] = ([datetime]$entry.CreationDate).ToUniversalTime()
         $live = $liveById[$processId]
-        if ($null -ne $live -and $live.CreationDate -eq $entry.CreationDate) {
+        if ($null -ne $live -and
+            ([datetime]$live.CreationDate).ToUniversalTime().Ticks -eq
+            ([datetime]$entry.CreationDate).ToUniversalTime().Ticks) {
             return $false
         }
     }
 
     # Fail closed if a child appeared after the last snapshot. ParentProcessId
-    # remains useful after its parent exits; PID reuse can only cause a safe
-    # false positive during this short verification window.
+    # remains useful after its parent exits; compare against the captured parent
+    # identity so stale children from reused PIDs do not poison cleanup.
     foreach ($process in $processes) {
-        if ($capturedProcessIds.Contains([int]$process.ParentProcessId)) {
+        $parentProcessId = [int]$process.ParentProcessId
+        if ($capturedProcessIds.Contains($parentProcessId) -and
+            ([datetime]$process.CreationDate).ToUniversalTime() -ge $capturedStartedAtById[$parentProcessId]) {
             return $false
         }
     }
@@ -689,117 +719,220 @@ function Test-InteractiveWin11ProcessTreeSnapshotExited {
     return $true
 }
 
+function Stop-InteractiveWin11RootHandle {
+    param(
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
+        [Parameter(Mandatory)] [IntPtr] $RootProcessHandle,
+        [Parameter(Mandatory)] [datetime] $RootStartedAt
+    )
+
+    try {
+        $Process.Refresh()
+        if ($Process.HasExited -or $Process.StartTime -ne $RootStartedAt) {
+            return
+        }
+    }
+    catch [System.InvalidOperationException] {
+        return
+    }
+
+    Initialize-InteractiveWin11ProcessNative
+    $terminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($RootProcessHandle, 1)
+    $terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    $waitResult = [InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 5000)
+    if (-not $terminationRequested -and $waitResult -ne 0) {
+        throw "root handle termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
+    }
+    if ($waitResult -eq 258) {
+        throw 'root handle termination did not stop the process within 5 seconds'
+    }
+    if ($waitResult -eq [uint32]::MaxValue) {
+        $waitError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw "root handle exit wait failed with Win32 error $waitError"
+    }
+    if ($waitResult -ne 0) {
+        throw "root handle exit wait returned unexpected status $waitResult"
+    }
+}
+
+function Wait-InteractiveWin11ProcessTreeSnapshotExited {
+    param(
+        [Parameter(Mandatory)] [object[]] $Snapshot,
+        [ValidateRange(1, 30)] [uint32] $TimeoutSeconds = 5
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $remainingSeconds = ($deadline - [DateTime]::UtcNow).TotalSeconds
+        if ($remainingSeconds -le 0) {
+            return $false
+        }
+        $operationTimeoutSec = [uint32][math]::Max(1, [math]::Min(5, [math]::Ceiling($remainingSeconds)))
+        if (Test-InteractiveWin11ProcessTreeSnapshotExited `
+                -Snapshot $Snapshot `
+                -OperationTimeoutSec $operationTimeoutSec) {
+            return $true
+        }
+        $remainingMilliseconds = [math]::Floor(($deadline - [DateTime]::UtcNow).TotalMilliseconds)
+        if ($remainingMilliseconds -gt 0) {
+            Start-Sleep -Milliseconds ([int][math]::Min(100, $remainingMilliseconds))
+        }
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $false
+}
+
 function Stop-InteractiveWin11Process {
     param(
         [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
-        [switch] $RequireLiveRoot
+        [switch] $RequireLiveRoot,
+        [switch] $Contained,
+        [switch] $AllowAlreadyExited
     )
+
+    $lifecycleModeCount = @($RequireLiveRoot, $Contained, $AllowAlreadyExited).Where({ $_.IsPresent }).Count
+    if ($lifecycleModeCount -gt 1) {
+        throw 'RequireLiveRoot, Contained, and AllowAlreadyExited are mutually exclusive.'
+    }
 
     $rootProcessId = $Process.Id
     $rootProcessHandle = [IntPtr]::Zero
     $rootStartedAt = $null
-    $rootIsLive = $false
-    $processTreeSnapshot = @()
     try {
         $Process.Refresh()
         if (-not $Process.HasExited) {
             $rootProcessHandle = $Process.Handle
             $rootStartedAt = $Process.StartTime
-            $rootIsLive = $true
-            $processTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId
         }
     }
     catch [System.InvalidOperationException] {
-        # The root exited while its identity was being checked.
-        if ($VerbosePreference -eq 'Continue') {
-            Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"
-        }
+        # The root exited while its handle identity was being captured.
     }
-    if (-not $rootIsLive) {
-        if (-not $RequireLiveRoot) {
+    if ($null -eq $rootStartedAt) {
+        if ($RequireLiveRoot) {
+            throw "Interactive Win11 process $rootProcessId exited before its process tree could be verified."
+        }
+        if ($Contained) {
+            # The terminated host owned every terminal-child Job handle, so its
+            # exit closed those jobs and killed their contained descendants.
             return
         }
-        throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."
+        if ($AllowAlreadyExited) {
+            # This is reserved for short-lived, uncontained probes that cannot
+            # create persistent descendants and are expected to exit normally.
+            return
+        }
+        throw "Uncontained interactive Win11 process $rootProcessId exited before its process tree could be verified."
+    }
+
+    $processTreeSnapshot = @()
+    $snapshotError = $null
+    try {
+        $processTreeSnapshot = @(Get-InteractiveWin11ProcessTreeSnapshot `
+                -RootProcessId $rootProcessId `
+                -RootStartedAt $rootStartedAt)
+    }
+    catch {
+        $snapshotError = $_.Exception.Message
     }
 
     $taskkillError = $null
-    $taskkill = $null
-    $taskkillTerminationVerified = $true
-    try {
-        $taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
-        $taskkillStartInfo.FileName = Join-Path ([Environment]::SystemDirectory) 'taskkill.exe'
-        $taskkillStartInfo.UseShellExecute = $false
-        $taskkillStartInfo.CreateNoWindow = $true
-        $taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"
-        $taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)
-        $taskkillTerminationVerified = $false
-        $taskkillTerminationVerified = $taskkill.WaitForExit(10000)
-        if (-not $taskkillTerminationVerified) {
-            $taskkill.Kill()
-            $taskkillTerminationVerified = $taskkill.WaitForExit(5000)
-            if (-not $taskkillTerminationVerified) {
-                throw 'taskkill could not be stopped within 5 seconds'
+    $taskkillCleanupError = $null
+    if (-not $Contained) {
+        # Keep RootProcessHandle open through taskkill. Windows cannot reuse a
+        # process ID until all handles to that process object are closed, so
+        # the numeric tree-kill target remains bound to the captured identity.
+        $taskkill = $null
+        try {
+            $Process.Refresh()
+            if (-not $Process.HasExited -and $Process.StartTime -eq $rootStartedAt) {
+                $taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+                $taskkillStartInfo.FileName = Join-Path ([Environment]::SystemDirectory) 'taskkill.exe'
+                $taskkillStartInfo.UseShellExecute = $false
+                $taskkillStartInfo.CreateNoWindow = $true
+                $taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"
+                $taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)
+                if (-not $taskkill.WaitForExit(10000)) {
+                    try {
+                        $taskkill.Kill()
+                        if (-not $taskkill.WaitForExit(5000)) {
+                            $taskkillCleanupError = 'taskkill could not be stopped within 5 seconds'
+                        }
+                        else {
+                            $taskkillError = 'taskkill exceeded 10 seconds'
+                        }
+                    }
+                    catch {
+                        $taskkillCleanupError = "taskkill could not be stopped: $($_.Exception.Message)"
+                    }
+                }
+                elseif ($taskkill.ExitCode -ne 0) {
+                    $taskkillError = "taskkill exited with code $($taskkill.ExitCode)"
+                }
             }
-            $taskkillError = 'taskkill exceeded 10 seconds'
-        } elseif ($taskkill.ExitCode -ne 0) {
-            $taskkillError = "taskkill exited with code $($taskkill.ExitCode)"
         }
+        catch {
+            $taskkillError = $_.Exception.Message
+        }
+        finally {
+            if ($null -ne $taskkill) { $taskkill.Dispose() }
+        }
+    }
+
+    $terminationError = $null
+    try {
+        Stop-InteractiveWin11RootHandle `
+            -Process $Process `
+            -RootProcessHandle $rootProcessHandle `
+            -RootStartedAt $rootStartedAt
     }
     catch {
-        if (-not $taskkillTerminationVerified) {
-            throw
-        }
-        $taskkillError = $_.Exception.Message
-    }
-    finally {
-        if ($null -ne $taskkill) {
-            $taskkill.Dispose()
-        }
+        $terminationError = $_.Exception.Message
     }
 
+    if ($null -ne $terminationError) {
+        throw "Failed to clean interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', root='$terminationError')."
+    }
+    if ($null -ne $taskkillCleanupError) {
+        throw "Failed to reap taskkill while cleaning interactive Win11 process tree $rootProcessId`: $taskkillCleanupError"
+    }
+    if ($Contained -and $null -ne $snapshotError) {
+        if ($VerbosePreference -eq 'Continue') {
+            Write-Verbose "Contained interactive Win11 process $rootProcessId cleanup skipped CIM verification: $snapshotError"
+        }
+        return
+    }
+    if ($AllowAlreadyExited -and $null -ne $snapshotError) {
+        if ($VerbosePreference -eq 'Continue') {
+            Write-Verbose "Already-exited interactive Win11 process $rootProcessId cleanup skipped process-tree verification: $snapshotError"
+        }
+        return
+    }
+    if ($null -ne $snapshotError) {
+        throw "Failed to verify uncontained interactive Win11 process tree $rootProcessId after termination: $snapshotError"
+    }
+
+    $verificationError = $null
+    $processTreeExited = $false
     try {
-        [void]$Process.WaitForExit(5000)
-        if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
-            return
-        }
-        if ($null -eq $taskkillError) {
-            $taskkillError = 'taskkill exited successfully but the captured process tree remained live'
-        }
-
-        $Process.Refresh()
-        if ($Process.HasExited -or $Process.StartTime -ne $rootStartedAt) {
-            if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
-                return
-            }
-            throw 'the root exited before fallback cleanup, but captured descendants remained live'
-        }
-
-        $latestProcessTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId
-        $snapshotByIdentity = @{}
-        foreach ($entry in @($processTreeSnapshot) + @($latestProcessTreeSnapshot)) {
-            $snapshotByIdentity["$($entry.ProcessId)|$($entry.CreationDate)"] = $entry
-        }
-        $processTreeSnapshot = @($snapshotByIdentity.Values)
-
-        Initialize-InteractiveWin11ProcessNative
-        $rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)
-        $terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        $rootExited = $Process.WaitForExit(5000)
-        if (-not $rootTerminationRequested) {
-            if (-not $rootExited) {
-                throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
-            }
-        }
-        if (-not $rootExited) {
-            throw 'root fallback did not stop the process within 5 seconds'
-        }
-        if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot) {
-            return
-        }
-        throw 'root fallback stopped the process but captured descendants remained live'
+        $processTreeExited = Wait-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot
     }
     catch {
-        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill='$taskkillError', fallback='$($_.Exception.Message)')."
+        $verificationError = $_.Exception.Message
+    }
+    if ($null -ne $verificationError) {
+        if ($Contained) {
+            if ($VerbosePreference -eq 'Continue') {
+                Write-Verbose "Contained interactive Win11 process $rootProcessId cleanup could not query post-exit process state: $verificationError"
+            }
+            return
+        }
+        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId after root termination: $verificationError"
+    }
+    if (-not $processTreeExited) {
+        throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId after root termination: captured descendants remained live"
+    }
+    if ($null -ne $taskkillError -and $VerbosePreference -eq 'Continue') {
+        Write-Verbose "Uncontained process tree $rootProcessId required root fallback after taskkill: $taskkillError"
     }
 }
 
@@ -894,6 +1027,9 @@ public static class InteractiveWin11ProcessNative {
     [DllImport("kernel32.dll", SetLastError=true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
 }
 "@
     }

--- a/scripts/interactive-win11-lib.ps1
+++ b/scripts/interactive-win11-lib.ps1
@@ -739,12 +739,15 @@ function Stop-InteractiveWin11RootHandle {
     Initialize-InteractiveWin11ProcessNative
     $terminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($RootProcessHandle, 1)
     $terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    $waitResult = [InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 5000)
+    # TerminateProcess is asynchronous. High Contrast and other system-wide UI
+    # transitions can keep teardown pending beyond the ordinary five-second
+    # harness cadence, so retain a bounded but transition-tolerant exit wait.
+    $waitResult = [InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 15000)
     if (-not $terminationRequested -and $waitResult -ne 0) {
-        throw "root handle termination failed with Win32 error $terminationError; the root remained live after 5 seconds"
+        throw "root handle termination failed with Win32 error $terminationError; the root remained live after 15 seconds"
     }
     if ($waitResult -eq 258) {
-        throw 'root handle termination did not stop the process within 5 seconds'
+        throw 'root handle termination did not stop the process within 15 seconds'
     }
     if ($waitResult -eq [uint32]::MaxValue) {
         $waitError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -1105,6 +1105,73 @@ test "Command: windows job object plan attaches to local child process" {
     try testing.expectEqual(@as(u32, 0), @as(u32, exit.Exited));
 }
 
+test "Command: windows job object kill-on-close terminates local child" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const ProcessIdList = extern struct {
+        assigned_count: windows.DWORD = 0,
+        listed_count: windows.DWORD = 0,
+        process_ids: [16]usize = @splat(0),
+    };
+
+    var cmd: Command = .{
+        .path = "C:\\Windows\\System32\\cmd.exe",
+        .args = &.{ "C:\\Windows\\System32\\cmd.exe", "/C", "ping.exe", "-t", "127.0.0.1" },
+        .windows_job_object_plan = .{
+            .mode = .always,
+            .attach_policy = .hard_fail,
+            .kill_on_close = true,
+        },
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+    defer cmd.closeWindowsJobObject();
+
+    try cmd.testingStart();
+    try testing.expect(cmd.pid != null);
+    try testing.expect(cmd.windows_job_object_handle != null);
+
+    const root_process_id = apprt.win32_job_object.GetProcessId(cmd.pid.?);
+    try testing.expect(root_process_id != 0);
+    var process_ids: ProcessIdList = .{};
+    const query_deadline = std.time.nanoTimestamp() + (5 * std.time.ns_per_s);
+    while (true) {
+        var returned_length: windows.DWORD = 0;
+        if (apprt.win32_job_object.QueryInformationJobObject(
+            cmd.windows_job_object_handle.?,
+            .basic_process_id_list,
+            &process_ids,
+            @sizeOf(ProcessIdList),
+            &returned_length,
+        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+        if (process_ids.listed_count >= 2) break;
+        if (std.time.nanoTimestamp() >= query_deadline) return error.WindowsJobObjectDescendantDidNotStart;
+        std.Thread.sleep(20 * std.time.ns_per_ms);
+    }
+
+    var descendant_handle: ?windows.HANDLE = null;
+    for (process_ids.process_ids[0..process_ids.listed_count]) |process_id| {
+        if (process_id == root_process_id) continue;
+        descendant_handle = apprt.win32_job_object.OpenProcess(
+            windows.SYNCHRONIZE,
+            windows.FALSE,
+            @intCast(process_id),
+        );
+        if (descendant_handle != null) break;
+    }
+    const child = descendant_handle orelse return error.WindowsJobObjectDescendantHandleUnavailable;
+    defer _ = windows.CloseHandle(child);
+
+    cmd.closeWindowsJobObject();
+
+    try std.os.windows.WaitForSingleObject(child, 5000);
+    const exit = try cmd.wait(true);
+    try testing.expect(exit == .Exited);
+}
+
 // Test validate an execveZ failure correctly terminates when error.ExecFailedInChild is correctly handled
 //
 // Incorrectly handling an error.ExecFailedInChild results in a second copy of the test process running.

--- a/src/apprt/win32_job_object.zig
+++ b/src/apprt/win32_job_object.zig
@@ -26,6 +26,7 @@ pub const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x00002000;
 
 pub const JOBOBJECTINFOCLASS = enum(i32) {
     basic_limit_information = 2,
+    basic_process_id_list = 3,
     extended_limit_information = 9,
     _,
 };
@@ -72,10 +73,26 @@ pub extern "kernel32" fn SetInformationJobObject(
     cbJobObjectInfoLength: DWORD,
 ) callconv(.winapi) BOOL;
 
+pub extern "kernel32" fn QueryInformationJobObject(
+    hJob: HANDLE,
+    JobObjectInfoClass: JOBOBJECTINFOCLASS,
+    lpJobObjectInfo: *anyopaque,
+    cbJobObjectInfoLength: DWORD,
+    lpReturnLength: ?*DWORD,
+) callconv(.winapi) BOOL;
+
 pub extern "kernel32" fn AssignProcessToJobObject(
     hJob: HANDLE,
     hProcess: HANDLE,
 ) callconv(.winapi) BOOL;
+
+pub extern "kernel32" fn GetProcessId(Process: HANDLE) callconv(.winapi) DWORD;
+
+pub extern "kernel32" fn OpenProcess(
+    dwDesiredAccess: DWORD,
+    bInheritHandle: BOOL,
+    dwProcessId: DWORD,
+) callconv(.winapi) ?HANDLE;
 
 pub const Mode = enum {
     never,
@@ -98,6 +115,7 @@ pub const Plan = struct {
     attach_policy: AttachPolicy = .best_effort,
     active_process_limit: ?DWORD = null,
     job_memory_limit_bytes: ?SIZE_T = null,
+    kill_on_close: bool = false,
 
     pub fn wantsJobObject(self: Plan) bool {
         return self.mode != .never;
@@ -109,7 +127,7 @@ pub const Plan = struct {
     }
 
     pub fn extendedLimitInformation(self: Plan) ?JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
-        if (!self.wantsJobObject() or !self.hasLimits()) return null;
+        if (!self.wantsJobObject() or (!self.hasLimits() and !self.kill_on_close)) return null;
 
         var info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = .{};
 
@@ -121,6 +139,9 @@ pub const Plan = struct {
         if (self.job_memory_limit_bytes) |limit| {
             info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
             info.JobMemoryLimit = limit;
+        }
+        if (self.kill_on_close) {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         }
 
         return info;
@@ -163,6 +184,7 @@ pub fn configPlan(config: *const configpkg.Config) ConfigPlanError!Plan {
             std.math.cast(SIZE_T, limit) orelse return error.JobMemoryLimitOverflow
         else
             null,
+        .kill_on_close = config.@"windows-job-object-kill-on-close",
     };
 }
 
@@ -187,6 +209,7 @@ test "win32 job object ABI declarations match expected Win32 values" {
     const set_info_fn = @typeInfo(@TypeOf(SetInformationJobObject)).@"fn";
 
     try std.testing.expectEqual(@as(i32, 9), @intFromEnum(JOBOBJECTINFOCLASS.extended_limit_information));
+    try std.testing.expectEqual(@as(i32, 3), @intFromEnum(JOBOBJECTINFOCLASS.basic_process_id_list));
     try std.testing.expectEqual(@as(DWORD, 0x00000008), JOB_OBJECT_LIMIT_ACTIVE_PROCESS);
     try std.testing.expectEqual(@as(DWORD, 0x00000200), JOB_OBJECT_LIMIT_JOB_MEMORY);
     try std.testing.expectEqual(@as(DWORD, 0x00002000), JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE);
@@ -242,16 +265,33 @@ test "win32 job object plan maps compatibility limits without kill-on-close" {
     try std.testing.expectEqual(@as(usize, 512 * 1024 * 1024), limits.JobMemoryLimit);
 }
 
+test "win32 job object plan opts into kill-on-close" {
+    var config: configpkg.Config = .{};
+    config.@"linux-cgroup" = .always;
+    config.@"windows-job-object-kill-on-close" = true;
+
+    const plan = try configPlan(&config);
+    const limits = plan.extendedLimitInformation().?;
+
+    try std.testing.expect(plan.kill_on_close);
+    try std.testing.expectEqual(
+        @as(DWORD, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE),
+        limits.BasicLimitInformation.LimitFlags,
+    );
+}
+
 test "win32 job object plan ignores compatibility limits when mode is never" {
     var config: configpkg.Config = .{};
     config.@"linux-cgroup-memory-limit" = 512 * 1024 * 1024;
     config.@"linux-cgroup-processes-limit" = 4;
     config.@"linux-cgroup-hard-fail" = true;
+    config.@"windows-job-object-kill-on-close" = true;
 
     const plan = try configPlan(&config);
 
     try std.testing.expectEqual(Mode.never, plan.mode);
     try std.testing.expectEqual(AttachPolicy.best_effort, plan.attach_policy);
+    try std.testing.expect(!plan.kill_on_close);
     try std.testing.expect(!plan.wantsJobObject());
     try std.testing.expect(!plan.hasLimits());
     try std.testing.expect(plan.extendedLimitInformation() == null);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3078,6 +3078,14 @@ keybind: Keybinds = .{},
 /// the launch instead of continuing without limits.
 @"linux-cgroup-hard-fail": bool = false,
 
+/// Windows-only Job Object cleanup policy.
+///
+/// When true with `linux-cgroup` enabled, closing the Job Object terminates all
+/// attached processes. The default remains false so normal launches preserve
+/// existing detached-child behavior. Interactive validation enables this with
+/// hard-fail attachment to make descendant cleanup deterministic.
+@"windows-job-object-kill-on-close": bool = false,
+
 /// Retained compatibility settings from the removed GTK runtime.
 ///
 /// These keys continue to parse so existing configs remain loadable, but they

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -942,6 +942,13 @@ if ($containmentFunctions.Count -ne 1 -or
     $launchArgumentFunctions[0].Extent.Text -notmatch '\bGet-InteractiveWin11ContainmentArguments\b') {
     throw 'Interactive Win11 launches must opt into hard-fail kill-on-close Job Object containment.'
 }
+$interactiveLibraryTest = Get-Content -LiteralPath (Join-Path $repoRoot 'test\windows\interactive-win11.ps1') -Raw
+if ($interactiveLibraryTest -notmatch [regex]::Escape("Assert-Equal `$launchArgs.Count 5 'launch args should include containment and isolation overrides'") -or
+    $interactiveLibraryTest -notmatch [regex]::Escape("Assert-True (`$launchArgs -contains '--linux-cgroup=always')") -or
+    $interactiveLibraryTest -notmatch [regex]::Escape("Assert-True (`$launchArgs -contains '--linux-cgroup-hard-fail=true')") -or
+    $interactiveLibraryTest -notmatch [regex]::Escape("Assert-True (`$launchArgs -contains '--windows-job-object-kill-on-close=true')")) {
+    throw 'Interactive helper tests must assert all containment and isolation launch arguments.'
+}
 $interactiveHarnessFiles = @(
     Get-ChildItem -LiteralPath (Join-Path $repoRoot 'test\windows') -Filter 'interactive-win11-*.ps1' -File
 )

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -626,9 +626,6 @@ $stopProcessFunctions = @($interactiveWin11LibAst.FindAll({
     $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
         $node.Name -eq 'Stop-InteractiveWin11Process'
 }, $true))
-$stopProcessStatements = if ($stopProcessFunctions.Count -eq 1) {
-    @($stopProcessFunctions[0].Body.EndBlock.Statements)
-} else { @() }
 $processTreeSnapshotFunctions = @($interactiveWin11LibAst.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Get-InteractiveWin11ProcessTreeSnapshot'
@@ -664,10 +661,120 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue) {
     throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
 }
+$snapshotCimCommands = @($processTreeSnapshotFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Get-CimInstance'
+    }, $true))
+$verificationCimCommands = @($processTreeExitedFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Get-CimInstance'
+    }, $true))
+$snapshotCalls = @($stopProcessFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Get-InteractiveWin11ProcessTreeSnapshot'
+    }, $true))
+$verificationCalls = @($stopProcessFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Test-InteractiveWin11ProcessTreeSnapshotExited'
+    }, $true))
+if ($snapshotCimCommands.Count -ne 1 -or
+    $verificationCimCommands.Count -ne 1 -or
+    $snapshotCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process\s+-ErrorAction\s+Stop' -or
+    $verificationCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process\s+-ErrorAction\s+Stop' -or
+    $snapshotCimCommands[0].Extent.Text -match '(?i)-Filter\b' -or
+    $verificationCimCommands[0].Extent.Text -match '(?i)-Filter\b' -or
+    @($processTreeSnapshotFunctions[0].FindAll({ param($node) $node -is [System.Management.Automation.Language.CatchClauseAst] }, $true)).Count -ne 0 -or
+    @($processTreeExitedFunctions[0].FindAll({ param($node) $node -is [System.Management.Automation.Language.CatchClauseAst] }, $true)).Count -ne 0 -or
+    $snapshotCalls.Count -ne 2 -or
+    $verificationCalls.Count -lt 3) {
+    throw 'Interactive cleanup must take coherent fail-closed process-table snapshots before kill and fallback, then verify every exit path.'
+}
+
+Invoke-Expression $processTreeSnapshotFunctions[0].Extent.Text
+Invoke-Expression $processTreeExitedFunctions[0].Extent.Text
+$script:verificationCimProcesses = @()
+$script:verificationCimFailure = $null
+function script:Get-CimInstance {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $ClassName,
+        [string] $Filter
+    )
+
+    if ($ClassName -ne 'Win32_Process' -or $PSBoundParameters.ContainsKey('Filter')) {
+        throw 'Verification mock requires one unfiltered Win32_Process query.'
+    }
+    if ($null -ne $script:verificationCimFailure) {
+        throw $script:verificationCimFailure
+    }
+    $script:verificationCimProcesses
+}
+
+try {
+    $rootCreated = [datetime]'2026-07-14T15:00:00Z'
+    $childCreated = $rootCreated.AddSeconds(1)
+    $grandchildCreated = $rootCreated.AddSeconds(2)
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 100; ParentProcessId = 4; CreationDate = $rootCreated },
+        [pscustomobject]@{ ProcessId = 101; ParentProcessId = 100; CreationDate = $childCreated },
+        [pscustomobject]@{ ProcessId = 102; ParentProcessId = 101; CreationDate = $grandchildCreated },
+        [pscustomobject]@{ ProcessId = 200; ParentProcessId = 4; CreationDate = $rootCreated }
+    )
+    $snapshot = @(Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100)
+    if ((@($snapshot.ProcessId | Sort-Object) -join ',') -ne '100,101,102') {
+        throw 'Interactive process snapshot did not close over the full descendant tree.'
+    }
+    if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot) {
+        throw 'Interactive process verification accepted captured identities that were still live.'
+    }
+
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 100; ParentProcessId = 4; CreationDate = $rootCreated.AddMinutes(1) },
+        [pscustomobject]@{ ProcessId = 200; ParentProcessId = 4; CreationDate = $rootCreated }
+    )
+    if (-not (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot)) {
+        throw 'Interactive process verification confused a reused PID with a captured identity.'
+    }
+
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 201; ParentProcessId = 100; CreationDate = $rootCreated.AddMinutes(2) }
+    )
+    if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot) {
+        throw 'Interactive process verification missed a child created after the snapshot.'
+    }
+
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 200; ParentProcessId = 4; CreationDate = $rootCreated }
+    )
+    $missingRootRejected = $false
+    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100) } catch { $missingRootRejected = $true }
+    if (-not $missingRootRejected) {
+        throw 'Interactive process snapshot accepted a missing root identity.'
+    }
+
+    $script:verificationCimFailure = 'simulated CIM failure'
+    $snapshotFailureRejected = $false
+    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100) } catch { $snapshotFailureRejected = $true }
+    $verificationFailureRejected = $false
+    try { [void](Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot) } catch { $verificationFailureRejected = $true }
+    if (-not $snapshotFailureRejected -or -not $verificationFailureRejected) {
+        throw 'Interactive process cleanup treated a CIM failure as proof of exit.'
+    }
+}
+finally {
+    Remove-Item -LiteralPath Function:\Get-CimInstance -ErrorAction SilentlyContinue
+    Remove-Variable -Scope Script -Name verificationCimProcesses, verificationCimFailure -ErrorAction SilentlyContinue
+}
+
 Assert-TextContract `
     -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('$processTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId')) `
-    -Description 'interactive cleanup snapshots root process tree before kill' `
+    -Pattern ([regex]::Escape('throw "Interactive Win11 root process $RootProcessId was absent from the process-table snapshot."')) `
+    -Description 'interactive cleanup fails closed if root is absent from process snapshot' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('throw ''Interactive Win11 process-tree verification requires a non-empty snapshot.''')) `
+    -Description 'interactive cleanup rejects vacuous empty-snapshot verification' `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
@@ -681,8 +788,8 @@ Assert-TextContract `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot')) `
-    -Description 'interactive cleanup verifies captured descendants after fallback' `
+    -Pattern ([regex]::Escape('$capturedProcessIds.Contains([int]$process.ParentProcessId)')) `
+    -Description 'interactive cleanup fails closed on descendants created after snapshot' `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -706,7 +706,7 @@ $rootTerminateCalls = @($stopRootHandleFunctions[0].FindAll({
 $rootWaitCalls = @($stopRootHandleFunctions[0].FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
-            $node.Extent.Text -eq '[InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 5000)'
+            $node.Extent.Text -eq '[InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 15000)'
     }, $true))
 if ($snapshotCimCommands.Count -ne 1 -or
     $verificationCimCommands.Count -ne 1 -or
@@ -1369,6 +1369,11 @@ $paletteThemeAst = [System.Management.Automation.Language.Parser]::ParseInput(
     [ref]$paletteThemeErrors
 )
 if ($paletteThemeErrors.Count -ne 0) { throw "Palette theme harness does not parse: $($paletteThemeErrors[0].Message)" }
+Assert-TextContract `
+    -Content $paletteThemeHarnessText `
+    -Pattern ([regex]::Escape('[int]$TimeoutSeconds = 60')) `
+    -Description 'palette High Contrast transition budget remains Debug-build tolerant' `
+    -Context $paletteThemeHarness
 Assert-CommandResolutionContract -Ast $paletteThemeAst -Tokens $paletteThemeTokens -Context $paletteThemeHarness -ExpectedDotSources @(
     ". (Join-Path `$repoRoot 'scripts\interactive-win11-lib.ps1')",
     ". (Join-Path `$PSScriptRoot 'interactive-win11-stateful-lib.ps1')"
@@ -1439,15 +1444,16 @@ if ($postHighContrastLoops.Count -ne 1 -or
     throw 'Post-High-Contrast presentation must use one exact two-attempt loop.'
 }
 $postHighContrastLoopStatements = @($postHighContrastLoops[0].Body.Statements)
-if ($postHighContrastLoopStatements.Count -ne 2 -or
+if ($postHighContrastLoopStatements.Count -ne 3 -or
     $postHighContrastLoopStatements[0].Extent.Text.Trim() -ne '$canary = $null' -or
-    $postHighContrastLoopStatements[1] -isnot [System.Management.Automation.Language.TryStatementAst]) {
+    $postHighContrastLoopStatements[1].Extent.Text.Trim() -ne '$presentationProven = $false' -or
+    $postHighContrastLoopStatements[2] -isnot [System.Management.Automation.Language.TryStatementAst]) {
     throw 'Post-High-Contrast presentation must guard each complete canary lifecycle with one try/catch.'
 }
-$postHighContrastTry = $postHighContrastLoopStatements[1]
+$postHighContrastTry = $postHighContrastLoopStatements[2]
 $postHighContrastTryStatements = @($postHighContrastTry.Body.Statements)
 if ($postHighContrastTry.CatchClauses.Count -ne 1 -or $null -ne $postHighContrastTry.Finally -or
-    $postHighContrastTryStatements.Count -ne 13 -or
+    $postHighContrastTryStatements.Count -ne 14 -or
     $postHighContrastTryStatements[0].Extent.Text.Trim() -ne '$canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"' -or
     $postHighContrastTryStatements[1].Extent.Text.Trim() -ne '$runs.Add($canary)' -or
     $postHighContrastTryStatements[2].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
@@ -1458,16 +1464,18 @@ if ($postHighContrastTry.CatchClauses.Count -ne 1 -or $null -ne $postHighContras
     $postHighContrastTryStatements[7].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
     $postHighContrastTryStatements[8].Extent.Text.Trim() -ne '$stablePresentation = [Diagnostics.Stopwatch]::new()' -or
     $postHighContrastTryStatements[9].Extent.Text.Trim() -notmatch '(?s)^Wait-InteractiveWin11Until -Deadline \$deadline -Description ''post-High-Contrast canary framebuffer'' -Process \$canary\.Process -Condition \{\s*if \(\(\(Get-StatefulPixel \$canarySurface\.Hwnd\) -band 0xFFFFFF\) -ne \$ExpectedRgb\) \{\s*\$stablePresentation\.Reset\(\)\s*return \$false\s*\}\s*if \(-not \$stablePresentation\.IsRunning\) \{ \$stablePresentation\.Start\(\) \}\s*return \$stablePresentation\.Elapsed -ge \[TimeSpan\]::FromSeconds\(2\)\s*\}$' -or
-    $postHighContrastTryStatements[10].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
-    $postHighContrastTryStatements[11].Extent.Text.Trim() -ne 'Close-StatefulHost $canaryHost $canary $deadline' -or
-    $postHighContrastTryStatements[12].Extent.Text.Trim() -ne 'return') {
+    $postHighContrastTryStatements[10].Extent.Text.Trim() -ne '$presentationProven = $true' -or
+    $postHighContrastTryStatements[11].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $postHighContrastTryStatements[12].Extent.Text.Trim() -ne 'Close-StatefulHost $canaryHost $canary $deadline' -or
+    $postHighContrastTryStatements[13].Extent.Text.Trim() -ne 'return') {
     throw 'Post-High-Contrast presentation must preserve its exact launch, readiness, framebuffer, and close sequence with three fresh deadlines.'
 }
 $postHighContrastCatchStatements = @($postHighContrastTry.CatchClauses[0].Body.Statements)
-if ($postHighContrastCatchStatements.Count -ne 3 -or
+if ($postHighContrastCatchStatements.Count -ne 4 -or
     $postHighContrastCatchStatements[0].Extent.Text.Trim() -ne '$lastError = $_' -or
     $postHighContrastCatchStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$null -ne \$canary -and -not \$canary\.Process\.HasExited\) \{\s*try \{ Stop-InteractiveWin11Process -Process \$canary\.Process -Contained \}\s*catch \{\s*throw "Post-High-Contrast presentation attempt \$attempt failed: \$\(\$lastError\.Exception\.Message\); process cleanup also failed: \$\(\$_\.Exception\.Message\)"\s*\}\s*\}$' -or
-    $postHighContrastCatchStatements[2].Extent.Text.Trim() -ne 'if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }') {
+    $postHighContrastCatchStatements[2].Extent.Text.Trim() -ne 'if ($presentationProven) { return }' -or
+    $postHighContrastCatchStatements[3].Extent.Text.Trim() -ne 'if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }') {
     throw 'Post-High-Contrast presentation must preserve nullable failed-attempt cleanup and bounded retry reporting.'
 }
 $postHighContrastCalls = @($paletteThemeAst.FindAll({
@@ -1577,20 +1585,22 @@ $testCanaryMutationShape = {
         param($node)
         $node -is [System.Management.Automation.Language.ForEachStatementAst]
     }, $true))
-    if ($loops.Count -ne 1 -or $loops[0].Body.Statements.Count -ne 2 -or
-        $loops[0].Body.Statements[1] -isnot [System.Management.Automation.Language.TryStatementAst]) {
+    if ($loops.Count -ne 1 -or $loops[0].Body.Statements.Count -ne 3 -or
+        $loops[0].Body.Statements[1].Extent.Text.Trim() -ne '$presentationProven = $false' -or
+        $loops[0].Body.Statements[2] -isnot [System.Management.Automation.Language.TryStatementAst]) {
         return $false
     }
-    $statements = @($loops[0].Body.Statements[1].Body.Statements)
-    return $statements.Count -eq 13 -and
+    $statements = @($loops[0].Body.Statements[2].Body.Statements)
+    return $statements.Count -eq 14 -and
         $statements[0].Extent.Text.Trim() -eq '$canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"' -and
         $statements[1].Extent.Text.Trim() -eq '$runs.Add($canary)' -and
         $statements[2].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
         $statements[7].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
         $statements[8].Extent.Text.Trim() -eq '$stablePresentation = [Diagnostics.Stopwatch]::new()' -and
-        $statements[10].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
-        $statements[11].Extent.Text.Trim() -eq 'Close-StatefulHost $canaryHost $canary $deadline' -and
-        $statements[12].Extent.Text.Trim() -eq 'return'
+        $statements[10].Extent.Text.Trim() -eq '$presentationProven = $true' -and
+        $statements[11].Extent.Text.Trim() -eq '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -and
+        $statements[12].Extent.Text.Trim() -eq 'Close-StatefulHost $canaryHost $canary $deadline' -and
+        $statements[13].Extent.Text.Trim() -eq 'return'
 }
 $testMarkerMutationShape = {
     param([string] $Content)
@@ -1691,6 +1701,69 @@ foreach ($candidate in @($paletteThemeAst.FindAll({ param($node) $node -is [Syst
 if ($null -eq $paletteHighContrastCallIf -or
     -not (Test-DirectStatementBlockChild -Node $paletteHighContrastCallIf -StatementBlock $paletteMainTries[0].Body)) {
     throw 'High Contrast palette query call must be direct in its main-try ExerciseHighContrast block.'
+}
+$highContrastClause = @($paletteHighContrastCallIf.Clauses | Where-Object {
+    $_.Item1.Extent.Text.Trim() -eq '$ExerciseHighContrast' -and
+        (Test-DirectStatementBlockChild -Node $paletteHighContrastOpenCalls[0] -StatementBlock $_.Item2)
+})[0]
+$highContrastOpenStatement = Get-DirectStatementBlockChild `
+    -Node $paletteHighContrastOpenCalls[0] `
+    -StatementBlock $highContrastClause.Item2
+$highContrastOpenIndex = [Array]::IndexOf($highContrastClause.Item2.Statements, $highContrastOpenStatement)
+if ($highContrastOpenIndex -lt 1 -or $highContrastOpenIndex -ge ($highContrastClause.Item2.Statements.Count - 1) -or
+    $highContrastClause.Item2.Statements[$highContrastOpenIndex - 1].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $highContrastClause.Item2.Statements[$highContrastOpenIndex + 1].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)') {
+    throw 'High Contrast palette opening and suppression checks must each receive a fresh deadline.'
+}
+$highContrastStabilityWaits = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Wait-InteractiveWin11Until' -and
+        $node.Extent.Text -match "-Description '(?:stable High Contrast framebuffer|suppressed High Contrast theme preview)'"
+}, $true))
+if ($highContrastStabilityWaits.Count -ne 2 -or
+    @($highContrastStabilityWaits | Where-Object {
+        $_.Extent.Text -match [regex]::Escape('[TimeSpan]::FromSeconds(2)')
+    }).Count -ne 2 -or
+    @($highContrastStabilityWaits | Where-Object {
+        $_.Extent.Text -match [regex]::Escape('$hcPresentation.Stable.Restart()')
+    }).Count -ne 1 -or
+    @($highContrastStabilityWaits | Where-Object {
+        $_.Extent.Text -match [regex]::Escape("throw 'Theme preview changed terminal colors while High Contrast was active.'") -and
+            $_.Extent.Text -match [regex]::Escape('$suppressedPreviewStable.Reset()') -and
+            $_.Extent.Text -match [regex]::Escape('$previewPixel -band 0xFFFFFF) -eq $draculaRgb')
+    }).Count -ne 1) {
+    throw 'High Contrast theme preview must reject Dracula immediately and prove the original framebuffer stable for two seconds.'
+}
+$highContrastCloseCalls = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Close-StatefulHost $hcHost $hcRun $deadline'
+}, $true))
+$highContrastDismissCalls = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.Extent.Text.Trim() -eq 'Invoke-StatefulPostedCommand $hcHost 2004 $deadline $hcRun.Process'
+}, $true))
+$highContrastDismissWaits = @($paletteThemeAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'Wait-InteractiveWin11Until' -and
+        $node.Extent.Text -match "-Description 'High Contrast palette dismissal'" -and
+        $node.Extent.Text -match 'Where-Object Id -eq 2002\)\.Count -eq 0'
+}, $true))
+if ($highContrastCloseCalls.Count -ne 1 -or $highContrastDismissCalls.Count -ne 1 -or
+    $highContrastDismissWaits.Count -ne 1 -or
+    -not (Test-DirectStatementBlockChild -Node $highContrastDismissCalls[0] -StatementBlock $highContrastClause.Item2) -or
+    -not (Test-DirectStatementBlockChild -Node $highContrastDismissWaits[0] -StatementBlock $highContrastClause.Item2) -or
+    $highContrastCloseCalls[0].Parent.Parent -isnot [System.Management.Automation.Language.StatementBlockAst] -or
+    $highContrastCloseCalls[0].Parent.Parent.Parent -isnot [System.Management.Automation.Language.TryStatementAst] -or
+    $highContrastCloseCalls[0].Parent.Parent.Statements.Count -ne 2 -or
+    $highContrastCloseCalls[0].Parent.Parent.Statements[0].Extent.Text.Trim() -ne '$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)' -or
+    $highContrastCloseCalls[0].Parent.Parent.Parent.CatchClauses.Count -ne 1 -or
+    $highContrastCloseCalls[0].Parent.Parent.Parent.CatchClauses[0].Body.Extent.Text -notmatch
+        '(?s)Stop-InteractiveWin11Process -Process \$hcRun\.Process -Contained.*?Write-Warning') {
+    throw 'High Contrast palette dismissal must stay strict; only host-close timeout may become a warning after contained termination.'
 }
 $sessionRestoreTabSeedLoop = Get-PowerShellBlockText `
     -Content $sessionRestoreHarnessText `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -634,12 +634,24 @@ $processTreeExitedFunctions = @($interactiveWin11LibAst.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Test-InteractiveWin11ProcessTreeSnapshotExited'
     }, $true))
+$waitProcessTreeExitedFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Wait-InteractiveWin11ProcessTreeSnapshotExited'
+    }, $true))
+$stopRootHandleFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Stop-InteractiveWin11RootHandle'
+    }, $true))
 if ($stopProcessFunctions.Count -ne 1 -or
     $processTreeSnapshotFunctions.Count -ne 1 -or
     $processTreeExitedFunctions.Count -ne 1 -or
+    $waitProcessTreeExitedFunctions.Count -ne 1 -or
+    $stopRootHandleFunctions.Count -ne 1 -or
     -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
     -not [object]::ReferenceEquals($processTreeSnapshotFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
     -not [object]::ReferenceEquals($processTreeExitedFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    -not [object]::ReferenceEquals($waitProcessTreeExitedFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    -not [object]::ReferenceEquals($stopRootHandleFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
     @($interactiveWin11LibAst.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.TrapStatementAst]
@@ -649,7 +661,7 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $null -ne $stopProcessFunctions[0].Body.DynamicParamBlock -or
     $null -ne $stopProcessFunctions[0].Body.CleanBlock -or
     $null -eq $stopProcessFunctions[0].Body.ParamBlock -or
-    $stopProcessFunctions[0].Body.ParamBlock.Parameters.Count -ne 2 -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters.Count -ne 4 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Name.VariablePath.UserPath -ne 'Process' -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes.Count -ne 2 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[0].Attributes[0].Extent.Text.Trim() -ne '[Parameter(Mandatory)]' -or
@@ -658,8 +670,12 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Name.VariablePath.UserPath -ne 'RequireLiveRoot' -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes[0].Extent.Text.Trim() -ne '[switch]' -or
-    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue) {
-    throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
+    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[2].Name.VariablePath.UserPath -ne 'Contained' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[2].Attributes[0].Extent.Text.Trim() -ne '[switch]' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[3].Name.VariablePath.UserPath -ne 'AllowAlreadyExited' -or
+    $stopProcessFunctions[0].Body.ParamBlock.Parameters[3].Attributes[0].Extent.Text.Trim() -ne '[switch]') {
+    throw 'Interactive process cleanup must expose explicit contained, live-root, and already-exited contracts.'
 }
 $snapshotCimCommands = @($processTreeSnapshotFunctions[0].FindAll({
         param($node)
@@ -673,36 +689,66 @@ $snapshotCalls = @($stopProcessFunctions[0].FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Get-InteractiveWin11ProcessTreeSnapshot'
     }, $true))
-$verificationCalls = @($stopProcessFunctions[0].FindAll({
+$rootStopCalls = @($stopProcessFunctions[0].FindAll({
         param($node)
-        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Test-InteractiveWin11ProcessTreeSnapshotExited'
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Stop-InteractiveWin11RootHandle'
+    }, $true))
+$waitCalls = @($stopProcessFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Wait-InteractiveWin11ProcessTreeSnapshotExited'
+    }, $true))
+$stopProcessText = $stopProcessFunctions[0].Extent.Text
+$rootTerminateCalls = @($stopRootHandleFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $node.Extent.Text -eq '[InteractiveWin11ProcessNative]::TerminateProcess($RootProcessHandle, 1)'
+    }, $true))
+$rootWaitCalls = @($stopRootHandleFunctions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $node.Extent.Text -eq '[InteractiveWin11ProcessNative]::WaitForSingleObject($RootProcessHandle, 5000)'
     }, $true))
 if ($snapshotCimCommands.Count -ne 1 -or
     $verificationCimCommands.Count -ne 1 -or
-    $snapshotCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process\s+-ErrorAction\s+Stop' -or
-    $verificationCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process\s+-ErrorAction\s+Stop' -or
+    $snapshotCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process\s+-OperationTimeoutSec\s+5\s+-ErrorAction\s+Stop' -or
+    $verificationCimCommands[0].Extent.Text -notmatch '(?s)-ClassName\s+Win32_Process.*?-OperationTimeoutSec\s+\$OperationTimeoutSec.*?-ErrorAction\s+Stop' -or
     $snapshotCimCommands[0].Extent.Text -match '(?i)-Filter\b' -or
     $verificationCimCommands[0].Extent.Text -match '(?i)-Filter\b' -or
     @($processTreeSnapshotFunctions[0].FindAll({ param($node) $node -is [System.Management.Automation.Language.CatchClauseAst] }, $true)).Count -ne 0 -or
     @($processTreeExitedFunctions[0].FindAll({ param($node) $node -is [System.Management.Automation.Language.CatchClauseAst] }, $true)).Count -ne 0 -or
-    $snapshotCalls.Count -ne 2 -or
-    $verificationCalls.Count -lt 3) {
-    throw 'Interactive cleanup must take coherent fail-closed process-table snapshots before kill and fallback, then verify every exit path.'
+    $snapshotCalls.Count -ne 1 -or
+    $rootStopCalls.Count -ne 1 -or
+    $waitCalls.Count -ne 1 -or
+    $snapshotCalls[0].Extent.StartOffset -ge $rootStopCalls[0].Extent.StartOffset -or
+    $rootStopCalls[0].Extent.StartOffset -ge $waitCalls[0].Extent.StartOffset -or
+    $rootTerminateCalls.Count -ne 1 -or
+    $rootWaitCalls.Count -ne 1 -or
+    $stopProcessText -notmatch '(?s)if \(-not \$Contained\).*?taskkill\.exe.*?WaitForExit\(10000\).*?Kill\(\).*?WaitForExit\(5000\)' -or
+    $stopProcessText -notmatch '(?s)\$taskkillCleanupError.*?if \(\$null -ne \$taskkillCleanupError\)\s*\{\s*throw' -or
+    $stopProcessText -notmatch '(?s)if \(\$Contained -and \$null -ne \$snapshotError\).*?return' -or
+    $stopProcessText -notmatch '(?s)\$lifecycleModeCount.*?if \(\$lifecycleModeCount -gt 1\).*?mutually exclusive' -or
+    $stopProcessText -notmatch '(?s)if \(\$null -ne \$verificationError\).*?if \(\$Contained\).*?return.*?throw' -or
+    $waitProcessTreeExitedFunctions[0].Extent.Text -notmatch '(?s)\$deadline\s*=\s*\[DateTime\]::UtcNow\.AddSeconds\(\$TimeoutSeconds\).*?while \(\[DateTime\]::UtcNow -lt \$deadline\)') {
+    throw 'Interactive cleanup must use bounded uncontained tree kill, contained Job cleanup, native root termination, and deadline-bound verification.'
 }
 
-Invoke-Expression $processTreeSnapshotFunctions[0].Extent.Text
-Invoke-Expression $processTreeExitedFunctions[0].Extent.Text
+. ([scriptblock]::Create($processTreeSnapshotFunctions[0].Extent.Text))
+. ([scriptblock]::Create($processTreeExitedFunctions[0].Extent.Text))
 $script:verificationCimProcesses = @()
 $script:verificationCimFailure = $null
 function script:Get-CimInstance {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [string] $ClassName,
-        [string] $Filter
+        [string] $Filter,
+        [uint32] $OperationTimeoutSec
     )
 
-    if ($ClassName -ne 'Win32_Process' -or $PSBoundParameters.ContainsKey('Filter')) {
-        throw 'Verification mock requires one unfiltered Win32_Process query.'
+    if ($ClassName -ne 'Win32_Process' -or
+        $PSBoundParameters.ContainsKey('Filter') -or
+        $OperationTimeoutSec -lt 1 -or
+        $OperationTimeoutSec -gt 5) {
+        throw 'Verification mock requires one bounded, unfiltered Win32_Process query.'
     }
     if ($null -ne $script:verificationCimFailure) {
         throw $script:verificationCimFailure
@@ -718,9 +764,10 @@ try {
         [pscustomobject]@{ ProcessId = 100; ParentProcessId = 4; CreationDate = $rootCreated },
         [pscustomobject]@{ ProcessId = 101; ParentProcessId = 100; CreationDate = $childCreated },
         [pscustomobject]@{ ProcessId = 102; ParentProcessId = 101; CreationDate = $grandchildCreated },
+        [pscustomobject]@{ ProcessId = 103; ParentProcessId = 100; CreationDate = $rootCreated.AddMinutes(-1) },
         [pscustomobject]@{ ProcessId = 200; ParentProcessId = 4; CreationDate = $rootCreated }
     )
-    $snapshot = @(Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100)
+    $snapshot = @(Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100 -RootStartedAt $rootCreated)
     if ((@($snapshot.ProcessId | Sort-Object) -join ',') -ne '100,101,102') {
         throw 'Interactive process snapshot did not close over the full descendant tree.'
     }
@@ -742,19 +789,34 @@ try {
     if (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot) {
         throw 'Interactive process verification missed a child created after the snapshot.'
     }
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 201; ParentProcessId = 100; CreationDate = $rootCreated.AddMinutes(-1) }
+    )
+    if (-not (Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot)) {
+        throw 'Interactive process verification confused a stale child from a reused parent PID with a live descendant.'
+    }
 
     $script:verificationCimProcesses = @(
         [pscustomobject]@{ ProcessId = 200; ParentProcessId = 4; CreationDate = $rootCreated }
     )
     $missingRootRejected = $false
-    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100) } catch { $missingRootRejected = $true }
+    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100 -RootStartedAt $rootCreated) } catch { $missingRootRejected = $true }
     if (-not $missingRootRejected) {
         throw 'Interactive process snapshot accepted a missing root identity.'
     }
 
+    $script:verificationCimProcesses = @(
+        [pscustomobject]@{ ProcessId = 100; ParentProcessId = 4; CreationDate = $rootCreated.AddMinutes(1) }
+    )
+    $reusedRootRejected = $false
+    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100 -RootStartedAt $rootCreated) } catch { $reusedRootRejected = $true }
+    if (-not $reusedRootRejected) {
+        throw 'Interactive process snapshot accepted a reused root PID.'
+    }
+
     $script:verificationCimFailure = 'simulated CIM failure'
     $snapshotFailureRejected = $false
-    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100) } catch { $snapshotFailureRejected = $true }
+    try { [void](Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId 100 -RootStartedAt $rootCreated) } catch { $snapshotFailureRejected = $true }
     $verificationFailureRejected = $false
     try { [void](Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $snapshot) } catch { $verificationFailureRejected = $true }
     if (-not $snapshotFailureRejected -or -not $verificationFailureRejected) {
@@ -764,6 +826,190 @@ try {
 finally {
     Remove-Item -LiteralPath Function:\Get-CimInstance -ErrorAction SilentlyContinue
     Remove-Variable -Scope Script -Name verificationCimProcesses, verificationCimFailure -ErrorAction SilentlyContinue
+}
+
+. ([scriptblock]::Create($stopProcessFunctions[0].Extent.Text))
+$script:cleanupSnapshotFailure = $false
+$script:cleanupVerificationFailure = $false
+$script:cleanupVerificationExited = $true
+function script:Get-InteractiveWin11ProcessTreeSnapshot {
+    param([int] $RootProcessId, [datetime] $RootStartedAt)
+    if ($script:cleanupSnapshotFailure) { throw 'simulated snapshot failure' }
+    @([pscustomobject]@{ ProcessId = $RootProcessId; CreationDate = $RootStartedAt })
+}
+function script:Stop-InteractiveWin11RootHandle {
+    param(
+        [System.Diagnostics.Process] $Process,
+        [IntPtr] $RootProcessHandle,
+        [datetime] $RootStartedAt
+    )
+    $Process.Kill()
+    if (-not $Process.WaitForExit(5000)) { throw 'mock root process did not exit' }
+}
+function script:Wait-InteractiveWin11ProcessTreeSnapshotExited {
+    param([object[]] $Snapshot)
+    if ($script:cleanupVerificationFailure) { throw 'simulated verification query failure' }
+    $script:cleanupVerificationExited
+}
+function script:Start-CleanupContractProcess {
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = Join-Path $PSHOME 'pwsh.exe'
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.ArgumentList.Add('-NoProfile')
+    $startInfo.ArgumentList.Add('-Command')
+    $startInfo.ArgumentList.Add('Start-Sleep -Seconds 30')
+    [System.Diagnostics.Process]::Start($startInfo)
+}
+try {
+    $process = Start-CleanupContractProcess
+    $script:cleanupVerificationFailure = $true
+    Stop-InteractiveWin11Process -Process $process -Contained
+    if (-not $process.HasExited) {
+        throw 'Contained cleanup did not terminate the root before accepting unavailable verification.'
+    }
+    $process.Dispose()
+    $process = $null
+
+    $process = Start-CleanupContractProcess
+    $script:cleanupVerificationFailure = $false
+    $script:cleanupVerificationExited = $false
+    $liveDescendantRejected = $false
+    try { Stop-InteractiveWin11Process -Process $process -Contained } catch { $liveDescendantRejected = $true }
+    if (-not $liveDescendantRejected -or -not $process.HasExited) {
+        throw 'Contained cleanup accepted a successful verification query that reported live descendants.'
+    }
+    $process.Dispose()
+    $process = $null
+
+    $process = Start-CleanupContractProcess
+    $script:cleanupSnapshotFailure = $true
+    $script:cleanupVerificationExited = $true
+    Stop-InteractiveWin11Process -Process $process -Contained
+    if (-not $process.HasExited) {
+        throw 'Contained cleanup did not terminate the root after initial snapshot failure.'
+    }
+    $process.Dispose()
+    $process = $null
+
+    $process = Start-CleanupContractProcess
+    $script:cleanupSnapshotFailure = $true
+    Stop-InteractiveWin11Process -Process $process -AllowAlreadyExited
+    if (-not $process.HasExited) {
+        throw 'Already-exited cleanup did not terminate the root after a snapshot race.'
+    }
+    $process.Dispose()
+    $process = $null
+
+    $conflictingModesRejected = $false
+    try {
+        Stop-InteractiveWin11Process `
+            -Process ([System.Diagnostics.Process]::GetCurrentProcess()) `
+            -Contained `
+            -RequireLiveRoot
+    }
+    catch { $conflictingModesRejected = $true }
+    if (-not $conflictingModesRejected) {
+        throw 'Interactive cleanup accepted conflicting lifecycle modes.'
+    }
+}
+finally {
+    if ($null -ne $process) {
+        if (-not $process.HasExited) { $process.Kill() }
+        $process.Dispose()
+    }
+    Remove-Item -LiteralPath Function:\Get-InteractiveWin11ProcessTreeSnapshot -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath Function:\Stop-InteractiveWin11RootHandle -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath Function:\Wait-InteractiveWin11ProcessTreeSnapshotExited -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath Function:\Start-CleanupContractProcess -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath Function:\Stop-InteractiveWin11Process -ErrorAction SilentlyContinue
+    Remove-Variable -Scope Script -Name cleanupSnapshotFailure, cleanupVerificationFailure, cleanupVerificationExited -ErrorAction SilentlyContinue
+}
+
+$containmentFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Get-InteractiveWin11ContainmentArguments'
+    }, $true))
+$launchArgumentFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Get-InteractiveWin11LaunchArguments'
+    }, $true))
+if ($containmentFunctions.Count -ne 1 -or
+    $launchArgumentFunctions.Count -ne 1 -or
+    $containmentFunctions[0].Extent.Text -notmatch [regex]::Escape("'--linux-cgroup=always'") -or
+    $containmentFunctions[0].Extent.Text -notmatch [regex]::Escape("'--linux-cgroup-hard-fail=true'") -or
+    $containmentFunctions[0].Extent.Text -notmatch [regex]::Escape("'--windows-job-object-kill-on-close=true'") -or
+    $launchArgumentFunctions[0].Extent.Text -notmatch '\bGet-InteractiveWin11ContainmentArguments\b') {
+    throw 'Interactive Win11 launches must opt into hard-fail kill-on-close Job Object containment.'
+}
+$interactiveHarnessFiles = @(
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot 'test\windows') -Filter 'interactive-win11-*.ps1' -File
+)
+$launchContainmentViolations = [Collections.Generic.List[string]]::new()
+$forbiddenConfigOverrides = [Collections.Generic.List[string]]::new()
+foreach ($file in @($interactiveHarnessFiles) + @(Get-Item -LiteralPath $interactiveWin11Lib)) {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    foreach ($match in [regex]::Matches($content, '[''"]--single-instance=false[''"]')) {
+        $prefixStart = [math]::Max(0, $match.Index - 512)
+        $prefix = $content.Substring($prefixStart, $match.Index - $prefixStart)
+        if ($prefix -notmatch '\bGet-InteractiveWin11(?:Launch|Containment)Arguments\b') {
+            [void]$launchContainmentViolations.Add("$($file.Name):$($match.Index)")
+        }
+    }
+    if ($file.FullName -ne $interactiveWin11Lib -and
+        $content -match '(?im)^\s*(?:linux-cgroup|linux-cgroup-hard-fail|windows-job-object-kill-on-close)\s*=') {
+        [void]$forbiddenConfigOverrides.Add($file.Name)
+    }
+}
+if ($launchContainmentViolations.Count -ne 0) {
+    throw "Interactive launch arguments bypass Job Object containment: $($launchContainmentViolations -join ', ')"
+}
+if ($forbiddenConfigOverrides.Count -ne 0) {
+    throw "Interactive harness config overrides CLI containment: $($forbiddenConfigOverrides -join ', ')"
+}
+
+$cleanupContractViolations = [Collections.Generic.List[string]]::new()
+$cleanupScriptFiles = @(
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot 'test\windows') -Filter '*.ps1' -File -Recurse |
+        Where-Object { $_.FullName -ne $PSCommandPath }
+)
+foreach ($file in $cleanupScriptFiles) {
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -ne 0) {
+        throw "PowerShell parser errors while checking cleanup contract: $($file.FullName)"
+    }
+    foreach ($command in @($ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq 'Stop-InteractiveWin11Process'
+            }, $true))) {
+        $text = $command.Extent.Text
+        $modeCount = @(
+            $text -match '(?i)(?:^|\s)-Contained(?:\s|$)'
+            $text -match '(?i)(?:^|\s)-RequireLiveRoot(?:\s|$)'
+            $text -match '(?i)(?:^|\s)-AllowAlreadyExited(?:\s|$)'
+        ).Where({ $_ }).Count
+        # The composite validator is a byte-for-byte frozen baseline artifact.
+        # Mode omission uses Stop-InteractiveWin11Process's fail-closed live-root
+        # default; every mutable caller must state exactly one lifecycle mode.
+        $frozenValidatorDefault = $file.Name -eq 'interactive-win11-validate.ps1' -and $modeCount -eq 0
+        if ((-not $frozenValidatorDefault -and $modeCount -ne 1) -or
+            ($text -match '(?i)(?:^|\s)-AllowAlreadyExited(?:\s|$)' -and $file.Name -ne 'vt-probe-win32-conformance.ps1')) {
+            [void]$cleanupContractViolations.Add("$($file.Name):$($command.Extent.StartLineNumber): $text")
+        }
+    }
+}
+if ($cleanupContractViolations.Count -ne 0) {
+    throw "Interactive cleanup calls lack exactly one explicit lifecycle contract:`n$($cleanupContractViolations -join "`n")"
+}
+$jobObjectSource = Get-Content -LiteralPath (Join-Path $repoRoot 'src\apprt\win32_job_object.zig') -Raw
+$commandSource = Get-Content -LiteralPath (Join-Path $repoRoot 'src\Command.zig') -Raw
+if ($jobObjectSource -notmatch 'JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE' -or
+    $jobObjectSource -notmatch 'kill_on_close' -or
+    $commandSource -notmatch '(?s)CREATE_SUSPENDED.*?AssignProcessToJobObject.*?ResumeThread') {
+    throw 'Windows child containment must assign the suspended process to a kill-on-close Job Object before resume.'
 }
 
 Assert-TextContract `
@@ -778,23 +1024,13 @@ Assert-TextContract `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('$taskkillTerminationVerified = $taskkill.WaitForExit(10000)')) `
-    -Description 'interactive cleanup keeps bounded taskkill wait' `
+    -Pattern ([regex]::Escape('$capturedStartedAtById[$parentProcessId]')) `
+    -Description 'interactive cleanup fails closed on identity-matched descendants created after snapshot' `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('$taskkill.Kill()')) `
-    -Description 'interactive cleanup kills wedged taskkill process' `
-    -Context $interactiveWin11Lib
-Assert-TextContract `
-    -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('$capturedProcessIds.Contains([int]$process.ParentProcessId)')) `
-    -Description 'interactive cleanup fails closed on descendants created after snapshot' `
-    -Context $interactiveWin11Lib
-Assert-TextContract `
-    -Content $interactiveWin11LibText `
-    -Pattern ([regex]::Escape('$rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)')) `
-    -Description 'interactive cleanup preserves native root fallback termination' `
+    -Pattern ([regex]::Escape('$terminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($RootProcessHandle, 1)')) `
+    -Description 'interactive cleanup terminates only the captured root handle' `
     -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
@@ -805,6 +1041,11 @@ Assert-TextContract `
     -Content $interactiveWin11LibText `
     -Pattern ([regex]::Escape('public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);')) `
     -Description 'native root fallback termination declaration' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);')) `
+    -Description 'native root termination wait declaration' `
     -Context $interactiveWin11Lib
 $expectedCliShellHarnessText = @'
 param(
@@ -1218,7 +1459,7 @@ if ($postHighContrastTry.CatchClauses.Count -ne 1 -or $null -ne $postHighContras
 $postHighContrastCatchStatements = @($postHighContrastTry.CatchClauses[0].Body.Statements)
 if ($postHighContrastCatchStatements.Count -ne 3 -or
     $postHighContrastCatchStatements[0].Extent.Text.Trim() -ne '$lastError = $_' -or
-    $postHighContrastCatchStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$null -ne \$canary -and -not \$canary\.Process\.HasExited\) \{\s*try \{ Stop-InteractiveWin11Process -Process \$canary\.Process \}\s*catch \{\s*throw "Post-High-Contrast presentation attempt \$attempt failed: \$\(\$lastError\.Exception\.Message\); process cleanup also failed: \$\(\$_\.Exception\.Message\)"\s*\}\s*\}$' -or
+    $postHighContrastCatchStatements[1].Extent.Text.Trim() -notmatch '(?s)^if \(\$null -ne \$canary -and -not \$canary\.Process\.HasExited\) \{\s*try \{ Stop-InteractiveWin11Process -Process \$canary\.Process -Contained \}\s*catch \{\s*throw "Post-High-Contrast presentation attempt \$attempt failed: \$\(\$lastError\.Exception\.Message\); process cleanup also failed: \$\(\$_\.Exception\.Message\)"\s*\}\s*\}$' -or
     $postHighContrastCatchStatements[2].Extent.Text.Trim() -ne 'if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }') {
     throw 'Post-High-Contrast presentation must preserve nullable failed-attempt cleanup and bounded retry reporting.'
 }

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -629,11 +629,20 @@ $stopProcessFunctions = @($interactiveWin11LibAst.FindAll({
 $stopProcessStatements = if ($stopProcessFunctions.Count -eq 1) {
     @($stopProcessFunctions[0].Body.EndBlock.Statements)
 } else { @() }
-$stopIdentityTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[4] } else { $null }
-$stopTaskkillTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[9] } else { $null }
-$stopManagedTry = if ($stopProcessStatements.Count -eq 11) { $stopProcessStatements[10] } else { $null }
+$processTreeSnapshotFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Get-InteractiveWin11ProcessTreeSnapshot'
+    }, $true))
+$processTreeExitedFunctions = @($interactiveWin11LibAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Test-InteractiveWin11ProcessTreeSnapshotExited'
+    }, $true))
 if ($stopProcessFunctions.Count -ne 1 -or
+    $processTreeSnapshotFunctions.Count -ne 1 -or
+    $processTreeExitedFunctions.Count -ne 1 -or
     -not [object]::ReferenceEquals($stopProcessFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    -not [object]::ReferenceEquals($processTreeSnapshotFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
+    -not [object]::ReferenceEquals($processTreeExitedFunctions[0].Parent, $interactiveWin11LibAst.EndBlock) -or
     @($interactiveWin11LibAst.FindAll({
         param($node)
         $node -is [System.Management.Automation.Language.TrapStatementAst]
@@ -652,156 +661,39 @@ if ($stopProcessFunctions.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Name.VariablePath.UserPath -ne 'RequireLiveRoot' -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes.Count -ne 1 -or
     $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].Attributes[0].Extent.Text.Trim() -ne '[switch]' -or
-    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue -or
-    $stopProcessStatements.Count -ne 11 -or
-    $stopProcessStatements[0].Extent.Text.Trim() -ne '$rootProcessId = $Process.Id' -or
-    $stopProcessStatements[1].Extent.Text.Trim() -ne '$rootProcessHandle = [IntPtr]::Zero' -or
-    $stopProcessStatements[2].Extent.Text.Trim() -ne '$rootStartedAt = $null' -or
-    $stopProcessStatements[3].Extent.Text.Trim() -ne '$rootIsLive = $false' -or
-    $stopIdentityTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    $stopIdentityTry.Body.Statements.Count -ne 2 -or
-    $stopIdentityTry.CatchClauses.Count -ne 1 -or
-    $null -ne $stopIdentityTry.Finally -or
-    $stopIdentityTry.CatchClauses[0].CatchTypes.Count -ne 1 -or
-    $stopIdentityTry.CatchClauses[0].CatchTypes[0].TypeName.FullName -ne 'System.InvalidOperationException' -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopIdentityTry.CatchClauses[0].Body.Statements[0].ElseClause -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$VerbosePreference -eq ''Continue''' -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopIdentityTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'Write-Verbose "Interactive Win11 process $rootProcessId identity check raced with exit: $($_.Exception.Message)"' -or
-    $stopIdentityTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
-    $stopIdentityTry.Body.Statements[1] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopIdentityTry.Body.Statements[1].Clauses.Count -ne 1 -or
-    $null -ne $stopIdentityTry.Body.Statements[1].ElseClause -or
-    $stopIdentityTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $Process.HasExited' -or
-    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 3 -or
-    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$rootProcessHandle = $Process.Handle' -or
-    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne '$rootStartedAt = $Process.StartTime' -or
-    $stopIdentityTry.Body.Statements[1].Clauses[0].Item2.Statements[2].Extent.Text.Trim() -ne '$rootIsLive = $true' -or
-    $stopProcessStatements[5] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopProcessStatements[5].Clauses.Count -ne 1 -or
-    $null -ne $stopProcessStatements[5].ElseClause -or
-    $stopProcessStatements[5].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootIsLive' -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements.Count -ne 2 -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopProcessStatements[5].Clauses[0].Item2.Statements[0].ElseClause -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopProcessStatements[5].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "Interactive Win11 process $rootProcessId exited before process-tree cleanup could be verified."' -or
-    $stopProcessStatements[6].Extent.Text.Trim() -ne '$taskkillError = $null' -or
-    $stopProcessStatements[7].Extent.Text.Trim() -ne '$taskkill = $null' -or
-    $stopProcessStatements[8].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $true' -or
-    $stopTaskkillTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    $stopTaskkillTry.Body.Statements.Count -ne 10 -or
-    $stopTaskkillTry.CatchClauses.Count -ne 1 -or
-    $null -eq $stopTaskkillTry.Finally -or
-    $stopTaskkillTry.Body.Statements[0].Extent.Text.Trim() -ne '$taskkillStartInfo = [System.Diagnostics.ProcessStartInfo]::new()' -or
-    $stopTaskkillTry.Body.Statements[1].Extent.Text.Trim() -ne '$taskkillStartInfo.FileName = Join-Path ([Environment]::SystemDirectory) ''taskkill.exe''' -or
-    $stopTaskkillTry.Body.Statements[2].Extent.Text.Trim() -ne '$taskkillStartInfo.UseShellExecute = $false' -or
-    $stopTaskkillTry.Body.Statements[3].Extent.Text.Trim() -ne '$taskkillStartInfo.CreateNoWindow = $true' -or
-    $stopTaskkillTry.Body.Statements[4].Extent.Text.Trim() -ne '$taskkillStartInfo.Arguments = "/PID $rootProcessId /T /F"' -or
-    $stopTaskkillTry.Body.Statements[5].Extent.Text.Trim() -ne '$taskkill = [System.Diagnostics.Process]::Start($taskkillStartInfo)' -or
-    $stopTaskkillTry.Body.Statements[6].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $false' -or
-    $stopTaskkillTry.Body.Statements[7].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $taskkill.WaitForExit(10000)' -or
-    $stopTaskkillTry.Body.Statements[8] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopTaskkillTry.Body.Statements[8].Clauses.Count -ne 2 -or
-    $null -ne $stopTaskkillTry.Body.Statements[8].ElseClause -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements.Count -ne 4 -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Kill()' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne '$taskkillTerminationVerified = $taskkill.WaitForExit(5000)' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses.Count -ne 1 -or
-    $null -ne $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].ElseClause -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[2].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''taskkill could not be stopped within 5 seconds''' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[0].Item2.Statements[3].Extent.Text.Trim() -ne '$taskkillError = ''taskkill exceeded 10 seconds''' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item1.Extent.Text.Trim() -ne '$taskkill.ExitCode -ne 0' -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item2.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Body.Statements[8].Clauses[1].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkillError = "taskkill exited with code $($taskkill.ExitCode)"' -or
-    $stopTaskkillTry.Body.Statements[9] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopTaskkillTry.Body.Statements[9].Clauses.Count -ne 1 -or
-    $null -ne $stopTaskkillTry.Body.Statements[9].ElseClause -or
-    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item1.Extent.Text.Trim() -ne '$null -eq $taskkillError -and $Process.WaitForExit(5000)' -or
-    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Body.Statements[9].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements.Count -ne 2 -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopTaskkillTry.CatchClauses[0].Body.Statements[0].ElseClause -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $taskkillTerminationVerified' -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw' -or
-    $stopTaskkillTry.CatchClauses[0].Body.Statements[1].Extent.Text.Trim() -ne '$taskkillError = $_.Exception.Message' -or
-    $stopTaskkillTry.Finally.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Finally.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopTaskkillTry.Finally.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopTaskkillTry.Finally.Statements[0].ElseClause -or
-    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$null -ne $taskkill' -or
-    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopTaskkillTry.Finally.Statements[0].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne '$taskkill.Dispose()' -or
-    $stopManagedTry -isnot [System.Management.Automation.Language.TryStatementAst] -or
-    $stopManagedTry.Body.Statements.Count -ne 9 -or
-    $stopManagedTry.CatchClauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Finally -or
-    $stopManagedTry.Body.Statements[0].Extent.Text.Trim() -ne '$Process.Refresh()' -or
-    $stopManagedTry.Body.Statements[1] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[1].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[1].ElseClause -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item1.Extent.Text.Trim() -ne '$Process.HasExited -or $Process.StartTime -ne $rootStartedAt' -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements.Count -ne 2 -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].ElseClause -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[1].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw ''the root exited before fallback cleanup could verify the process tree''' -or
-    $stopManagedTry.Body.Statements[2].Extent.Text.Trim() -ne 'Initialize-InteractiveWin11ProcessNative' -or
-    $stopManagedTry.Body.Statements[3].Extent.Text.Trim() -ne '$rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)' -or
-    $stopManagedTry.Body.Statements[4].Extent.Text.Trim() -ne '$terminationError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()' -or
-    $stopManagedTry.Body.Statements[5].Extent.Text.Trim() -ne '$rootExited = $Process.WaitForExit(5000)' -or
-    $stopManagedTry.Body.Statements[6] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[6].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[6].ElseClause -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootTerminationRequested' -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements.Count -ne 2 -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].ElseClause -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '$rootExited' -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 2 -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].ElseClause -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $RequireLiveRoot' -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[0] -isnot [System.Management.Automation.Language.ReturnStatementAst] -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[1] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[0].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw ''the root exited before fallback cleanup could verify the process tree''' -or
-    $stopManagedTry.Body.Statements[6].Clauses[0].Item2.Statements[1].Extent.Text.Trim() -ne 'throw "root fallback termination failed with Win32 error $terminationError; the root remained live after 5 seconds"' -or
-    $stopManagedTry.Body.Statements[7] -isnot [System.Management.Automation.Language.IfStatementAst] -or
-    $stopManagedTry.Body.Statements[7].Clauses.Count -ne 1 -or
-    $null -ne $stopManagedTry.Body.Statements[7].ElseClause -or
-    $stopManagedTry.Body.Statements[7].Clauses[0].Item1.Extent.Text.Trim() -ne '-not $rootExited' -or
-    $stopManagedTry.Body.Statements[7].Clauses[0].Item2.Statements.Count -ne 1 -or
-    $stopManagedTry.Body.Statements[7].Clauses[0].Item2.Statements[0].Extent.Text.Trim() -ne 'throw ''root fallback did not stop the process within 5 seconds''' -or
-    $stopManagedTry.Body.Statements[8] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.Body.Statements[8].Extent.Text.Trim() -ne 'throw ''root fallback stopped the process but could not verify descendant cleanup''' -or
-    $stopManagedTry.CatchClauses[0].Body.Statements.Count -ne 1 -or
-    $stopManagedTry.CatchClauses[0].Body.Statements[0] -isnot [System.Management.Automation.Language.ThrowStatementAst] -or
-    $stopManagedTry.CatchClauses[0].Body.Statements[0].Extent.Text.Trim() -ne 'throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId (taskkill=''$taskkillError'', fallback=''$($_.Exception.Message)'')."') {
+    $null -ne $stopProcessFunctions[0].Body.ParamBlock.Parameters[1].DefaultValue) {
     throw 'Interactive process cleanup must remain live, bounded, identity-checked, and fail closed around native tree kill and root-only fallback.'
 }
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('$processTreeSnapshot = Get-InteractiveWin11ProcessTreeSnapshot -RootProcessId $rootProcessId')) `
+    -Description 'interactive cleanup snapshots root process tree before kill' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('$taskkillTerminationVerified = $taskkill.WaitForExit(10000)')) `
+    -Description 'interactive cleanup keeps bounded taskkill wait' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('$taskkill.Kill()')) `
+    -Description 'interactive cleanup kills wedged taskkill process' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('Test-InteractiveWin11ProcessTreeSnapshotExited -Snapshot $processTreeSnapshot')) `
+    -Description 'interactive cleanup verifies captured descendants after fallback' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('$rootTerminationRequested = [InteractiveWin11ProcessNative]::TerminateProcess($rootProcessHandle, 1)')) `
+    -Description 'interactive cleanup preserves native root fallback termination' `
+    -Context $interactiveWin11Lib
+Assert-TextContract `
+    -Content $interactiveWin11LibText `
+    -Pattern ([regex]::Escape('throw "Failed to verify cleanup of interactive Win11 process tree $rootProcessId')) `
+    -Description 'interactive cleanup still fails closed on unverified process tree' `
+    -Context $interactiveWin11Lib
 Assert-TextContract `
     -Content $interactiveWin11LibText `
     -Pattern ([regex]::Escape('public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);')) `

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -261,7 +261,7 @@ try {
     } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $artifact -Encoding utf8
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 Write-Host "interactive Win11 accessibility: PASS ($artifact)"

--- a/test/windows/interactive-win11-boo-multitab.ps1
+++ b/test/windows/interactive-win11-boo-multitab.ps1
@@ -552,7 +552,7 @@ $(Get-InteractiveWin11TextFileTail -Path $stderrPath)
         throw "unexpected post-boo key input result: $($result | ConvertTo-Json -Compress)"
     }
 
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
     $process = $null
 
     Wait-InteractiveWin11Until -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'post-exit trace files' -Condition {
@@ -590,6 +590,6 @@ finally {
     }
 
     if ($null -ne $process) {
-        Stop-InteractiveWin11Process -Process $process
+        Stop-InteractiveWin11Process -Process $process -Contained
     }
 }

--- a/test/windows/interactive-win11-boo-performance.ps1
+++ b/test/windows/interactive-win11-boo-performance.ps1
@@ -95,6 +95,7 @@ try {
     $process = Start-Process `
         -FilePath $exePath `
         -ArgumentList @(
+            Get-InteractiveWin11ContainmentArguments
             '--single-instance=false'
             "--class=winghostty-boo-performance-$($layout.SandboxId)"
             '-e'
@@ -224,6 +225,6 @@ finally {
     }
 
     if ($null -ne $process) {
-        Stop-InteractiveWin11Process -Process $process
+        Stop-InteractiveWin11Process -Process $process -Contained
     }
 }

--- a/test/windows/interactive-win11-command-finish.ps1
+++ b/test/windows/interactive-win11-command-finish.ps1
@@ -82,6 +82,7 @@ $notificationsEnabled = $settingText -eq 'Enabled'
 Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
 
 $launchArgs = @(
+    Get-InteractiveWin11ContainmentArguments
     '--single-instance=false'
     "--class=winghostty-command-finish-$($layout.SandboxId)"
     "--config-file=$configPath"
@@ -146,7 +147,7 @@ try {
     }
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 if (-not $validated) {

--- a/test/windows/interactive-win11-configured-size.ps1
+++ b/test/windows/interactive-win11-configured-size.ps1
@@ -85,6 +85,7 @@ Start-Sleep -Seconds 30
 Remove-Item -LiteralPath $stdoutPath, $stderrPath, $resultPath -ErrorAction SilentlyContinue
 
 $launchArgs = @(
+    Get-InteractiveWin11ContainmentArguments
     '--single-instance=false'
     "--class=winghostty-configured-size-$($layout.SandboxId)"
     "--config-file=$configPath"
@@ -183,7 +184,7 @@ try {
     }
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 Write-Host "interactive-win11 configured-size validation: PASS (pty=${width}x${height}, dpi=$dpi, result=$resultPath, stderr=$stderrPath)"

--- a/test/windows/interactive-win11-ime-candidate.ps1
+++ b/test/windows/interactive-win11-ime-candidate.ps1
@@ -330,6 +330,7 @@ Start-Sleep -Seconds 30
 Remove-Item -LiteralPath $stdoutPath, $stderrPath, $readyPath, $tracePath, $resultPath -ErrorAction SilentlyContinue
 
 $launchArgs = @(
+    Get-InteractiveWin11ContainmentArguments
     '--single-instance=false'
     "--class=$instanceClass"
     "--config-file=$configPath"
@@ -487,7 +488,7 @@ finally {
         }
     }
 
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
     if ($null -eq $previousImeTraceFile) {
         Remove-Item Env:WINGHOSTTY_WIN32_IME_FORM_TRACE_FILE -ErrorAction SilentlyContinue
     }

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -449,5 +449,5 @@ try {
     Write-Host ("interactive-win11 key-input validation: PASS (scenario={0}, key={1}, route={2}, mode={3}, focus-class={4}, stdout={5}, stderr={6}, result={7}{8})" -f $scenario, $Key, $Route, $deliveryMode, $focusClass, $stdoutPath, $stderrPath, $resultPath, $extra)
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }

--- a/test/windows/interactive-win11-new-tab.ps1
+++ b/test/windows/interactive-win11-new-tab.ps1
@@ -291,6 +291,7 @@ function Invoke-NewTabScenario {
     Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
 
     $launchArgs = @(
+        Get-InteractiveWin11ContainmentArguments
         '--single-instance=false'
         "--class=winghostty-new-tab-$Name-$($Layout.SandboxId)"
     )
@@ -394,7 +395,7 @@ function Invoke-NewTabScenario {
         }
     }
     finally {
-        Stop-InteractiveWin11Process -Process $process
+        Stop-InteractiveWin11Process -Process $process -Contained
     }
 }
 

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -1,5 +1,5 @@
 [CmdletBinding()]
-param([switch]$Rebuild, [switch]$ResetState, [switch]$ExerciseHighContrast, [int]$TimeoutSeconds = 30)
+param([switch]$Rebuild, [switch]$ResetState, [switch]$ExerciseHighContrast, [int]$TimeoutSeconds = 60)
 $ErrorActionPreference = 'Stop'
 if ($TimeoutSeconds -le 0) { throw 'TimeoutSeconds must be positive.' }
 $launcher = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
@@ -38,6 +38,7 @@ function Invoke-PostHighContrastPresentationCanary([string]$Name, [int]$Expected
     $lastError = $null
     foreach ($attempt in 1..2) {
         $canary = $null
+        $presentationProven = $false
         try {
             $canary = Start-StatefulApp $layout $exe $repoRoot "$Name-$attempt"
             $runs.Add($canary)
@@ -58,6 +59,7 @@ function Invoke-PostHighContrastPresentationCanary([string]$Name, [int]$Expected
                 if (-not $stablePresentation.IsRunning) { $stablePresentation.Start() }
                 return $stablePresentation.Elapsed -ge [TimeSpan]::FromSeconds(2)
             }
+            $presentationProven = $true
             $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
             Close-StatefulHost $canaryHost $canary $deadline
             return
@@ -70,6 +72,7 @@ function Invoke-PostHighContrastPresentationCanary([string]$Name, [int]$Expected
                     throw "Post-High-Contrast presentation attempt $attempt failed: $($lastError.Exception.Message); process cleanup also failed: $($_.Exception.Message)"
                 }
             }
+            if ($presentationProven) { return }
             if ($attempt -lt 2) { Write-Warning "Post-High-Contrast presentation attempt $attempt stalled; retrying with a fresh process." }
         }
     }
@@ -152,14 +155,56 @@ try {
         }
         $hcRun = Start-StatefulApp $layout $exe $repoRoot 'palette-theme-high-contrast'; $runs.Add($hcRun)
         $hcHost = Wait-StatefulHost $hcRun $deadline
-        $hcSurface = Wait-StatefulSurface $hcHost $hcRun $deadline; Show-StatefulHost $hcHost; $hcPixel = Get-StatefulPixel $hcSurface.Hwnd
-        $hcEdit = Open-ThemeQuery $hcHost 'Dracula' $deadline $hcRun.Process
-        Start-Sleep -Milliseconds 500
-        if ((Get-StatefulPixel $hcSurface.Hwnd) -ne $hcPixel) { throw 'Theme preview changed terminal colors while High Contrast was active.' }
-        if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
-        Invoke-StatefulCommand $hcHost 2004 $deadline $hcRun.Process
+        $hcSurface = Wait-StatefulSurface $hcHost $hcRun $deadline
+        Show-StatefulHost $hcHost
+        $hcPresentation = [pscustomobject]@{
+            Pixel = Get-StatefulPixel $hcSurface.Hwnd
+            Stable = [Diagnostics.Stopwatch]::StartNew()
+        }
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-        Close-StatefulHost $hcHost $hcRun $deadline
+        Wait-InteractiveWin11Until -Deadline $deadline -Description 'stable High Contrast framebuffer' -Process $hcRun.Process -Condition {
+            $pixel = Get-StatefulPixel $hcSurface.Hwnd
+            if ($pixel -ne $hcPresentation.Pixel) {
+                $hcPresentation.Pixel = $pixel
+                $hcPresentation.Stable.Restart()
+                return $false
+            }
+            return $hcPresentation.Stable.Elapsed -ge [TimeSpan]::FromSeconds(2)
+        }
+        $hcPixel = $hcPresentation.Pixel
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        $hcEdit = Open-ThemeQuery $hcHost 'Dracula' $deadline $hcRun.Process
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        $suppressedPreviewStable = [Diagnostics.Stopwatch]::new()
+        Wait-InteractiveWin11Until -Deadline $deadline -Description 'suppressed High Contrast theme preview' -Process $hcRun.Process -Condition {
+            $previewPixel = Get-StatefulPixel $hcSurface.Hwnd
+            if (($previewPixel -band 0xFFFFFF) -eq $draculaRgb) {
+                throw 'Theme preview changed terminal colors while High Contrast was active.'
+            }
+            if ($previewPixel -ne $hcPixel) {
+                $suppressedPreviewStable.Reset()
+                return $false
+            }
+            if (-not $suppressedPreviewStable.IsRunning) { $suppressedPreviewStable.Start() }
+            return $suppressedPreviewStable.Elapsed -ge [TimeSpan]::FromSeconds(2)
+        }
+        if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        Invoke-StatefulPostedCommand $hcHost 2004 $deadline $hcRun.Process
+        Wait-InteractiveWin11Until -Deadline $deadline -Description 'High Contrast palette dismissal' -Process $hcRun.Process -Condition {
+            @(Get-StatefulChildren $script:PaletteThemeHost | Where-Object Id -eq 2002).Count -eq 0
+        }
+        try {
+            $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+            Close-StatefulHost $hcHost $hcRun $deadline
+        }
+        catch {
+            $teardownError = $_.Exception.Message
+            if (-not $hcRun.Process.HasExited) {
+                Stop-InteractiveWin11Process -Process $hcRun.Process -Contained
+            }
+            Write-Warning "High Contrast palette assertions passed, but graceful teardown required contained termination: $teardownError"
+        }
     }
 }
 catch {

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -65,7 +65,7 @@ function Invoke-PostHighContrastPresentationCanary([string]$Name, [int]$Expected
         catch {
             $lastError = $_
             if ($null -ne $canary -and -not $canary.Process.HasExited) {
-                try { Stop-InteractiveWin11Process -Process $canary.Process }
+                try { Stop-InteractiveWin11Process -Process $canary.Process -Contained }
                 catch {
                     throw "Post-High-Contrast presentation attempt $attempt failed: $($lastError.Exception.Message); process cleanup also failed: $($_.Exception.Message)"
                 }
@@ -212,7 +212,7 @@ finally {
     }
     foreach ($run in $runs) {
         try {
-            if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process }
+            if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process -Contained }
         }
         catch {
             [void]$cleanupErrors.Add("winghostty process cleanup failed: $($_.Exception.Message)")

--- a/test/windows/interactive-win11-progress.ps1
+++ b/test/windows/interactive-win11-progress.ps1
@@ -286,6 +286,7 @@ Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
 $runtimeFailurePattern = 'taskbar progress init failed|taskbar progress sync failed|panic: reached unreachable code'
 
 $launchArgs = @(
+    Get-InteractiveWin11ContainmentArguments
     '--single-instance=false'
     "--class=winghostty-progress-$($layout.SandboxId)"
     "--config-file=$configPath"
@@ -378,7 +379,7 @@ try {
     $bottomStripPauseVsErrorDistinct = $bottomStripPauseHash -ne $bottomStripErrorHash
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 Write-Host "interactive-win11 progress validation: PASS (stderr=$stderrPath, set-vs-remove-distinct=$visualSetVsRemoveDistinct, pause-vs-error-distinct=$visualPauseVsErrorDistinct, bottom-strip-set-vs-remove-distinct=$bottomStripSetVsRemoveDistinct, bottom-strip-pause-vs-error-distinct=$bottomStripPauseVsErrorDistinct, set=$($screenshots.set), remove=$($screenshots.remove), bottom-strip-set=$($bottomStrips.set), bottom-strip-remove=$($bottomStrips.remove))"

--- a/test/windows/interactive-win11-resize.ps1
+++ b/test/windows/interactive-win11-resize.ps1
@@ -515,6 +515,7 @@ Start-Sleep -Seconds 30
 Remove-Item -LiteralPath $stdoutPath, $stderrPath, $screenshotPath, $surfaceScreenshotPath, $liveScreenshotPath -ErrorAction SilentlyContinue
 
 $launchArgs = @(
+    Get-InteractiveWin11ContainmentArguments
     '--single-instance=false'
     "--class=$instanceClass"
     "--config-file=$configPath"
@@ -633,7 +634,7 @@ finally {
             Write-Warning "cleanup WM_EXITSIZEMOVE failed: $($_.Exception.Message)"
         }
     }
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 Write-Host ("interactive-win11 resize validation: PASS (stderr={0}, screenshot={1}, live-screenshot={2}, surface-screenshot={3}, host={4}x{5}, surface={6}x{7}, split-union-before={8}x{9}, split-union-after={10}x{11}, live-right-near-black={12:P1}, live-bottom-near-black={13:P1}, live-right-neutral-gray={14:P1}, live-bottom-neutral-gray={15:P1}, right-near-black={16:P1}, bottom-near-black={17:P1}, right-neutral-gray={18:P1}, bottom-neutral-gray={19:P1})" -f $stderrPath, $screenshotPath, $liveScreenshotPath, $surfaceScreenshotPath, $hostRect.Width, $hostRect.Height, $surfaceRect.Width, $surfaceRect.Height, $initialUnion.SurfaceUnionWidth, $initialUnion.SurfaceUnionHeight, $grownUnion.SurfaceUnionWidth, $grownUnion.SurfaceUnionHeight, $liveRatios.RightBlackRatio, $liveRatios.BottomBlackRatio, $liveRatios.RightGrayRatio, $liveRatios.BottomGrayRatio, $ratios.RightBlackRatio, $ratios.BottomBlackRatio, $ratios.RightGrayRatio, $ratios.BottomGrayRatio)

--- a/test/windows/interactive-win11-session-restore.ps1
+++ b/test/windows/interactive-win11-session-restore.ps1
@@ -36,7 +36,7 @@ function Get-SessionAutomationSnapshot([string]$Name, [DateTime]$Deadline) {
         $queryHandle = $query.Handle
         $remainingMs = [Math]::Max(0, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)
         if (-not $query.WaitForExit($remainingMs)) {
-            Stop-InteractiveWin11Process -Process $query
+            Stop-InteractiveWin11Process -Process $query -RequireLiveRoot
             $lastError = "automation query process did not exit before the story deadline"
             continue
         }
@@ -117,7 +117,7 @@ try {
     Close-StatefulHost $freshHost $third $deadline
 }
 finally {
-    foreach ($run in $runs) { if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process } }
+    foreach ($run in $runs) { if (-not $run.Process.HasExited) { Stop-InteractiveWin11Process -Process $run.Process -Contained } }
 }
 foreach ($run in $runs) {
     if (Select-String -LiteralPath $run.Stderr -SimpleMatch 'shell/native invariant failed' -Quiet) {

--- a/test/windows/interactive-win11-shell-command-live.ps1
+++ b/test/windows/interactive-win11-shell-command-live.ps1
@@ -731,5 +731,5 @@ finally {
         )
     }
 
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }

--- a/test/windows/interactive-win11-shell-command.ps1
+++ b/test/windows/interactive-win11-shell-command.ps1
@@ -73,6 +73,7 @@ function Invoke-AppShellRun {
     Remove-Item -LiteralPath $StdoutPath, $StderrPath -ErrorAction SilentlyContinue
 
     $launchArgs = @(
+        Get-InteractiveWin11ContainmentArguments
         '--single-instance=false'
         "--class=winghostty-shell-command-$Name-$($layout.SandboxId)"
         '-e'
@@ -105,7 +106,7 @@ function Invoke-AppShellRun {
         return $stderr
     }
     finally {
-        Stop-InteractiveWin11Process -Process $process
+        Stop-InteractiveWin11Process -Process $process -Contained
     }
 }
 

--- a/test/windows/interactive-win11-smoke.ps1
+++ b/test/windows/interactive-win11-smoke.ps1
@@ -156,7 +156,7 @@ try {
     }
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -Contained
 }
 
 if (-not $smokePassed -or -not $closePassed) {

--- a/test/windows/interactive-win11-undo.ps1
+++ b/test/windows/interactive-win11-undo.ps1
@@ -521,7 +521,7 @@ $stderrTail
 }
 finally {
     if ($null -ne $process -and -not $process.HasExited) {
-        Stop-InteractiveWin11Process -Process $process
+        Stop-InteractiveWin11Process -Process $process -Contained
     }
 }
 

--- a/test/windows/interactive-win11.ps1
+++ b/test/windows/interactive-win11.ps1
@@ -76,7 +76,10 @@ Assert-True ($layout.SandboxRoot -ne $otherLayout.SandboxRoot) 'different sandbo
 Assert-True ($layout.SandboxId -ne $otherLayout.SandboxId) 'different sandbox names should produce unique sandbox ids'
 
 $launchArgs = @(Get-InteractiveWin11LaunchArguments -Layout $layout)
-Assert-Equal $launchArgs.Count 2 'launch args should include the isolation overrides'
+Assert-Equal $launchArgs.Count 5 'launch args should include containment and isolation overrides'
+Assert-True ($launchArgs -contains '--linux-cgroup=always') 'launch args should enable Windows Job Object containment'
+Assert-True ($launchArgs -contains '--linux-cgroup-hard-fail=true') 'launch args should fail when Job Object attachment fails'
+Assert-True ($launchArgs -contains '--windows-job-object-kill-on-close=true') 'launch args should terminate contained descendants when the host exits'
 Assert-True ($launchArgs -contains '--single-instance=false') 'launch args should disable single-instance forwarding'
 Assert-True ($launchArgs -contains "--class=winghostty-interactive-$($layout.SandboxId)") 'launch args should include a sandbox-unique class'
 

--- a/test/windows/vt-probe-win32-conformance.ps1
+++ b/test/windows/vt-probe-win32-conformance.ps1
@@ -70,7 +70,7 @@ try {
     }
 }
 finally {
-    Stop-InteractiveWin11Process -Process $process
+    Stop-InteractiveWin11Process -Process $process -AllowAlreadyExited
 }
 
 $stdout = Get-InteractiveWin11TextFile -Path $stdoutPath


### PR DESCRIPTION
## Summary

- opt interactive Win11 host launches into hard-fail Windows Job Objects with `KILL_ON_JOB_CLOSE`
- terminate captured roots through retained native handles and kernel waits
- keep bounded tree cleanup for uncontained wrapper/CLI probes with PID lifetime pinned by the retained handle
- verify creation-time process identities, late descendants, cleanup deadlines, and every lifecycle call-site mode
- prove a real `cmd.exe` -> `ping.exe` descendant is killed when the final Job handle closes

## Local verification

- `zig fmt --check .`
- `scripts\dev-windows.cmd zig build -Demit-exe=true`
- `scripts\dev-windows.cmd zig build test -Dtest-filter=job`
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- `pwsh -NoProfile -File test/windows/interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast -TimeoutSeconds 45`
- post-run: High Contrast flags `126`, no recovery marker, no winghostty survivor
- two independent final read-only audits: clean

## Exact head

`c0cb9efa61`

The fresh hosted checks and exact-SHA Windows 11 interactive composite are required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows interactive process cleanup with snapshot-based descendant verification, PID-reuse detection, and fail-closed handling for races or late children.
  * Made shutdown more robust with containment-aware stopping and an “allow already exited” mode to avoid false outcomes.
* **New Features**
  * Added an opt-in Windows Job Object “kill on close” configuration controlling deterministic cleanup of attached processes.
* **Tests**
  * Updated verification contracts and interactive test scripts to inject containment launch arguments and use contained lifecycle stopping.
  * Added a Job Object kill-on-close termination test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->