### PR TITLE
win32: fix terminal accessibility and theme preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Issues are reserved for reproducible bugs.
 
 Latest stable release:
 **[winghostty 1.3.119](https://github.com/amanthanvi/winghostty/releases/tag/v1.3.119)**,
-published 2026-07-23.
+published 2026-07-24.
 
 Download directly from **[Releases](https://github.com/amanthanvi/winghostty/releases)**:
 

--- a/plans/2026-07-23-terminal-accessibility-settings-theme-regression.md
+++ b/plans/2026-07-23-terminal-accessibility-settings-theme-regression.md
@@ -1,0 +1,354 @@
+# Terminal accessibility and Settings theme regression plan
+
+Status: follow-up in progress. Targeted unit/provider tests, focused native
+key-input scenarios, flagship contracts, a full Zig suite, and the full
+accessibility harness passed before the latest audit. Verifier follow-up and
+the output-architecture redesign are now source-complete: committed terminal
+output is emitted at the authoritative `StreamHandler`/parser seam and the raw
+Win32 VT re-parser is deleted. Focused semantic-output, transport, and
+announcement tests pass, and independent source implementation,
+semantic/deslop, and existing flagship-contract audits are clean. The final
+semantic-interest contract refresh, unified executable build, and full Zig
+suite also pass. The final automated live accessibility/theme/High
+Contrast/scaling/idle harness passes. Release workflow gates and human
+Narrator/NVDA acceptance remain pending.
+
+Date: 2026-07-23.
+
+Base: `3f0a928c5ee5bb5dcf52c32547a406363c4d53de`.
+
+## Objective
+
+Close two release-blocking human-test failures without weakening native Windows
+behavior:
+
+1. Narrator must enter and read terminal text, not only announce the tab or
+   document title. A pane or tab that receives focus after background output
+   must expose current text and geometry on the first focused query.
+2. Changing `Window theme` from System to Dark in Settings must produce an
+   immediate, visible, reversible preview in terminal chrome and the Settings
+   window. High Contrast must continue to use Windows system colors.
+
+The release remains blocked until the deterministic gates pass and a human
+Narrator/NVDA cell confirms usable speech and navigation.
+
+## Evidence
+
+### Terminal accessibility
+
+- `src/apprt/win32_uia/widgets.zig:2292-2303` returns an empty legacy
+  `ITextProvider::GetSelection` array for terminal documents.
+- `src/apprt/win32_uia/widgets.zig:2361-2372` advertises
+  `SupportedTextSelection_None`.
+- `src/apprt/win32_uia/widgets.zig:2423-2447` simultaneously exposes the real
+  caret through TextPattern2 `GetCaretRange`.
+- `test/windows/interactive-win11-accessibility.ps1:1392-1398` currently locks
+  in the empty-selection behavior.
+- `src/apprt/win32.zig:24878-24922` ties accessible-snapshot publication to
+  renderer refresh and listener/query activity.
+- `src/apprt/win32.zig:27175-27186` publishes terminal focus without first
+  forcing the retained snapshot current.
+- Human repro: Narrator announces tab/document titles but not terminal content;
+  background output joins its visual bounding box only after a pane/tab focus
+  round trip.
+- Microsoft Terminal is the compatibility oracle: it exposes one degenerate
+  cursor range through legacy `GetSelection` and advertises single selection.
+- Microsoft Terminal also exposes `LiveSetting=Polite` and sends sanitized new
+  terminal output through `UiaRaiseNotificationEvent` with
+  `NotificationProcessing_All`, suppressing unreadable output and key echoes.
+
+### Theme preview
+
+- `src/apprt/win32_settings.zig:2538-2553` correctly stages
+  `window-theme` with `live_preview=true`.
+- `src/apprt/win32.zig:17587-17623` correctly updates the live config and calls
+  `reconfigureTheme`.
+- `src/apprt/win32.zig:5476-5514` rebuilds host resources, but queues a host
+  chrome repaint only when frame mode changes; ordinary System-to-Dark swaps
+  can retain stale pixels.
+- `src/apprt/win32_settings.zig:5086-5106` paints the Settings client area with
+  unconditional `COLOR_BTNFACE` and `COLOR_WINDOW`.
+- `src/apprt/win32_settings.zig:1998-2002` invalidates Settings on theme change
+  but does not apply dark DWM/native-control theming.
+- Human repro: selecting Dark is announced but does not visibly darken the
+  foreground Settings experience.
+
+## Architecture decision
+
+### Terminal accessibility session
+
+Create one deep `TerminalAccessibilitySession` module at the Surface/UIA seam.
+Its narrow interface owns:
+
+- provider acquisition for `WM_GETOBJECT`;
+- immutable terminal snapshot cache;
+- query-triggered refresh scheduling;
+- activation/focus refresh;
+- timer handling;
+- TextChanged and caret event policy;
+- polite live-setting metadata and bounded new-output notification policy;
+- provider detach and lifetime.
+
+Its implementation may use the existing terminal-text adapter and UIA provider,
+but callers must not know timer IDs, query windows, listener predicates, cache
+locks, or event selection. Renderer repaint remains an input signal, not the
+semantic ownership boundary.
+
+The canonical caret is one state value consumed by both:
+
+- legacy TextPattern `GetSelection`; and
+- TextPattern2 `GetCaretRange`.
+
+This creates depth, improves locality, and prevents the current interface drift.
+It is a replace-not-layer refactor: delete superseded Surface/context scheduling
+code as the module takes ownership.
+
+### Window theme adapter
+
+Deepen `win32_theme` behind one window-kind-aware implementation for host and
+Settings windows. `WindowThemeAdapter` consumes resolved theme and High
+Contrast state and owns:
+
+- DWM light/dark attributes;
+- native control theme application;
+- High Contrast fallback to Windows system colors.
+
+`win32_settings.SettingsThemeAdapter` retains local ownership of semantic
+colors, GDI brushes, reentry protection, teardown, child theming, and complete
+Settings repaint. Host theme replacement retains host repaint ownership.
+Settings transaction code only emits typed live-preview effects.
+
+## Implementation sequence
+
+### 1. Correct the canonical caret contract
+
+- For terminal role, return one immutable degenerate range at the cached caret
+  from legacy `GetSelection`.
+- Advertise `SupportedTextSelection_Single`.
+- Return `E_NOTIMPL` from terminal range `Select`; the immutable degenerate
+  caret remains readable/expandable without claiming a mutable selection.
+- Reuse the same snapshot/caret normalization as TextPattern2.
+- Replace tests that require `None`/zero ranges with parity assertions between
+  legacy selection and TextPattern2 caret.
+
+### 2. Extract and wire `TerminalAccessibilitySession`
+
+- Move `TerminalUiaContext`, retained cache, query timestamps, refresh timer,
+  publication policy, and event selection out of `win32.zig`.
+- Give `Surface` one session field and lifecycle calls only.
+- Force a bounded current snapshot before publishing terminal focus/activation.
+- Keep event emission listener-gated and coalesced.
+- Preserve lock order: renderer snapshot first, release renderer lock, then
+  publish under session cache lock.
+- Preserve cold-query timeout and detached-provider behavior.
+- Delete the old split ownership and implementation-name source-regex checks.
+
+### 3. Add Windows-Terminal-compatible spoken output
+
+- Expose the terminal as the platform-compatible Text control/localized
+  `terminal` role where required by the provider contract.
+- Return `LiveSetting=Polite`.
+- Keep TextChanged and TextSelectionChanged for range invalidation/caret state.
+- Emit committed semantic terminal output from the authoritative
+  `StreamHandler`/parser seam after parsing and the render decision complete;
+  offer only that output to the Surface-owned `TerminalOutputTransport`.
+- Keep the producer interest-gated, allocation-free, and nonblocking. The fixed
+  eight-by-1000-byte transport never enters the global app mailbox; contention
+  or capacity exhaustion becomes one ordered omission barrier.
+- Drain retained chunks plus the omission marker on the Win32 UI thread into
+  `TerminalAccessibilitySession`; its bounded notification FIFO owns
+  echo suppression and speech ordering. Snapshot refresh and provider queries
+  never derive, consume, or clear speech.
+- Keep the raw Win32 VT/control re-parser deleted. Control-string, C1,
+  malformed-sequence, and parser resynchronization behavior belongs to the
+  authoritative terminal parser, not a second accessibility state machine.
+- Suppress matching echoed key input and control-only/unreadable output.
+- Raise `UiaRaiseNotificationEvent` with an activity identifier dedicated to
+  terminal output and a processing mode that preserves command output order
+  while allowing keyboard input to interrupt speech.
+- Never announce the full retained snapshot for each change.
+- Coalesce chunks without merging unrelated command boundaries or allowing an
+  unbounded backlog.
+
+### 4. Complete host theme repaint ownership
+
+- Make `App.reconfigureTheme` always queue the known full chrome/control repaint
+  after replacing theme resources.
+- Retain live-resize coalescing and avoid synchronous repaint storms.
+- Ensure discard/revert crosses the same path and restores pixels immediately.
+
+### 5. Add the Settings window theme adapter
+
+- Resolve semantic Settings colors from app theme outside High Contrast.
+- In High Contrast, preserve current `GetSysColor` behavior exactly.
+- Apply the appropriate DWM titlebar and native-control theme to the Settings
+  HWND and control tree.
+- Handle `WM_CTLCOLORSTATIC`, `WM_CTLCOLORBTN`, `WM_CTLCOLOREDIT`, and related
+  combo/list children through cached semantic brushes where Win32 requires it.
+- Recreate/delete cached brushes on theme transition and teardown.
+- Keep focus, disabled, validation, and selection states readable; do not
+  owner-draw standard controls unless native theming cannot meet contrast.
+
+### 6. Close the false-green test gaps
+
+Unit/provider tests:
+
+- legacy terminal `GetSelection` returns one degenerate caret range;
+- legacy and TextPattern2 caret offsets are equal;
+- SupportedTextSelection is Single;
+- selection calls are safe and detached providers fail correctly;
+- session focus refresh decision and event coalescing;
+- terminal LiveSetting, notification metadata, key-echo suppression,
+  readability filtering, chunk bounds, and ordering;
+- semantic Settings color mapping for light, dark, system, and High Contrast;
+- theme-resource replacement implies invalidation.
+
+Interactive Windows 11 tests:
+
+- produce output in an unfocused pane, focus it once, and verify the first
+  acquired focused range contains the output without a pre-registered
+  TextChanged listener;
+- verify existing TextPattern objects refresh without requiring a second focus
+  switch;
+- verify legacy selection can expand/read the current line;
+- select forced Dark in Settings and sample stable host and Settings client
+  pixels until both change;
+- discard, verify both pixels restore, and verify config remains unchanged;
+- enable High Contrast and verify Settings uses system colors rather than
+  app-theme colors.
+
+Manual acceptance:
+
+- Narrator reads existing terminal content after entering a pane;
+- Narrator announces new output at a usable cadence without duplicate speech;
+- Narrator/NVDA can navigate current and prior terminal lines;
+- background pane/tab output is current on first focus;
+- NVDA review cursor works;
+- Settings Dark preview and discard are immediate at 100%, 200%, and 300%;
+- High Contrast remains legible and reversible.
+
+## Rejected alternatives
+
+- Raising a notification with the full terminal snapshot on every TextChanged:
+  duplicates speech, destroys command boundaries, and creates an unbounded
+  output cadence. Use the Windows Terminal new-output contract instead.
+- Unconditional UIA snapshot on every render: defeats the existing idle-cost
+  boundary.
+- A parent-background-only dark Settings patch: leaves controls/titlebar
+  visually incoherent.
+- A new cross-platform accessibility abstraction: no second implementation or
+  caller; the real seam is Win32 Surface/UIA lifecycle.
+
+## Validation commands
+
+Use the repository Windows wrapper where applicable.
+
+```powershell
+scripts/dev-windows.cmd zig fmt --check src/apprt
+scripts/dev-windows.cmd zig build test -Dtest-filter=TerminalProvider
+scripts/dev-windows.cmd zig build test -Dtest-filter=terminal_UIA
+scripts/dev-windows.cmd zig build test -Dtest-filter=win32_settings
+scripts/dev-windows.cmd zig build -Demit-exe=true
+pwsh -NoProfile -File test/windows/interactive-win11-accessibility.ps1 -ResetState -TimeoutSeconds 20 -IdleSoakSeconds 60
+```
+
+The final validation ran the repository full Zig suite, focused native
+key-input scenarios, and the full accessibility harness. This plan does not
+claim a pass for the broader interactive composite suite.
+
+## Completion gates
+
+- [x] Canonical caret exposed through legacy TextPattern and TextPattern2.
+- [x] Focus/activation publishes a current snapshot before focus event.
+- [x] Polite metadata and the bounded, nonblocking Surface-to-session output
+      transport are implemented with echo suppression and explicit omission.
+- [x] Terminal accessibility lifecycle has one deep module and old duplicate
+      ownership is deleted.
+- [x] System-to-Dark host repaint path is implemented.
+- [x] Settings HWND/native-control explicit-Dark path is implemented.
+- [x] High Contrast reset/system-color policy is implemented.
+- [x] Preview discard follows the same restoration path and preserves persisted
+      config bytes.
+- [x] Post-redesign targeted/unit/provider filters, unified executable build,
+      and full Zig suite pass on the final tree.
+- [x] Final automated live accessibility/theme/High-Contrast/scaling/idle
+      harness passes after the verifier and production follow-up; no broader
+      composite-suite result is claimed.
+- [x] Independent source implementation and semantic/deslop audits pass after
+      the production input/transport follow-up.
+- [x] Existing flagship verification contracts pass on the source-confirmed
+      closure.
+- [x] Final semantic-interest verification-contract refresh passes.
+- [ ] Human Narrator and NVDA acceptance cells pass.
+
+## Completion ledger
+
+- Targeted Zig filters for terminal-output transport/session,
+  `TerminalProvider`, and `win32_settings` pass on the current tree.
+- The semantic-output redesign is source-complete. `StreamHandler` records only
+  successfully committed, charset-mapped print/REP/CR/LF/tab output; hidden
+  status-display output is excluded. Same-batch RIS discards its erased prefix
+  and emits an ordered silent continuity reset, and interest epochs reject
+  stale pre-disable batches.
+- The duplicate Win32 VT/control re-parser and raw Termio forwarding are
+  deleted. Focused semantic-output, transport, and announcement filters plus
+  formatting and scoped diff checks pass.
+- Attached, focused panes with an acquired provider keep bounded semantic
+  capture interested independently of listener activity, closing the
+  false-to-true listener first-output gap; UIA event emission remains
+  listener-gated.
+- Independent source implementation and semantic/deslop closure audits are
+  clean. Existing flagship verification contracts and the final
+  semantic-interest contract refresh pass.
+- Final-tree `scripts/dev-windows.cmd zig build -Demit-exe=true`: PASS.
+- Final-tree `scripts/dev-windows.cmd zig build test
+  -Demit-test-exe=true`: PASS.
+- Real Win32 message-loop coverage passes five exact key-input scenarios:
+  classic `A`, classic Space, BMP Unicode, supplementary Unicode, and a
+  256-unit Unicode burst. Per-scenario sandbox/artifact names are unique;
+  the pure Zig test independently proves a 256-authorization deferred backlog.
+- Cursor-blink reset deadlines now ceil nanosecond remainders to milliseconds,
+  layered on the existing lifecycle rule that an active libxev completion is
+  never canceled or reset; its callback owns logical rearming.
+- The UIA selection contract is clean: terminal mutation support reports
+  `None`, legacy `GetSelection` still exposes one degenerate compatibility
+  caret, and `Select`/`AddToSelection`/`RemoveFromSelection` fail with the
+  expected invalid-operation contract.
+- Native C0 delivery for CR, LF, Tab, Backspace, and Escape is proven.
+  Alt+numpad experiments were fully reverted and remain a human/native residual
+  rather than an automated pass claim.
+- PowerShell 7 and Windows PowerShell 5.1 parse the accessibility harness and
+  flagship contract script; `Test-VerificationContracts.ps1` reports
+  `flagship verification contracts: PASS (2 scenarios)`.
+- The earlier full-suite pass was reconfirmed by the final-tree run above.
+- Final-tree full accessibility validation with `-ResetState -TimeoutSeconds
+  20 -IdleSoakSeconds 60`: PASS. Evidence:
+  `.sandbox/win11/github-winghostty-accessibility-6d522bd7417b/accessibility/logs/uia-tree.json`
+  (`outcome=pass`, 119.962 seconds). It proves UIA notification/TextPattern
+  behavior, inactive-pane silence, and a 60-second idle soak with zero
+  TextChanged events or handle/thread/private-byte growth.
+- The final High Contrast proof completed an exact compound SPI, host HWND/DWM,
+  and Settings HWND/UIA/DWM restore with `DWMSBT_NONE=1`. The retained
+  diagnostic is
+  `high-contrast-restore-diagnostic.json`; the temporary recovery snapshot was
+  deleted after verified restoration.
+- Dark theme persistence is proven across Save, process exit, and a fresh
+  relaunch: Settings index `3`, exact dark host/Settings pixels, immersive-dark
+  DWM `1`, and host/Settings backdrop `1`, followed by exact sandbox-config
+  restoration.
+- Final cleanup restored High Contrast off and DPI 96 and left zero unexpected
+  winghostty processes.
+- Pending: PR/review/merge/release gates and human Narrator/NVDA acceptance.
+
+## Residual risks
+
+- Narrator’s exact legacy-caret heuristic is not a documented guarantee; human
+  retest remains mandatory.
+- Native dark theming varies by Windows build; the supported Windows 11 matrix
+  still requires human validation of titlebar, combos, edit fields, disabled
+  controls, and focus.
+- Session ownership remains concurrency-sensitive despite clean automated
+  lock-order, provider-lifetime, and timer-lifecycle coverage.
+- Alt+numpad behavior remains a human/native compatibility residual; no
+  reverted experiment is counted as passing evidence.
+- Speech-output automation is not a substitute for a human screen-reader pass.

--- a/plans/README.md
+++ b/plans/README.md
@@ -5,3 +5,5 @@ scope, objective checks, dependencies, and completion evidence.
 
 - [2026 aggressive improvement roadmap](2026-aggressive-improvement.md)
 - [Architecture report](architecture-report.html)
+- [Terminal accessibility and Settings theme regression plan](2026-07-23-terminal-accessibility-settings-theme-regression.md)
+- [Terminal accessibility and Settings theme architecture review](architecture-review-2026-07-23.html)

--- a/plans/architecture-review-2026-07-23.html
+++ b/plans/architecture-review-2026-07-23.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>winghostty architecture review — terminal accessibility and Settings theme</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module">
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+    mermaid.initialize({ startOnLoad: true, theme: "dark" });
+  </script>
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="mx-auto max-w-6xl space-y-8 p-8">
+    <header class="rounded-2xl border border-slate-700 bg-slate-900 p-7">
+      <p class="text-sm font-semibold uppercase tracking-widest text-sky-400">Architecture review · 2026-07-23</p>
+      <h1 class="mt-2 text-3xl font-bold">One terminal accessibility session. One window-theme adapter.</h1>
+      <p class="mt-3 max-w-4xl text-slate-300">Follow-up in progress. The output-architecture redesign is source-complete: committed terminal output is emitted at the authoritative <code>StreamHandler</code>/parser seam and the raw Win32 VT re-parser is deleted. Focused tests, independent source implementation and semantic/deslop audits, the final semantic-interest contract refresh, unified executable build, full Zig suite, and final automated live accessibility/theme/High-Contrast/scaling/idle harness all pass. Release workflow gates and human Narrator/NVDA acceptance remain pending.</p>
+    </header>
+
+    <section class="grid gap-5 md:grid-cols-3">
+      <article class="rounded-xl border border-rose-800 bg-rose-950/40 p-5">
+        <h2 class="font-semibold text-rose-300">Terminal contract drift</h2>
+        <p class="mt-2 text-sm text-slate-300">TextPattern2 exposes a caret while legacy TextPattern advertises no selection. Snapshot freshness is coupled to repaint/listener policy.</p>
+      </article>
+      <article class="rounded-xl border border-amber-800 bg-amber-950/40 p-5">
+        <h2 class="font-semibold text-amber-300">Theme ownership gap</h2>
+        <p class="mt-2 text-sm text-slate-300">The model previews Dark, but host invalidation is conditional and Settings paints unconditional system colors.</p>
+      </article>
+      <article class="rounded-xl border border-emerald-800 bg-emerald-950/40 p-5">
+        <h2 class="font-semibold text-emerald-300">High-leverage seam</h2>
+        <p class="mt-2 text-sm text-slate-300">Both defects cross stable boundaries with multiple callers and sensitive policy: real candidates for module depth and locality.</p>
+      </article>
+    </section>
+
+    <section class="rounded-2xl border border-slate-700 bg-slate-900 p-6">
+      <h2 class="text-xl font-semibold">Before: shallow ownership, hidden coupling</h2>
+      <div class="mermaid mt-5">
+flowchart LR
+  R[Renderer .render] --> S[Surface.refreshTerminalUiaText]
+  Q[UIA query] --> P[TerminalProvider]
+  P --> C[TerminalUiaContext]
+  C --> M[Posted HWND message]
+  M --> S
+  F[Surface focus] --> E[FocusChanged event]
+  S --> C
+  C --> P
+  T[Settings combo] --> X[Generic preview callback]
+  X --> A[App.reconfigureTheme]
+  A --> H[Host DWM + brushes]
+  A --> I[Settings invalidate]
+  I --> G[GetSysColor paint]
+      </div>
+      <p class="mt-4 text-sm text-slate-400">The focus path bypasses snapshot refresh. The Settings path invalidates pixels that are recomputed from unchanged system colors.</p>
+    </section>
+
+    <section class="rounded-2xl border border-slate-700 bg-slate-900 p-6">
+      <h2 class="text-xl font-semibold">After: deep modules, explicit interfaces</h2>
+      <div class="mermaid mt-5">
+flowchart LR
+  O[Committed semantic output from StreamHandler/parser seam] --> ST
+  subgraph ST[Surface TerminalOutputTransport]
+    B[8 × 1000-byte fixed chunks]
+    G[Interest gate + nonblocking tryLock]
+    X[Ordered reset + omission barriers]
+    G --> B --> X
+  end
+  ST --> DRAIN[Win32 UI-thread drain]
+  DRAIN --> TAS
+  R[Renderer repaint signal] --> TAS
+  F[Focus/activation] --> TAS
+  Q[WM_GETOBJECT/query] --> TAS
+  Z[Timer/detach] --> TAS
+  subgraph TAS[TerminalAccessibilitySession]
+    C[Snapshot cache + refresh policy]
+    K[Canonical caret]
+    P[UIA provider adapter]
+    V[Echo suppression + ordered 1000-byte speech FIFO]
+    C --> K --> P
+    C --> V
+  end
+  T[Typed theme preview/revert] --> WTA
+  HC[High Contrast state] --> WTA
+  subgraph WTA[WindowThemeAdapter]
+    DWM[DWM attributes]
+    N[Native control theme]
+  end
+  WTA --> H[Terminal host]
+  WTA --> S[Settings window]
+  S --> STA[SettingsThemeAdapter: brushes + reentry + teardown + invalidation]
+      </div>
+      <p class="mt-4 text-sm text-slate-400">The authoritative parser emits committed semantic output; its producer never allocates, blocks, or enters the global app mailbox. Win32 drains retained data plus ordered silent-reset and omission markers into the session, but does not re-parse VT/control syntax. DWM/native theming is centralized, while Settings retains local GDI resource ownership.</p>
+    </section>
+
+    <section class="grid gap-5 md:grid-cols-2">
+      <article class="rounded-xl border border-slate-700 bg-slate-900 p-5">
+        <h2 class="font-semibold text-sky-300">TerminalAccessibilitySession interface</h2>
+        <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-300">
+          <li><code>acquireProvider</code> — provider acquisition and current snapshot</li>
+          <li><code>outputInterested</code> — producer-side idle-cost gate</li>
+          <li><code>noteOutput</code> / <code>noteOutputOmitted</code> — committed semantic output, echo suppression, and bounded ordered speech</li>
+          <li><code>focusChanged</code> — refresh before focus publication</li>
+          <li><code>handleTimer</code> / <code>deinit</code> — scheduling and lifetime</li>
+        </ul>
+      </article>
+      <article class="rounded-xl border border-slate-700 bg-slate-900 p-5">
+        <h2 class="font-semibold text-sky-300">WindowThemeAdapter interface</h2>
+        <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-300">
+          <li><code>applyHost</code>, <code>applySettings</code>, and <code>applyNativeControl</code></li>
+          <li>DWM/native-control implementation hidden inside</li>
+          <li>High Contrast actively resets sticky DWM attributes to documented defaults</li>
+          <li>Settings-local adapter owns semantic brushes, reentry guard, teardown, and repaint</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="rounded-2xl border border-slate-700 bg-slate-900 p-6">
+      <h2 class="text-xl font-semibold">Validation state</h2>
+      <ul class="mt-4 list-disc space-y-2 pl-5 text-sm text-slate-300">
+        <li>Final-tree PASS: targeted terminal-output/session, <code>TerminalProvider</code>, and <code>win32_settings</code> tests; executable build; flagship contracts; and full Zig suite.</li>
+        <li>PASS: five exact native key-input scenarios with unique artifacts—classic A, classic Space, BMP Unicode, supplementary Unicode, and a 256-unit Unicode burst—plus a pure 256-authorization backlog test.</li>
+        <li>Final-tree PASS: full accessibility harness with <code>-ResetState -TimeoutSeconds 20 -IdleSoakSeconds 60</code>. Evidence: <code>.sandbox/win11/github-winghostty-accessibility-6d522bd7417b/accessibility/logs/uia-tree.json</code>, <code>outcome=pass</code>, 119.962 seconds. This is not a claim that the broader composite suite ran.</li>
+        <li>Final-tree PASS: UIA notification/TextPattern behavior, inactive-pane silence, 60-second idle with zero TextChanged/resource growth, exact High Contrast restore with backdrop <code>1</code>, and DPI 96/High Contrast off/zero unexpected processes at cleanup.</li>
+        <li>Final-tree PASS: Dark Save and fresh-process relaunch preserve combo index <code>3</code>, exact host/Settings pixels, immersive-dark DWM <code>1</code>, and host/Settings backdrop <code>1</code>; sandbox config bytes are restored.</li>
+        <li>Source closure: committed, charset-mapped semantic print/REP/CR/LF/tab output now originates at the authoritative parser seam; hidden status output is excluded; RIS emits a silent continuity reset; interest epochs reject stale batches; raw Win32 VT parsing and Termio forwarding are deleted. Attached, focused panes with an acquired provider remain capture-interested independently of listener activity, while UIA event emission remains listener-gated. Focused semantic-output, transport, and announcement filters pass.</li>
+        <li>Audit closure: independent source implementation and semantic/deslop audits are clean. Existing flagship verification contracts and the final semantic-interest contract refresh pass.</li>
+        <li>Clean contract: terminal selection mutation support is <code>None</code>; legacy selection exposes one degenerate compatibility caret; mutation methods return the expected invalid-operation result.</li>
+        <li>Native scope: CR, LF, Tab, Backspace, and Escape are proven. Alt+numpad experiments were reverted and remain a human/native residual.</li>
+        <li>Pending: PR/review/merge/release gates and human Narrator/NVDA acceptance.</li>
+      </ul>
+    </section>
+
+    <section class="rounded-2xl border border-slate-700 bg-slate-900 p-6">
+      <h2 class="text-xl font-semibold">Decision and risk</h2>
+      <div class="mt-4 overflow-x-auto">
+        <table class="w-full text-left text-sm">
+          <thead class="text-slate-400"><tr><th class="p-2">Change</th><th class="p-2">Leverage</th><th class="p-2">Risk</th><th class="p-2">Guardrail</th></tr></thead>
+          <tbody class="divide-y divide-slate-800">
+            <tr><td class="p-2">Canonical legacy/TextPattern2 caret</td><td class="p-2">Very high</td><td class="p-2">Medium</td><td class="p-2">Microsoft Terminal parity + human Narrator/NVDA</td></tr>
+            <tr><td class="p-2">Accessibility session extraction</td><td class="p-2">High</td><td class="p-2">Medium</td><td class="p-2">Replace old code; preserve lock order and teardown tests</td></tr>
+            <tr><td class="p-2">Complete host theme repaint</td><td class="p-2">High</td><td class="p-2">Medium</td><td class="p-2">Known repaint scope; retain live-resize coalescing</td></tr>
+            <tr><td class="p-2">Settings theme adapter</td><td class="p-2">High</td><td class="p-2">Medium</td><td class="p-2">High Contrast system-color override</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -128,6 +128,7 @@ last_binding_trigger: u64 = 0,
 io: termio.Termio,
 io_thread: termio.Thread,
 io_thr: std.Thread,
+terminal_output_transport: apprt.surface.TerminalOutputTransport = .{},
 
 /// Terminal inspector
 inspector: ?*inspectorpkg.Inspector = null,
@@ -746,6 +747,7 @@ pub fn init(
             .renderer_wakeup = render_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+            .terminal_output_transport = &self.terminal_output_transport,
         });
     }
     // Outside the block, IO has now taken ownership of our temporary state
@@ -902,6 +904,18 @@ inline fn surfaceMailbox(self: *Surface) Mailbox {
         .surface = self,
         .app = .{ .rt_app = self.rt_app, .mailbox = &self.app.mailbox },
     };
+}
+
+pub fn setTerminalOutputInterested(self: *Surface, interested: bool) void {
+    self.terminal_output_transport.setInterested(interested);
+}
+
+pub fn drainTerminalOutput(
+    self: *Surface,
+    ctx: *anyopaque,
+    callback: apprt.surface.TerminalOutputTransport.DrainCallback,
+) void {
+    self.terminal_output_transport.drain(ctx, callback);
 }
 
 /// Queue a message for the IO thread.

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -7,8 +7,241 @@ const App = @import("../App.zig");
 const Surface = @import("../Surface.zig");
 const renderer = @import("../renderer.zig");
 const terminal = @import("../terminal/main.zig");
+const semantic_output = @import("../terminal/semantic_output.zig");
 const Config = @import("../config.zig").Config;
 const MessageData = @import("../datastruct/main.zig").MessageData;
+
+/// Fixed-memory semantic terminal-output handoff from the PTY thread to the UI
+/// thread. Producers never block: lock contention and capacity exhaustion
+/// become one ordered omission barrier. While that barrier is pending, newer
+/// bytes are rejected until the UI consumes all retained chunks and the
+/// omission marker.
+pub const TerminalOutputTransport = struct {
+    pub const chunk_bytes = semantic_output.transport_chunk_bytes;
+    pub const max_chunks = semantic_output.transport_max_chunks;
+    pub const capacity = semantic_output.capacity;
+    pub const InterestEpoch = u64;
+
+    pub const PushResult = enum {
+        uninterested,
+        stale,
+        enqueued,
+        omitted,
+        contended,
+        rejecting,
+    };
+
+    pub const Item = union(enum) {
+        reset,
+        data: []const u8,
+        omitted,
+    };
+
+    pub const DrainCallback = *const fn (*anyopaque, Item) void;
+
+    interest_state: std.atomic.Value(u64) = .init(0),
+    omission_pending: std.atomic.Value(u64) = .init(0),
+    mutex: std.Thread.Mutex = .{},
+    chunks: [max_chunks][chunk_bytes]u8 = undefined,
+    lengths: [max_chunks]usize = [_]usize{0} ** max_chunks,
+    resets_before: [max_chunks]bool = [_]bool{false} ** max_chunks,
+    trailing_reset: bool = false,
+    head: usize = 0,
+    count: usize = 0,
+
+    pub fn setInterested(self: *TerminalOutputTransport, interested: bool) void {
+        const state = self.interest_state.load(.acquire);
+        if ((state & 1 != 0) == interested) return;
+        if (!interested) self.interest_state.store(state +% 1, .release);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.head = 0;
+        self.count = 0;
+        self.trailing_reset = false;
+        self.omission_pending.store(0, .release);
+        if (interested) {
+            const disabled_state = self.interest_state.load(.acquire);
+            self.interest_state.store(disabled_state +% 1, .release);
+        }
+    }
+
+    pub inline fn isInterested(self: *const TerminalOutputTransport) bool {
+        return self.captureEpoch() != null;
+    }
+
+    pub inline fn captureEpoch(
+        self: *const TerminalOutputTransport,
+    ) ?InterestEpoch {
+        const state = self.interest_state.load(.acquire);
+        return if (state & 1 != 0) state else null;
+    }
+
+    pub fn push(self: *TerminalOutputTransport, output: []const u8) PushResult {
+        return self.pushBatch(output, false);
+    }
+
+    pub fn pushBatch(
+        self: *TerminalOutputTransport,
+        output: []const u8,
+        omitted_after: bool,
+    ) PushResult {
+        const epoch = self.captureEpoch() orelse return .uninterested;
+        return self.pushBatchForEpoch(epoch, output, omitted_after);
+    }
+
+    pub fn pushBatchForEpoch(
+        self: *TerminalOutputTransport,
+        epoch: InterestEpoch,
+        output: []const u8,
+        omitted_after: bool,
+    ) PushResult {
+        return self.pushSemanticBatchForEpoch(
+            epoch,
+            output,
+            omitted_after,
+            false,
+        );
+    }
+
+    pub fn pushSemanticBatchForEpoch(
+        self: *TerminalOutputTransport,
+        epoch: InterestEpoch,
+        output: []const u8,
+        omitted_after: bool,
+        reset_before: bool,
+    ) PushResult {
+        if (self.interest_state.load(.acquire) != epoch) return .stale;
+        if (self.omissionPendingForEpoch(epoch)) return .rejecting;
+        if (!self.mutex.tryLock()) {
+            if (!self.markOmissionForEpoch(epoch)) return .stale;
+            return .contended;
+        }
+        defer self.mutex.unlock();
+
+        if (self.interest_state.load(.acquire) != epoch) return .stale;
+        if (self.omissionPendingForEpoch(epoch)) return .rejecting;
+
+        var remaining = output;
+        var reset_pending = reset_before or self.trailing_reset;
+        if (remaining.len == 0 and reset_pending) self.trailing_reset = true;
+        while (remaining.len != 0) {
+            if (self.count == max_chunks) {
+                _ = self.markOmissionForEpoch(epoch);
+                return .omitted;
+            }
+            const chunk_len = utf8PrefixLen(remaining, chunk_bytes);
+            const index = (self.head + self.count) % max_chunks;
+            @memcpy(self.chunks[index][0..chunk_len], remaining[0..chunk_len]);
+            self.lengths[index] = chunk_len;
+            self.resets_before[index] = reset_pending;
+            if (reset_pending) {
+                self.trailing_reset = false;
+                reset_pending = false;
+            }
+            self.count += 1;
+            remaining = remaining[chunk_len..];
+        }
+        if (omitted_after) {
+            _ = self.markOmissionForEpoch(epoch);
+            return .omitted;
+        }
+        return .enqueued;
+    }
+
+    fn omissionPendingForEpoch(
+        self: *TerminalOutputTransport,
+        epoch: InterestEpoch,
+    ) bool {
+        while (true) {
+            const pending = self.omission_pending.load(.acquire);
+            if (pending == 0) return false;
+            if (pending == epoch) return true;
+            const current = self.interest_state.load(.acquire);
+            if (current != epoch) return false;
+            if (pending == current) return false;
+            _ = self.omission_pending.cmpxchgStrong(
+                pending,
+                0,
+                .acq_rel,
+                .acquire,
+            );
+        }
+    }
+
+    fn markOmissionForEpoch(
+        self: *TerminalOutputTransport,
+        epoch: InterestEpoch,
+    ) bool {
+        while (self.interest_state.load(.acquire) == epoch) {
+            if (self.omissionPendingForEpoch(epoch)) return true;
+            if (self.omission_pending.cmpxchgStrong(
+                0,
+                epoch,
+                .acq_rel,
+                .acquire,
+            ) == null) return true;
+        }
+        return false;
+    }
+
+    fn utf8PrefixLen(output: []const u8, max_len: usize) usize {
+        if (output.len <= max_len) return output.len;
+
+        var len = max_len;
+        while (len > 0 and output[len] & 0xc0 == 0x80) len -= 1;
+        // Semantic producers always provide valid UTF-8. Keep the historical
+        // progress guarantee for generic callers if malformed bytes arrive.
+        return if (len == 0) max_len else len;
+    }
+
+    pub fn drain(
+        self: *TerminalOutputTransport,
+        ctx: *anyopaque,
+        callback: DrainCallback,
+    ) void {
+        const epoch = self.captureEpoch() orelse return;
+
+        var chunks: [max_chunks][chunk_bytes]u8 = undefined;
+        var lengths: [max_chunks]usize = [_]usize{0} ** max_chunks;
+        var resets_before: [max_chunks]bool = [_]bool{false} ** max_chunks;
+        var count: usize = 0;
+        self.mutex.lock();
+        if (self.interest_state.load(.acquire) != epoch) {
+            self.mutex.unlock();
+            return;
+        }
+        while (self.count != 0) {
+            const index = self.head;
+            const chunk_len = self.lengths[index];
+            @memcpy(chunks[count][0..chunk_len], self.chunks[index][0..chunk_len]);
+            lengths[count] = chunk_len;
+            resets_before[count] = self.resets_before[index];
+            count += 1;
+            self.head = (index + 1) % max_chunks;
+            self.count -= 1;
+        }
+        self.head = 0;
+        const trailing_reset = self.trailing_reset;
+        self.trailing_reset = false;
+        // Close this retained-data epoch while still holding the queue lock.
+        // Producers that race after the swap either enqueue into the next
+        // epoch or establish a fresh omission barrier for its next drain.
+        const emit_omission = self.omission_pending.cmpxchgStrong(
+            epoch,
+            0,
+            .acq_rel,
+            .acquire,
+        ) == null;
+        self.mutex.unlock();
+
+        for (0..count) |index| {
+            if (resets_before[index]) callback(ctx, .reset);
+            callback(ctx, .{ .data = chunks[index][0..lengths[index]] });
+        }
+        if (trailing_reset) callback(ctx, .reset);
+        if (emit_omission) callback(ctx, .omitted);
+    }
+};
 
 /// The message types that can be sent to a single surface.
 pub const Message = union(enum) {
@@ -190,6 +423,329 @@ pub const Mailbox = struct {
         }, timeout);
     }
 };
+
+test "terminal output transport ignores uninterested producers without copying" {
+    var transport: TerminalOutputTransport = .{};
+    const input = "uninterested output";
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.uninterested,
+        transport.push(input),
+    );
+    try std.testing.expectEqual(@as(usize, 0), transport.count);
+    try std.testing.expectEqual(@as(u64, 0), transport.omission_pending.load(.acquire));
+}
+
+test "terminal output transport saturation is nonblocking and ordered" {
+    const Context = struct {
+        bytes: std.ArrayList(u8) = .empty,
+        omissions: usize = 0,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => {},
+                .data => |data| self.bytes.appendSlice(std.testing.allocator, data) catch unreachable,
+                .omitted => self.omissions += 1,
+            }
+        }
+    };
+
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    const retained = [_][]const u8{
+        "old-0|",
+        "old-1|",
+        "old-2|",
+        "old-3|",
+        "old-4|",
+        "old-5|",
+        "old-6|",
+        "old-7|",
+    };
+    for (retained) |chunk| {
+        try std.testing.expectEqual(
+            TerminalOutputTransport.PushResult.enqueued,
+            transport.push(chunk),
+        );
+    }
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.omitted,
+        transport.push("dropped"),
+    );
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.rejecting,
+        transport.push("newer"),
+    );
+
+    var ctx: Context = .{};
+    defer ctx.bytes.deinit(std.testing.allocator);
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings(
+        "old-0|old-1|old-2|old-3|old-4|old-5|old-6|old-7|",
+        ctx.bytes.items,
+    );
+    try std.testing.expectEqual(@as(usize, 1), ctx.omissions);
+
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.push("accepted-after-omission"),
+    );
+    ctx.bytes.clearRetainingCapacity();
+    ctx.omissions = 0;
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings("accepted-after-omission", ctx.bytes.items);
+    try std.testing.expectEqual(@as(usize, 0), ctx.omissions);
+}
+
+test "terminal output transport keeps utf8 chunks before batch omission marker" {
+    const Context = struct {
+        bytes: std.ArrayList(u8) = .empty,
+        omissions: usize = 0,
+        chunks_valid: bool = true,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => {},
+                .data => |data| {
+                    self.chunks_valid = self.chunks_valid and
+                        std.unicode.utf8ValidateSlice(data);
+                    self.bytes.appendSlice(std.testing.allocator, data) catch unreachable;
+                },
+                .omitted => self.omissions += 1,
+            }
+        }
+    };
+
+    var semantic: [TerminalOutputTransport.chunk_bytes + 3]u8 = undefined;
+    @memset(semantic[0 .. TerminalOutputTransport.chunk_bytes - 1], 'x');
+    @memcpy(semantic[TerminalOutputTransport.chunk_bytes - 1 ..], "🙂");
+
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.omitted,
+        transport.pushBatch(&semantic, true),
+    );
+
+    var ctx: Context = .{};
+    defer ctx.bytes.deinit(std.testing.allocator);
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expect(ctx.chunks_valid);
+    try std.testing.expectEqualSlices(u8, &semantic, ctx.bytes.items);
+    try std.testing.expectEqual(@as(usize, 1), ctx.omissions);
+}
+
+test "terminal output transport lock contention returns immediately" {
+    const Context = struct {
+        omissions: usize = 0,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => {},
+                .data => {},
+                .omitted => self.omissions += 1,
+            }
+        }
+    };
+
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    transport.mutex.lock();
+    var parsing_continued = false;
+    const result = transport.push("cannot wait");
+    parsing_continued = true;
+    transport.mutex.unlock();
+    try std.testing.expectEqual(TerminalOutputTransport.PushResult.contended, result);
+    try std.testing.expect(parsing_continued);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.rejecting,
+        transport.push("later bytes"),
+    );
+
+    var ctx: Context = .{};
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqual(@as(usize, 1), ctx.omissions);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.push("accepted"),
+    );
+}
+
+test "terminal output transport reentrant callbacks preserve epochs and contention marker" {
+    const Context = struct {
+        transport: *TerminalOutputTransport,
+        events: std.ArrayList(u8) = .empty,
+        reenter: bool = true,
+        pushed_from_data: ?TerminalOutputTransport.PushResult = null,
+        pushed_from_omission: ?TerminalOutputTransport.PushResult = null,
+        contended_after_clear: ?TerminalOutputTransport.PushResult = null,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => self.events.appendSlice(std.testing.allocator, "<reset>|") catch unreachable,
+                .data => |data| {
+                    self.events.appendSlice(std.testing.allocator, data) catch unreachable;
+                    if (self.reenter and self.pushed_from_data == null) {
+                        self.pushed_from_data = self.transport.push("during-data|");
+                    }
+                },
+                .omitted => {
+                    self.events.appendSlice(std.testing.allocator, "<omitted>|") catch unreachable;
+                    if (self.reenter) {
+                        self.pushed_from_omission = self.transport.push("during-omission|");
+                        self.transport.mutex.lock();
+                        self.contended_after_clear = self.transport.push("dropped-after-clear");
+                        self.transport.mutex.unlock();
+                        self.reenter = false;
+                    }
+                },
+            }
+        }
+    };
+
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.push("old|"),
+    );
+    transport.mutex.lock();
+    const initial_contention = transport.push("initially-dropped");
+    transport.mutex.unlock();
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.contended,
+        initial_contention,
+    );
+
+    var ctx: Context = .{ .transport = &transport };
+    defer ctx.events.deinit(std.testing.allocator);
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings("old|<omitted>|", ctx.events.items);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        ctx.pushed_from_data.?,
+    );
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        ctx.pushed_from_omission.?,
+    );
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.contended,
+        ctx.contended_after_clear.?,
+    );
+    try std.testing.expect(transport.omission_pending.load(.acquire) != 0);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.rejecting,
+        transport.push("rejected-after-contention"),
+    );
+
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings(
+        "old|<omitted>|during-data|during-omission|<omitted>|",
+        ctx.events.items,
+    );
+    try std.testing.expectEqual(@as(u64, 0), transport.omission_pending.load(.acquire));
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.push("accepted-next-epoch"),
+    );
+}
+
+test "terminal output transport rejects stale interest epoch without poisoning new epoch" {
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    const stale_epoch = transport.captureEpoch().?;
+
+    transport.setInterested(false);
+    transport.setInterested(true);
+    const current_epoch = transport.captureEpoch().?;
+    try std.testing.expect(stale_epoch != current_epoch);
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.stale,
+        transport.pushSemanticBatchForEpoch(
+            stale_epoch,
+            "stale",
+            true,
+            true,
+        ),
+    );
+    try std.testing.expectEqual(@as(u64, 0), transport.omission_pending.load(.acquire));
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.pushBatchForEpoch(current_epoch, "current", false),
+    );
+
+    const Context = struct {
+        events: std.ArrayList(u8) = .empty,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => self.events.appendSlice(std.testing.allocator, "<reset>|") catch unreachable,
+                .data => |data| self.events.appendSlice(std.testing.allocator, data) catch unreachable,
+                .omitted => self.events.appendSlice(std.testing.allocator, "<omitted>|") catch unreachable,
+            }
+        }
+    };
+    var ctx: Context = .{};
+    defer ctx.events.deinit(std.testing.allocator);
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings("current", ctx.events.items);
+}
+
+test "terminal output transport orders silent reset before post reset data" {
+    const Context = struct {
+        events: std.ArrayList(u8) = .empty,
+
+        fn callback(raw: *anyopaque, item: TerminalOutputTransport.Item) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (item) {
+                .reset => self.events.appendSlice(std.testing.allocator, "<reset>|") catch unreachable,
+                .data => |data| self.events.appendSlice(std.testing.allocator, data) catch unreachable,
+                .omitted => self.events.appendSlice(std.testing.allocator, "<omitted>|") catch unreachable,
+            }
+        }
+    };
+
+    var transport: TerminalOutputTransport = .{};
+    transport.setInterested(true);
+    const epoch = transport.captureEpoch().?;
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.pushBatchForEpoch(epoch, "before|", false),
+    );
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.pushSemanticBatchForEpoch(
+            epoch,
+            "after|",
+            false,
+            true,
+        ),
+    );
+
+    var ctx: Context = .{};
+    defer ctx.events.deinit(std.testing.allocator);
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings("before|<reset>|after|", ctx.events.items);
+
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.pushSemanticBatchForEpoch(epoch, "", false, true),
+    );
+    try std.testing.expectEqual(
+        TerminalOutputTransport.PushResult.enqueued,
+        transport.pushBatchForEpoch(epoch, "later|", false),
+    );
+    transport.drain(&ctx, Context.callback);
+    try std.testing.expectEqualStrings(
+        "before|<reset>|after|<reset>|later|",
+        ctx.events.items,
+    );
+}
 
 /// Context for new surface creation to determine inheritance behavior
 pub const NewSurfaceContext = enum(c_int) {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -22,6 +22,7 @@ const SplitTree = @import("../datastruct/split_tree.zig").SplitTree;
 const win32_theme = @import("win32_theme.zig");
 const win32_tween = @import("win32_tween.zig");
 const win32_uia = @import("win32_uia/mod.zig");
+const win32_terminal_accessibility = @import("win32_terminal_accessibility.zig");
 const win32_palette = @import("win32_palette.zig");
 const win32_layout = @import("win32_layout.zig");
 const win32_settings = @import("win32_settings.zig");
@@ -491,6 +492,7 @@ const WM_DRAWITEM = 0x002B;
 const WM_ERASEBKGND = 0x0014;
 const WM_GETMINMAXINFO = 0x0024;
 const WM_CHAR = 0x0102;
+const WM_DEADCHAR = 0x0103;
 const WM_HOTKEY = 0x0312;
 const WM_IME_SETCONTEXT = 0x0281;
 const WM_IME_STARTCOMPOSITION = 0x010D;
@@ -551,15 +553,13 @@ const SIZE_MINIMIZED: u32 = 1;
 const SIZE_RESTORED: u32 = 0;
 const WM_SYSKEYDOWN = 0x0104;
 const WM_SYSKEYUP = 0x0105;
+const WM_SYSDEADCHAR = 0x0107;
 const WM_WINHOSTTY_WAKE = WM_APP + 1;
 const WM_WINHOSTTY_UPDATE = WM_APP + 2;
 const WM_WINHOSTTY_TOAST_ACTIVATION = WM_APP + 3;
 const WM_WINHOSTTY_HOST_NEW_TAB = WM_APP + 4;
 const WM_WINHOSTTY_UIA_DISCONNECT = WM_APP + 5;
 const WM_WINHOSTTY_UIA_QUERY_REFRESH = WM_APP + 6;
-const SMTO_BLOCK: UINT = 0x0001;
-const SMTO_ABORTIFHUNG: UINT = 0x0002;
-const terminal_uia_cold_query_timeout_ms: UINT = 500;
 
 const DeferredUiaDisconnect = struct {
     ctx: *anyopaque,
@@ -741,11 +741,6 @@ const WM_THEMECHANGED = 0x031A;
 const WM_SYSCOLORCHANGE = 0x0015;
 const WM_DWMCOLORIZATIONCOLORCHANGED: UINT = 0x0320;
 const WM_DPICHANGED: UINT = 0x02E0;
-const DWMWA_USE_IMMERSIVE_DARK_MODE_V1: DWORD = 19;
-const DWMWA_USE_IMMERSIVE_DARK_MODE: DWORD = 20;
-const DWMWA_CAPTION_COLOR: DWORD = 35;
-const DWMWA_TEXT_COLOR: DWORD = 36;
-const DWMWA_SYSTEMBACKDROP_TYPE: DWORD = 38;
 const DWMSBT_NONE: u32 = 1;
 /// Mica-tabbed backdrop for main windows with visible tab strips.
 /// Win11 22H2+ (build >= 22621).
@@ -904,6 +899,7 @@ const VK_OEM_4 = 0xDB;
 const VK_OEM_5 = 0xDC;
 const VK_OEM_6 = 0xDD;
 const VK_OEM_7 = 0xDE;
+const VK_PACKET = 0xE7;
 
 const KF_EXTENDED = 1 << 24;
 const KF_REPEAT = 1 << 30;
@@ -1134,15 +1130,6 @@ extern "user32" fn SetWindowLongPtrW(hWnd: HWND, nIndex: i32, dwNewLong: LONG_PT
 extern "user32" fn SetWindowPos(hWnd: HWND, hWndInsertAfter: ?*anyopaque, X: i32, Y: i32, cx: i32, cy: i32, uFlags: UINT) callconv(.winapi) BOOL;
 extern "user32" fn SetFocus(hWnd: HWND) callconv(.winapi) ?HWND;
 extern "user32" fn SendMessageW(hWnd: HWND, Msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
-extern "user32" fn SendMessageTimeoutW(
-    hWnd: HWND,
-    Msg: UINT,
-    wParam: WPARAM,
-    lParam: LPARAM,
-    fuFlags: UINT,
-    uTimeout: UINT,
-    lpdwResult: *usize,
-) callconv(.winapi) LRESULT;
 extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: LPCWSTR) callconv(.winapi) BOOL;
 extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: i32) callconv(.winapi) LONG_PTR;
 extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: i32) callconv(.winapi) BOOL;
@@ -1304,7 +1291,6 @@ extern "opengl32" fn wglGetCurrentDC() callconv(.winapi) HDC;
 extern "opengl32" fn wglGetProcAddress(lpszProc: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
 extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
 extern "dwmapi" fn DwmDefWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM, plResult: *LRESULT) callconv(.winapi) BOOL;
-extern "dwmapi" fn DwmSetWindowAttribute(hwnd: HWND, dwAttribute: DWORD, pvAttribute: *const anyopaque, cbAttribute: DWORD) callconv(.winapi) i32;
 extern "imm32" fn ImmGetContext(hWnd: HWND) callconv(.winapi) ?*anyopaque;
 extern "imm32" fn ImmReleaseContext(hWnd: HWND, hIMC: ?*anyopaque) callconv(.winapi) BOOL;
 extern "imm32" fn ImmGetCompositionStringW(hIMC: *anyopaque, dwIndex: u32, lpBuf: ?[*]u16, dwBufLen: u32) callconv(.winapi) i32;
@@ -2846,6 +2832,8 @@ pub const App = struct {
             .ownerWindow = &settingsOwnerWindowThunk,
             .chromeBg = &settingsChromeBgThunk,
             .textPrimary = &settingsTextPrimaryThunk,
+            .themeColors = &settingsThemeColorsThunk,
+            .highContrast = &settingsHighContrastThunk,
             .openInEditor = &settingsOpenInEditorThunk,
             .currentConfig = &settingsCurrentConfigThunk,
             .saveAndReload = &settingsSaveAndReloadThunk,
@@ -4782,13 +4770,15 @@ pub const App = struct {
                     .app => blk: {
                         for (self.windows.items) |surface| {
                             try surface.requestRepaintWithMode(rendererRepaintRequestMode(surface.host));
-                            surface.refreshTerminalUiaText();
+                            surface.drainTerminalAccessibilityOutput();
+                            if (surface.terminal_accessibility) |session| session.rendererUpdated();
                         }
                         break :blk true;
                     },
                     .surface => if (self.findSurfaceForTarget(target)) |surface| blk: {
                         try surface.requestRepaintWithMode(rendererRepaintRequestMode(surface.host));
-                        surface.refreshTerminalUiaText();
+                        surface.drainTerminalAccessibilityOutput();
+                        if (surface.terminal_accessibility) |session| session.rendererUpdated();
                         break :blk true;
                     } else false,
                 };
@@ -5505,8 +5495,18 @@ pub const App = struct {
                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
                     );
                     host.layout() catch {};
-                    host.invalidateChrome();
                 }
+                // Theme resource replacement always invalidates the full host
+                // chrome plus native child controls. A System->Dark swap does
+                // not necessarily change frame mode, but every retained pixel
+                // still belongs to the previous palette.
+                host.invalidateChrome();
+                _ = RedrawWindow(
+                    hwnd,
+                    null,
+                    null,
+                    RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN,
+                );
             }
         }
         for (self.windows.items) |surface| surface.invalidateScrollbarWindow();
@@ -10723,8 +10723,8 @@ const Host = struct {
         lParam: LPARAM,
     ) bool {
         if (self.activeSurface() != null) return false;
-        const event = keyEventFromWin32Message(msg, wParam, lParam) orelse return false;
-        return self.app.core_app.keyEvent(self.app, event);
+        const message = keyEventFromWin32Message(msg, wParam, lParam) orelse return false;
+        return self.app.core_app.keyEvent(self.app, message.event);
     }
 
     fn prepareActiveTabVisibility(self: *Host, active_index: usize) void {
@@ -11130,7 +11130,7 @@ const Host = struct {
         lParam: LPARAM,
     ) bool {
         if (self.overlay_mode != .command_palette) return false;
-        const event = keyEventFromWin32Message(msg, wParam, lParam) orelse return false;
+        const event = (keyEventFromWin32Message(msg, wParam, lParam) orelse return false).event;
         const entry = self.app.config.keybind.set.getEvent(event) orelse return false;
         const actions: []const input.Binding.Action = switch (entry.value_ptr.*) {
             .leader => return false,
@@ -17123,25 +17123,17 @@ fn titlebarTextColor(theme: *const ThemeColors, config: *const configpkg.Config)
 }
 
 fn applyDwmThemeWithBuild(hwnd: HWND, theme: *const ThemeColors, config: *const configpkg.Config, os_build: u32) void {
-    if (isHighContrastActive()) return; // Let system control title bar in HC mode
-    const dark_mode: u32 = if (theme.is_dark) 1 else 0;
-    // Try attribute 20 first (Win10 20H1+), fall back to 19 (Win10 1809-20H1)
-    const hr = DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, @ptrCast(&dark_mode), @sizeOf(u32));
-    if (hr == @as(i32, @bitCast(@as(u32, 0x80070057)))) { // E_INVALIDARG
-        _ = DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_V1, @ptrCast(&dark_mode), @sizeOf(u32));
-    }
-    // Set caption color to match chrome (Win11 only; fails silently on Win10)
     const caption_color = titlebarCaptionColor(theme, config);
     const text_color = titlebarTextColor(theme, config);
-    _ = DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, @ptrCast(&caption_color), @sizeOf(u32));
-    _ = DwmSetWindowAttribute(hwnd, DWMWA_TEXT_COLOR, @ptrCast(&text_color), @sizeOf(u32));
-    // Toggle system backdrop blur through DWMWA_SYSTEMBACKDROP_TYPE. That
-    // attribute is supported starting with Windows 11 22H2 (build 22621);
-    // older builds skip the call entirely.
-    if (supportsDwmSystemBackdropAttribute(os_build)) {
-        const backdrop_type: u32 = systemBackdropTypeForBuild(config, os_build);
-        _ = DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, @ptrCast(&backdrop_type), @sizeOf(u32));
-    }
+    win32_theme.WindowThemeAdapter.applyHost(
+        hwnd,
+        theme.*,
+        isHighContrastActive(),
+        caption_color,
+        text_color,
+        systemBackdropTypeForBuild(config, os_build),
+        supportsDwmSystemBackdropAttribute(os_build),
+    );
 }
 
 /// Linear-interpolate two `COLORREF`-shaped values (`0x00BBGGRR` on
@@ -17569,6 +17561,13 @@ fn settingsChromeBgThunk(ctx: *anyopaque) u32 {
 fn settingsTextPrimaryThunk(ctx: *anyopaque) u32 {
     const app: *const App = @ptrCast(@alignCast(ctx));
     return app.resolved_theme.text_primary;
+}
+fn settingsThemeColorsThunk(ctx: *anyopaque) win32_theme.ThemeColors {
+    const app: *const App = @ptrCast(@alignCast(ctx));
+    return app.resolved_theme;
+}
+fn settingsHighContrastThunk(_: *anyopaque) bool {
+    return isHighContrastActive();
 }
 fn settingsOpenInEditorThunk(ctx: *anyopaque) void {
     const app: *App = @ptrCast(@alignCast(ctx));
@@ -23167,10 +23166,16 @@ const KeyText = struct {
     len: usize = 0,
     consumed_mods: input.Mods = .{},
     unshifted_codepoint: u21 = 0,
+    deferred_utf16_units: usize = 0,
 };
 
 fn isControlCodepoint(codepoint: u21) bool {
     return codepoint < 0x20 or codepoint == 0x7F;
+}
+
+fn utf16CodeUnitCount(codepoint: u21) usize {
+    if (codepoint == 0) return 0;
+    return if (codepoint <= std.math.maxInt(u16)) 1 else 2;
 }
 
 fn shouldDeferTextToCharMessage(
@@ -23188,13 +23193,85 @@ fn shouldDeferTextToCharMessage(
         else => {},
     }
 
+    if (translated.deferred_utf16_units == 0) return false;
     if (translated.len > 0) return true;
-    if (translated.unshifted_codepoint == 0) return false;
+    if (translated.unshifted_codepoint == 0) return true;
     return !isControlCodepoint(translated.unshifted_codepoint);
 }
 
-fn shouldCommitDeferredCharMessage(pending_wm_char_text: bool, ime_composing: bool) bool {
-    return pending_wm_char_text and !ime_composing;
+const DeferredCharState = struct {
+    pending_units: usize = 0,
+    high_surrogate: ?u16 = null,
+
+    fn authorize(self: *DeferredCharState, expected_units: usize) void {
+        self.pending_units = self.pending_units +| expected_units;
+    }
+
+    fn clear(self: *DeferredCharState) void {
+        self.* = .{};
+    }
+
+    fn consumeDeadChar(self: *DeferredCharState) void {
+        if (self.pending_units > 0) self.pending_units -= 1;
+        self.high_surrogate = null;
+    }
+
+    fn consumeCodeUnit(
+        self: *DeferredCharState,
+        code_unit: u16,
+        ime_composing: bool,
+    ) ?u21 {
+        if (ime_composing) {
+            self.clear();
+            return null;
+        }
+        if (self.pending_units == 0) {
+            self.high_surrogate = null;
+            return null;
+        }
+        self.pending_units -= 1;
+
+        if (self.high_surrogate) |high| {
+            if (!std.unicode.utf16IsLowSurrogate(code_unit)) {
+                self.clear();
+                return null;
+            }
+            const codepoint = std.unicode.utf16DecodeSurrogatePair(
+                &.{ high, code_unit },
+            ) catch {
+                self.clear();
+                return null;
+            };
+            self.high_surrogate = null;
+            return codepoint;
+        }
+
+        if (std.unicode.utf16IsHighSurrogate(code_unit)) {
+            self.high_surrogate = code_unit;
+            return null;
+        }
+        if (std.unicode.utf16IsLowSurrogate(code_unit)) {
+            self.clear();
+            return null;
+        }
+
+        return code_unit;
+    }
+};
+
+fn charCommitEvent(
+    codepoint: u21,
+    lParam: LPARAM,
+    utf8_buf: *[8]u8,
+) ?input.KeyEvent {
+    const utf8_len = std.unicode.utf8Encode(codepoint, utf8_buf) catch return null;
+    return .{
+        .action = if (isRepeatedKey(lParam)) .repeat else .press,
+        .key = .unidentified,
+        .mods = .{},
+        .unshifted_codepoint = codepoint,
+        .utf8 = utf8_buf[0..utf8_len],
+    };
 }
 
 fn translateKeyTextToUnicode(
@@ -23216,17 +23293,28 @@ fn translateKeyText(
     keyboard_state: ?*const [256]u8,
 ) KeyText {
     const state = keyboard_state orelse {
-        return .{ .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk) };
+        const unshifted = unshiftedCodepointForVirtualKey(vk);
+        return .{
+            .unshifted_codepoint = unshifted,
+            .deferred_utf16_units = utf16CodeUnitCount(unshifted),
+        };
     };
 
     var utf16: [4]u16 = [_]u16{0} ** 4;
     const count = translateKeyTextToUnicode(vk, scanCodeFromLParam(lParam), state, &utf16);
-    if (count <= 0) {
+    if (count < 0) {
+        return .{
+            .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
+            .deferred_utf16_units = 1,
+        };
+    }
+    if (count == 0) {
         return .{ .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk) };
     }
 
     var result: KeyText = .{
         .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
+        .deferred_utf16_units = @intCast(count),
     };
 
     const codepoint: u21 = cp: {
@@ -23247,11 +23335,32 @@ fn translateKeyText(
     return result;
 }
 
+const Win32KeyMessage = struct {
+    event: input.KeyEvent,
+    deferred_utf16_units: usize = 0,
+};
+
+fn packetKeyMessage(action: input.Action) Win32KeyMessage {
+    const commit_pending = action != .release;
+    return .{
+        .event = .{
+            .action = action,
+            .key = .unidentified,
+            .mods = .{},
+            .consumed_mods = .{},
+            .unshifted_codepoint = 0,
+            .utf8 = "",
+            .composing = commit_pending,
+        },
+        .deferred_utf16_units = if (commit_pending) 1 else 0,
+    };
+}
+
 fn keyEventFromWin32Message(
     msg: UINT,
     wParam: WPARAM,
     lParam: LPARAM,
-) ?input.KeyEvent {
+) ?Win32KeyMessage {
     const action: input.Action = switch (msg) {
         WM_KEYUP, WM_SYSKEYUP => .release,
         WM_KEYDOWN, WM_SYSKEYDOWN => if (isRepeatedKey(lParam)) .repeat else .press,
@@ -23259,36 +23368,42 @@ fn keyEventFromWin32Message(
     };
 
     const vk: UINT = @intCast(wParam & 0xFFFF);
+    // KEYEVENTF_UNICODE arrives as VK_PACKET followed by one WM_CHAR UTF-16
+    // code unit. Authorize that unit explicitly without consulting live
+    // keyboard modifiers or ToUnicode; both belong to physical-key handling.
+    if (vk == VK_PACKET) return packetKeyMessage(action);
+
     const key = keyFromVirtualKey(vk, lParam);
     var keyboard_state_storage: [256]u8 = [_]u8{0} ** 256;
     const keyboard_state = currentKeyboardState(&keyboard_state_storage);
     const mods = currentModsFromKeyboardState(keyboard_state);
 
-    var event: input.KeyEvent = .{
+    var result: Win32KeyMessage = .{ .event = .{
         .action = action,
         .key = key,
         .mods = mods,
         .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
-    };
+    } };
 
     if (action != .release) {
         const translated = translateKeyText(vk, lParam, mods, keyboard_state);
-        event.utf8 = translated.utf8[0..translated.len];
-        event.consumed_mods = translated.consumed_mods;
+        result.event.utf8 = translated.utf8[0..translated.len];
+        result.event.consumed_mods = translated.consumed_mods;
         if (translated.unshifted_codepoint != 0) {
-            event.unshifted_codepoint = translated.unshifted_codepoint;
+            result.event.unshifted_codepoint = translated.unshifted_codepoint;
         }
         if (shouldDeferTextToCharMessage(action, key, mods, translated)) {
             // Keep the physical-key event visible to bindings/modifier state
             // but defer text emission to WM_CHAR so plain typing doesn't rely
             // on ToUnicode/GetKeyboardState timing.
-            event.utf8 = "";
-            event.consumed_mods = .{};
-            event.composing = true;
+            result.event.utf8 = "";
+            result.event.consumed_mods = .{};
+            result.event.composing = true;
+            result.deferred_utf16_units = translated.deferred_utf16_units;
         }
     }
 
-    return event;
+    return result;
 }
 
 fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT {
@@ -23306,10 +23421,8 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
 
         WM_WINHOSTTY_UIA_QUERY_REFRESH => {
             if (surface) |v| {
-                if (v.terminal_uia_context) |context| {
-                    context.query_refresh_post_pending.store(false, .release);
-                    v.refreshTerminalUiaTextWithMode(wParam != 0);
-                }
+                v.drainTerminalAccessibilityOutput();
+                if (v.terminal_accessibility) |session| session.handleQueryRefresh(wParam != 0);
             }
             return 0;
         },
@@ -23320,7 +23433,10 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
         },
 
         WM_KILLFOCUS => {
-            if (surface) |v| v.focusChanged(false);
+            if (surface) |v| {
+                v.deferred_char.clear();
+                v.focusChanged(false);
+            }
             return 0;
         },
 
@@ -23332,8 +23448,8 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
         WM_TIMER => {
             if (wParam == TERMINAL_UIA_TIMER_ID) {
                 if (surface) |v| {
-                    v.cancelTerminalUiaRefreshTimer();
-                    v.refreshTerminalUiaText();
+                    v.drainTerminalAccessibilityOutput();
+                    if (v.terminal_accessibility) |session| session.handleTimer();
                 }
                 return 0;
             }
@@ -23398,6 +23514,7 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
 
         WM_IME_STARTCOMPOSITION => {
             if (surface) |v| {
+                v.deferred_char.clear();
                 v.ime_composing = true;
                 v.positionImeWindow();
             }
@@ -23406,6 +23523,7 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
 
         WM_IME_COMPOSITION => {
             if (surface) |v| {
+                v.deferred_char.clear();
                 // Handle finalized (committed) text first
                 if ((@as(u32, @intCast(lParam)) & GCS_RESULTSTR) != 0) {
                     v.handleImeResult();
@@ -23421,6 +23539,7 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
 
         WM_IME_ENDCOMPOSITION => {
             if (surface) |v| {
+                v.deferred_char.clear();
                 v.ime_composing = false;
                 v.core_surface.preeditCallback(null) catch {};
             }
@@ -23437,6 +23556,11 @@ fn windowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.w
             if (surface) |v| {
                 v.handleCharMessage(wParam, lParam);
             }
+            return 0;
+        },
+
+        WM_DEADCHAR, WM_SYSDEADCHAR => {
+            if (surface) |v| v.deferred_char.consumeDeadChar();
             return 0;
         },
 
@@ -23633,363 +23757,72 @@ fn getSurface(hwnd: HWND) ?*Surface {
     return @ptrFromInt(@as(usize, @intCast(raw)));
 }
 
-const TerminalUiaContext = struct {
+fn terminalAccessibilityHwnd(ctx: *anyopaque) ?HWND {
+    const surface: *Surface = @ptrCast(@alignCast(ctx));
+    return surface.hwnd;
+}
+
+fn terminalAccessibilityName(ctx: *anyopaque, buf: []u8) []const u8 {
+    const surface: *Surface = @ptrCast(@alignCast(ctx));
+    const title = surface.effectiveTitle() orelse "Terminal";
+    return std.fmt.bufPrint(buf, "Terminal: {s}", .{title}) catch "Terminal";
+}
+
+fn terminalAccessibilityFocused(ctx: *anyopaque) bool {
+    const surface: *Surface = @ptrCast(@alignCast(ctx));
+    return surface.app.isSurfaceFocused(surface);
+}
+
+fn terminalAccessibilityCapture(
+    ctx: *anyopaque,
     alloc: Allocator,
-    refcount: std.atomic.Value(u32),
-    mutex: std.Thread.Mutex = .{},
-    surface: ?*Surface,
-    /// UIA polling does not make `UiaClientsAreListening` return true. Record
-    /// recent text queries and coalesce a UI-thread refresh request so polling
-    /// clients see current text without keeping renderer snapshots alive after
-    /// the client goes idle.
-    last_query_ms: std.atomic.Value(u64) = .init(0),
-    query_refresh_post_pending: std.atomic.Value(bool) = .init(false),
-    /// Bounded, immutable-to-readers terminal snapshot. UIA callbacks copy
-    /// this cache and never acquire the renderer mutex.
-    cached_text: []u8,
-    cached_visible_text: []u8,
-    cached_visible_range: win32_uia.OffsetRange = .{ .start = 0, .end = 0 },
-    cached_caret_offset: usize = 0,
-    cached_cells: []win32_uia.TerminalCellPosition,
-    viewport_rows: u32 = 0,
-    viewport_columns: u32 = 0,
-    cell_width: f64 = 0,
-    cell_height: f64 = 0,
-    origin_x: f64 = 0,
-    origin_y: f64 = 0,
+) !win32_terminal_accessibility.Capture {
+    const surface: *Surface = @ptrCast(@alignCast(ctx));
+    if (!surface.core_initialized) return error.SurfaceNotInitialized;
 
-    fn create(alloc: Allocator, surface: *Surface) !*TerminalUiaContext {
-        const self = try alloc.create(TerminalUiaContext);
-        errdefer alloc.destroy(self);
-        const cached_text = try alloc.dupe(u8, "");
-        errdefer alloc.free(cached_text);
-        const cached_visible_text = try alloc.dupe(u8, "");
-        errdefer alloc.free(cached_visible_text);
-        const cached_cells = try alloc.alloc(win32_uia.TerminalCellPosition, 0);
-        errdefer alloc.free(cached_cells);
-        self.* = .{
-            .alloc = alloc,
-            .refcount = std.atomic.Value(u32).init(1),
-            .surface = surface,
-            .cached_text = cached_text,
-            .cached_visible_text = cached_visible_text,
-            .cached_cells = cached_cells,
-        };
-        return self;
-    }
-
-    fn retain(ctx: *anyopaque) void {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        _ = self.refcount.fetchAdd(1, .monotonic);
-    }
-
-    fn release(ctx: *anyopaque) void {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        const prev = self.refcount.fetchSub(1, .acq_rel);
-        if (prev == 1) {
-            self.alloc.free(self.cached_cells);
-            self.alloc.free(self.cached_visible_text);
-            self.alloc.free(self.cached_text);
-            self.alloc.destroy(self);
-        }
-    }
-
-    fn detachSurface(self: *TerminalUiaContext) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        self.surface = null;
-        self.query_refresh_post_pending.store(false, .release);
-    }
-
-    fn noteTextQuery(self: *TerminalUiaContext) void {
-        const now_ms = GetTickCount64();
-        const previous_query_ms = self.last_query_ms.swap(now_ms, .acq_rel);
-
-        self.mutex.lock();
-        const hwnd = if (self.surface) |surface| surface.hwnd else null;
-        self.mutex.unlock();
-
-        if (hwnd == null) return;
-        if (terminalUiaQueryNeedsSynchronousRefresh(previous_query_ms, now_ms)) {
-            var ignored: usize = 0;
-            if (SendMessageTimeoutW(
-                hwnd.?,
-                WM_WINHOSTTY_UIA_QUERY_REFRESH,
-                1,
-                0,
-                SMTO_BLOCK | SMTO_ABORTIFHUNG,
-                terminal_uia_cold_query_timeout_ms,
-                &ignored,
-            ) != 0) return;
-        }
-
-        if (self.query_refresh_post_pending.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) return;
-        if (PostMessageW(hwnd.?, WM_WINHOSTTY_UIA_QUERY_REFRESH, 0, 0) == 0) {
-            self.query_refresh_post_pending.store(false, .release);
-        }
-    }
-
-    fn queryRecentlyActive(self: *const TerminalUiaContext, now_ms: u64) bool {
-        return terminalUiaQueryRecentlyActive(self.last_query_ms.load(.acquire), now_ms);
-    }
-
-    /// Refresh on the application/UI thread after terminal mutations. The
-    /// renderer lock is never held together with the context lock.
-    const Change = enum { unchanged, geometry, caret, text, text_and_caret };
-
-    fn refresh(self: *TerminalUiaContext, surface: *Surface) !Change {
-        if (!surface.core_initialized) return .unchanged;
-
-        surface.core_surface.renderer_state.mutex.lock();
-        var snapshot = win32_uia.snapshotTerminalAccessiblePlainText(
-            self.alloc,
-            surface.core_surface.renderer_state.terminal,
-        ) catch |err| {
-            surface.core_surface.renderer_state.mutex.unlock();
-            return err;
-        };
-        const renderer_size = surface.core_surface.size;
+    surface.core_surface.renderer_state.mutex.lock();
+    const snapshot = win32_uia.snapshotTerminalAccessiblePlainText(
+        alloc,
+        surface.core_surface.renderer_state.terminal,
+    ) catch |err| {
         surface.core_surface.renderer_state.mutex.unlock();
-        defer snapshot.deinit();
-
-        const text = snapshot.text;
-        snapshot.text = text[0..0];
-        errdefer self.alloc.free(text);
-        const cells = snapshot.cell_for_byte;
-        snapshot.cell_for_byte = cells[0..0];
-        errdefer self.alloc.free(cells);
-        const visible_range = snapshot.visible_range;
-        const caret_offset = snapshot.caret_offset;
-        const visible_text = try self.alloc.dupe(u8, text[visible_range.start..visible_range.end]);
-        errdefer self.alloc.free(visible_text);
-
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        if (self.surface != surface) {
-            self.alloc.free(visible_text);
-            self.alloc.free(cells);
-            self.alloc.free(text);
-            return .unchanged;
-        }
-        const text_changed = !std.mem.eql(u8, self.cached_text, text) or
-            self.cached_visible_range.start != visible_range.start or
-            self.cached_visible_range.end != visible_range.end;
-        const caret_changed = self.cached_caret_offset != caret_offset;
-        const unchanged = std.mem.eql(u8, self.cached_text, text) and
-            self.cached_visible_range.start == visible_range.start and
-            self.cached_visible_range.end == visible_range.end and
-            self.cached_caret_offset == caret_offset and
-            self.viewport_rows == snapshot.viewport_rows and
-            self.viewport_columns == snapshot.viewport_columns and
-            self.cell_width == @as(f64, @floatFromInt(renderer_size.cell.width)) and
-            self.cell_height == @as(f64, @floatFromInt(renderer_size.cell.height)) and
-            self.origin_x == @as(f64, @floatFromInt(renderer_size.padding.left)) and
-            self.origin_y == @as(f64, @floatFromInt(renderer_size.padding.top)) and
-            terminalUiaCellsEqual(self.cached_cells, cells);
-        if (unchanged) {
-            self.alloc.free(visible_text);
-            self.alloc.free(cells);
-            self.alloc.free(text);
-            return .unchanged;
-        }
-
-        self.alloc.free(self.cached_cells);
-        self.alloc.free(self.cached_visible_text);
-        self.alloc.free(self.cached_text);
-        self.cached_text = text;
-        self.cached_visible_text = visible_text;
-        self.cached_visible_range = visible_range;
-        self.cached_caret_offset = caret_offset;
-        self.cached_cells = cells;
-        self.viewport_rows = snapshot.viewport_rows;
-        self.viewport_columns = snapshot.viewport_columns;
-        self.cell_width = @floatFromInt(renderer_size.cell.width);
-        self.cell_height = @floatFromInt(renderer_size.cell.height);
-        self.origin_x = @floatFromInt(renderer_size.padding.left);
-        self.origin_y = @floatFromInt(renderer_size.padding.top);
-        return if (text_changed and caret_changed)
-            .text_and_caret
-        else if (text_changed)
-            .text
-        else if (caret_changed)
-            .caret
-        else
-            .geometry;
-    }
-
-    fn state(self: *TerminalUiaContext) win32_uia.TerminalState {
-        return .{
-            .ctx = @ptrCast(self),
-            .retain = retain,
-            .release = release,
-            .name = terminalUiaName,
-            .value = terminalUiaValue,
-            .snapshot = terminalUiaSnapshot,
-            .focused = terminalUiaFocused,
-        };
-    }
-
-    fn terminalUiaName(ctx: *anyopaque, buf: []u8) []const u8 {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        const surface = self.surface orelse return std.fmt.bufPrint(buf, "Terminal", .{}) catch "Terminal";
-        const title = surface.effectiveTitle() orelse "Terminal";
-        return std.fmt.bufPrint(buf, "Terminal: {s}", .{title}) catch "Terminal";
-    }
-
-    fn terminalUiaValue(ctx: *anyopaque, alloc: Allocator) ![]u8 {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        self.noteTextQuery();
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        return try alloc.dupe(u8, self.cached_text);
-    }
-
-    fn terminalUiaSnapshot(ctx: *anyopaque, alloc: Allocator) !win32_uia.widgets.TerminalSnapshot {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        self.noteTextQuery();
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        const document_text = try alloc.dupe(u8, self.cached_text);
-        errdefer alloc.free(document_text);
-        const visible_text = try alloc.dupe(u8, self.cached_visible_text);
-        errdefer alloc.free(visible_text);
-        const cells = try alloc.dupe(win32_uia.TerminalCellPosition, self.cached_cells);
-        return .{
-            .document_text = document_text,
-            .visible_text = visible_text,
-            .visible_range = self.cached_visible_range,
-            .caret_offset = self.cached_caret_offset,
-            .geometry = .{
-                .cell_for_byte = cells,
-                .viewport_rows = self.viewport_rows,
-                .viewport_columns = self.viewport_columns,
-                .cell_width = self.cell_width,
-                .cell_height = self.cell_height,
-                .origin_x = self.origin_x,
-                .origin_y = self.origin_y,
-            },
-        };
-    }
-
-    fn terminalUiaFocused(ctx: *anyopaque) bool {
-        const self: *TerminalUiaContext = @ptrCast(@alignCast(ctx));
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        const surface = self.surface orelse return false;
-        return surface.app.isSurfaceFocused(surface);
-    }
-};
-
-fn terminalUiaCellsEqual(
-    lhs: []const win32_uia.TerminalCellPosition,
-    rhs: []const win32_uia.TerminalCellPosition,
-) bool {
-    if (lhs.len != rhs.len) return false;
-    for (lhs, rhs) |a, b| {
-        if (a.row != b.row or a.column != b.column or a.width != b.width) return false;
-    }
-    return true;
-}
-
-const terminal_uia_refresh_interval_ms: u64 = 100;
-const terminal_uia_query_activity_window_ms: u64 = 1_000;
-
-fn terminalUiaRefreshDue(last_refresh_ms: u64, now_ms: u64) bool {
-    return last_refresh_ms == 0 or now_ms -| last_refresh_ms >= terminal_uia_refresh_interval_ms;
-}
-
-fn terminalUiaRefreshDelay(last_refresh_ms: u64, now_ms: u64) UINT {
-    const elapsed = now_ms -| last_refresh_ms;
-    return @intCast(@max(1, terminal_uia_refresh_interval_ms -| elapsed));
-}
-
-fn terminalUiaSnapshotWasSlow(start_ms: u64, completed_ms: u64) bool {
-    return completed_ms -| start_ms >= terminal_uia_refresh_interval_ms;
-}
-
-fn terminalUiaQueryRecentlyActive(last_query_ms: u64, now_ms: u64) bool {
-    return last_query_ms != 0 and now_ms -| last_query_ms <= terminal_uia_query_activity_window_ms;
-}
-
-fn terminalUiaQueryNeedsSynchronousRefresh(last_query_ms: u64, now_ms: u64) bool {
-    return !terminalUiaQueryRecentlyActive(last_query_ms, now_ms);
-}
-
-const TerminalUiaPublishPolicy = struct {
-    refresh_snapshot: bool,
-    emit_events: bool,
-};
-
-fn terminalUiaPublishPolicy(
-    clients_listening_for_events: bool,
-    query_recently_active: bool,
-) TerminalUiaPublishPolicy {
+        return err;
+    };
+    const renderer_size = surface.core_surface.size;
+    surface.core_surface.renderer_state.mutex.unlock();
     return .{
-        .refresh_snapshot = clients_listening_for_events or query_recently_active,
-        .emit_events = clients_listening_for_events,
+        .snapshot = snapshot,
+        .cell_width = @floatFromInt(renderer_size.cell.width),
+        .cell_height = @floatFromInt(renderer_size.cell.height),
+        .origin_x = @floatFromInt(renderer_size.padding.left),
+        .origin_y = @floatFromInt(renderer_size.padding.top),
     };
 }
 
-test "terminal UIA snapshots are rate limited while a client is connected" {
-    try std.testing.expect(terminalUiaRefreshDue(0, 1));
-    try std.testing.expect(!terminalUiaRefreshDue(100, 199));
-    try std.testing.expect(terminalUiaRefreshDue(100, 200));
-    try std.testing.expectEqual(@as(UINT, 1), terminalUiaRefreshDelay(100, 199));
-    try std.testing.expectEqual(@as(UINT, 80), terminalUiaRefreshDelay(100, 120));
-    try std.testing.expect(!terminalUiaSnapshotWasSlow(100, 199));
-    try std.testing.expect(terminalUiaSnapshotWasSlow(100, 200));
+fn terminalAccessibilityDeferProviderRelease(
+    ctx: *anyopaque,
+    provider: *win32_uia.TerminalProvider,
+) void {
+    const surface: *Surface = @ptrCast(@alignCast(ctx));
+    scheduleDeferredUiaDisconnect(
+        surface.app,
+        @ptrCast(provider),
+        &terminalDisconnectThunk,
+        &terminalReleaseThunk,
+    );
 }
 
-test "terminal UIA query-only clients refresh without event emission" {
-    try std.testing.expect(!terminalUiaQueryRecentlyActive(0, 1));
-    try std.testing.expect(terminalUiaQueryRecentlyActive(100, 1_100));
-    try std.testing.expect(!terminalUiaQueryRecentlyActive(100, 1_101));
-    try std.testing.expect(terminalUiaQueryNeedsSynchronousRefresh(0, 1));
-    try std.testing.expect(!terminalUiaQueryNeedsSynchronousRefresh(100, 1_100));
-    try std.testing.expect(terminalUiaQueryNeedsSynchronousRefresh(100, 1_101));
-
-    const idle = terminalUiaPublishPolicy(false, false);
-    try std.testing.expect(!idle.refresh_snapshot);
-    try std.testing.expect(!idle.emit_events);
-
-    const query_only = terminalUiaPublishPolicy(false, true);
-    try std.testing.expect(query_only.refresh_snapshot);
-    try std.testing.expect(!query_only.emit_events);
-
-    const subscribed = terminalUiaPublishPolicy(true, false);
-    try std.testing.expect(subscribed.refresh_snapshot);
-    try std.testing.expect(subscribed.emit_events);
-}
-
-test "terminal UIA document callback and snapshot expose distinct cached ranges" {
-    var context = TerminalUiaContext{
-        .alloc = std.testing.allocator,
-        .refcount = std.atomic.Value(u32).init(1),
-        .surface = null,
-        .cached_text = try std.testing.allocator.dupe(u8, "history\nvisible"),
-        .cached_visible_text = try std.testing.allocator.dupe(u8, "visible"),
-        .cached_visible_range = .{ .start = 8, .end = 15 },
-        .cached_cells = try std.testing.allocator.alloc(win32_uia.TerminalCellPosition, 0),
-    };
-    defer std.testing.allocator.free(context.cached_cells);
-    defer std.testing.allocator.free(context.cached_visible_text);
-    defer std.testing.allocator.free(context.cached_text);
-
-    const document = try TerminalUiaContext.terminalUiaValue(&context, std.testing.allocator);
-    defer std.testing.allocator.free(document);
-    const snapshot = try TerminalUiaContext.terminalUiaSnapshot(&context, std.testing.allocator);
-    defer std.testing.allocator.free(snapshot.geometry.?.cell_for_byte);
-    defer std.testing.allocator.free(snapshot.visible_text);
-    defer std.testing.allocator.free(snapshot.document_text);
-    try std.testing.expectEqualStrings("history\nvisible", document);
-    try std.testing.expectEqualStrings("history\nvisible", snapshot.document_text);
-    try std.testing.expectEqualStrings("visible", snapshot.visible_text);
-    try std.testing.expectEqual(win32_uia.OffsetRange{ .start = 8, .end = 15 }, snapshot.visible_range);
+fn terminalAccessibilityOutputCallback(
+    ctx: *anyopaque,
+    item: apprt.surface.TerminalOutputTransport.Item,
+) void {
+    const session: *win32_terminal_accessibility.TerminalAccessibilitySession =
+        @ptrCast(@alignCast(ctx));
+    switch (item) {
+        .reset => session.resetSemanticOutputContinuity(),
+        .data => |output| session.noteSemanticOutput(output),
+        .omitted => session.noteOutputOmitted(),
+    }
 }
 
 pub const Surface = struct {
@@ -24069,8 +23902,7 @@ pub const Surface = struct {
     renderer_repaint_retry_pending: std.atomic.Value(bool) = .init(false),
     draw_in_progress: bool = false,
     ime_composing: bool = false,
-    pending_wm_char_text: bool = false,
-    pending_wm_char_high_surrogate: ?u16 = null,
+    deferred_char: DeferredCharState = .{},
     undo_capture_suspended: bool = false,
     render_trace: RenderTrace = .{},
     /// Per-surface bounded undo stack for terminal-local replayable
@@ -24125,10 +23957,7 @@ pub const Surface = struct {
     /// and by `Surface.destroyWindow` so a close-while-pending doesn't
     /// leak.
     pending_clipboard_op: ?PendingClipboardOp = null,
-    terminal_uia_context: ?*TerminalUiaContext = null,
-    terminal_uia_provider: ?*win32_uia.TerminalProvider = null,
-    terminal_uia_last_refresh_ms: u64 = 0,
-    terminal_uia_refresh_timer_active: bool = false,
+    terminal_accessibility: ?*win32_terminal_accessibility.TerminalAccessibilitySession = null,
     /// Close preflight ownership. Normal close paths build both candidates
     /// before HWND/core teardown; `windowDestroyed` consumes them without
     /// allocating after the Surface is already dead.
@@ -24838,94 +24667,48 @@ pub const Surface = struct {
         return self.effectiveTitle();
     }
 
-    fn terminalUiaState(self: *Surface) !win32_uia.TerminalState {
-        if (self.terminal_uia_context == null) {
-            self.terminal_uia_context = try TerminalUiaContext.create(std.heap.page_allocator, self);
-        }
-        return self.terminal_uia_context.?.state();
-    }
-
     fn terminalUiaProvider(self: *Surface) !*win32_uia.TerminalProvider {
-        if (self.terminal_uia_provider == null) {
-            const hwnd = self.hwnd orelse return error.NoWindow;
-            const context = self.terminal_uia_context orelse context: {
-                _ = try self.terminalUiaState();
-                break :context self.terminal_uia_context.?;
-            };
-            _ = try context.refresh(self);
-            self.terminal_uia_last_refresh_ms = GetTickCount64();
-            self.terminal_uia_provider = try win32_uia.TerminalProvider.create(
+        if (self.terminal_accessibility == null) {
+            self.terminal_accessibility = try win32_terminal_accessibility.TerminalAccessibilitySession.create(
                 std.heap.page_allocator,
-                hwnd,
-                context.state(),
-            );
-        } else if (self.terminal_uia_context) |context| {
-            // WM_GETOBJECT is also delivered when a client reconnects after
-            // terminal output occurred with no UIA listeners. Refresh here so
-            // the first TextPattern query cannot observe that stale cache.
-            _ = try context.refresh(self);
-            self.terminal_uia_last_refresh_ms = GetTickCount64();
-        }
-        return self.terminal_uia_provider.?;
-    }
-
-    /// Publish a bounded accessible-text snapshot after a coalesced renderer
-    /// update. Provider calls never format terminal state themselves.
-    fn refreshTerminalUiaText(self: *Surface) void {
-        self.refreshTerminalUiaTextWithMode(false);
-    }
-
-    fn refreshTerminalUiaTextWithMode(self: *Surface, force: bool) void {
-        const context = self.terminal_uia_context orelse return;
-        const provider = self.terminal_uia_provider orelse return;
-        const now_ms = GetTickCount64();
-        const publish_policy = terminalUiaPublishPolicy(
-            win32_uia.events.clientsAreListening(),
-            context.queryRecentlyActive(now_ms),
-        );
-        if (!publish_policy.refresh_snapshot) return;
-        if (!force and !terminalUiaRefreshDue(self.terminal_uia_last_refresh_ms, now_ms)) {
-            if (!self.terminal_uia_refresh_timer_active) {
-                const hwnd = self.hwnd orelse return;
-                if (SetTimer(
-                    hwnd,
-                    TERMINAL_UIA_TIMER_ID,
-                    terminalUiaRefreshDelay(self.terminal_uia_last_refresh_ms, now_ms),
-                    null,
-                ) != 0) self.terminal_uia_refresh_timer_active = true;
-            }
-            return;
-        }
-        self.cancelTerminalUiaRefreshTimer();
-        const refresh_started_ms = now_ms;
-        const refresh_result = context.refresh(self);
-        const refresh_completed_ms = GetTickCount64();
-        self.terminal_uia_last_refresh_ms = refresh_completed_ms;
-        if (terminalUiaSnapshotWasSlow(refresh_started_ms, refresh_completed_ms)) {
-            log.warn("win32 terminal UIA snapshot slow elapsed_ms={d}", .{refresh_completed_ms -| refresh_started_ms});
-        }
-        if (refresh_result) |change| {
-            // Query-only clients do not make UiaClientsAreListening return
-            // true. Keep their snapshot current and gate only event emission.
-            if (!publish_policy.emit_events) return;
-            switch (change) {
-                .text => provider.raiseTextChanged(),
-                .caret => provider.raiseTextSelectionChanged(),
-                .text_and_caret => {
-                    provider.raiseTextChanged();
-                    provider.raiseTextSelectionChanged();
+                .{
+                    .ctx = @ptrCast(self),
+                    .hwnd = terminalAccessibilityHwnd,
+                    .name = terminalAccessibilityName,
+                    .focused = terminalAccessibilityFocused,
+                    .capture = terminalAccessibilityCapture,
+                    .defer_provider_release = terminalAccessibilityDeferProviderRelease,
                 },
-                .unchanged, .geometry => {},
-            }
-        } else |err| {
-            log.warn("win32 terminal UIA snapshot refresh failed err={}", .{err});
+                WM_WINHOSTTY_UIA_QUERY_REFRESH,
+                TERMINAL_UIA_TIMER_ID,
+            );
         }
+        const provider = try self.terminal_accessibility.?.acquireProvider();
+        self.syncTerminalAccessibilityOutputInterest();
+        return provider;
     }
 
-    fn cancelTerminalUiaRefreshTimer(self: *Surface) void {
-        if (!self.terminal_uia_refresh_timer_active) return;
-        if (self.hwnd) |hwnd| _ = KillTimer(hwnd, TERMINAL_UIA_TIMER_ID);
-        self.terminal_uia_refresh_timer_active = false;
+    fn syncTerminalAccessibilityOutputInterest(self: *Surface) void {
+        const interested = if (self.terminal_accessibility) |session|
+            session.outputInterested()
+        else
+            false;
+        if (!interested) {
+            if (self.terminal_accessibility) |session| {
+                session.resetSemanticOutputContinuity();
+            }
+        }
+        self.core_surface.setTerminalOutputInterested(interested);
+    }
+
+    fn drainTerminalAccessibilityOutput(self: *Surface) void {
+        self.syncTerminalAccessibilityOutputInterest();
+        const session = self.terminal_accessibility orelse return;
+        if (!session.outputInterested()) return;
+        self.core_surface.drainTerminalOutput(
+            @ptrCast(session),
+            terminalAccessibilityOutputCallback,
+        );
     }
 
     pub fn getContentScale(self: *const Surface) !apprt.ContentScale {
@@ -25302,10 +25085,7 @@ pub const Surface = struct {
     }
 
     fn notifyTerminalUiaNameChanged(self: *Surface) void {
-        if (!win32_uia.events.clientsAreListening()) return;
-        const provider = self.terminal_uia_provider orelse return;
-        win32_uia.events.raiseNameChanged(&provider.base);
-        win32_uia.events.raiseStructureChanged(&provider.base, .children_invalidated, null);
+        if (self.terminal_accessibility) |session| session.nameChanged();
     }
 
     fn setTitleOverride(self: *Surface, title: ?[]const u8) !void {
@@ -27180,11 +26960,8 @@ pub const Surface = struct {
         self.core_surface.focusCallback(focused) catch |err| {
             log.err("win32 focus callback failed err={}", .{err});
         };
-        if (focused and win32_uia.events.clientsAreListening()) {
-            if (self.terminal_uia_provider) |provider| {
-                win32_uia.events.raiseFocusChanged(&provider.base);
-            }
-        }
+        if (self.terminal_accessibility) |session| session.focusChanged(focused);
+        self.syncTerminalAccessibilityOutputInterest();
         // Host chrome only changes for split-pane focus borders.
         if (self.host) |host| {
             const pane_count = if (host.activeTab()) |tab| tab.leafCount() else 0;
@@ -27196,8 +26973,9 @@ pub const Surface = struct {
     fn handleKeyMessage(self: *Surface, msg: UINT, wParam: WPARAM, lParam: LPARAM) void {
         if (!self.core_initialized) return;
 
-        const event = keyEventFromWin32Message(msg, wParam, lParam) orelse return;
-        self.pending_wm_char_text = event.composing and event.action != .release;
+        const message = keyEventFromWin32Message(msg, wParam, lParam) orelse return;
+        const event = message.event;
+        self.deferred_char.authorize(message.deferred_utf16_units);
 
         _ = self.core_surface.keyCallback(event) catch |err| {
             log.err("win32 key callback failed err={} vk={} action={} key={} mods={}", .{
@@ -27209,46 +26987,23 @@ pub const Surface = struct {
             });
             return;
         };
+        if (event.utf8.len != 0) {
+            if (self.terminal_accessibility) |session| session.noteInput(event.utf8);
+        }
     }
 
     fn handleCharMessage(self: *Surface, wParam: WPARAM, lParam: LPARAM) void {
         if (!self.core_initialized) return;
-        if (!shouldCommitDeferredCharMessage(self.pending_wm_char_text, self.ime_composing)) {
-            self.pending_wm_char_text = false;
-            self.pending_wm_char_high_surrogate = null;
-            return;
-        }
 
         const code_unit: u16 = @intCast(wParam & 0xFFFF);
-        if (std.unicode.utf16IsHighSurrogate(code_unit)) {
-            self.pending_wm_char_high_surrogate = code_unit;
-            return;
-        }
-
-        const codepoint: u21 = cp: {
-            if (std.unicode.utf16IsLowSurrogate(code_unit)) {
-                const high = self.pending_wm_char_high_surrogate orelse return;
-                self.pending_wm_char_high_surrogate = null;
-                break :cp std.unicode.utf16DecodeSurrogatePair(&.{ high, code_unit }) catch return;
-            }
-
-            self.pending_wm_char_high_surrogate = null;
-            break :cp code_unit;
-        };
-        self.pending_wm_char_text = false;
-
-        if (isControlCodepoint(codepoint)) return;
+        const codepoint = self.deferred_char.consumeCodeUnit(
+            code_unit,
+            self.ime_composing,
+        ) orelse return;
 
         var utf8_buf: [8]u8 = undefined;
-        const utf8_len = std.unicode.utf8Encode(codepoint, &utf8_buf) catch return;
-
-        var event: input.KeyEvent = .{
-            .action = if (isRepeatedKey(lParam)) .repeat else .press,
-            .key = .unidentified,
-            .mods = .{},
-            .unshifted_codepoint = codepoint,
-        };
-        event.utf8 = utf8_buf[0..utf8_len];
+        const event = charCommitEvent(codepoint, lParam, &utf8_buf) orelse return;
+        if (self.terminal_accessibility) |session| session.noteInput(event.utf8);
         _ = self.core_surface.keyCallback(event) catch |err| {
             log.err("win32 char commit failed err={} codepoint={}", .{ err, codepoint });
         };
@@ -27313,7 +27068,9 @@ pub const Surface = struct {
         event.utf8 = utf8_buf[0..utf8_len];
         _ = self.core_surface.keyCallback(event) catch |err| {
             log.err("win32 IME commit failed err={}", .{err});
+            return;
         };
+        if (self.terminal_accessibility) |session| session.noteInput(event.utf8);
     }
 
     fn handleImeComposition(self: *Surface) void {
@@ -27526,22 +27283,12 @@ pub const Surface = struct {
     fn destroy(self: *Surface) void {
         const alloc = self.app.core_app.alloc;
         self.destroy_on_wm_destroy = false;
+        self.deferred_char.clear();
 
-        self.cancelTerminalUiaRefreshTimer();
-        if (self.terminal_uia_context) |ctx| {
-            ctx.detachSurface();
-            if (self.terminal_uia_provider) |provider| {
-                self.terminal_uia_provider = null;
-                provider.detach();
-                scheduleDeferredUiaDisconnect(
-                    self.app,
-                    @ptrCast(provider),
-                    &terminalDisconnectThunk,
-                    &terminalReleaseThunk,
-                );
-            }
-            TerminalUiaContext.release(@ptrCast(ctx));
-            self.terminal_uia_context = null;
+        if (self.terminal_accessibility) |session| {
+            self.core_surface.setTerminalOutputInterested(false);
+            self.terminal_accessibility = null;
+            session.deinit();
         }
 
         // Revoke the drop target BEFORE destroying the HWND — Ole
@@ -27640,6 +27387,7 @@ pub const Surface = struct {
     fn setVisible(self: *Surface, visible: bool) void {
         const visibility_changed = self.window_visible != visible;
         self.window_visible = visible;
+        if (!visible) self.deferred_char.clear();
 
         const hwnd = self.hwnd orelse return;
         const child_visibility_changed = applyChildVisibility(hwnd, &self.placement, visible);
@@ -31740,29 +31488,31 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     try std.testing.expectEqual(@as(UINT, 0x0004), TO_UNICODE_NO_STATE_CHANGE);
+    try std.testing.expectEqual(@as(usize, 1), utf16CodeUnitCount('a'));
+    try std.testing.expectEqual(@as(usize, 2), utf16CodeUnitCount(0x1F642));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .key_a,
         .{},
-        .{ .len = 1, .unshifted_codepoint = 'a' },
+        .{ .len = 1, .unshifted_codepoint = 'a', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .repeat,
         .space,
         .{},
-        .{ .len = 1, .unshifted_codepoint = ' ' },
+        .{ .len = 1, .unshifted_codepoint = ' ', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .quote,
         .{},
-        .{ .unshifted_codepoint = '\'' },
+        .{ .unshifted_codepoint = '\'', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
         .digit_2,
         .{ .ctrl = true, .alt = true },
-        .{ .unshifted_codepoint = '2' },
+        .{ .unshifted_codepoint = '2', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
@@ -31770,9 +31520,125 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .{},
         .{ .unshifted_codepoint = 0x0D },
     ));
-    try std.testing.expect(!shouldCommitDeferredCharMessage(false, false));
-    try std.testing.expect(!shouldCommitDeferredCharMessage(true, true));
-    try std.testing.expect(shouldCommitDeferredCharMessage(true, false));
+}
+
+test "win32 VK_PACKET key down authorizes one unit without direct text or modifiers" {
+    const message = keyEventFromWin32Message(WM_KEYDOWN, VK_PACKET, 0).?;
+    try std.testing.expectEqual(input.Action.press, message.event.action);
+    try std.testing.expectEqual(input.Key.unidentified, message.event.key);
+    try std.testing.expectEqualStrings("", message.event.utf8);
+    try std.testing.expect(message.event.composing);
+    try std.testing.expectEqual(@as(u21, 0), message.event.unshifted_codepoint);
+    try std.testing.expect(std.meta.eql(input.Mods{}, message.event.mods));
+    try std.testing.expect(std.meta.eql(input.Mods{}, message.event.consumed_mods));
+    try std.testing.expectEqual(@as(usize, 1), message.deferred_utf16_units);
+}
+
+test "win32 VK_PACKET key up authorizes no units or text" {
+    const message = keyEventFromWin32Message(WM_KEYUP, VK_PACKET, 0).?;
+    try std.testing.expectEqual(input.Action.release, message.event.action);
+    try std.testing.expectEqual(input.Key.unidentified, message.event.key);
+    try std.testing.expectEqualStrings("", message.event.utf8);
+    try std.testing.expect(!message.event.composing);
+    try std.testing.expectEqual(@as(u21, 0), message.event.unshifted_codepoint);
+    try std.testing.expect(std.meta.eql(input.Mods{}, message.event.mods));
+    try std.testing.expect(std.meta.eql(input.Mods{}, message.event.consumed_mods));
+    try std.testing.expectEqual(@as(usize, 0), message.deferred_utf16_units);
+}
+
+test "win32 authorized char commit preserves packet control characters" {
+    var utf8_buf: [8]u8 = undefined;
+    const fixtures = [_]struct { codepoint: u21, expected: []const u8 }{
+        .{ .codepoint = '\r', .expected = "\r" },
+        .{ .codepoint = '\n', .expected = "\n" },
+        .{ .codepoint = '\t', .expected = "\t" },
+        .{ .codepoint = 0x08, .expected = "\x08" },
+        .{ .codepoint = 0x1B, .expected = "\x1B" },
+    };
+    for (fixtures) |fixture| {
+        const event = charCommitEvent(fixture.codepoint, 0, &utf8_buf).?;
+        try std.testing.expectEqual(input.Key.unidentified, event.key);
+        try std.testing.expectEqual(fixture.codepoint, event.unshifted_codepoint);
+        try std.testing.expectEqualStrings(fixture.expected, event.utf8);
+    }
+}
+
+test "win32 deferred char authorization preserves pending units across non-text events" {
+    var state: DeferredCharState = .{};
+    state.authorize(1);
+    // Release and unrelated non-text key messages authorize zero units.
+    state.authorize(0);
+    try std.testing.expectEqual(@as(usize, 1), state.pending_units);
+    try std.testing.expectEqual(@as(?u21, 'a'), state.consumeCodeUnit('a', false));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+}
+
+test "win32 deferred char dead key and composition consume exact units" {
+    var state: DeferredCharState = .{};
+    state.authorize(1);
+    state.consumeDeadChar();
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+
+    state.authorize(1);
+    try std.testing.expectEqual(@as(?u21, 0x00E9), state.consumeCodeUnit(0x00E9, false));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+}
+
+test "win32 deferred char authorization blocks unsolicited and IME text" {
+    var state: DeferredCharState = .{};
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit('a', false));
+
+    state.authorize(1);
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit('a', true));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit('a', false));
+}
+
+test "win32 deferred char two surrogate keydowns consume two code units" {
+    var state: DeferredCharState = .{};
+    state.authorize(1);
+    state.authorize(1);
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit(0xD83D, false));
+    try std.testing.expectEqual(@as(usize, 1), state.pending_units);
+    try std.testing.expectEqual(@as(?u21, 0x1F642), state.consumeCodeUnit(0xDE42, false));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+}
+
+test "win32 deferred char supplementary expectation authorizes both units" {
+    var state: DeferredCharState = .{};
+    state.authorize(2);
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit(0xD83D, false));
+    try std.testing.expectEqual(@as(usize, 1), state.pending_units);
+    try std.testing.expectEqual(@as(?u21, 0x1F642), state.consumeCodeUnit(0xDE42, false));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+}
+
+test "win32 deferred char commits 256 delayed BMP authorizations" {
+    var state: DeferredCharState = .{};
+    for (0..256) |_| state.authorize(1);
+    try std.testing.expectEqual(@as(usize, 256), state.pending_units);
+
+    for (0..256) |_| {
+        try std.testing.expectEqual(@as(?u21, 'a'), state.consumeCodeUnit('a', false));
+    }
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+}
+
+test "win32 deferred char malformed surrogate clears authorization state" {
+    var state: DeferredCharState = .{};
+    state.authorize(3);
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit(0xD83D, false));
+    try std.testing.expectEqual(@as(?u21, null), state.consumeCodeUnit('a', false));
+    try std.testing.expectEqual(@as(usize, 0), state.pending_units);
+    try std.testing.expectEqual(@as(?u16, null), state.high_surrogate);
+}
+
+test "win32 deferred char authorization saturates only at usize maximum" {
+    var state: DeferredCharState = .{
+        .pending_units = std.math.maxInt(usize) - 1,
+    };
+    state.authorize(2);
+    try std.testing.expectEqual(std.math.maxInt(usize), state.pending_units);
 }
 
 test "win32 hotkeySpecForTrigger maps physical key triggers" {

--- a/src/apprt/win32_settings.zig
+++ b/src/apprt/win32_settings.zig
@@ -22,6 +22,7 @@ const windows = std.os.windows;
 const Config = @import("../config/Config.zig");
 const cli_help = @import("../cli/help.zig");
 const win32_types = @import("win32_types.zig");
+const win32_theme = @import("win32_theme.zig");
 const win32_uia = @import("win32_uia/mod.zig");
 const settings_transaction = @import("win32_settings_transaction.zig");
 
@@ -85,6 +86,12 @@ const WM_SETFONT: UINT = 0x0030;
 const WM_SETTINGCHANGE: UINT = 0x001A;
 const WM_SYSCOLORCHANGE: UINT = 0x0015;
 const WM_THEMECHANGED: UINT = 0x031A;
+const WM_CTLCOLORMSGBOX: UINT = 0x0132;
+const WM_CTLCOLOREDIT: UINT = 0x0133;
+const WM_CTLCOLORLISTBOX: UINT = 0x0134;
+const WM_CTLCOLORBTN: UINT = 0x0135;
+const WM_CTLCOLORDLG: UINT = 0x0136;
+const WM_CTLCOLORSTATIC: UINT = 0x0138;
 const WM_APP: UINT = 0x8000;
 // Keep Settings-private window messages out of the App pump's reserved
 // WM_APP+1..+6 range; the pump consumes those before DispatchMessageW.
@@ -261,6 +268,12 @@ fn clickedButton(id: usize, notify: u16, expected_id: usize) bool {
 fn clickedSection(id: usize, notify: u16) ?Section {
     if (notify != BN_CLICKED) return null;
     return Section.fromButtonId(id);
+}
+
+fn validatedSectionClickFocusTarget(source: ?HWND, expected: ?HWND) ?HWND {
+    const source_hwnd = source orelse return null;
+    const expected_hwnd = expected orelse return null;
+    return if (source_hwnd == expected_hwnd) source_hwnd else null;
 }
 
 fn backgroundBlurFromCheckbox(
@@ -571,9 +584,17 @@ extern "kernel32" fn MulDiv(nNumber: i32, nNumerator: i32, nDenominator: i32) ca
 extern "gdi32" fn FillRect(hdc: HDC, lprc: *const RECT, hbr: HBRUSH) callconv(.winapi) i32;
 extern "gdi32" fn GetStockObject(i: i32) callconv(.winapi) HGDIOBJ;
 extern "gdi32" fn SetDCBrushColor(hdc: HDC, color: COLORREF) callconv(.winapi) COLORREF;
+extern "gdi32" fn CreateSolidBrush(color: COLORREF) callconv(.winapi) HBRUSH;
+extern "gdi32" fn SetBkColor(hdc: HDC, color: COLORREF) callconv(.winapi) COLORREF;
+extern "gdi32" fn SetTextColor(hdc: HDC, color: COLORREF) callconv(.winapi) COLORREF;
+extern "gdi32" fn SetBkMode(hdc: HDC, mode: c_int) callconv(.winapi) c_int;
 const DC_BRUSH: i32 = 18;
+const TRANSPARENT: c_int = 1;
 const COLOR_WINDOW: c_int = 5;
+const COLOR_WINDOWTEXT: c_int = 8;
 const COLOR_BTNFACE: c_int = 15;
+const COLOR_GRAYTEXT: c_int = 17;
+const COLOR_BTNTEXT: c_int = 18;
 
 const PAINTSTRUCT = win32_types.PAINTSTRUCT;
 const CREATESTRUCTW = win32_types.CREATESTRUCTW;
@@ -705,6 +726,95 @@ pub fn saveReloadOutcome(result: SaveError!void) SaveReloadOutcome {
     return .completed;
 }
 
+const SettingsThemeAdapter = struct {
+    colors: win32_theme.SettingsColors = win32_theme.settingsColors(
+        win32_theme.lightTheme(),
+        .{
+            .window = 0,
+            .window_text = 0,
+            .button_face = 0,
+            .button_text = 0,
+            .gray_text = 0,
+        },
+        false,
+    ),
+    window_brush: HBRUSH = null,
+    rail_brush: HBRUSH = null,
+    edit_brush: HBRUSH = null,
+    button_brush: HBRUSH = null,
+    applying: bool = false,
+
+    fn deinit(self: *SettingsThemeAdapter) void {
+        self.deleteBrushes();
+    }
+
+    fn deleteBrushes(self: *SettingsThemeAdapter) void {
+        if (self.window_brush) |brush| _ = DeleteObject(brush);
+        if (self.rail_brush) |brush| _ = DeleteObject(brush);
+        if (self.edit_brush) |brush| _ = DeleteObject(brush);
+        if (self.button_brush) |brush| _ = DeleteObject(brush);
+        self.window_brush = null;
+        self.rail_brush = null;
+        self.edit_brush = null;
+        self.button_brush = null;
+    }
+
+    fn apply(
+        self: *SettingsThemeAdapter,
+        hwnd: HWND,
+        colors: win32_theme.SettingsColors,
+    ) void {
+        if (self.applying) return;
+        self.applying = true;
+        defer self.applying = false;
+        self.deleteBrushes();
+        self.colors = colors;
+        self.window_brush = CreateSolidBrush(colors.window_bg);
+        self.rail_brush = CreateSolidBrush(colors.rail_bg);
+        self.edit_brush = CreateSolidBrush(colors.edit_bg);
+        self.button_brush = CreateSolidBrush(colors.button_bg);
+
+        win32_theme.WindowThemeAdapter.applySettings(hwnd, colors);
+        applyNativeControlTheme(hwnd, colors);
+        _ = EnumChildWindows(
+            hwnd,
+            applyNativeControlThemeToChild,
+            @bitCast(@intFromPtr(&self.colors)),
+        );
+        _ = InvalidateRect(hwnd, null, 1);
+        _ = EnumChildWindows(hwnd, invalidateThemeChild, 0);
+    }
+
+    fn controlBrush(self: *const SettingsThemeAdapter, message: UINT) HBRUSH {
+        return switch (message) {
+            WM_CTLCOLOREDIT, WM_CTLCOLORLISTBOX => self.edit_brush,
+            WM_CTLCOLORBTN => self.button_brush,
+            WM_CTLCOLORMSGBOX, WM_CTLCOLORDLG, WM_CTLCOLORSTATIC => self.window_brush,
+            else => null,
+        };
+    }
+};
+
+fn applyNativeControlTheme(hwnd: HWND, colors: win32_theme.SettingsColors) void {
+    win32_theme.WindowThemeAdapter.applyNativeControl(hwnd, colors);
+}
+
+fn applyNativeControlThemeToChild(hwnd: HWND, lParam: LPARAM) callconv(.winapi) BOOL {
+    const colors: *const win32_theme.SettingsColors =
+        @ptrFromInt(@as(usize, @bitCast(lParam)));
+    applyNativeControlTheme(hwnd, colors.*);
+    return 1;
+}
+
+fn invalidateThemeChild(hwnd: HWND, _: LPARAM) callconv(.winapi) BOOL {
+    _ = InvalidateRect(hwnd, null, 1);
+    return 1;
+}
+
+fn pointerLresult(pointer: anytype) LRESULT {
+    return @bitCast(@intFromPtr(pointer));
+}
+
 /// Minimal hook into the apprt `App` so the settings module can fetch
 /// the chrome brush colors without pulling in the whole app type.
 pub const AppHandle = struct {
@@ -721,6 +831,10 @@ pub const AppHandle = struct {
     chromeBg: *const fn (ctx: *anyopaque) COLORREF,
     /// Primary text color.
     textPrimary: *const fn (ctx: *anyopaque) COLORREF,
+    /// Full resolved app palette and High Contrast state for native Settings
+    /// theming. Optional defaults retain compatibility with model-only tests.
+    themeColors: ?*const fn (ctx: *anyopaque) win32_theme.ThemeColors = null,
+    highContrast: ?*const fn (ctx: *anyopaque) bool = null,
     /// Fire-and-forget shell-out to the OS default text editor with
     /// the resolved `ghostty.conf` path. Used by the Advanced-pane
     /// escape hatch.
@@ -821,6 +935,7 @@ pub const SettingsWindow = struct {
     control_uia_providers: [settings_control_count]?*win32_uia.SettingsControlProvider = [_]?*win32_uia.SettingsControlProvider{null} ** settings_control_count,
     ui_font: HGDIOBJ = null,
     header_font: HGDIOBJ = null,
+    theme_adapter: SettingsThemeAdapter = .{},
     close_prompt_measure_width: i32 = -1,
     close_prompt_measure_dpi: u32 = 0,
     close_prompt_measure_saving: bool = false,
@@ -929,6 +1044,7 @@ pub const SettingsWindow = struct {
         self.releaseControlUiaProviders();
         self.hwnd = null;
         self.deleteUiFont();
+        self.theme_adapter.deinit();
         self.btn_open_editor = null;
         self.btn_section_appearance = null;
         self.btn_section_terminal = null;
@@ -1577,6 +1693,7 @@ pub const SettingsWindow = struct {
     /// both WM_CLOSE and WM_NCDESTROY so the next `open()` recreates
     /// fresh children and clones.
     fn clearChildRefs(self: *SettingsWindow) void {
+        self.theme_adapter.deinit();
         self.releaseSectionUiaProviders();
         self.releaseTextUiaProviders();
         self.releaseControlUiaProviders();
@@ -1996,9 +2113,38 @@ pub const SettingsWindow = struct {
     }
 
     pub fn themeChanged(self: *SettingsWindow) void {
+        if (self.hwnd) |hwnd| {
+            self.theme_adapter.apply(hwnd, self.resolveThemeColors());
+        }
         self.recreateUiFont();
         layoutChildren(self);
         if (self.hwnd) |hwnd| _ = InvalidateRect(hwnd, null, 1);
+    }
+
+    fn resolveThemeColors(self: *const SettingsWindow) win32_theme.SettingsColors {
+        var theme = if (self.handle.themeColors) |resolve|
+            resolve(self.handle.ctx)
+        else
+            win32_theme.lightTheme();
+        if (self.handle.themeColors == null) {
+            theme.chrome_bg = self.handle.chromeBg(self.handle.ctx);
+            theme.text_primary = self.handle.textPrimary(self.handle.ctx);
+        }
+        const high_contrast = if (self.handle.highContrast) |probe|
+            probe(self.handle.ctx)
+        else
+            false;
+        return win32_theme.settingsColors(
+            theme,
+            .{
+                .window = GetSysColor(COLOR_WINDOW),
+                .window_text = GetSysColor(COLOR_WINDOWTEXT),
+                .button_face = GetSysColor(COLOR_BTNFACE),
+                .button_text = GetSysColor(COLOR_BTNTEXT),
+                .gray_text = GetSysColor(COLOR_GRAYTEXT),
+            },
+            high_contrast,
+        );
     }
 
     fn ensureControlVisible(self: *SettingsWindow, control: HWND) void {
@@ -3549,6 +3695,7 @@ pub const SettingsWindow = struct {
 
         self.refreshAllControls();
         self.refreshNativeSectionText();
+        self.theme_adapter.apply(hwnd, self.resolveThemeColors());
         self.recreateUiFont();
 
         layoutChildren(self);
@@ -4760,6 +4907,45 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             if (owner) |o| paint(hwnd, o);
             return 0;
         },
+        WM_CTLCOLORMSGBOX,
+        WM_CTLCOLOREDIT,
+        WM_CTLCOLORLISTBOX,
+        WM_CTLCOLORBTN,
+        WM_CTLCOLORDLG,
+        WM_CTLCOLORSTATIC,
+        => {
+            if (owner) |o| {
+                const hdc: HDC = @ptrFromInt(wParam);
+                const child: ?HWND = if (lParam == 0)
+                    null
+                else
+                    @ptrFromInt(@as(usize, @bitCast(lParam)));
+                const colors = o.theme_adapter.colors;
+                const edit_like = msg == WM_CTLCOLOREDIT or msg == WM_CTLCOLORLISTBOX;
+                const background = if (edit_like) colors.edit_bg else if (msg == WM_CTLCOLORBTN)
+                    colors.button_bg
+                else
+                    colors.window_bg;
+                const foreground = if (child) |control|
+                    if (IsWindowEnabled(control) == 0)
+                        colors.disabled_text
+                    else if (edit_like)
+                        colors.edit_text
+                    else if (msg == WM_CTLCOLORBTN)
+                        colors.button_text
+                    else
+                        colors.text
+                else
+                    colors.text;
+                _ = SetTextColor(hdc, foreground);
+                _ = SetBkColor(hdc, background);
+                if (msg == WM_CTLCOLORSTATIC) _ = SetBkMode(hdc, TRANSPARENT);
+                if (o.theme_adapter.controlBrush(msg)) |brush| {
+                    return pointerLresult(brush);
+                }
+            }
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
+        },
         WM_DPICHANGED => {
             if (owner) |o| {
                 o.dpi = normalizedDpi(@intCast(wParam & 0xFFFF));
@@ -5013,7 +5199,19 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
                 return 0;
             }
             if (clickedSection(id, notify)) |section| {
-                if (owner) |o| o.setActiveSection(section);
+                if (owner) |o| {
+                    const source: ?HWND = if (lParam == 0)
+                        null
+                    else
+                        @ptrFromInt(@as(usize, @bitCast(lParam)));
+                    if (validatedSectionClickFocusTarget(
+                        source,
+                        o.sectionButton(section),
+                    )) |button| {
+                        _ = SetFocus(button);
+                    }
+                    o.setActiveSection(section);
+                }
                 return 0;
             }
             return DefWindowProcW(hwnd, msg, wParam, lParam);
@@ -5091,18 +5289,21 @@ fn paint(hwnd: HWND, owner: *SettingsWindow) void {
     var rect: RECT = undefined;
     if (GetClientRect(hwnd, &rect) == 0) return;
 
-    // Standard dialog background keeps native STATIC/BUTTON controls visually
-    // coherent, including High Contrast. EDIT/COMBO fields retain COLOR_WINDOW.
-    const bg = GetSysColor(COLOR_BTNFACE);
-    const brush = GetStockObject(DC_BRUSH);
-    _ = SetDCBrushColor(hdc, bg);
-    _ = FillRect(hdc, &rect, brush);
+    const colors = owner.theme_adapter.colors;
+    const fallback_brush = GetStockObject(DC_BRUSH);
+    const window_brush = owner.theme_adapter.window_brush orelse fallback_brush;
+    if (owner.theme_adapter.window_brush == null) {
+        _ = SetDCBrushColor(hdc, colors.window_bg);
+    }
+    _ = FillRect(hdc, &rect, window_brush);
 
-    // A light system-role rail preserves hierarchy without custom theme colors.
     var rail_rect = rect;
     rail_rect.right = owner.px(left_rail_width);
-    _ = SetDCBrushColor(hdc, GetSysColor(COLOR_WINDOW));
-    _ = FillRect(hdc, &rail_rect, brush);
+    const rail_brush = owner.theme_adapter.rail_brush orelse fallback_brush;
+    if (owner.theme_adapter.rail_brush == null) {
+        _ = SetDCBrushColor(hdc, colors.rail_bg);
+    }
+    _ = FillRect(hdc, &rail_rect, rail_brush);
 }
 
 fn readEditUtf8(edit: HWND, buf: []u8) ?[]const u8 {
@@ -5295,6 +5496,11 @@ test "win32_settings: utf8ToW never splits a supplementary scalar" {
     try std.testing.expectEqual(@as(u16, 0), fits[2]);
 }
 
+test "settings pointer result preserves high-bit handle bits" {
+    const pointer: *anyopaque = @ptrFromInt(std.math.maxInt(usize));
+    try std.testing.expectEqual(@as(LRESULT, -1), pointerLresult(pointer));
+}
+
 test "settings background blur checkbox preserves enabled radius" {
     try std.testing.expectEqual(
         Config.BackgroundBlur{ .radius = 42 },
@@ -5354,6 +5560,21 @@ test "settings action and section buttons activate only on click" {
     try std.testing.expectEqual(Section.appearance, clickedSection(BTN_SECTION_APPEARANCE, BN_CLICKED).?);
     try std.testing.expectEqual(@as(?Section, null), clickedSection(BTN_SECTION_APPEARANCE, BN_SETFOCUS));
     try std.testing.expectEqual(@as(?Section, null), clickedSection(BTN_SECTION_APPEARANCE, BN_KILLFOCUS));
+
+    const section_hwnd: HWND = @ptrFromInt(1);
+    const other_hwnd: HWND = @ptrFromInt(2);
+    try std.testing.expectEqual(
+        section_hwnd,
+        validatedSectionClickFocusTarget(section_hwnd, section_hwnd).?,
+    );
+    try std.testing.expectEqual(
+        @as(?HWND, null),
+        validatedSectionClickFocusTarget(null, section_hwnd),
+    );
+    try std.testing.expectEqual(
+        @as(?HWND, null),
+        validatedSectionClickFocusTarget(other_hwnd, section_hwnd),
+    );
 }
 
 test "win32_settings: every tracked field maps to its matching config value" {

--- a/src/apprt/win32_terminal_accessibility.zig
+++ b/src/apprt/win32_terminal_accessibility.zig
@@ -1,0 +1,1499 @@
+//! Terminal UIA session at the Surface/provider seam.
+//!
+//! Owns the retained immutable snapshot, provider lifetime, query wakeups,
+//! refresh cadence, event selection, and incremental spoken-output policy.
+//! The Surface supplies one renderer-snapshot callback; renderer and session
+//! locks are therefore never held together.
+
+const std = @import("std");
+const win32_types = @import("win32_types.zig");
+const win32_uia = @import("win32_uia/mod.zig");
+
+const Allocator = std.mem.Allocator;
+const HWND = win32_types.HWND;
+const UINT = win32_types.UINT;
+const WPARAM = win32_types.WPARAM;
+const LPARAM = win32_types.LPARAM;
+const BOOL = win32_types.BOOL;
+
+const refresh_interval_ms: u64 = 100;
+const query_activity_window_ms: u64 = 1_000;
+const input_echo_window_ms: u64 = 1_000;
+const cold_query_timeout_ms: UINT = 500;
+const max_announcement_bytes: usize = 1_000;
+const max_pending_announcements: usize = 8;
+const omitted_output_notice = "terminal output omitted";
+const SMTO_BLOCK: UINT = 0x0001;
+const SMTO_ABORTIFHUNG: UINT = 0x0002;
+
+const AnnouncementNormalizer = struct {
+    pending_space: bool = false,
+    has_text: bool = false,
+};
+
+extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
+extern "user32" fn PostMessageW(HWND, UINT, WPARAM, LPARAM) callconv(.winapi) BOOL;
+extern "user32" fn SendMessageTimeoutW(
+    HWND,
+    UINT,
+    WPARAM,
+    LPARAM,
+    UINT,
+    UINT,
+    *usize,
+) callconv(.winapi) isize;
+extern "user32" fn SetTimer(?HWND, usize, UINT, ?*const anyopaque) callconv(.winapi) usize;
+extern "user32" fn KillTimer(?HWND, usize) callconv(.winapi) BOOL;
+
+pub const Capture = struct {
+    snapshot: win32_uia.AccessibleTextSnapshot,
+    cell_width: f64,
+    cell_height: f64,
+    origin_x: f64,
+    origin_y: f64,
+
+    pub fn deinit(self: *Capture) void {
+        self.snapshot.deinit();
+        self.* = undefined;
+    }
+};
+
+pub const Ops = struct {
+    ctx: *anyopaque,
+    hwnd: *const fn (*anyopaque) ?HWND,
+    name: *const fn (*anyopaque, []u8) []const u8,
+    focused: *const fn (*anyopaque) bool,
+    capture: *const fn (*anyopaque, Allocator) anyerror!Capture,
+    defer_provider_release: *const fn (*anyopaque, *win32_uia.TerminalProvider) void,
+};
+
+pub const Change = enum { unchanged, geometry, caret, text, text_and_caret };
+const SpeechMode = enum { discard, accumulate, emit };
+
+pub const PublishPolicy = struct {
+    refresh_snapshot: bool,
+    emit_events: bool,
+};
+
+pub const TerminalAccessibilitySession = struct {
+    alloc: Allocator,
+    refcount: std.atomic.Value(u32) = .init(1),
+    mutex: std.Thread.Mutex = .{},
+    ops: Ops,
+    query_message: UINT,
+    timer_id: usize,
+    attached: bool = true,
+    provider: ?*win32_uia.TerminalProvider = null,
+    last_query_ms: std.atomic.Value(u64) = .init(0),
+    query_refresh_post_pending: std.atomic.Value(bool) = .init(false),
+    last_refresh_ms: u64 = 0,
+    refresh_timer_active: bool = false,
+    cached_text: []u8,
+    cached_name: [256]u8 = undefined,
+    cached_name_len: usize = 0,
+    cached_focused: std.atomic.Value(bool) = .init(false),
+    cached_visible_text: []u8,
+    cached_visible_range: win32_uia.OffsetRange = .{ .start = 0, .end = 0 },
+    cached_caret_offset: usize = 0,
+    cached_cells: []win32_uia.TerminalCellPosition,
+    viewport_rows: u32 = 0,
+    viewport_columns: u32 = 0,
+    cell_width: f64 = 0,
+    cell_height: f64 = 0,
+    origin_x: f64 = 0,
+    origin_y: f64 = 0,
+    pending_announcements: [max_pending_announcements][max_announcement_bytes]u8 = undefined,
+    pending_announcement_lengths: [max_pending_announcements]usize = [_]usize{0} ** max_pending_announcements,
+    pending_announcement_omitted: [max_pending_announcements]bool = [_]bool{false} ** max_pending_announcements,
+    pending_announcement_head: usize = 0,
+    pending_announcement_count: usize = 0,
+    pending_output_omitted: bool = false,
+    announcement_normalizer: AnnouncementNormalizer = .{},
+    recent_input: [256]u8 = undefined,
+    recent_input_len: usize = 0,
+    recent_input_matched: usize = 0,
+    recent_input_complete: bool = true,
+    recent_input_ms: u64 = 0,
+
+    pub fn create(
+        alloc: Allocator,
+        ops: Ops,
+        query_message: UINT,
+        timer_id: usize,
+    ) !*TerminalAccessibilitySession {
+        const self = try alloc.create(TerminalAccessibilitySession);
+        errdefer alloc.destroy(self);
+        const cached_text = try alloc.dupe(u8, "");
+        errdefer alloc.free(cached_text);
+        const cached_visible_text = try alloc.dupe(u8, "");
+        errdefer alloc.free(cached_visible_text);
+        const cached_cells = try alloc.alloc(win32_uia.TerminalCellPosition, 0);
+        errdefer alloc.free(cached_cells);
+        self.* = .{
+            .alloc = alloc,
+            .ops = ops,
+            .query_message = query_message,
+            .timer_id = timer_id,
+            .cached_text = cached_text,
+            .cached_visible_text = cached_visible_text,
+            .cached_cells = cached_cells,
+        };
+        self.cacheName();
+        self.cached_focused.store(ops.focused(ops.ctx), .release);
+        return self;
+    }
+
+    pub fn acquireProvider(self: *TerminalAccessibilitySession) !*win32_uia.TerminalProvider {
+        if (self.provider) |provider| {
+            _ = try self.refresh(.discard, false);
+            return provider;
+        }
+        _ = try self.refresh(.discard, false);
+        const hwnd = self.ops.hwnd(self.ops.ctx) orelse return error.NoWindow;
+        self.provider = try win32_uia.TerminalProvider.create(
+            self.alloc,
+            hwnd,
+            self.state(),
+        );
+        return self.provider.?;
+    }
+
+    pub fn rendererUpdated(self: *TerminalAccessibilitySession) void {
+        self.publish(false, .emit);
+    }
+
+    pub fn outputInterested(self: *TerminalAccessibilitySession) bool {
+        self.mutex.lock();
+        const attached = self.attached;
+        const provider_ready = self.provider != null;
+        self.mutex.unlock();
+        return semanticOutputInterestPolicy(
+            attached,
+            provider_ready,
+            self.cached_focused.load(.acquire),
+        );
+    }
+
+    pub fn handleQueryRefresh(self: *TerminalAccessibilitySession, force: bool) void {
+        self.query_refresh_post_pending.store(false, .release);
+        self.publish(force, .accumulate);
+    }
+
+    pub fn handleTimer(self: *TerminalAccessibilitySession) void {
+        self.cancelTimer();
+        self.publish(false, .emit);
+    }
+
+    /// Refresh the retained document before publishing focus. This ordering is
+    /// intentional: a screen reader's first synchronous focused query must see
+    /// background output and current geometry.
+    pub fn focusChanged(self: *TerminalAccessibilitySession, focused_now: bool) void {
+        self.cached_focused.store(focused_now, .release);
+        if (!focused_now) {
+            self.cancelTimer();
+            self.mutex.lock();
+            self.clearPendingAnnouncements();
+            self.clearRecentInput();
+            self.announcement_normalizer = .{};
+            self.mutex.unlock();
+            return;
+        }
+        if (self.provider == null) return;
+        self.publish(true, .discard);
+        if (self.provider) |provider| win32_uia.events.raiseFocusChanged(&provider.base);
+    }
+
+    pub fn nameChanged(self: *TerminalAccessibilitySession) void {
+        self.mutex.lock();
+        self.cacheName();
+        self.mutex.unlock();
+        const provider = self.provider orelse return;
+        if (!win32_uia.events.clientsAreListening()) return;
+        win32_uia.events.raiseNameChanged(&provider.base);
+        win32_uia.events.raiseStructureChanged(
+            &provider.base,
+            .children_invalidated,
+            null,
+        );
+    }
+
+    fn cacheName(self: *TerminalAccessibilitySession) void {
+        var scratch: @TypeOf(self.cached_name) = undefined;
+        const name = self.ops.name(self.ops.ctx, &scratch);
+        const len = @min(name.len, self.cached_name.len);
+        @memmove(self.cached_name[0..len], name[0..len]);
+        self.cached_name_len = len;
+    }
+
+    pub fn noteInput(self: *TerminalAccessibilitySession, input: []const u8) void {
+        if (input.len == 0) return;
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (appendInputQueue(
+            &self.recent_input,
+            &self.recent_input_len,
+            &self.recent_input_matched,
+            &self.recent_input_complete,
+            input,
+        )) {
+            self.recent_input_ms = GetTickCount64();
+        }
+    }
+
+    pub fn noteSemanticOutput(self: *TerminalAccessibilitySession, output: []const u8) void {
+        if (output.len == 0) return;
+        const should_announce = self.cached_focused.load(.acquire) and
+            win32_uia.events.clientsAreListening();
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) return;
+        const without_echo = self.stripRecentInputEcho(output, GetTickCount64());
+        const candidate = self.normalizeSemanticOutputLocked(
+            without_echo.held_prefix,
+            without_echo.output,
+            should_announce,
+        ) orelse return;
+        defer self.alloc.free(candidate);
+        if (!should_announce) return;
+        self.enqueuePendingAnnouncements(candidate);
+        self.armAnnouncementTimer();
+    }
+
+    fn normalizeSemanticOutputLocked(
+        self: *TerminalAccessibilitySession,
+        prefix: []const u8,
+        output: []const u8,
+        should_announce: bool,
+    ) ?[]u8 {
+        return normalizeSemanticAnnouncementParts(
+            self.alloc,
+            &self.announcement_normalizer,
+            prefix,
+            output,
+        ) catch {
+            self.clearRecentInput();
+            self.announcement_normalizer = .{};
+            if (should_announce) {
+                self.pending_output_omitted = true;
+                self.armAnnouncementTimer();
+            }
+            return null;
+        };
+    }
+
+    pub fn resetSemanticOutputContinuity(self: *TerminalAccessibilitySession) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.clearRecentInput();
+        self.announcement_normalizer = .{};
+    }
+
+    pub fn noteOutputOmitted(self: *TerminalAccessibilitySession) void {
+        self.recordOutputOmission(
+            self.cached_focused.load(.acquire) and
+                win32_uia.events.clientsAreListening(),
+        );
+    }
+
+    fn recordOutputOmission(
+        self: *TerminalAccessibilitySession,
+        should_announce: bool,
+    ) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) return;
+        self.clearRecentInput();
+        self.announcement_normalizer = .{};
+        if (!should_announce) return;
+        self.pending_output_omitted = true;
+        self.armAnnouncementTimer();
+    }
+
+    pub fn deinit(self: *TerminalAccessibilitySession) void {
+        self.cancelTimer();
+        self.mutex.lock();
+        self.attached = false;
+        self.query_refresh_post_pending.store(false, .release);
+        self.mutex.unlock();
+        if (self.provider) |provider| {
+            self.provider = null;
+            provider.detach();
+            self.ops.defer_provider_release(self.ops.ctx, provider);
+        }
+        release(@ptrCast(self));
+    }
+
+    fn publish(
+        self: *TerminalAccessibilitySession,
+        force: bool,
+        requested_speech_mode: SpeechMode,
+    ) void {
+        const provider = self.provider orelse return;
+        const now_ms = GetTickCount64();
+        const policy = publishPolicy(
+            win32_uia.events.clientsAreListening(),
+            queryRecentlyActive(self.last_query_ms.load(.acquire), now_ms),
+        );
+        if (!force and !policy.refresh_snapshot) return;
+        if (!force and !refreshDue(self.last_refresh_ms, now_ms)) {
+            if (!self.refresh_timer_active) {
+                const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
+                if (SetTimer(hwnd, self.timer_id, refreshDelay(self.last_refresh_ms, now_ms), null) != 0) {
+                    self.refresh_timer_active = true;
+                }
+            }
+            return;
+        }
+        self.cancelTimer();
+        const started_ms = now_ms;
+        const is_focused = self.cached_focused.load(.acquire);
+        const speech_mode: SpeechMode = if (requested_speech_mode == .discard or !is_focused)
+            .discard
+        else if (requested_speech_mode == .accumulate)
+            .accumulate
+        else if (policy.emit_events)
+            .emit
+        else
+            .discard;
+        const result = self.refresh(speech_mode, true);
+        const completed_ms = GetTickCount64();
+        self.last_refresh_ms = completed_ms;
+        if (snapshotWasSlow(started_ms, completed_ms)) {
+            std.log.warn("win32 terminal UIA snapshot slow elapsed_ms={d}", .{completed_ms -| started_ms});
+        }
+        const refresh_result = result catch |err| {
+            std.log.warn("win32 terminal UIA snapshot refresh failed err={}", .{err});
+            return;
+        };
+        defer if (refresh_result.announcement) |announcement| self.alloc.free(announcement);
+        if (policy.emit_events) {
+            switch (refresh_result.change) {
+                .text => provider.raiseTextChanged(),
+                .caret => provider.raiseTextSelectionChanged(),
+                .text_and_caret => {
+                    provider.raiseTextChanged();
+                    provider.raiseTextSelectionChanged();
+                },
+                .unchanged, .geometry => {},
+            }
+            if (refresh_result.announcement) |announcement| {
+                win32_uia.events.raiseTerminalOutputNotification(&provider.base, announcement);
+            }
+        }
+        if (refresh_result.announcement_pending and !self.refresh_timer_active) {
+            const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
+            if (SetTimer(hwnd, self.timer_id, refresh_interval_ms, null) != 0) {
+                self.refresh_timer_active = true;
+            }
+        }
+    }
+
+    const RefreshResult = struct {
+        change: Change,
+        announcement: ?[]u8 = null,
+        announcement_pending: bool = false,
+    };
+
+    fn refresh(
+        self: *TerminalAccessibilitySession,
+        speech_mode: SpeechMode,
+        update_refresh_time: bool,
+    ) !RefreshResult {
+        // Capture obtains and releases the renderer lock. Only after it returns
+        // do we take the session cache lock.
+        var capture = try self.ops.capture(self.ops.ctx, self.alloc);
+        defer capture.deinit();
+        const snapshot = &capture.snapshot;
+
+        const text = snapshot.text;
+        snapshot.text = text[0..0];
+        errdefer self.alloc.free(text);
+        const cells = snapshot.cell_for_byte;
+        snapshot.cell_for_byte = cells[0..0];
+        errdefer self.alloc.free(cells);
+        const visible_range = snapshot.visible_range;
+        const caret_offset = snapshot.caret_offset;
+        const visible_text = try self.alloc.dupe(u8, text[visible_range.start..visible_range.end]);
+        errdefer self.alloc.free(visible_text);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) {
+            self.alloc.free(visible_text);
+            self.alloc.free(cells);
+            self.alloc.free(text);
+            return .{ .change = .unchanged };
+        }
+
+        const text_changed = !std.mem.eql(u8, self.cached_text, text) or
+            self.cached_visible_range.start != visible_range.start or
+            self.cached_visible_range.end != visible_range.end;
+        const caret_changed = self.cached_caret_offset != caret_offset;
+        const unchanged = std.mem.eql(u8, self.cached_text, text) and
+            self.cached_visible_range.start == visible_range.start and
+            self.cached_visible_range.end == visible_range.end and
+            self.cached_caret_offset == caret_offset and
+            self.viewport_rows == snapshot.viewport_rows and
+            self.viewport_columns == snapshot.viewport_columns and
+            self.cell_width == capture.cell_width and
+            self.cell_height == capture.cell_height and
+            self.origin_x == capture.origin_x and
+            self.origin_y == capture.origin_y and
+            cellsEqual(self.cached_cells, cells);
+        if (unchanged) {
+            self.alloc.free(visible_text);
+            self.alloc.free(cells);
+            self.alloc.free(text);
+            if (update_refresh_time) self.last_refresh_ms = GetTickCount64();
+            return .{
+                .change = .unchanged,
+                .announcement = if (speech_mode == .emit)
+                    try self.takePendingAnnouncement()
+                else
+                    null,
+                .announcement_pending = self.hasPendingAnnouncement(),
+            };
+        }
+
+        const announcement = if (speech_mode == .emit)
+            try self.takePendingAnnouncement()
+        else
+            null;
+        errdefer if (announcement) |value| self.alloc.free(value);
+
+        self.alloc.free(self.cached_cells);
+        self.alloc.free(self.cached_visible_text);
+        self.alloc.free(self.cached_text);
+        self.cached_text = text;
+        self.cached_visible_text = visible_text;
+        self.cached_visible_range = visible_range;
+        self.cached_caret_offset = caret_offset;
+        self.cached_cells = cells;
+        self.viewport_rows = snapshot.viewport_rows;
+        self.viewport_columns = snapshot.viewport_columns;
+        self.cell_width = capture.cell_width;
+        self.cell_height = capture.cell_height;
+        self.origin_x = capture.origin_x;
+        self.origin_y = capture.origin_y;
+        if (update_refresh_time) self.last_refresh_ms = GetTickCount64();
+        return .{
+            .change = if (text_changed and caret_changed)
+                .text_and_caret
+            else if (text_changed)
+                .text
+            else if (caret_changed)
+                .caret
+            else
+                .geometry,
+            .announcement = announcement,
+            .announcement_pending = self.hasPendingAnnouncement(),
+        };
+    }
+
+    fn stripRecentInputEcho(
+        self: *TerminalAccessibilitySession,
+        output: []const u8,
+        now_ms: u64,
+    ) EchoOutput {
+        if (self.recent_input_len == 0) return .{ .output = output };
+        if (now_ms -| self.recent_input_ms > input_echo_window_ms) {
+            const held = self.recent_input[0..self.recent_input_matched];
+            self.clearRecentInput();
+            return .{ .held_prefix = held, .output = output };
+        }
+        return consumeEchoPrefix(
+            &self.recent_input,
+            &self.recent_input_len,
+            &self.recent_input_matched,
+            &self.recent_input_complete,
+            output,
+        );
+    }
+
+    fn clearRecentInput(self: *TerminalAccessibilitySession) void {
+        self.recent_input_len = 0;
+        self.recent_input_matched = 0;
+        self.recent_input_complete = true;
+    }
+
+    fn takePendingAnnouncement(self: *TerminalAccessibilitySession) !?[]u8 {
+        if (self.pending_announcement_count != 0) {
+            const index = self.pending_announcement_head;
+            const announcement = if (self.pending_announcement_omitted[index])
+                try self.alloc.dupe(u8, omitted_output_notice)
+            else
+                try self.alloc.dupe(
+                    u8,
+                    self.pending_announcements[index][0..self.pending_announcement_lengths[index]],
+                );
+            self.pending_announcement_head = (index + 1) % max_pending_announcements;
+            self.pending_announcement_count -= 1;
+            self.materializePendingOmission();
+            return announcement;
+        }
+        if (!self.pending_output_omitted) return null;
+        self.pending_output_omitted = false;
+        return try self.alloc.dupe(u8, omitted_output_notice);
+    }
+
+    fn hasPendingAnnouncement(self: *const TerminalAccessibilitySession) bool {
+        return self.pending_announcement_count != 0 or self.pending_output_omitted;
+    }
+
+    fn clearPendingAnnouncements(self: *TerminalAccessibilitySession) void {
+        self.pending_announcement_head = 0;
+        self.pending_announcement_count = 0;
+        self.pending_output_omitted = false;
+    }
+
+    fn materializePendingOmission(self: *TerminalAccessibilitySession) void {
+        if (!self.pending_output_omitted or
+            self.pending_announcement_count == max_pending_announcements) return;
+        const index = (self.pending_announcement_head + self.pending_announcement_count) %
+            max_pending_announcements;
+        self.pending_announcement_lengths[index] = 0;
+        self.pending_announcement_omitted[index] = true;
+        self.pending_announcement_count += 1;
+        self.pending_output_omitted = false;
+    }
+
+    fn armAnnouncementTimer(self: *TerminalAccessibilitySession) void {
+        if (!self.hasPendingAnnouncement() or self.refresh_timer_active) return;
+        const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
+        if (SetTimer(hwnd, self.timer_id, 1, null) != 0) self.refresh_timer_active = true;
+    }
+
+    fn enqueuePendingAnnouncements(
+        self: *TerminalAccessibilitySession,
+        announcement: []const u8,
+    ) void {
+        self.materializePendingOmission();
+        if (self.pending_output_omitted) return;
+        var remaining = announcement;
+        while (remaining.len != 0) {
+            if (self.pending_announcement_count == max_pending_announcements) {
+                self.pending_output_omitted = true;
+                return;
+            }
+            var chunk_len = @min(remaining.len, max_announcement_bytes);
+            while (chunk_len != 0 and !std.unicode.utf8ValidateSlice(remaining[0..chunk_len])) {
+                chunk_len -= 1;
+            }
+            if (chunk_len == 0) return;
+            const index = (self.pending_announcement_head + self.pending_announcement_count) %
+                max_pending_announcements;
+            @memcpy(self.pending_announcements[index][0..chunk_len], remaining[0..chunk_len]);
+            self.pending_announcement_lengths[index] = chunk_len;
+            self.pending_announcement_omitted[index] = false;
+            self.pending_announcement_count += 1;
+            remaining = remaining[chunk_len..];
+        }
+    }
+
+    fn cancelTimer(self: *TerminalAccessibilitySession) void {
+        if (!self.refresh_timer_active) return;
+        if (self.ops.hwnd(self.ops.ctx)) |hwnd| _ = KillTimer(hwnd, self.timer_id);
+        self.refresh_timer_active = false;
+    }
+
+    fn state(self: *TerminalAccessibilitySession) win32_uia.TerminalState {
+        return .{
+            .ctx = @ptrCast(self),
+            .retain = retain,
+            .release = release,
+            .name = providerName,
+            .value = providerValue,
+            .snapshot = providerSnapshot,
+            .focused = providerFocused,
+        };
+    }
+
+    fn retain(ctx: *anyopaque) void {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        _ = self.refcount.fetchAdd(1, .monotonic);
+    }
+
+    fn release(ctx: *anyopaque) void {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        const previous = self.refcount.fetchSub(1, .acq_rel);
+        if (previous != 1) return;
+        self.alloc.free(self.cached_cells);
+        self.alloc.free(self.cached_visible_text);
+        self.alloc.free(self.cached_text);
+        self.alloc.destroy(self);
+    }
+
+    fn providerName(ctx: *anyopaque, buf: []u8) []const u8 {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) return std.fmt.bufPrint(buf, "Terminal", .{}) catch "Terminal";
+        const len = @min(buf.len, self.cached_name_len);
+        @memcpy(buf[0..len], self.cached_name[0..len]);
+        return buf[0..len];
+    }
+
+    fn providerValue(ctx: *anyopaque, alloc: Allocator) ![]u8 {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        self.noteTextQuery();
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) return error.ElementNotAvailable;
+        return alloc.dupe(u8, self.cached_text);
+    }
+
+    fn providerSnapshot(ctx: *anyopaque, alloc: Allocator) !win32_uia.widgets.TerminalSnapshot {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        self.noteTextQuery();
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.attached) return error.ElementNotAvailable;
+        const document_text = try alloc.dupe(u8, self.cached_text);
+        errdefer alloc.free(document_text);
+        const visible_text = try alloc.dupe(u8, self.cached_visible_text);
+        errdefer alloc.free(visible_text);
+        const cells = try alloc.dupe(win32_uia.TerminalCellPosition, self.cached_cells);
+        return .{
+            .document_text = document_text,
+            .visible_text = visible_text,
+            .visible_range = self.cached_visible_range,
+            .caret_offset = self.cached_caret_offset,
+            .geometry = .{
+                .cell_for_byte = cells,
+                .viewport_rows = self.viewport_rows,
+                .viewport_columns = self.viewport_columns,
+                .cell_width = self.cell_width,
+                .cell_height = self.cell_height,
+                .origin_x = self.origin_x,
+                .origin_y = self.origin_y,
+            },
+        };
+    }
+
+    fn providerFocused(ctx: *anyopaque) bool {
+        const self: *TerminalAccessibilitySession = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.attached and self.cached_focused.load(.acquire);
+    }
+
+    fn noteTextQuery(self: *TerminalAccessibilitySession) void {
+        const now_ms = GetTickCount64();
+        const previous_query_ms = self.last_query_ms.swap(now_ms, .acq_rel);
+        self.mutex.lock();
+        const hwnd = if (self.attached) self.ops.hwnd(self.ops.ctx) else null;
+        self.mutex.unlock();
+        if (hwnd == null) return;
+        if (queryNeedsSynchronousRefresh(previous_query_ms, now_ms)) {
+            var ignored: usize = 0;
+            if (SendMessageTimeoutW(
+                hwnd.?,
+                self.query_message,
+                1,
+                0,
+                SMTO_BLOCK | SMTO_ABORTIFHUNG,
+                cold_query_timeout_ms,
+                &ignored,
+            ) != 0) return;
+        }
+        if (self.query_refresh_post_pending.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) return;
+        if (PostMessageW(hwnd.?, self.query_message, 0, 0) == 0) {
+            self.query_refresh_post_pending.store(false, .release);
+        }
+    }
+};
+
+pub fn refreshDue(last_refresh_ms: u64, now_ms: u64) bool {
+    return last_refresh_ms == 0 or now_ms -| last_refresh_ms >= refresh_interval_ms;
+}
+
+pub fn refreshDelay(last_refresh_ms: u64, now_ms: u64) UINT {
+    return @intCast(@max(1, refresh_interval_ms -| (now_ms -| last_refresh_ms)));
+}
+
+pub fn snapshotWasSlow(start_ms: u64, completed_ms: u64) bool {
+    return completed_ms -| start_ms >= refresh_interval_ms;
+}
+
+pub fn queryRecentlyActive(last_query_ms: u64, now_ms: u64) bool {
+    return last_query_ms != 0 and now_ms -| last_query_ms <= query_activity_window_ms;
+}
+
+fn semanticOutputInterestPolicy(
+    attached: bool,
+    provider_ready: bool,
+    focused: bool,
+) bool {
+    // Once UIA has requested a provider, pre-arm focused output capture so a
+    // listener transition cannot lose its first terminal output batch.
+    return attached and provider_ready and focused;
+}
+
+pub fn queryNeedsSynchronousRefresh(last_query_ms: u64, now_ms: u64) bool {
+    return !queryRecentlyActive(last_query_ms, now_ms);
+}
+
+pub fn publishPolicy(clients_listening: bool, query_recently_active: bool) PublishPolicy {
+    return .{
+        .refresh_snapshot = clients_listening or query_recently_active,
+        .emit_events = clients_listening,
+    };
+}
+
+pub fn cellsEqual(
+    lhs: []const win32_uia.TerminalCellPosition,
+    rhs: []const win32_uia.TerminalCellPosition,
+) bool {
+    if (lhs.len != rhs.len) return false;
+    for (lhs, rhs) |a, b| {
+        if (a.row != b.row or a.column != b.column or a.width != b.width) return false;
+    }
+    return true;
+}
+
+const TestOps = struct {
+    fn hwnd(_: *anyopaque) ?HWND {
+        return null;
+    }
+
+    fn name(_: *anyopaque, buf: []u8) []const u8 {
+        return std.fmt.bufPrint(buf, "Terminal", .{}) catch "Terminal";
+    }
+
+    fn focused(_: *anyopaque) bool {
+        return true;
+    }
+
+    fn capture(_: *anyopaque, alloc: Allocator) !Capture {
+        const text = try alloc.dupe(u8, "");
+        errdefer alloc.free(text);
+        const cells = try alloc.alloc(win32_uia.TerminalCellPosition, 0);
+        return .{
+            .snapshot = .{
+                .alloc = alloc,
+                .text = text,
+                .visible_range = .{ .start = 0, .end = 0 },
+                .caret_offset = 0,
+                .cell_for_byte = cells,
+                .viewport_rows = 0,
+                .viewport_columns = 0,
+            },
+            .cell_width = 0,
+            .cell_height = 0,
+            .origin_x = 0,
+            .origin_y = 0,
+        };
+    }
+
+    fn deferProviderRelease(_: *anyopaque, _: *win32_uia.TerminalProvider) void {}
+
+    fn ops(ctx: *anyopaque) Ops {
+        return .{
+            .ctx = ctx,
+            .hwnd = hwnd,
+            .name = name,
+            .focused = focused,
+            .capture = capture,
+            .defer_provider_release = deferProviderRelease,
+        };
+    }
+};
+
+const MutableTestOps = struct {
+    const Context = struct {
+        focused: bool,
+        text: []const u8,
+        name: []const u8 = "Terminal",
+        return_name_without_copy: bool = false,
+    };
+
+    fn hwnd(_: *anyopaque) ?HWND {
+        return null;
+    }
+
+    fn name(ctx: *anyopaque, buf: []u8) []const u8 {
+        const value: *Context = @ptrCast(@alignCast(ctx));
+        if (value.return_name_without_copy) return value.name;
+        return std.fmt.bufPrint(buf, "{s}", .{value.name}) catch "Terminal";
+    }
+
+    fn focused(ctx: *anyopaque) bool {
+        const value: *Context = @ptrCast(@alignCast(ctx));
+        return value.focused;
+    }
+
+    fn capture(ctx: *anyopaque, alloc: Allocator) !Capture {
+        const value: *Context = @ptrCast(@alignCast(ctx));
+        const text = try alloc.dupe(u8, value.text);
+        errdefer alloc.free(text);
+        const cells = try alloc.alloc(win32_uia.TerminalCellPosition, 0);
+        return .{
+            .snapshot = .{
+                .alloc = alloc,
+                .text = text,
+                .visible_range = .{ .start = 0, .end = text.len },
+                .caret_offset = text.len,
+                .cell_for_byte = cells,
+                .viewport_rows = 1,
+                .viewport_columns = @intCast(text.len),
+            },
+            .cell_width = 1,
+            .cell_height = 1,
+            .origin_x = 0,
+            .origin_y = 0,
+        };
+    }
+
+    fn deferProviderRelease(_: *anyopaque, _: *win32_uia.TerminalProvider) void {}
+
+    fn ops(ctx: *Context) Ops {
+        return .{
+            .ctx = ctx,
+            .hwnd = hwnd,
+            .name = name,
+            .focused = focused,
+            .capture = capture,
+            .defer_provider_release = deferProviderRelease,
+        };
+    }
+};
+
+fn normalizeSemanticAnnouncementSlice(
+    normalizer: *AnnouncementNormalizer,
+    output: []u8,
+    write_index: *usize,
+    input: []const u8,
+) !void {
+    var view = try std.unicode.Utf8View.init(input);
+    var iterator = view.iterator();
+    while (iterator.nextCodepointSlice()) |sequence| {
+        const cp = std.unicode.utf8Decode(sequence) catch unreachable;
+        if (cp <= 0x7f and std.ascii.isWhitespace(@intCast(cp))) {
+            if (normalizer.has_text) normalizer.pending_space = true;
+            continue;
+        }
+        if (normalizer.pending_space) {
+            output[write_index.*] = ' ';
+            write_index.* += 1;
+            normalizer.pending_space = false;
+        }
+        @memcpy(output[write_index.*..][0..sequence.len], sequence);
+        write_index.* += sequence.len;
+        normalizer.has_text = true;
+    }
+}
+
+fn normalizeSemanticAnnouncementParts(
+    alloc: Allocator,
+    normalizer: *AnnouncementNormalizer,
+    prefix: []const u8,
+    output: []const u8,
+) ![]u8 {
+    const normalized = try alloc.alloc(u8, prefix.len + output.len + 1);
+    errdefer alloc.free(normalized);
+    var write_index: usize = 0;
+    try normalizeSemanticAnnouncementSlice(normalizer, normalized, &write_index, prefix);
+    try normalizeSemanticAnnouncementSlice(normalizer, normalized, &write_index, output);
+    return alloc.realloc(normalized, write_index);
+}
+
+fn normalizeSemanticAnnouncement(alloc: Allocator, input: []const u8) ![]u8 {
+    var normalizer: AnnouncementNormalizer = .{};
+    return normalizeSemanticAnnouncementParts(alloc, &normalizer, "", input);
+}
+
+fn normalizeSemanticAnnouncementJoined(
+    alloc: Allocator,
+    prefix: []const u8,
+    output: []const u8,
+) ![]u8 {
+    var normalizer: AnnouncementNormalizer = .{};
+    return normalizeSemanticAnnouncementParts(alloc, &normalizer, prefix, output);
+}
+/// Append only valid printable UTF-8 input to the bounded echo queue.
+fn appendInputQueue(
+    queue: []u8,
+    queue_len: *usize,
+    matched_len: *usize,
+    complete: *bool,
+    input: []const u8,
+) bool {
+    var appended = false;
+    var read_index: usize = 0;
+    while (read_index < input.len) {
+        const sequence_len = std.unicode.utf8ByteSequenceLength(input[read_index]) catch {
+            read_index += 1;
+            continue;
+        };
+        if (read_index + sequence_len > input.len) break;
+        const sequence = input[read_index .. read_index + sequence_len];
+        const codepoint = std.unicode.utf8Decode(sequence) catch {
+            read_index += 1;
+            continue;
+        };
+        read_index += sequence_len;
+        if (codepoint < 0x20 or (codepoint >= 0x7f and codepoint <= 0x9f)) continue;
+        if (sequence_len > queue.len) continue;
+
+        while (queue_len.* + sequence_len > queue.len) {
+            complete.* = false;
+            matched_len.* = 0;
+            const front_len = std.unicode.utf8ByteSequenceLength(queue[0]) catch 1;
+            const remove_len = @min(front_len, queue_len.*);
+            const remaining = queue_len.* - remove_len;
+            std.mem.copyForwards(u8, queue[0..remaining], queue[remove_len..queue_len.*]);
+            queue_len.* = remaining;
+        }
+        @memcpy(queue[queue_len.* .. queue_len.* + sequence_len], sequence);
+        queue_len.* += sequence_len;
+        appended = true;
+    }
+    return appended;
+}
+
+/// Suppress an echo only after the complete retained input is observed at a
+/// terminal boundary. Partial increments advance a match cursor without
+/// deleting the retained input, so an ambiguous suffix can never truncate real
+/// output. A truncated queue disables suppression and favors extra speech.
+pub const EchoOutput = struct {
+    held_prefix: []const u8 = "",
+    output: []const u8,
+};
+
+fn consumeEchoPrefix(
+    queue: []u8,
+    queue_len: *usize,
+    matched_len: *usize,
+    complete: *bool,
+    output: []const u8,
+) EchoOutput {
+    if (!complete.*) {
+        const held = queue[0..matched_len.*];
+        queue_len.* = 0;
+        matched_len.* = 0;
+        complete.* = true;
+        return .{ .held_prefix = held, .output = output };
+    }
+    const pending = queue[matched_len.*..queue_len.*];
+    const compared = @min(pending.len, output.len);
+    if (!std.mem.eql(u8, pending[0..compared], output[0..compared])) {
+        const held = queue[0..matched_len.*];
+        queue_len.* = 0;
+        matched_len.* = 0;
+        complete.* = true;
+        return .{ .held_prefix = held, .output = output };
+    }
+    if (output.len <= pending.len) {
+        matched_len.* += output.len;
+        return .{ .output = output[0..0] };
+    }
+    const boundary = output[pending.len];
+    if (!std.ascii.isWhitespace(boundary) and boundary >= 0x20 and boundary != 0x7f) {
+        const held = queue[0..matched_len.*];
+        queue_len.* = 0;
+        matched_len.* = 0;
+        complete.* = true;
+        return .{ .held_prefix = held, .output = output };
+    }
+    queue_len.* = 0;
+    matched_len.* = 0;
+    complete.* = true;
+    return .{ .output = std.mem.trimLeft(u8, output[pending.len..], " \t\r\n") };
+}
+
+test "terminal accessibility refresh and query policies" {
+    try std.testing.expect(refreshDue(0, 1));
+    try std.testing.expect(!refreshDue(100, 199));
+    try std.testing.expect(refreshDue(100, 200));
+    try std.testing.expectEqual(@as(UINT, 1), refreshDelay(100, 199));
+    try std.testing.expectEqual(@as(UINT, 80), refreshDelay(100, 120));
+    try std.testing.expect(!snapshotWasSlow(100, 199));
+    try std.testing.expect(snapshotWasSlow(100, 200));
+    try std.testing.expect(!queryRecentlyActive(0, 1));
+    try std.testing.expect(queryRecentlyActive(100, 1_100));
+    try std.testing.expect(!queryRecentlyActive(100, 1_101));
+    try std.testing.expect(queryNeedsSynchronousRefresh(0, 1));
+    try std.testing.expect(!queryNeedsSynchronousRefresh(100, 1_100));
+
+    const idle = publishPolicy(false, false);
+    try std.testing.expect(!idle.refresh_snapshot);
+    try std.testing.expect(!idle.emit_events);
+    const query_only = publishPolicy(false, true);
+    try std.testing.expect(query_only.refresh_snapshot);
+    try std.testing.expect(!query_only.emit_events);
+    const subscribed = publishPolicy(true, false);
+    try std.testing.expect(subscribed.refresh_snapshot);
+    try std.testing.expect(subscribed.emit_events);
+
+    // No listener or recent query is required after provider acquisition.
+    try std.testing.expect(semanticOutputInterestPolicy(true, true, true));
+    try std.testing.expect(!semanticOutputInterestPolicy(true, true, false));
+    try std.testing.expect(!semanticOutputInterestPolicy(true, false, true));
+    try std.testing.expect(!semanticOutputInterestPolicy(false, true, true));
+}
+
+test "terminal output announcements are readable bounded increments" {
+    const announcement = try normalizeSemanticAnnouncement(
+        std.testing.allocator,
+        "hello\r\n\tworld  🚀 ",
+    );
+    defer std.testing.allocator.free(announcement);
+    try std.testing.expectEqualStrings("hello world 🚀", announcement);
+}
+
+test "terminal output announcement normalization allocation failure becomes ordered omission" {
+    var ctx: u8 = 0;
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        TestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    session.recent_input[0] = 'x';
+    session.recent_input_len = 1;
+    session.recent_input_matched = 1;
+    session.announcement_normalizer = .{
+        .pending_space = true,
+        .has_text = true,
+    };
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    const original_alloc = session.alloc;
+    session.alloc = failing.allocator();
+    session.mutex.lock();
+    const candidate = session.normalizeSemanticOutputLocked("", "output", true);
+    session.mutex.unlock();
+    session.alloc = original_alloc;
+
+    try std.testing.expect(candidate == null);
+    try std.testing.expectEqual(@as(usize, 0), session.recent_input_len);
+    try std.testing.expect(!session.announcement_normalizer.pending_space);
+    try std.testing.expect(!session.announcement_normalizer.has_text);
+    const omission = (try session.takePendingAnnouncement()).?;
+    defer std.testing.allocator.free(omission);
+    try std.testing.expectEqualStrings(omitted_output_notice, omission);
+}
+
+test "terminal output suppression normalizes per-key input and Enter" {
+    var queue: [64]u8 = undefined;
+    var queue_len: usize = 0;
+    var matched_len: usize = 0;
+    var complete = true;
+    for ([_][]const u8{ "e", "c", "h", "o", " ", "f", "o", "o", "\r" }) |key| {
+        _ = appendInputQueue(&queue, &queue_len, &matched_len, &complete, key);
+    }
+    try std.testing.expectEqualStrings("echo foo", queue[0..queue_len]);
+
+    try std.testing.expectEqualStrings(
+        "",
+        consumeEchoPrefix(&queue, &queue_len, &matched_len, &complete, "echo ").output,
+    );
+    try std.testing.expectEqualStrings(
+        "",
+        consumeEchoPrefix(&queue, &queue_len, &matched_len, &complete, "foo").output,
+    );
+    const raw_spoken = consumeEchoPrefix(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "\r\nresult\r\n",
+    );
+    const announcement = try normalizeSemanticAnnouncementJoined(
+        std.testing.allocator,
+        raw_spoken.held_prefix,
+        raw_spoken.output,
+    );
+    defer std.testing.allocator.free(announcement);
+    try std.testing.expectEqualStrings("result", announcement);
+    try std.testing.expectEqual(@as(usize, 0), queue_len);
+}
+
+test "long split input echo keeps the complete output marker" {
+    const command =
+        "cmd.exe /d /c \"echo whi0123456789abcdef0123456789abcdef^" ++
+        "fedcba9876543210fedcba9876543210\"";
+    const marker =
+        "whi0123456789abcdef0123456789abcdeffedcba9876543210fedcba9876543210";
+    var queue: [256]u8 = undefined;
+    var queue_len: usize = 0;
+    var matched_len: usize = 0;
+    var complete = true;
+    try std.testing.expect(appendInputQueue(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        command,
+    ));
+    try std.testing.expect(command.len > 64);
+    try std.testing.expect(complete);
+    try std.testing.expectEqualStrings(
+        "",
+        consumeEchoPrefix(
+            &queue,
+            &queue_len,
+            &matched_len,
+            &complete,
+            command[0..47],
+        ).output,
+    );
+    try std.testing.expectEqualStrings(
+        "",
+        consumeEchoPrefix(
+            &queue,
+            &queue_len,
+            &matched_len,
+            &complete,
+            command[47..],
+        ).output,
+    );
+    const raw_spoken = consumeEchoPrefix(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "\r\n" ++ marker ++ "\r\n",
+    );
+    const announcement = try normalizeSemanticAnnouncementJoined(
+        std.testing.allocator,
+        raw_spoken.held_prefix,
+        raw_spoken.output,
+    );
+    defer std.testing.allocator.free(announcement);
+    try std.testing.expectEqualStrings(marker, announcement);
+    try std.testing.expect(std.mem.indexOf(u8, announcement, command) == null);
+}
+
+test "truncated input queue never truncates real output" {
+    var queue: [8]u8 = undefined;
+    var queue_len: usize = 0;
+    var matched_len: usize = 0;
+    var complete = true;
+    _ = appendInputQueue(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "long-command",
+    );
+    try std.testing.expect(!complete);
+    const output = "command\r\nresult";
+    try std.testing.expectEqualStrings(
+        output,
+        consumeEchoPrefix(
+            &queue,
+            &queue_len,
+            &matched_len,
+            &complete,
+            output,
+        ).output,
+    );
+}
+
+test "ambiguous partial echo mismatch preserves held output" {
+    var queue: [32]u8 = undefined;
+    var queue_len: usize = 0;
+    var matched_len: usize = 0;
+    var complete = true;
+    _ = appendInputQueue(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "echo foo",
+    );
+    const ambiguous = consumeEchoPrefix(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "e",
+    );
+    try std.testing.expectEqualStrings("", ambiguous.output);
+    const mismatch = consumeEchoPrefix(
+        &queue,
+        &queue_len,
+        &matched_len,
+        &complete,
+        "rror",
+    );
+    const spoken = try normalizeSemanticAnnouncementJoined(
+        std.testing.allocator,
+        mismatch.held_prefix,
+        mismatch.output,
+    );
+    defer std.testing.allocator.free(spoken);
+    try std.testing.expectEqualStrings("error", spoken);
+}
+
+test "terminal output queue chunks a multi-kilobyte burst without losing tail" {
+    var session: TerminalAccessibilitySession = undefined;
+    session.alloc = std.testing.allocator;
+    session.pending_announcement_head = 0;
+    session.pending_announcement_count = 0;
+    session.pending_output_omitted = false;
+    const burst = "a" ** 2_400 ++ " UNIQUE_TAIL";
+    session.enqueuePendingAnnouncements(burst);
+    try std.testing.expectEqual(@as(usize, 3), session.pending_announcement_count);
+    const tail_index = (session.pending_announcement_head + 2) % max_pending_announcements;
+    const tail = session.pending_announcements[tail_index][0..session.pending_announcement_lengths[tail_index]];
+    try std.testing.expect(std.mem.endsWith(u8, tail, "UNIQUE_TAIL"));
+    try std.testing.expect(!session.pending_output_omitted);
+}
+
+test "snapshot refresh never consumes or clears queued terminal output" {
+    var ctx: u8 = 0;
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        TestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+    session.enqueuePendingAnnouncements("background output before provider reacquisition");
+    const before_count = session.pending_announcement_count;
+    const before_head = session.pending_announcement_head;
+
+    const result = try session.refresh(.discard, false);
+    try std.testing.expect(result.announcement == null);
+    try std.testing.expect(result.announcement_pending);
+    try std.testing.expectEqual(before_count, session.pending_announcement_count);
+    try std.testing.expectEqual(before_head, session.pending_announcement_head);
+    const queued = session.pending_announcements[before_head][0..session.pending_announcement_lengths[before_head]];
+    try std.testing.expectEqualStrings("background output before provider reacquisition", queued);
+}
+
+test "terminal focus loss cancels speech and echo backlog" {
+    var ctx: u8 = 0;
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        TestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+    session.enqueuePendingAnnouncements("stale output");
+    session.noteInput("typed input");
+    session.refresh_timer_active = true;
+
+    session.focusChanged(false);
+
+    try std.testing.expect(!session.refresh_timer_active);
+    try std.testing.expectEqual(@as(usize, 0), session.pending_announcement_count);
+    try std.testing.expect(!session.pending_output_omitted);
+    try std.testing.expectEqual(@as(usize, 0), session.recent_input_len);
+}
+
+test "terminal name cache refreshes without an event listener" {
+    var ctx: MutableTestOps.Context = .{
+        .focused = true,
+        .text = "",
+        .name = "Terminal: old",
+    };
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        MutableTestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    ctx.name = "Terminal: current";
+    session.nameChanged();
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Terminal: current",
+        TerminalAccessibilitySession.providerName(@ptrCast(session), &buf),
+    );
+}
+
+test "terminal name cache copies non-aliasing initial fallback" {
+    var ctx: MutableTestOps.Context = .{
+        .focused = true,
+        .text = "",
+        .name = "Terminal",
+        .return_name_without_copy = true,
+    };
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        MutableTestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Terminal",
+        TerminalAccessibilitySession.providerName(@ptrCast(session), &buf),
+    );
+}
+
+test "terminal name cache replaces normal name with non-aliasing fallback" {
+    var ctx: MutableTestOps.Context = .{
+        .focused = true,
+        .text = "",
+        .name = "Terminal: stale long title",
+    };
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        MutableTestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    ctx.name = "Terminal";
+    ctx.return_name_without_copy = true;
+    session.nameChanged();
+
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Terminal",
+        TerminalAccessibilitySession.providerName(@ptrCast(session), &buf),
+    );
+}
+
+test "terminal name cache caps non-aliasing names to capacity" {
+    const long_name = "n" ** 300;
+    var ctx: MutableTestOps.Context = .{
+        .focused = true,
+        .text = "",
+        .name = long_name,
+        .return_name_without_copy = true,
+    };
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        MutableTestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    var buf: [512]u8 = undefined;
+    const name = TerminalAccessibilitySession.providerName(@ptrCast(session), &buf);
+    try std.testing.expectEqual(@as(usize, 256), name.len);
+    try std.testing.expectEqualStrings(long_name[0..256], name);
+}
+
+test "inactive terminal output snapshot is fresh on later focus without speech" {
+    var ctx: MutableTestOps.Context = .{
+        .focused = false,
+        .text = "initial",
+    };
+    const session = try TerminalAccessibilitySession.create(
+        std.testing.allocator,
+        MutableTestOps.ops(&ctx),
+        0,
+        0,
+    );
+    defer session.deinit();
+
+    ctx.text = "background output";
+    const background = try session.refresh(.discard, false);
+    try std.testing.expectEqual(Change.text_and_caret, background.change);
+    try std.testing.expect(background.announcement == null);
+    try std.testing.expectEqualStrings("background output", session.cached_text);
+    try std.testing.expectEqual(@as(usize, 0), session.pending_announcement_count);
+
+    ctx.text = "background output UNIQUE_INACTIVE_MARKER";
+    const focus_refresh = try session.refresh(.discard, false);
+    try std.testing.expectEqual(Change.text_and_caret, focus_refresh.change);
+    try std.testing.expect(focus_refresh.announcement == null);
+    try std.testing.expectEqual(@as(usize, 0), session.pending_announcement_count);
+    ctx.focused = true;
+    session.focusChanged(true);
+    const first_text = try TerminalAccessibilitySession.providerValue(
+        @ptrCast(session),
+        std.testing.allocator,
+    );
+    defer std.testing.allocator.free(first_text);
+    try std.testing.expectEqualStrings(
+        "background output UNIQUE_INACTIVE_MARKER",
+        first_text,
+    );
+    try std.testing.expectEqual(@as(usize, 0), session.pending_announcement_count);
+}
+
+test "bounded terminal output queue emits explicit omission after retained chunks" {
+    var session: TerminalAccessibilitySession = undefined;
+    session.alloc = std.testing.allocator;
+    session.pending_announcement_head = 0;
+    session.pending_announcement_count = 0;
+    session.pending_output_omitted = false;
+    session.enqueuePendingAnnouncements("z" ** (max_announcement_bytes * (max_pending_announcements + 2)));
+    try std.testing.expectEqual(max_pending_announcements, session.pending_announcement_count);
+    try std.testing.expect(session.pending_output_omitted);
+
+    for (0..max_pending_announcements) |_| {
+        const chunk = (try session.takePendingAnnouncement()).?;
+        defer std.testing.allocator.free(chunk);
+        try std.testing.expectEqual(max_announcement_bytes, chunk.len);
+        try std.testing.expect(std.mem.allEqual(u8, chunk, 'z'));
+    }
+    const omission = (try session.takePendingAnnouncement()).?;
+    defer std.testing.allocator.free(omission);
+    try std.testing.expectEqualStrings(omitted_output_notice, omission);
+    try std.testing.expect((try session.takePendingAnnouncement()) == null);
+}
+
+test "terminal output omission remains ordered before newer output" {
+    var session: TerminalAccessibilitySession = undefined;
+    session.alloc = std.testing.allocator;
+    session.pending_announcement_head = 0;
+    session.pending_announcement_count = 0;
+    session.pending_output_omitted = false;
+    session.pending_announcement_omitted = [_]bool{false} ** max_pending_announcements;
+
+    const old = [_][]const u8{ "old-0", "old-1", "old-2", "old-3", "old-4", "old-5", "old-6", "old-7" };
+    for (old) |announcement| session.enqueuePendingAnnouncements(announcement);
+    session.enqueuePendingAnnouncements("dropped-before-barrier");
+
+    const first = (try session.takePendingAnnouncement()).?;
+    defer std.testing.allocator.free(first);
+    try std.testing.expectEqualStrings("old-0", first);
+    const second = (try session.takePendingAnnouncement()).?;
+    defer std.testing.allocator.free(second);
+    try std.testing.expectEqualStrings("old-1", second);
+    session.enqueuePendingAnnouncements("new-after-barrier");
+
+    var drained: std.ArrayList(u8) = .empty;
+    defer drained.deinit(std.testing.allocator);
+    while (try session.takePendingAnnouncement()) |announcement| {
+        defer std.testing.allocator.free(announcement);
+        if (drained.items.len != 0) try drained.append(std.testing.allocator, '|');
+        try drained.appendSlice(std.testing.allocator, announcement);
+    }
+    try std.testing.expectEqualStrings(
+        "old-2|old-3|old-4|old-5|old-6|old-7|terminal output omitted|new-after-barrier",
+        drained.items,
+    );
+}
+
+test "terminal output stream survives more than six hundred lines in order" {
+    var bytes: [7_000]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&bytes);
+    for (0..650) |index| try stream.writer().print("line-{d:0>3}\n", .{index});
+    const readable = try normalizeSemanticAnnouncement(std.testing.allocator, stream.getWritten());
+    defer std.testing.allocator.free(readable);
+
+    var session: TerminalAccessibilitySession = undefined;
+    session.alloc = std.testing.allocator;
+    session.pending_announcement_head = 0;
+    session.pending_announcement_count = 0;
+    session.pending_output_omitted = false;
+    session.enqueuePendingAnnouncements(readable);
+    var drained: std.ArrayList(u8) = .empty;
+    defer drained.deinit(std.testing.allocator);
+    while (try session.takePendingAnnouncement()) |announcement| {
+        defer std.testing.allocator.free(announcement);
+        try drained.appendSlice(std.testing.allocator, announcement);
+    }
+    try std.testing.expectEqualStrings(readable, drained.items);
+    try std.testing.expect(!session.pending_output_omitted);
+}

--- a/src/apprt/win32_terminal_accessibility.zig
+++ b/src/apprt/win32_terminal_accessibility.zig
@@ -441,16 +441,17 @@ pub const TerminalAccessibilitySession = struct {
             self.origin_y == capture.origin_y and
             cellsEqual(self.cached_cells, cells);
         if (unchanged) {
+            const announcement = if (speech_mode == .emit)
+                try self.takePendingAnnouncement()
+            else
+                null;
             self.alloc.free(visible_text);
             self.alloc.free(cells);
             self.alloc.free(text);
             if (update_refresh_time) self.last_refresh_ms = GetTickCount64();
             return .{
                 .change = .unchanged,
-                .announcement = if (speech_mode == .emit)
-                    try self.takePendingAnnouncement()
-                else
-                    null,
+                .announcement = announcement,
                 .announcement_pending = self.hasPendingAnnouncement(),
             };
         }
@@ -1076,6 +1077,33 @@ test "terminal output announcement normalization allocation failure becomes orde
     const omission = (try session.takePendingAnnouncement()).?;
     defer std.testing.allocator.free(omission);
     try std.testing.expectEqualStrings(omitted_output_notice, omission);
+}
+
+test "unchanged terminal refresh emit handles every allocation failure" {
+    const run = struct {
+        fn testRefresh(alloc: Allocator) !void {
+            var ctx: u8 = 0;
+            const session = try TerminalAccessibilitySession.create(
+                alloc,
+                TestOps.ops(&ctx),
+                0,
+                0,
+            );
+            defer session.deinit();
+
+            session.enqueuePendingAnnouncements("pending");
+            const result = try session.refresh(.emit, false);
+            defer if (result.announcement) |announcement| alloc.free(announcement);
+            try std.testing.expectEqual(Change.unchanged, result.change);
+            try std.testing.expectEqualStrings("pending", result.announcement.?);
+        }
+    }.testRefresh;
+
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        run,
+        .{},
+    );
 }
 
 test "terminal output suppression normalizes per-key input and Enter" {

--- a/src/apprt/win32_theme.zig
+++ b/src/apprt/win32_theme.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const win32_types = @import("win32_types.zig");
 const ProfileKind = @import("../config/windows_shell_types.zig").ProfileKind;
 
 /// Pack r/g/b bytes into a Win32 COLORREF (0x00BBGGRR).
@@ -95,6 +96,196 @@ pub const ThemeColors = struct {
 
     // Whether this is a dark theme (for DWM)
     is_dark: bool,
+};
+
+pub const SettingsSystemColors = struct {
+    window: u32,
+    window_text: u32,
+    button_face: u32,
+    button_text: u32,
+    gray_text: u32,
+};
+
+pub const SettingsColors = struct {
+    window_bg: u32,
+    rail_bg: u32,
+    text: u32,
+    disabled_text: u32,
+    edit_bg: u32,
+    edit_text: u32,
+    button_bg: u32,
+    button_text: u32,
+    is_dark: bool,
+    high_contrast: bool,
+};
+
+/// Resolve semantic Settings colors. High Contrast deliberately ignores every
+/// app-theme token and maps directly to the corresponding Windows system role.
+pub fn settingsColors(
+    theme: ThemeColors,
+    system: SettingsSystemColors,
+    high_contrast: bool,
+) SettingsColors {
+    if (high_contrast) {
+        return .{
+            .window_bg = system.button_face,
+            .rail_bg = system.window,
+            .text = system.button_text,
+            .disabled_text = system.gray_text,
+            .edit_bg = system.window,
+            .edit_text = system.window_text,
+            .button_bg = system.button_face,
+            .button_text = system.button_text,
+            .is_dark = false,
+            .high_contrast = true,
+        };
+    }
+    return .{
+        .window_bg = theme.chrome_bg,
+        .rail_bg = theme.overlay_bg,
+        .text = theme.text_primary,
+        .disabled_text = theme.text_disabled,
+        .edit_bg = theme.edit_bg,
+        .edit_text = theme.edit_fg,
+        .button_bg = theme.button_bg,
+        .button_text = theme.button_fg,
+        .is_dark = theme.is_dark,
+        .high_contrast = false,
+    };
+}
+
+pub fn settingsDwmDarkModeValue(colors: SettingsColors) u32 {
+    return if (!colors.high_contrast and colors.is_dark) 1 else 0;
+}
+
+const HWND = win32_types.HWND;
+const E_INVALIDARG: i32 = @bitCast(@as(u32, 0x80070057));
+const DWMWA_USE_IMMERSIVE_DARK_MODE_V1: u32 = 19;
+const DWMWA_USE_IMMERSIVE_DARK_MODE: u32 = 20;
+const DWMWA_CAPTION_COLOR: u32 = 35;
+const DWMWA_TEXT_COLOR: u32 = 36;
+const DWMWA_SYSTEMBACKDROP_TYPE: u32 = 38;
+const DWMSBT_AUTO: u32 = 0;
+const DWMSBT_NONE: u32 = 1;
+const DWMSBT_MAINWINDOW: u32 = 2;
+const DWMSBT_TRANSIENTWINDOW: u32 = 3;
+const DWMSBT_TABBEDWINDOW: u32 = 4;
+
+extern "dwmapi" fn DwmSetWindowAttribute(HWND, u32, *const anyopaque, u32) callconv(.winapi) i32;
+extern "uxtheme" fn SetWindowTheme(HWND, ?[*:0]const u16, ?[*:0]const u16) callconv(.winapi) i32;
+
+const WindowKind = enum { host, settings };
+const NativeControlTheme = enum { system, explorer_light, explorer_dark };
+pub const dwm_color_default: u32 = 0xffff_ffff;
+
+const WindowThemePolicy = struct {
+    immersive_dark: u32,
+    caption_color: u32,
+    text_color: u32,
+    backdrop_type: u32,
+    native_controls: NativeControlTheme,
+};
+
+/// Shared window-kind-aware DWM/native policy. HWND resource ownership and
+/// invalidation remain with each window, but Host and Settings cannot diverge
+/// on Dark/High Contrast reset semantics.
+fn windowThemePolicy(
+    kind: WindowKind,
+    is_dark: bool,
+    high_contrast: bool,
+    caption_color: u32,
+    text_color: u32,
+    backdrop_type: u32,
+) WindowThemePolicy {
+    if (high_contrast) return .{
+        .immersive_dark = 0,
+        .caption_color = dwm_color_default,
+        .text_color = dwm_color_default,
+        .backdrop_type = DWMSBT_NONE,
+        .native_controls = .system,
+    };
+    return .{
+        .immersive_dark = @intFromBool(is_dark),
+        .caption_color = caption_color,
+        .text_color = text_color,
+        .backdrop_type = backdrop_type,
+        .native_controls = switch (kind) {
+            .host => .system,
+            .settings => if (is_dark) .explorer_dark else .explorer_light,
+        },
+    };
+}
+
+pub const WindowThemeAdapter = struct {
+    pub fn applyHost(
+        hwnd: HWND,
+        theme: ThemeColors,
+        high_contrast: bool,
+        caption_color: u32,
+        text_color: u32,
+        backdrop_type: u32,
+        supports_backdrop: bool,
+    ) void {
+        applyWindow(hwnd, windowThemePolicy(
+            .host,
+            theme.is_dark,
+            high_contrast,
+            caption_color,
+            text_color,
+            backdrop_type,
+        ), supports_backdrop);
+    }
+
+    pub fn applySettings(hwnd: HWND, colors: SettingsColors) void {
+        applyWindow(hwnd, windowThemePolicy(
+            .settings,
+            colors.is_dark,
+            colors.high_contrast,
+            colors.window_bg,
+            colors.text,
+            DWMSBT_NONE,
+        ), true);
+    }
+
+    pub fn applyNativeControl(hwnd: HWND, colors: SettingsColors) void {
+        const policy = windowThemePolicy(
+            .settings,
+            colors.is_dark,
+            colors.high_contrast,
+            colors.window_bg,
+            colors.text,
+            DWMSBT_NONE,
+        );
+        const theme: ?[*:0]const u16 = switch (policy.native_controls) {
+            .system => null,
+            .explorer_light => std.unicode.utf8ToUtf16LeStringLiteral("Explorer"),
+            .explorer_dark => std.unicode.utf8ToUtf16LeStringLiteral("DarkMode_Explorer"),
+        };
+        _ = SetWindowTheme(hwnd, theme, null);
+    }
+
+    fn applyWindow(hwnd: HWND, policy: WindowThemePolicy, supports_backdrop: bool) void {
+        const hr = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_USE_IMMERSIVE_DARK_MODE,
+            @ptrCast(&policy.immersive_dark),
+            @sizeOf(u32),
+        );
+        if (hr == E_INVALIDARG) _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_USE_IMMERSIVE_DARK_MODE_V1,
+            @ptrCast(&policy.immersive_dark),
+            @sizeOf(u32),
+        );
+        _ = DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, @ptrCast(&policy.caption_color), @sizeOf(u32));
+        _ = DwmSetWindowAttribute(hwnd, DWMWA_TEXT_COLOR, @ptrCast(&policy.text_color), @sizeOf(u32));
+        if (supports_backdrop) _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_SYSTEMBACKDROP_TYPE,
+            @ptrCast(&policy.backdrop_type),
+            @sizeOf(u32),
+        );
+    }
 };
 
 pub const ProfileChromeAccent = struct {
@@ -825,4 +1016,68 @@ test "blendSemanticAccent stays in sane ranges" {
         try std.testing.expect(hsv.s >= 0.45 - 0.01 and hsv.s <= 0.75 + 0.01);
         try std.testing.expect(hsv.v >= 0.40 - 0.01 and hsv.v <= 0.90 + 0.01);
     }
+}
+
+test "settings colors follow explicit light and dark app themes" {
+    const system = SettingsSystemColors{
+        .window = 1,
+        .window_text = 2,
+        .button_face = 3,
+        .button_text = 4,
+        .gray_text = 5,
+    };
+    const light = settingsColors(lightTheme(), system, false);
+    const dark = settingsColors(darkTheme(), system, false);
+    try std.testing.expect(!light.is_dark);
+    try std.testing.expect(dark.is_dark);
+    try std.testing.expectEqual(lightTheme().chrome_bg, light.window_bg);
+    try std.testing.expectEqual(darkTheme().chrome_bg, dark.window_bg);
+    try std.testing.expect(light.window_bg != dark.window_bg);
+    try std.testing.expect(light.edit_bg != dark.edit_bg);
+}
+
+test "settings high contrast uses only exact system color roles" {
+    const system = SettingsSystemColors{
+        .window = 11,
+        .window_text = 12,
+        .button_face = 13,
+        .button_text = 14,
+        .gray_text = 15,
+    };
+    const colors = settingsColors(darkTheme(), system, true);
+    try std.testing.expect(colors.high_contrast);
+    try std.testing.expectEqual(system.button_face, colors.window_bg);
+    try std.testing.expectEqual(system.window, colors.rail_bg);
+    try std.testing.expectEqual(system.button_text, colors.text);
+    try std.testing.expectEqual(system.gray_text, colors.disabled_text);
+    try std.testing.expectEqual(system.window, colors.edit_bg);
+    try std.testing.expectEqual(system.window_text, colors.edit_text);
+    try std.testing.expectEqual(@as(u32, 0), settingsDwmDarkModeValue(colors));
+    try std.testing.expectEqual(
+        @as(u32, 1),
+        settingsDwmDarkModeValue(settingsColors(darkTheme(), system, false)),
+    );
+}
+
+test "window theme policy actively resets sticky DWM state in high contrast" {
+    const policy = windowThemePolicy(.host, true, true, 1, 2, 4);
+    try std.testing.expectEqual(@as(u32, 0), policy.immersive_dark);
+    try std.testing.expectEqual(dwm_color_default, policy.caption_color);
+    try std.testing.expectEqual(dwm_color_default, policy.text_color);
+    try std.testing.expectEqual(DWMSBT_NONE, policy.backdrop_type);
+    try std.testing.expectEqual(NativeControlTheme.system, policy.native_controls);
+}
+
+test "settings window policy explicitly disables system backdrop" {
+    const policy = windowThemePolicy(.settings, true, false, 1, 2, DWMSBT_NONE);
+    try std.testing.expectEqual(DWMSBT_NONE, policy.backdrop_type);
+    try std.testing.expectEqual(NativeControlTheme.explorer_dark, policy.native_controls);
+}
+
+test "DWM system backdrop constants match Win32 ABI" {
+    try std.testing.expectEqual(@as(u32, 0), DWMSBT_AUTO);
+    try std.testing.expectEqual(@as(u32, 1), DWMSBT_NONE);
+    try std.testing.expectEqual(@as(u32, 2), DWMSBT_MAINWINDOW);
+    try std.testing.expectEqual(@as(u32, 3), DWMSBT_TRANSIENTWINDOW);
+    try std.testing.expectEqual(@as(u32, 4), DWMSBT_TABBEDWINDOW);
 }

--- a/src/apprt/win32_uia/com.zig
+++ b/src/apprt/win32_uia/com.zig
@@ -365,6 +365,7 @@ pub const StructureChangeType_ChildrenReordered: i32 = 5;
 pub const NotificationKind_ActionCompleted: i32 = 2;
 pub const NotificationKind_ActionAborted: i32 = 3;
 pub const NotificationKind_Other: i32 = 4;
+pub const NotificationProcessing_All: i32 = 2;
 pub const NotificationProcessing_MostRecent: i32 = 3;
 
 // ── UIA externs ─────────────────────────────────────────────────────────

--- a/src/apprt/win32_uia/constants.zig
+++ b/src/apprt/win32_uia/constants.zig
@@ -43,6 +43,11 @@ pub const UIA_ValueIsReadOnlyPropertyId: i32 = 30046;
 pub const UIA_IsControlElementPropertyId: i32 = 30016;
 pub const UIA_IsContentElementPropertyId: i32 = 30017;
 pub const UIA_SelectionItemIsSelectedPropertyId: i32 = 30079;
+pub const UIA_LiveSettingPropertyId: i32 = 30135;
+
+pub const LiveSetting_Off: i32 = 0;
+pub const LiveSetting_Polite: i32 = 1;
+pub const LiveSetting_Assertive: i32 = 2;
 
 // ── Event IDs ──────────────────────────────────────────────────────────
 

--- a/src/apprt/win32_uia/events.zig
+++ b/src/apprt/win32_uia/events.zig
@@ -100,6 +100,30 @@ pub fn raiseNotification(
     logIfFailed("UiaRaiseNotificationEvent", hr);
 }
 
+/// Announce only newly appended, already-sanitized terminal output. TextChanged
+/// remains the semantic document-change signal; this notification is the
+/// Windows Terminal-compatible speech path for screen readers.
+pub fn raiseTerminalOutputNotification(
+    provider: *com.IRawElementProviderSimple,
+    message: []const u8,
+) void {
+    if (!clientsAreListening() or message.len == 0) return;
+    const message_bstr = allocNotificationBstr(std.heap.page_allocator, message) catch return;
+    defer com.SysFreeString(message_bstr);
+    const activity_id = com.SysAllocString(
+        std.unicode.utf8ToUtf16LeStringLiteral("TerminalTextOutput"),
+    ) orelse return;
+    defer com.SysFreeString(activity_id);
+    const hr = com.UiaRaiseNotificationEvent(
+        provider,
+        com.NotificationKind_ActionCompleted,
+        com.NotificationProcessing_All,
+        message_bstr,
+        activity_id,
+    );
+    logIfFailed("UiaRaiseNotificationEvent(TerminalTextOutput)", hr);
+}
+
 fn allocNotificationBstr(
     allocator: std.mem.Allocator,
     message: []const u8,

--- a/src/apprt/win32_uia/widgets.zig
+++ b/src/apprt/win32_uia/widgets.zig
@@ -11,7 +11,7 @@
 //!     ControlType=List with a live name that names the currently
 //!     selected match so Narrator announces it on arrow-key nav.
 //!   * `TerminalProvider` — the terminal child HWND. Reports
-//!     ControlType=Document and exposes terminal content through TextPattern.
+//!     ControlType=Text and exposes terminal content through TextPattern.
 //!
 //! The owner-drawn palette list is a fragment root. Its rows are ephemeral
 //! fragment/SelectionItem providers backed by live widget state; native HWND
@@ -2171,7 +2171,7 @@ pub const TerminalProvider = struct {
         switch (prop_id) {
             constants.UIA_ControlTypePropertyId => {
                 out.* = com.VARIANT.fromI4(switch (self.state.role) {
-                    .terminal => constants.UIA_DocumentControlTypeId,
+                    .terminal => constants.UIA_TextControlTypeId,
                     .edit => constants.UIA_EditControlTypeId,
                 });
             },
@@ -2211,6 +2211,9 @@ pub const TerminalProvider = struct {
             },
             constants.UIA_ValueIsReadOnlyPropertyId => if (self.state.role == .edit) {
                 out.* = com.VARIANT.fromBool(self.state.set_value == null);
+            },
+            constants.UIA_LiveSettingPropertyId => if (self.state.role == .terminal) {
+                out.* = com.VARIANT.fromI4(constants.LiveSetting_Polite);
             },
             constants.UIA_IsControlElementPropertyId,
             constants.UIA_IsContentElementPropertyId,
@@ -2296,19 +2299,23 @@ pub const TerminalProvider = struct {
         out.* = null;
         const self = fromText(self_text);
         if (self.detached.load(.acquire)) return com.UIA_E_ELEMENTNOTAVAILABLE;
-        if (self.state.role == .terminal) {
-            out.* = com.SafeArrayCreateVector(com.VT_UNKNOWN, 0, 0) orelse
-                return com.E_OUTOFMEMORY;
-            return com.S_OK;
-        }
-
         var snapshot = self.terminalSnapshot() catch |err| return switch (err) {
             error.ElementNotAvailable => com.UIA_E_ELEMENTNOTAVAILABLE,
             else => com.E_OUTOFMEMORY,
         };
         defer self.alloc.free(snapshot.visible_text);
+        // TextPattern2.GetCaretRange is the canonical terminal caret API.
+        // Preserve a degenerate legacy GetSelection range for older clients
+        // even though terminals truthfully advertise no mutable selection.
+        const selection_range = if (self.state.role == .terminal)
+            terminal_text.OffsetRange{
+                .start = snapshot.caret_offset,
+                .end = snapshot.caret_offset,
+            }
+        else
+            snapshot.selection_range;
         var range: ?*com.ITextRangeProvider = null;
-        const range_hr = self.createRangeFromSnapshot(&snapshot, snapshot.selection_range, &range);
+        const range_hr = self.createRangeFromSnapshot(&snapshot, selection_range, &range);
         if (range_hr != com.S_OK) return range_hr;
         defer _ = TerminalTextRangeProvider.Release(range.?);
 
@@ -2365,10 +2372,9 @@ pub const TerminalProvider = struct {
         const self = fromText(self_text);
         out.* = com.SupportedTextSelection_None;
         if (self.detached.load(.acquire)) return com.UIA_E_ELEMENTNOTAVAILABLE;
-        out.* = if (self.state.role == .edit)
-            com.SupportedTextSelection_Single
-        else
-            com.SupportedTextSelection_None;
+        if (self.state.role == .edit) {
+            out.* = com.SupportedTextSelection_Single;
+        }
         return com.S_OK;
     }
 
@@ -3106,7 +3112,10 @@ const TerminalTextRangeProvider = struct {
     fn Select(self_base: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
         const self = fromBase(self_base);
         if (self.parent.detached.load(.acquire)) return com.UIA_E_ELEMENTNOTAVAILABLE;
-        if (self.parent.state.role != .edit) return com.E_NOTIMPL;
+        // A terminal owns its PTY caret and cannot persist an arbitrary UIA
+        // selection. Keep GetSelection useful for caret review, but report
+        // mutation as unsupported rather than acknowledging a no-op.
+        if (self.parent.state.role == .terminal) return com.UIA_E_INVALIDOPERATION;
         const select_range = self.parent.state.select_range orelse return com.E_NOTIMPL;
         select_range(self.parent.state.ctx, self.text, self.range) catch |err| {
             return if (err == error.OutOfMemory) com.E_OUTOFMEMORY else com.UIA_E_INVALIDOPERATION;
@@ -3117,13 +3126,13 @@ const TerminalTextRangeProvider = struct {
     fn AddToSelection(self_base: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
         const self = fromBase(self_base);
         if (self.parent.detached.load(.acquire)) return com.UIA_E_ELEMENTNOTAVAILABLE;
-        return if (self.parent.state.role == .edit) com.UIA_E_INVALIDOPERATION else com.E_NOTIMPL;
+        return com.UIA_E_INVALIDOPERATION;
     }
 
     fn RemoveFromSelection(self_base: *com.ITextRangeProvider) callconv(.winapi) com.HRESULT {
         const self = fromBase(self_base);
         if (self.parent.detached.load(.acquire)) return com.UIA_E_ELEMENTNOTAVAILABLE;
-        return if (self.parent.state.role == .edit) com.UIA_E_INVALIDOPERATION else com.E_NOTIMPL;
+        return com.UIA_E_INVALIDOPERATION;
     }
 
     fn ScrollIntoView(
@@ -4182,7 +4191,7 @@ test "TerminalProvider refcount and state retain balance across text provider re
     try std.testing.expectEqual(@as(u32, 1), state_data.releases);
 }
 
-test "TerminalProvider reports no legacy selection for a PTY-owned caret" {
+test "TerminalProvider legacy caret compatibility reports no mutable selection" {
     var state_data = TestTerminalStateData{ .caret_offset = 6 };
     const state = testTerminalState(&state_data);
 
@@ -4203,7 +4212,32 @@ test "TerminalProvider reports no legacy selection for a PTY-owned caret" {
     try std.testing.expectEqual(com.S_OK, com.SafeArrayGetLBound(ranges.?, 1, &lower));
     try std.testing.expectEqual(com.S_OK, com.SafeArrayGetUBound(ranges.?, 1, &upper));
     try std.testing.expectEqual(@as(i32, 0), lower);
-    try std.testing.expectEqual(@as(i32, -1), upper);
+    try std.testing.expectEqual(@as(i32, 0), upper);
+
+    var index: i32 = 0;
+    var selected: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(
+        com.S_OK,
+        com.SafeArrayGetElement(ranges.?, &index, @ptrCast(&selected)),
+    );
+    defer _ = TerminalTextRangeProvider.Release(selected.?);
+
+    var active: com.BOOL = 0;
+    var caret: ?*com.ITextRangeProvider = null;
+    try std.testing.expectEqual(
+        com.S_OK,
+        TerminalProvider.GetCaretRange(&p.text2_iface, &active, &caret),
+    );
+    defer _ = TerminalTextRangeProvider.Release(caret.?);
+    try std.testing.expectEqual(
+        TerminalTextRangeProvider.fromBase(caret.?).range,
+        TerminalTextRangeProvider.fromBase(selected.?).range,
+    );
+    try std.testing.expectEqual(
+        terminal_text.OffsetRange{ .start = 6, .end = 6 },
+        TerminalTextRangeProvider.fromBase(selected.?).range,
+    );
+    try std.testing.expectEqual(com.UIA_E_INVALIDOPERATION, TerminalTextRangeProvider.Select(selected.?));
 }
 
 test "TerminalProvider visible ranges returns a SAFEARRAY" {
@@ -4223,7 +4257,7 @@ test "TerminalProvider visible ranges returns a SAFEARRAY" {
     try std.testing.expectEqual(@as(u32, 1), state_data.snapshot_calls);
 }
 
-test "TerminalProvider reports document control type" {
+test "TerminalProvider reports text control type and polite live setting" {
     var state_data = TestTerminalStateData{};
     const state = testTerminalState(&state_data);
 
@@ -4233,7 +4267,14 @@ test "TerminalProvider reports document control type" {
     var value = com.VARIANT.empty();
     const hr = TerminalProvider.GetPropertyValue(&p.base, constants.UIA_ControlTypePropertyId, &value);
     try std.testing.expectEqual(com.S_OK, hr);
-    try std.testing.expectEqual(constants.UIA_DocumentControlTypeId, value.value.i4);
+    try std.testing.expectEqual(constants.UIA_TextControlTypeId, value.value.i4);
+
+    value = com.VARIANT.empty();
+    try std.testing.expectEqual(
+        com.S_OK,
+        TerminalProvider.GetPropertyValue(&p.base, constants.UIA_LiveSettingPropertyId, &value),
+    );
+    try std.testing.expectEqual(constants.LiveSetting_Polite, value.value.i4);
 }
 
 test "TerminalProvider DocumentRange returns terminal text" {
@@ -5524,9 +5565,9 @@ test "TerminalTextRangeProvider reports unsupported mutation and scrolling hones
     );
     defer _ = TerminalTextRangeProvider.Release(&range.base);
 
-    try std.testing.expectEqual(com.E_NOTIMPL, TerminalTextRangeProvider.Select(&range.base));
-    try std.testing.expectEqual(com.E_NOTIMPL, TerminalTextRangeProvider.AddToSelection(&range.base));
-    try std.testing.expectEqual(com.E_NOTIMPL, TerminalTextRangeProvider.RemoveFromSelection(&range.base));
+    try std.testing.expectEqual(com.UIA_E_INVALIDOPERATION, TerminalTextRangeProvider.Select(&range.base));
+    try std.testing.expectEqual(com.UIA_E_INVALIDOPERATION, TerminalTextRangeProvider.AddToSelection(&range.base));
+    try std.testing.expectEqual(com.UIA_E_INVALIDOPERATION, TerminalTextRangeProvider.RemoveFromSelection(&range.base));
     try std.testing.expectEqual(com.E_NOTIMPL, TerminalTextRangeProvider.ScrollIntoView(&range.base, 1));
 }
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -764,29 +764,33 @@ fn cursorTimerCallback(
         return .disarm;
     };
 
-    // An unfocused surface needs no recurring cursor timer. Focus regain will
-    // arm a new one once this callback has been popped and the completion is
-    // therefore safe to reuse.
-    if (!t.flags.focused) {
-        t.flags.cursor_blink_visible = true;
-        t.cursor_blink_reset_at = null;
-        return .disarm;
-    }
-
     // Input or focus regain may have requested a fresh interval while this
     // completion was already queued. Honor the remaining logical delay here,
     // from the timer's own callback, rather than resetting the queued object.
-    if (t.cursor_blink_reset_at) |reset_at| {
-        const elapsed_ms = elapsed: {
+    const reset_elapsed_ns: ?u64 = if (t.flags.focused)
+        if (t.cursor_blink_reset_at) |reset_at| elapsed: {
             const now = std.time.Instant.now() catch break :elapsed 0;
-            break :elapsed now.since(reset_at) / std.time.ns_per_ms;
-        };
-        const remaining_ms = cursorBlinkRemainingMs(cursorBlinkInterval(), elapsed_ms);
-        if (remaining_ms > 0) {
-            t.armCursorTimerIfDead(remaining_ms);
+            break :elapsed now.since(reset_at);
+        } else null
+    else
+        null;
+    switch (cursorBlinkTimerDecision(
+        t.flags.focused,
+        cursorBlinkInterval(),
+        reset_elapsed_ns,
+    )) {
+        .disarm => {
+            // An unfocused surface needs no recurring cursor timer. Focus
+            // regain will arm a new one once this callback has been popped.
+            t.flags.cursor_blink_visible = true;
+            t.cursor_blink_reset_at = null;
             return .disarm;
-        }
-        t.cursor_blink_reset_at = null;
+        },
+        .rearm_after => |delay_ms| {
+            t.armCursorTimerIfDead(delay_ms);
+            return .disarm;
+        },
+        .toggle => t.cursor_blink_reset_at = null,
     }
 
     t.flags.cursor_blink_visible = !t.flags.cursor_blink_visible;
@@ -829,17 +833,70 @@ fn cursorBlinkInterval() u64 {
     return CURSOR_BLINK_INTERVAL;
 }
 
-fn cursorBlinkRemainingMs(interval_ms: u64, elapsed_ms: u64) u64 {
-    return interval_ms -| elapsed_ms;
+fn cursorBlinkRemainingMs(interval_ms: u64, elapsed_ns: u64) u64 {
+    const interval_ns = interval_ms *| std.time.ns_per_ms;
+    const remaining_ns = interval_ns -| elapsed_ns;
+    return remaining_ns / std.time.ns_per_ms +
+        @intFromBool(remaining_ns % std.time.ns_per_ms != 0);
 }
 
-test "cursor blink reset deadline saturates safely" {
+const CursorBlinkTimerDecision = union(enum) {
+    disarm,
+    rearm_after: u64,
+    toggle,
+};
+
+fn cursorBlinkTimerDecision(
+    focused: bool,
+    interval_ms: u64,
+    reset_elapsed_ns: ?u64,
+) CursorBlinkTimerDecision {
+    if (!focused) return .disarm;
+    if (reset_elapsed_ns) |elapsed_ns| {
+        const remaining_ms = cursorBlinkRemainingMs(interval_ms, elapsed_ns);
+        if (remaining_ms > 0) return .{ .rearm_after = remaining_ms };
+    }
+    return .toggle;
+}
+
+test "cursor blink reset deadline rounds up and clamps" {
     const testing = std.testing;
 
     try testing.expectEqual(@as(u64, 500), cursorBlinkRemainingMs(500, 0));
-    try testing.expectEqual(@as(u64, 1), cursorBlinkRemainingMs(500, 499));
-    try testing.expectEqual(@as(u64, 0), cursorBlinkRemainingMs(500, 500));
-    try testing.expectEqual(@as(u64, 0), cursorBlinkRemainingMs(500, 750));
+    try testing.expectEqual(@as(u64, 500), cursorBlinkRemainingMs(500, 1));
+    try testing.expectEqual(
+        @as(u64, 1),
+        cursorBlinkRemainingMs(500, 500 * std.time.ns_per_ms - 1),
+    );
+    try testing.expectEqual(
+        @as(u64, 0),
+        cursorBlinkRemainingMs(500, 500 * std.time.ns_per_ms),
+    );
+    try testing.expectEqual(
+        @as(u64, 0),
+        cursorBlinkRemainingMs(500, 750 * std.time.ns_per_ms),
+    );
+}
+
+test "cursor blink timer decision preserves focus and reset state" {
+    const testing = std.testing;
+
+    try testing.expectEqual(
+        CursorBlinkTimerDecision.disarm,
+        cursorBlinkTimerDecision(false, 500, 1),
+    );
+    try testing.expectEqual(
+        CursorBlinkTimerDecision.toggle,
+        cursorBlinkTimerDecision(true, 500, null),
+    );
+    try testing.expectEqual(
+        CursorBlinkTimerDecision{ .rearm_after = 500 },
+        cursorBlinkTimerDecision(true, 500, 1),
+    );
+    try testing.expectEqual(
+        CursorBlinkTimerDecision.toggle,
+        cursorBlinkTimerDecision(true, 500, 500 * std.time.ns_per_ms),
+    );
 }
 
 test "renderer follow-up check tracks visible terminal dirtiness" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -75,6 +75,10 @@ colors: Colors,
 /// char CSI (ESC [ <n> b).
 previous_char: ?u21 = null,
 
+/// Display scalar committed by the most recent print call. Null means the
+/// print succeeded without committing a glyph.
+last_printed_codepoint: ?u21 = null,
+
 /// The modes that this terminal currently has active.
 modes: modespkg.ModeState = .{},
 
@@ -291,6 +295,7 @@ pub fn printRepeat(self: *Terminal, count_req: usize) !void {
 
 pub fn print(self: *Terminal, c: u21) !void {
     // log.debug("print={x} y={} x={}", .{ c, self.screens.active.cursor.y, self.screens.active.cursor.x });
+    self.last_printed_codepoint = null;
 
     // If we're not on the main display, do nothing for now
     if (self.status_display != .main) {
@@ -527,6 +532,7 @@ pub fn print(self: *Terminal, c: u21) !void {
             });
             self.screens.active.cursorMarkDirty();
             try self.screens.active.appendGrapheme(prev.cell, c);
+            self.last_printed_codepoint = c;
             return;
         }
     }
@@ -581,6 +587,7 @@ pub fn print(self: *Terminal, c: u21) !void {
         }
 
         try self.screens.active.appendGrapheme(prev, c);
+        self.last_printed_codepoint = c;
         return;
     }
 
@@ -663,6 +670,10 @@ pub fn print(self: *Terminal, c: u21) !void {
     self.screens.active.cursorRight(1);
 }
 
+pub inline fn committedPrintCodepoint(self: *const Terminal) ?u21 {
+    return self.last_printed_codepoint;
+}
+
 fn printCell(
     self: *Terminal,
     unmapped_c: u21,
@@ -697,6 +708,7 @@ fn printCell(
         const table = charsets.table(set);
         break :c @intCast(table[@intCast(unmapped_c)]);
     };
+    if (unmapped_c != 0) self.last_printed_codepoint = c;
 
     const cell = self.screens.active.cursor.page_cell;
 

--- a/src/terminal/semantic_output.zig
+++ b/src/terminal/semantic_output.zig
@@ -1,0 +1,3 @@
+pub const transport_chunk_bytes = 1_000;
+pub const transport_max_chunks = 8;
+pub const capacity = transport_chunk_bytes * transport_max_chunks;

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -43,3 +43,6 @@ renderer_mailbox: *RendererThread.Mailbox,
 
 /// The mailbox for sending the surface messages.
 surface_mailbox: apprt.surface.Mailbox,
+
+/// Nonblocking semantic terminal-output transport owned by the Surface.
+terminal_output_transport: *apprt.surface.TerminalOutputTransport,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -214,6 +214,9 @@ renderer_mailbox: *renderer.Thread.Mailbox,
 /// The mailbox for communicating with the surface.
 surface_mailbox: apprt.surface.Mailbox,
 
+/// Nonblocking semantic terminal-output transport owned by the Surface.
+terminal_output_transport: *apprt.surface.TerminalOutputTransport,
+
 /// The cached size info
 size: renderer.Size,
 
@@ -476,6 +479,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .renderer_wakeup = opts.renderer_wakeup,
         .renderer_mailbox = opts.renderer_mailbox,
         .surface_mailbox = opts.surface_mailbox,
+        .terminal_output_transport = opts.terminal_output_transport,
         .size = opts.size,
         .backend = backend,
         .mailbox = opts.mailbox,
@@ -846,6 +850,7 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
+    const semantic_output_epoch = self.terminal_output_transport.captureEpoch();
     const decision = render: {
         // We are modifying terminal state from here on out and we need
         // the lock to grab our read data.
@@ -853,7 +858,9 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
         defer self.renderer_state.mutex.unlock();
         const had_render_work = terminal_render_dirty.needsRendererWake(&self.terminal);
         const was_synchronized_output = self.terminal.modes.get(.synchronized_output);
+        self.terminal_stream.handler.semantic_output.begin(semantic_output_epoch != null);
         const processing = self.processOutputLocked(buf);
+        const semantic_output = self.terminal_stream.handler.semantic_output.finish();
         const has_render_work = terminal_render_dirty.needsRendererWake(&self.terminal);
         const synchronized_output_active = self.terminal.modes.get(.synchronized_output);
         const ended_synchronized_output =
@@ -876,8 +883,25 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
             .ended_synchronized_output = ended_synchronized_output,
             .completed_synchronized_output_batch = completed_synchronized_output_batch,
             .has_render_work = has_render_work,
+            .semantic_output = semantic_output,
+            .semantic_output_epoch = semantic_output_epoch,
         };
     };
+
+    if (decision.semantic_output_epoch) |epoch| {
+        if (decision.semantic_output.len != 0 or
+            decision.semantic_output.omitted_after or
+            decision.semantic_output.reset_before)
+        {
+            const semantic_bytes = decision.semantic_output.slice();
+            _ = self.terminal_output_transport.pushSemanticBatchForEpoch(
+                epoch,
+                semantic_bytes,
+                decision.semantic_output.omitted_after,
+                decision.semantic_output.reset_before,
+            );
+        }
+    }
 
     self.output_trace.noteProcessOutput(
         buf.len,

--- a/src/termio/semantic_output_capture.zig
+++ b/src/termio/semantic_output_capture.zig
@@ -1,0 +1,170 @@
+const std = @import("std");
+const semantic_output = @import("../terminal/semantic_output.zig");
+
+/// Fixed-memory capture of semantic terminal output produced by one PTY read
+/// batch. This is owned and driven by StreamHandler while the terminal mutex is
+/// held, then copied into the UI transport after that mutex is released.
+pub const SemanticOutputCapture = struct {
+    pub const capacity = semantic_output.capacity;
+
+    pub const Batch = struct {
+        bytes: [capacity]u8,
+        len: usize,
+        omitted_after: bool,
+        reset_before: bool,
+
+        pub fn slice(self: *const Batch) []const u8 {
+            return self.bytes[0..self.len];
+        }
+    };
+
+    bytes: [capacity]u8 = undefined,
+    len: usize = 0,
+    active: bool = false,
+    omitted_after: bool = false,
+    reset_before: bool = false,
+
+    pub fn begin(self: *SemanticOutputCapture, interested: bool) void {
+        self.len = 0;
+        self.active = interested;
+        self.omitted_after = false;
+        self.reset_before = false;
+    }
+
+    pub fn recordPrint(self: *SemanticOutputCapture, cp: u21) void {
+        if (!self.active or self.omitted_after) return;
+
+        var encoded: [4]u8 = undefined;
+        const encoded_len = std.unicode.utf8Encode(cp, &encoded) catch {
+            self.omitRemainder();
+            return;
+        };
+        self.record(encoded[0..encoded_len]);
+    }
+
+    pub fn recordCarriageReturn(self: *SemanticOutputCapture) void {
+        self.record("\r");
+    }
+
+    pub fn recordLinefeed(self: *SemanticOutputCapture) void {
+        self.record("\n");
+    }
+
+    pub fn recordTab(self: *SemanticOutputCapture) void {
+        self.record("\t");
+    }
+
+    pub fn omitRemainder(self: *SemanticOutputCapture) void {
+        if (self.active) self.omitted_after = true;
+    }
+
+    pub fn resetForFullReset(self: *SemanticOutputCapture) void {
+        if (!self.active) return;
+        self.len = 0;
+        self.omitted_after = false;
+        self.reset_before = true;
+    }
+
+    pub fn finish(self: *SemanticOutputCapture) Batch {
+        var result: Batch = .{
+            .bytes = undefined,
+            .len = self.len,
+            .omitted_after = self.omitted_after,
+            .reset_before = self.reset_before,
+        };
+        @memcpy(result.bytes[0..self.len], self.bytes[0..self.len]);
+        self.active = false;
+        return result;
+    }
+
+    fn record(self: *SemanticOutputCapture, value: []const u8) void {
+        if (!self.active or self.omitted_after or value.len == 0) return;
+        if (value.len > self.bytes.len - self.len) {
+            self.omitted_after = true;
+            return;
+        }
+        @memcpy(self.bytes[self.len..][0..value.len], value);
+        self.len += value.len;
+    }
+};
+
+test "semantic output capture uninterested fast path" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(false);
+    capture.recordPrint('A');
+    for (0..3) |_| capture.recordPrint('B');
+    capture.recordCarriageReturn();
+    capture.recordLinefeed();
+    capture.recordTab();
+    const batch = capture.finish();
+    try std.testing.expectEqual(@as(usize, 0), batch.len);
+    try std.testing.expect(!batch.omitted_after);
+}
+
+test "semantic output capture preserves utf8 and control order" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(true);
+    capture.recordPrint('A');
+    capture.recordPrint('🙂');
+    capture.recordCarriageReturn();
+    capture.recordLinefeed();
+    capture.recordTab();
+    for (0..2) |_| capture.recordPrint('é');
+    const batch = capture.finish();
+    try std.testing.expectEqualStrings("A🙂\r\n\téé", batch.slice());
+    try std.testing.expect(!batch.omitted_after);
+}
+
+test "semantic output finished batch owns bytes across capture reuse" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(true);
+    capture.recordPrint('A');
+    const first = capture.finish();
+    try std.testing.expectEqualStrings("A", first.slice());
+
+    capture.begin(true);
+    capture.recordPrint('B');
+    const batch = capture.finish();
+    try std.testing.expectEqualStrings("B", batch.slice());
+    try std.testing.expectEqualStrings("A", first.slice());
+    try std.testing.expect(!batch.omitted_after);
+}
+
+test "semantic output full reset discards prior bytes and omission" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(true);
+    capture.recordPrint('A');
+    capture.omitRemainder();
+    capture.resetForFullReset();
+    capture.recordPrint('B');
+    const batch = capture.finish();
+    try std.testing.expectEqualStrings("B", batch.slice());
+    try std.testing.expect(!batch.omitted_after);
+    try std.testing.expect(batch.reset_before);
+}
+
+test "semantic output capture retains codepoint-aligned prefix before omission" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(true);
+    for (0..SemanticOutputCapture.capacity - 1) |_| capture.recordPrint('x');
+    capture.recordPrint('🙂');
+    capture.recordPrint('z');
+    const batch = capture.finish();
+    try std.testing.expectEqual(
+        SemanticOutputCapture.capacity - 1,
+        batch.len,
+    );
+    try std.testing.expect(std.unicode.utf8ValidateSlice(batch.slice()));
+    try std.testing.expect(batch.omitted_after);
+}
+
+test "semantic output capture explicit partial error omission retains prefix" {
+    var capture: SemanticOutputCapture = .{};
+    capture.begin(true);
+    for (0..3) |_| capture.recordPrint('R');
+    capture.omitRemainder();
+    capture.recordPrint('X');
+    const batch = capture.finish();
+    try std.testing.expectEqualStrings("RRR", batch.slice());
+    try std.testing.expect(batch.omitted_after);
+}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -11,6 +11,7 @@ const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
 const terminal = @import("../terminal/main.zig");
 const terminfo = @import("../terminfo/main.zig");
+const SemanticOutputCapture = @import("semantic_output_capture.zig").SemanticOutputCapture;
 const posix = std.posix;
 
 const log = std.log.scoped(.io_handler);
@@ -84,6 +85,9 @@ pub const StreamHandler = struct {
 
     /// This is set for the duration of a parse batch when we see 2026h.
     saw_synchronized_output_start: bool = false,
+
+    /// Semantic output committed during the current PTY read batch.
+    semantic_output: SemanticOutputCapture = .{},
 
     pub const Stream = terminal.Stream(StreamHandler);
 
@@ -208,20 +212,42 @@ pub const StreamHandler = struct {
         switch (action) {
             .print => {
                 @branchHint(.likely);
-                try self.terminal.print(value.cp);
+                const captured = self.terminal.status_display == .main;
+                self.terminal.print(value.cp) catch |err| {
+                    if (captured) self.semantic_output.omitRemainder();
+                    return err;
+                };
+                if (captured) {
+                    if (self.terminal.committedPrintCodepoint()) |cp| {
+                        self.semantic_output.recordPrint(cp);
+                    }
+                }
             },
-            .print_repeat => try self.terminal.printRepeat(value),
+            .print_repeat => try self.printRepeat(value),
             .bell => self.bell(),
             .backspace => self.terminal.backspace(),
-            .horizontal_tab => self.horizontalTab(value),
+            .horizontal_tab => {
+                const captured = self.terminal.status_display == .main;
+                const committed = self.horizontalTab(value);
+                if (captured) {
+                    for (0..committed) |_| self.semantic_output.recordTab();
+                }
+            },
             .horizontal_tab_back => self.horizontalTabBack(value),
             .linefeed => {
                 @branchHint(.likely);
-                try self.linefeed();
+                const captured = self.terminal.status_display == .main;
+                self.linefeed() catch |err| {
+                    if (captured) self.semantic_output.omitRemainder();
+                    return err;
+                };
+                if (captured) self.semantic_output.recordLinefeed();
             },
             .carriage_return => {
                 @branchHint(.likely);
+                const captured = self.terminal.status_display == .main;
                 self.terminal.carriageReturn();
+                if (captured) self.semantic_output.recordCarriageReturn();
             },
             .enquiry => try self.enquiry(),
             .invoke_charset => self.terminal.invokeCharset(value.bank, value.charset, value.locking),
@@ -270,7 +296,13 @@ pub const StreamHandler = struct {
             .index => try self.index(),
             .next_line => try self.nextLine(),
             .reverse_index => try self.reverseIndex(),
-            .full_reset => try self.fullReset(),
+            .full_reset => {
+                self.fullReset() catch |err| {
+                    self.semantic_output.omitRemainder();
+                    return err;
+                };
+                self.semantic_output.resetForFullReset();
+            },
             .set_mode => try self.setMode(value.mode, true),
             .reset_mode => try self.setMode(value.mode, false),
             .save_mode => self.terminal.modes.save(value.mode),
@@ -570,12 +602,15 @@ pub const StreamHandler = struct {
         self.surfaceMessageWriter(.ring_bell);
     }
 
-    inline fn horizontalTab(self: *StreamHandler, count: u16) void {
+    inline fn horizontalTab(self: *StreamHandler, count: u16) usize {
+        var committed: usize = 0;
         for (0..count) |_| {
             const x = self.terminal.screens.active.cursor.x;
             self.terminal.horizontalTab();
             if (x == self.terminal.screens.active.cursor.x) break;
+            committed += 1;
         }
+        return committed;
     }
 
     inline fn horizontalTabBack(self: *StreamHandler, count: u16) void {
@@ -590,6 +625,25 @@ pub const StreamHandler = struct {
         // Small optimization: call index instead of linefeed because they're
         // identical and this avoids one layer of function call overhead.
         try self.terminal.index();
+    }
+
+    inline fn printRepeat(self: *StreamHandler, count_req: usize) !void {
+        if (self.terminal.status_display != .main) {
+            try self.terminal.printRepeat(count_req);
+            return;
+        }
+
+        const cp = self.terminal.previous_char orelse return;
+        const count = @max(count_req, 1);
+        for (0..count) |_| {
+            self.terminal.print(cp) catch |err| {
+                self.semantic_output.omitRemainder();
+                return err;
+            };
+            if (self.terminal.committedPrintCodepoint()) |committed| {
+                self.semantic_output.recordPrint(committed);
+            }
+        }
     }
 
     pub inline fn reverseIndex(self: *StreamHandler) !void {
@@ -1568,6 +1622,120 @@ pub const StreamHandler = struct {
         self.surfaceMessageWriter(.{ .progress_report = report });
     }
 };
+
+test "semantic output capture follows real stream handler parser" {
+    var term = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(std.testing.allocator);
+
+    var termio_mailbox = try termio.Mailbox.initSPSC(std.testing.allocator);
+    defer termio_mailbox.deinit(std.testing.allocator);
+    var renderer_mutex: std.Thread.Mutex = .{};
+    var renderer_state: renderer.State = undefined;
+    renderer_state.mutex = &renderer_mutex;
+    renderer_state.terminal = &term;
+    var rt_app: apprt.App = undefined;
+    rt_app.windows = .empty;
+    rt_app.ui_thread_id = 0;
+    const AppMailbox = @TypeOf(@as(apprt.surface.Mailbox, undefined).app);
+    const app_queue = try AppMailbox.Queue.create(std.testing.allocator);
+    defer app_queue.destroy(std.testing.allocator);
+    const surface_mailbox: apprt.surface.Mailbox = .{
+        .surface = undefined,
+        .app = .{
+            .rt_app = &rt_app,
+            .mailbox = app_queue,
+        },
+    };
+
+    var stream = StreamHandler.Stream.initAlloc(std.testing.allocator, .{
+        .alloc = std.testing.allocator,
+        .size = undefined,
+        .terminal = &term,
+        .termio_mailbox = &termio_mailbox,
+        .surface_mailbox = surface_mailbox,
+        .renderer_state = &renderer_state,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .default_cursor_style = .block,
+        .default_cursor_blink = true,
+        .enquiry_response = "",
+        .osc_color_report_format = .none,
+        .clipboard_write = .allow,
+    });
+    defer stream.deinit();
+
+    stream.handler.semantic_output.begin(false);
+    stream.nextSlice("uninterested");
+    const uninterested = stream.handler.semantic_output.finish();
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        uninterested.len,
+    );
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("A\xf0\x9f");
+    const split_lead = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("A", split_lead.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\x99\x82B");
+    const split_tail = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("🙂B", split_tail.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\x1b[3b");
+    const repeated = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("BBB", repeated.slice());
+
+    term.fullReset();
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\x1b[2b");
+    const reset_repeat = stream.handler.semantic_output.finish();
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        reset_repeat.len,
+    );
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("X\r\n\tY");
+    const controls = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("X\r\n\tY", controls.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice(
+        "left\x1b[31mright" ++
+            "\x1b]8;;https://secret.example\x1b\\link\x1b]8;;\x1b\\" ++
+            "\x1bPqDCS-SECRET\x1b\\done",
+    );
+    const escaped = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("leftrightlinkdone", escaped.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\x1b[1$}\r\n\thidden\x1b[0$}visible");
+    const status_display = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("visible", status_display.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\x1b(0`\x1b(B");
+    const special_graphics = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("◆", special_graphics.slice());
+
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("before\x1bcafter");
+    const full_reset = stream.handler.semantic_output.finish();
+    try std.testing.expectEqualStrings("after", full_reset.slice());
+    try std.testing.expect(full_reset.reset_before);
+    try std.testing.expect(!full_reset.omitted_after);
+
+    term.fullReset();
+    stream.handler.semantic_output.begin(true);
+    stream.nextSlice("\xcc\x81");
+    const combining_noop = stream.handler.semantic_output.finish();
+    try std.testing.expectEqual(@as(usize, 0), combining_noop.len);
+}
 
 test "decodeOsc7PathForPwd handles Windows file URI with a single fallback allocator" {
     const uri = try internal_os.uri.parse("file://localhost/C:/Users/test/project", .{

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -78,6 +78,41 @@ function Assert-TextContract {
     if ($Content -notmatch $Pattern) { throw "Contract missing: $Description ($Context)" }
 }
 
+function Assert-ZigTestsDiscoveredAndRun {
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot,
+        [Parameter(Mandatory)] [hashtable] $Sources,
+        [Parameter(Mandatory)] [string[]] $ExpectedNames,
+        [Parameter(Mandatory)] [string] $Filter
+    )
+
+    $declarations = [Collections.Generic.List[object]]::new()
+    foreach ($entry in $Sources.GetEnumerator()) {
+        foreach ($match in [regex]::Matches(
+            $entry.Value,
+            '(?m)^test "(?<name>[^"\r\n]+)" \{$'
+        )) {
+            [void]$declarations.Add([pscustomobject]@{
+                Path = $entry.Key
+                Name = $match.Groups['name'].Value
+            })
+        }
+    }
+    foreach ($expectedName in $ExpectedNames) {
+        $matches = @($declarations | Where-Object { $_.Name -ceq $expectedName })
+        if ($matches.Count -ne 1) {
+            throw "Expected exactly one Zig test declaration '$expectedName'; found $($matches.Count)."
+        }
+    }
+
+    $filterArgument = "-Dtest-filter=$Filter"
+    & (Join-Path $RepoRoot 'scripts\dev-windows.cmd') `
+        zig build test $filterArgument
+    if ($LASTEXITCODE -ne 0) {
+        throw "Zig semantic fixture '$Filter' failed with exit code $LASTEXITCODE."
+    }
+}
+
 function Get-YamlJobText {
     param(
         [Parameter(Mandatory)] [string] $Content,
@@ -187,10 +222,352 @@ function Get-DirectStatementBlockChild {
     return $statement
 }
 
+function Test-DirectNamedBlockChild {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [System.Management.Automation.Language.NamedBlockAst] $NamedBlock
+    )
+
+    $ancestor = $Node.Parent
+    while ($null -ne $ancestor -and
+        $ancestor -isnot [System.Management.Automation.Language.NamedBlockAst]) {
+        if ($ancestor -isnot [System.Management.Automation.Language.PipelineAst] -and
+            $ancestor -isnot
+                [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $ancestor -isnot
+                [System.Management.Automation.Language.CommandExpressionAst]) {
+            return $false
+        }
+        $ancestor = $ancestor.Parent
+    }
+    [object]::ReferenceEquals($ancestor, $NamedBlock)
+}
+
 function Get-MemberExpressionName {
     param([Parameter(Mandatory)] [System.Management.Automation.Language.MemberExpressionAst] $Node)
 
     return ([string] $Node.Member.Value).Trim()
+}
+
+function Get-NamedFunctionDefinitions {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    return @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $Name
+    }, $true))
+}
+
+function Get-NamedCommands {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    return @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -eq $Name
+    }, $true))
+}
+
+function Get-NamedMemberExpressions {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Name,
+        [switch] $InvocationOnly
+    )
+
+    return @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.MemberExpressionAst] -and
+            (-not $InvocationOnly -or
+                $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst]) -and
+            (Get-MemberExpressionName -Node $node) -eq $Name
+    }, $true))
+}
+
+function Get-ExpressionRootVariableName {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
+
+    while ($Node -is [System.Management.Automation.Language.MemberExpressionAst] -or
+        $Node -is [System.Management.Automation.Language.ParenExpressionAst]) {
+        if ($Node -is [System.Management.Automation.Language.MemberExpressionAst]) {
+            $Node = $Node.Expression
+        } else {
+            $pipelineElements = @($Node.Pipeline.PipelineElements)
+            if ($pipelineElements.Count -ne 1 -or
+                $pipelineElements[0] -isnot
+                    [System.Management.Automation.Language.CommandExpressionAst]) {
+                return ''
+            }
+            $Node = $pipelineElements[0].Expression
+        }
+    }
+    if ($Node -isnot [System.Management.Automation.Language.VariableExpressionAst]) {
+        return ''
+    }
+    return ($Node.VariablePath.UserPath -split ':')[-1]
+}
+
+function Test-CommandHasStringArgument {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.CommandAst] $Command,
+        [Parameter(Mandatory)] [string] $Value
+    )
+
+    return @($Command.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+            $node.Value -eq $Value
+    }, $true)).Count -gt 0
+}
+
+function Get-CommandParameterArgument {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.CommandAst] $Command,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    $elements = @($Command.CommandElements)
+    for ($index = 0; $index -lt $elements.Count; $index++) {
+        $element = $elements[$index]
+        if ($element -isnot [System.Management.Automation.Language.CommandParameterAst] -or
+            $element.ParameterName -ne $Name) {
+            continue
+        }
+        if ($null -ne $element.Argument) { return $element.Argument }
+        if (($index + 1) -lt $elements.Count -and
+            $elements[$index + 1] -isnot
+                [System.Management.Automation.Language.CommandParameterAst]) {
+            return $elements[$index + 1]
+        }
+        return $null
+    }
+    return $null
+}
+
+function Get-ContainingStatementBlock {
+    param([Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Node)
+
+    while ($null -ne $Node -and
+        $Node -isnot [System.Management.Automation.Language.StatementBlockAst]) {
+        $Node = $Node.Parent
+    }
+    return $Node
+}
+
+function Get-VariableExpressionName {
+    param([System.Management.Automation.Language.Ast] $Node)
+
+    if ($Node -isnot [System.Management.Automation.Language.VariableExpressionAst]) {
+        return ''
+    }
+    return ($Node.VariablePath.UserPath -split ':')[-1]
+}
+
+function Test-StaticMemberReference {
+    param(
+        [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [string] $TypeName,
+        [Parameter(Mandatory)] [string] $MemberName
+    )
+
+    return $Node -is [System.Management.Automation.Language.MemberExpressionAst] -and
+        $Node.Static -and
+        (Get-MemberExpressionName -Node $Node) -eq $MemberName -and
+        $Node.Expression -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        $Node.Expression.TypeName.FullName -eq $TypeName
+}
+
+function Test-DirectJoinPathNameExpression {
+    param(
+        [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [string] $ParentVariable,
+        [AllowEmptyString()] [string] $ParentMember = '',
+        [Parameter(Mandatory)] [string] $ChildVariable,
+        [Parameter(Mandatory)] [string] $ChildSuffix,
+        [Parameter(Mandatory)] [ValidateSet('Expandable', 'Format')] [string] $Style
+    )
+
+    if ($Node -isnot [System.Management.Automation.Language.PipelineAst] -or
+        $Node.PipelineElements.Count -ne 1 -or
+        $Node.PipelineElements[0] -isnot
+            [System.Management.Automation.Language.CommandAst]) {
+        return $false
+    }
+    $command = $Node.PipelineElements[0]
+    $elements = @($command.CommandElements)
+    if ($command.GetCommandName() -ne 'Join-Path' -or $elements.Count -ne 3) {
+        return $false
+    }
+    $parent = $elements[1]
+    if ([string]::IsNullOrEmpty($ParentMember)) {
+        if ((Get-VariableExpressionName -Node $parent) -ne $ParentVariable) {
+            return $false
+        }
+    } elseif ($parent -isnot
+            [System.Management.Automation.Language.MemberExpressionAst] -or
+        (Get-ExpressionRootVariableName -Node $parent) -ne $ParentVariable -or
+        (Get-MemberExpressionName -Node $parent) -ne $ParentMember) {
+        return $false
+    }
+
+    $child = $elements[2]
+    if ($Style -eq 'Expandable') {
+        return $child -is
+                [System.Management.Automation.Language.ExpandableStringExpressionAst] -and
+            $child.Value -ceq ('$' + $ChildVariable + $ChildSuffix) -and
+            $child.NestedExpressions.Count -eq 1 -and
+            (Get-VariableExpressionName -Node $child.NestedExpressions[0]) -eq
+                $ChildVariable
+    }
+    if ($child -isnot [System.Management.Automation.Language.ParenExpressionAst] -or
+        $child.Pipeline.PipelineElements.Count -ne 1 -or
+        $child.Pipeline.PipelineElements[0] -isnot
+            [System.Management.Automation.Language.CommandExpressionAst]) {
+        return $false
+    }
+    $format = $child.Pipeline.PipelineElements[0].Expression
+    return $format -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+        $format.Operator -eq [System.Management.Automation.Language.TokenKind]::Format -and
+        $format.Left -is
+            [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        $format.Left.Value -ceq ('{0}' + $ChildSuffix) -and
+        (Get-VariableExpressionName -Node $format.Right) -eq $ChildVariable
+}
+
+function Test-InjectiveHarnessRunNameExpression {
+    param([System.Management.Automation.Language.Ast] $Node)
+
+    if ($Node -isnot [System.Management.Automation.Language.IfStatementAst] -or
+        $Node.Clauses.Count -ne 1 -or $null -eq $Node.ElseClause) {
+        return $false
+    }
+    $conditionElements = @($Node.Clauses[0].Item1.PipelineElements)
+    $thenStatements = @($Node.Clauses[0].Item2.Statements)
+    $elseStatements = @($Node.ElseClause.Statements)
+    if ($conditionElements.Count -ne 1 -or
+        $conditionElements[0] -isnot
+            [System.Management.Automation.Language.CommandExpressionAst] -or
+        $thenStatements.Count -ne 1 -or $elseStatements.Count -ne 1) {
+        return $false
+    }
+    $condition = $conditionElements[0].Expression
+    if ($condition -isnot
+            [System.Management.Automation.Language.InvokeMemberExpressionAst] -or
+        -not $condition.Static -or
+        $condition.Expression -isnot
+            [System.Management.Automation.Language.TypeExpressionAst] -or
+        $condition.Expression.TypeName.FullName -ne 'string' -or
+        (Get-MemberExpressionName -Node $condition) -ne 'IsNullOrWhiteSpace' -or
+        $condition.Arguments.Count -ne 1 -or
+        (Get-VariableExpressionName -Node $condition.Arguments[0]) -ne
+            'ScenarioSlug') {
+        return $false
+    }
+    $thenElements = @($thenStatements[0].PipelineElements)
+    $elseElements = @($elseStatements[0].PipelineElements)
+    if ($thenElements.Count -ne 1 -or $elseElements.Count -ne 1 -or
+        $thenElements[0] -isnot
+            [System.Management.Automation.Language.CommandExpressionAst] -or
+        $elseElements[0] -isnot
+            [System.Management.Automation.Language.CommandExpressionAst] -or
+        (Get-VariableExpressionName -Node $thenElements[0].Expression) -ne
+            'ScriptName') {
+        return $false
+    }
+    $format = $elseElements[0].Expression
+    if ($format -isnot [System.Management.Automation.Language.BinaryExpressionAst] -or
+        $format.Operator -ne [System.Management.Automation.Language.TokenKind]::Format -or
+        $format.Left -isnot
+            [System.Management.Automation.Language.StringConstantExpressionAst] -or
+        $format.Left.Value -cne '{0}-{1}' -or
+        $format.Right -isnot [System.Management.Automation.Language.ArrayLiteralAst] -or
+        $format.Right.Elements.Count -ne 2) {
+        return $false
+    }
+    $scriptName = $format.Right.Elements[0]
+    return $scriptName -is
+            [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+        $scriptName.Static -and
+        $scriptName.Expression -is
+            [System.Management.Automation.Language.TypeExpressionAst] -and
+        $scriptName.Expression.TypeName.FullName -eq 'System.IO.Path' -and
+        (Get-MemberExpressionName -Node $scriptName) -eq
+            'GetFileNameWithoutExtension' -and
+        $scriptName.Arguments.Count -eq 1 -and
+        (Get-VariableExpressionName -Node $scriptName.Arguments[0]) -eq
+            'ScriptName' -and
+        (Get-VariableExpressionName -Node $format.Right.Elements[1]) -eq
+            'ScenarioSlug'
+}
+
+function Test-TextChangedHandlerOperation {
+    param(
+        [System.Management.Automation.Language.Ast] $Node,
+        [Parameter(Mandatory)] [ValidateSet('Add', 'Remove')] [string] $Operation
+    )
+
+    if ($Node -isnot [System.Management.Automation.Language.InvokeMemberExpressionAst] -or
+        -not $Node.Static -or
+        $Node.Expression -isnot [System.Management.Automation.Language.TypeExpressionAst] -or
+        $Node.Expression.TypeName.FullName -ne
+            'System.Windows.Automation.Automation' -or
+        (Get-MemberExpressionName -Node $Node) -ne
+            "${Operation}AutomationEventHandler") {
+        return $false
+    }
+    $arguments = @($Node.Arguments)
+    $expectedCount = if ($Operation -eq 'Add') { 4 } else { 3 }
+    if ($arguments.Count -ne $expectedCount -or
+        -not (Test-StaticMemberReference `
+            -Node $arguments[0] `
+            -TypeName 'System.Windows.Automation.TextPattern' `
+            -MemberName 'TextChangedEvent') -or
+        (Get-VariableExpressionName -Node $arguments[1]) -eq '' -or
+        (Get-VariableExpressionName -Node $arguments[-1]) -eq '') {
+        return $false
+    }
+    if ($Operation -eq 'Add' -and
+        -not (Test-StaticMemberReference `
+            -Node $arguments[2] `
+            -TypeName 'System.Windows.Automation.TreeScope' `
+            -MemberName 'Element')) {
+        return $false
+    }
+    return $true
+}
+
+function Assert-NoUnreachableStatements {
+    param(
+        [Parameter(Mandatory)] [System.Management.Automation.Language.Ast] $Ast,
+        [Parameter(Mandatory)] [string] $Context
+    )
+
+    $terminatorTypes = @(
+        [System.Management.Automation.Language.ReturnStatementAst],
+        [System.Management.Automation.Language.ThrowStatementAst],
+        [System.Management.Automation.Language.ExitStatementAst],
+        [System.Management.Automation.Language.BreakStatementAst],
+        [System.Management.Automation.Language.ContinueStatementAst]
+    )
+    foreach ($block in @($Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.StatementBlockAst]
+    }, $true))) {
+        $statements = @($block.Statements)
+        for ($index = 0; $index -lt ($statements.Count - 1); $index++) {
+            $statementType = $statements[$index].GetType()
+            if ($terminatorTypes -contains $statementType) {
+                throw "Unreachable statement after $($statementType.Name): $Context"
+            }
+        }
+    }
 }
 
 function Test-DynamicScriptTypeName {
@@ -579,9 +956,18 @@ $paletteThemeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-palet
 $newTabHarness = Join-Path $repoRoot 'test\windows\interactive-win11-new-tab.ps1'
 $undoHarness = Join-Path $repoRoot 'test\windows\interactive-win11-undo.ps1'
 $resizeHarness = Join-Path $repoRoot 'test\windows\interactive-win11-resize.ps1'
+$keyInputHarness = Join-Path $repoRoot 'test\windows\interactive-win11-key-input.ps1'
+$interactiveValidator = Join-Path $repoRoot 'test\windows\interactive-win11-validate.ps1'
 $win32Runtime = Join-Path $repoRoot 'src\apprt\win32.zig'
 $win32Settings = Join-Path $repoRoot 'src\apprt\win32_settings.zig'
+$win32Theme = Join-Path $repoRoot 'src\apprt\win32_theme.zig'
 $win32UiaWidgets = Join-Path $repoRoot 'src\apprt\win32_uia\widgets.zig'
+$terminalOutputCapture = Join-Path $repoRoot 'src\termio\semantic_output_capture.zig'
+$terminalStreamHandler = Join-Path $repoRoot 'src\termio\stream_handler.zig'
+$terminalSemanticOutput = Join-Path $repoRoot 'src\terminal\semantic_output.zig'
+$termioRuntime = Join-Path $repoRoot 'src\termio\Termio.zig'
+$surfaceRuntime = Join-Path $repoRoot 'src\apprt\surface.zig'
+$terminalAccessibility = Join-Path $repoRoot 'src\apprt\win32_terminal_accessibility.zig'
 $interactivePrSmoke = Join-Path $repoRoot 'test\windows\interactive-win11-pr-smoke.ps1'
 $releaseCopyChecker = Join-Path $repoRoot 'scripts\check-release-copy.ps1'
 $releasePreflight = Join-Path $repoRoot 'scripts\release-preflight.ps1'
@@ -602,9 +988,18 @@ $signingTrustText = Get-Content -LiteralPath $signingTrust -Raw
 $signingTrustTestText = Get-Content -LiteralPath $signingTrustTest -Raw
 $win32RuntimeText = Get-Content -LiteralPath $win32Runtime -Raw
 $win32SettingsText = Get-Content -LiteralPath $win32Settings -Raw
+$win32ThemeText = Get-Content -LiteralPath $win32Theme -Raw
 $win32UiaWidgetsText = Get-Content -LiteralPath $win32UiaWidgets -Raw
+$terminalOutputCaptureText = Get-Content -LiteralPath $terminalOutputCapture -Raw
+$terminalStreamHandlerText = Get-Content -LiteralPath $terminalStreamHandler -Raw
+$terminalSemanticOutputText = Get-Content -LiteralPath $terminalSemanticOutput -Raw
+$termioRuntimeText = Get-Content -LiteralPath $termioRuntime -Raw
+$surfaceRuntimeText = Get-Content -LiteralPath $surfaceRuntime -Raw
+$terminalAccessibilityText = Get-Content -LiteralPath $terminalAccessibility -Raw
 $sessionRestoreHarnessText = Get-Content -LiteralPath $sessionRestoreHarness -Raw
 $paletteThemeHarnessText = Get-Content -LiteralPath $paletteThemeHarness -Raw
+$keyInputHarnessText = Get-Content -LiteralPath $keyInputHarness -Raw
+$interactiveValidatorText = Get-Content -LiteralPath $interactiveValidator -Raw
 $accessibilityHarnessTokens = $null
 $accessibilityHarnessErrors = $null
 $accessibilityHarnessAst = [System.Management.Automation.Language.Parser]::ParseInput(
@@ -615,6 +1010,557 @@ $accessibilityHarnessAst = [System.Management.Automation.Language.Parser]::Parse
 if ($accessibilityHarnessErrors.Count -ne 0) {
     throw "Accessibility harness does not parse: $($accessibilityHarnessErrors[0].Message)"
 }
+foreach ($source in @(
+    [pscustomobject]@{ Name = 'key-input harness'; Text = $keyInputHarnessText },
+    [pscustomobject]@{ Name = 'interactive validator'; Text = $interactiveValidatorText }
+)) {
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $source.Text,
+        [ref]$tokens,
+        [ref]$errors
+    )
+    if ($errors.Count -ne 0) {
+        throw "$($source.Name) does not parse: $($errors[0].Message)"
+    }
+    if ($source.Name -eq 'key-input harness') { $keyInputHarnessAst = $ast }
+    else { $interactiveValidatorAst = $ast }
+}
+
+$injectiveMutationTokens = $null
+$injectiveMutationErrors = $null
+$injectiveMutationAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    @'
+$stdoutPath = Join-Path $layout.Logs "constant.log"
+$runName = if ([string]::IsNullOrWhiteSpace($ScenarioSlug)) {
+    $ScriptName
+} else {
+    $ScriptName
+}
+'@,
+    [ref] $injectiveMutationTokens,
+    [ref] $injectiveMutationErrors
+)
+$injectiveMutationAssignments = @($injectiveMutationAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst]
+}, $true))
+if ($injectiveMutationErrors.Count -ne 0 -or
+    $injectiveMutationAssignments.Count -ne 2 -or
+    (Test-DirectJoinPathNameExpression `
+        -Node $injectiveMutationAssignments[0].Right `
+        -ParentVariable 'layout' `
+        -ParentMember 'Logs' `
+        -ChildVariable 'artifactPrefix' `
+        -ChildSuffix '-stdout.log' `
+        -Style Expandable) -or
+    (Test-InjectiveHarnessRunNameExpression `
+        -Node $injectiveMutationAssignments[1].Right)) {
+    throw 'Injective artifact-name contracts must reject constant-path mutations.'
+}
+
+$keyInputParameterNames = @($keyInputHarnessAst.ParamBlock.Parameters | ForEach-Object {
+    $_.Name.VariablePath.UserPath
+})
+if ($keyInputParameterNames -contains 'Route') {
+    throw 'Key-input harness must always target the surface directly; Route is not a valid public option.'
+}
+$keyInputKeyParameters = @($keyInputHarnessAst.ParamBlock.Parameters | Where-Object {
+    $_.Name.VariablePath.UserPath -eq 'Key'
+})
+$keyInputKeyValidateSets = if ($keyInputKeyParameters.Count -eq 1) {
+    @($keyInputKeyParameters[0].Attributes | Where-Object {
+        $_ -is [System.Management.Automation.Language.AttributeAst] -and
+            $_.TypeName.FullName -eq 'ValidateSet'
+    })
+} else {
+    @()
+}
+$keyInputKeyValues = if ($keyInputKeyValidateSets.Count -eq 1) {
+    @($keyInputKeyValidateSets[0].PositionalArguments | ForEach-Object {
+        if ($_ -isnot [System.Management.Automation.Language.StringConstantExpressionAst]) {
+            throw 'Key-input Key ValidateSet values must be static strings.'
+        }
+        $_.Value
+    })
+} else {
+    @()
+}
+$requiredKeyInputValues = @(
+    'a',
+    'space',
+    'unicode-bmp',
+    'unicode-supplementary',
+    'unicode-burst',
+    'unicode-cr',
+    'unicode-lf',
+    'unicode-tab',
+    'unicode-backspace',
+    'unicode-escape'
+)
+if ($keyInputKeyValues.Count -ne $requiredKeyInputValues.Count -or
+    @(Compare-Object `
+        -ReferenceObject $requiredKeyInputValues `
+        -DifferenceObject $keyInputKeyValues `
+        -SyncWindow 0 `
+        -CaseSensitive).Count -ne 0 -or
+    @($keyInputKeyValues | Sort-Object -Unique).Count -ne
+        $keyInputKeyValues.Count) {
+    throw 'Key-input harness must expose the exact ten-key input ValidateSet.'
+}
+if (@($keyInputKeyValues | Where-Object {
+    $_ -match '(?i)alt|numpad'
+}).Count -ne 0) {
+    throw 'Key-input harness cannot expose Alt+numpad input synthesis.'
+}
+$slugFunctions = @(Get-NamedFunctionDefinitions -Ast $keyInputHarnessAst -Name 'Get-KeyInputScenarioSlug')
+if ($slugFunctions.Count -ne 1) {
+    throw 'Key-input harness must own exactly one scenario-slug function.'
+}
+try {
+    . ([scriptblock]::Create($slugFunctions[0].Extent.Text))
+    $slugFixtures = @(
+        foreach ($keyValue in $keyInputKeyValues) {
+            Get-KeyInputScenarioSlug -Key $keyValue
+            Get-KeyInputScenarioSlug -Key $keyValue -PostBoo
+        }
+    )
+    if (@($slugFixtures | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -ne 0 -or
+        $slugFixtures.Count -ne 20 -or
+        @($slugFixtures | Sort-Object -Unique).Count -ne
+            $slugFixtures.Count) {
+        throw 'The ten-key by PostBoo cross-product must produce exactly twenty unique artifact slugs.'
+    }
+}
+finally {
+    Remove-Item -LiteralPath Function:\Get-KeyInputScenarioSlug -ErrorAction SilentlyContinue
+}
+$sandboxCalls = @(Get-NamedCommands -Ast $keyInputHarnessAst -Name 'Initialize-InteractiveWin11Sandbox')
+$scenarioSlugAssignments = @($keyInputHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        (Get-VariableExpressionName -Node $node.Left) -eq 'scenarioSlug'
+}, $true))
+$artifactAssignments = @($keyInputHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        (Get-VariableExpressionName -Node $node.Left) -in @(
+            'artifactPrefix', 'stdoutPath', 'stderrPath', 'resultPath'
+        )
+}, $true))
+$sandboxName = if ($sandboxCalls.Count -eq 1) {
+    Get-CommandParameterArgument -Command $sandboxCalls[0] -Name 'SandboxName'
+}
+$scenarioSlugCalls = if ($scenarioSlugAssignments.Count -eq 1) {
+    @(Get-NamedCommands `
+        -Ast $scenarioSlugAssignments[0].Right `
+        -Name 'Get-KeyInputScenarioSlug')
+} else {
+    @()
+}
+$scenarioSlugKey = if ($scenarioSlugCalls.Count -eq 1) {
+    Get-CommandParameterArgument -Command $scenarioSlugCalls[0] -Name 'Key'
+}
+$scenarioSlugPostBoo = if ($scenarioSlugCalls.Count -eq 1) {
+    Get-CommandParameterArgument -Command $scenarioSlugCalls[0] -Name 'PostBoo'
+}
+$artifactVariableNames = @(
+    'artifactPrefix', 'stdoutPath', 'stderrPath', 'resultPath'
+)
+$artifactAssignmentContract = @(
+    foreach ($artifactVariableName in $artifactVariableNames) {
+        $assignments = @($artifactAssignments | Where-Object {
+            (Get-VariableExpressionName -Node $_.Left) -eq
+                $artifactVariableName
+        })
+        if ($assignments.Count -ne 1) { $false; continue }
+        if ($artifactVariableName -eq 'artifactPrefix') {
+            $expression = $assignments[0].Right
+            $expression -is
+                    [System.Management.Automation.Language.CommandExpressionAst] -and
+                $expression.Expression -is
+                    [System.Management.Automation.Language.ExpandableStringExpressionAst] -and
+                $expression.Expression.Value -ceq
+                    'interactive-win11-key-input-$scenarioSlug' -and
+                $expression.Expression.NestedExpressions.Count -eq 1 -and
+                (Get-VariableExpressionName `
+                    -Node $expression.Expression.NestedExpressions[0]) -eq
+                        'scenarioSlug'
+            continue
+        }
+        $spec = switch ($artifactVariableName) {
+            'stdoutPath' { @('layout', 'Logs', 'artifactPrefix', '-stdout.log') }
+            'stderrPath' { @('layout', 'Logs', 'artifactPrefix', '-stderr.log') }
+            'resultPath' { @('layout', 'Temp', 'artifactPrefix', '-result.json') }
+        }
+        Test-DirectJoinPathNameExpression `
+            -Node $assignments[0].Right `
+            -ParentVariable $spec[0] `
+            -ParentMember $spec[1] `
+            -ChildVariable $spec[2] `
+            -ChildSuffix $spec[3] `
+            -Style Expandable
+    }
+)
+if ($sandboxCalls.Count -ne 1 -or
+    -not (Test-DirectNamedBlockChild `
+        -Node $sandboxCalls[0] `
+        -NamedBlock $keyInputHarnessAst.EndBlock) -or
+    $sandboxName -isnot
+        [System.Management.Automation.Language.ExpandableStringExpressionAst] -or
+    $sandboxName.Value -cne 'key-input-$scenarioSlug' -or
+    $sandboxName.NestedExpressions.Count -ne 1 -or
+    (Get-VariableExpressionName -Node $sandboxName.NestedExpressions[0]) -ne
+        'scenarioSlug' -or
+    $scenarioSlugAssignments.Count -ne 1 -or
+    -not [object]::ReferenceEquals(
+        $scenarioSlugAssignments[0].Parent,
+        $keyInputHarnessAst.EndBlock
+    ) -or
+    $scenarioSlugAssignments[0].Right -isnot
+        [System.Management.Automation.Language.PipelineAst] -or
+    $scenarioSlugAssignments[0].Right.PipelineElements.Count -ne 1 -or
+    -not [object]::ReferenceEquals(
+        $scenarioSlugAssignments[0].Right.PipelineElements[0],
+        $scenarioSlugCalls[0]
+    ) -or
+    $scenarioSlugCalls.Count -ne 1 -or
+    (Get-VariableExpressionName -Node $scenarioSlugKey) -ne 'Key' -or
+    (Get-VariableExpressionName -Node $scenarioSlugPostBoo) -ne
+        'RunBooFirst' -or
+    @($artifactAssignments | Where-Object {
+        -not [object]::ReferenceEquals($_.Parent, $keyInputHarnessAst.EndBlock)
+    }).Count -ne 0 -or
+    $artifactAssignmentContract.Count -ne $artifactVariableNames.Count -or
+    @($artifactAssignmentContract | Where-Object { -not $_ }).Count -ne 0) {
+    throw 'Key-input scenario slug must flow into its sandbox, result, and log artifact names.'
+}
+
+$keyInputCompositeCalls = @(Get-NamedCommands -Ast $interactiveValidatorAst -Name 'Invoke-HarnessWithPassSentinel' |
+    Where-Object {
+        $scriptName = Get-CommandParameterArgument -Command $_ -Name 'ScriptName'
+        $scriptName -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+            $scriptName.Value -eq 'interactive-win11-key-input.ps1'
+    })
+$coveredKeyScenarios = [Collections.Generic.List[string]]::new()
+$compositeSlugs = [Collections.Generic.List[string]]::new()
+foreach ($command in $keyInputCompositeCalls) {
+    $slug = Get-CommandParameterArgument -Command $command -Name 'ScenarioSlug'
+    if ($slug -isnot [System.Management.Automation.Language.StringConstantExpressionAst] -or
+        [string]::IsNullOrWhiteSpace($slug.Value)) {
+        throw 'Every composite key-input run must provide a nonempty static scenario slug.'
+    }
+    [void]$compositeSlugs.Add($slug.Value)
+    $additional = Get-CommandParameterArgument -Command $command -Name 'AdditionalArguments'
+    if ($null -eq $additional) {
+        [void]$coveredKeyScenarios.Add('a')
+        continue
+    }
+    $keyValues = @($additional.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+            $node.Value -in @(
+                'unicode-bmp',
+                'unicode-supplementary',
+                'unicode-burst',
+                'unicode-cr',
+                'unicode-lf',
+                'unicode-tab',
+                'unicode-backspace',
+                'unicode-escape'
+            )
+    }, $true))
+    if ($keyValues.Count -ne 1) { throw 'Composite key-input run has an ambiguous Unicode scenario.' }
+    [void]$coveredKeyScenarios.Add($keyValues[0].Value)
+}
+$expectedKeyScenarios = @(
+    'a',
+    'unicode-bmp',
+    'unicode-supplementary',
+    'unicode-burst',
+    'unicode-cr',
+    'unicode-lf',
+    'unicode-tab',
+    'unicode-backspace',
+    'unicode-escape'
+)
+if ($keyInputCompositeCalls.Count -ne 9 -or
+    @($compositeSlugs | Sort-Object -Unique).Count -ne 9 -or
+    (Compare-Object $expectedKeyScenarios @($coveredKeyScenarios) -SyncWindow 0)) {
+    throw 'Composite validator must isolate every key-input scenario except space.'
+}
+$invokeHarnessFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $interactiveValidatorAst `
+        -Name 'Invoke-HarnessWithPassSentinel'
+)
+$startHarnessFunctions = @(Get-NamedFunctionDefinitions -Ast $interactiveValidatorAst -Name 'Start-Harness')
+$getHarnessArgumentsFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $interactiveValidatorAst `
+        -Name 'Get-HarnessArguments'
+)
+$invokeStartHarnessCalls = if ($invokeHarnessFunctions.Count -eq 1) {
+    @(Get-NamedCommands `
+        -Ast $invokeHarnessFunctions[0].Body `
+        -Name 'Start-Harness')
+} else {
+    @()
+}
+$startGetHarnessArgumentsCalls = if ($startHarnessFunctions.Count -eq 1) {
+    @(Get-NamedCommands `
+        -Ast $startHarnessFunctions[0].Body `
+        -Name 'Get-HarnessArguments')
+} else {
+    @()
+}
+$invokeAdditionalArguments =
+    if ($invokeStartHarnessCalls.Count -eq 1) {
+        Get-CommandParameterArgument `
+            -Command $invokeStartHarnessCalls[0] `
+            -Name 'AdditionalArguments'
+    }
+$invokeScenarioSlug =
+    if ($invokeStartHarnessCalls.Count -eq 1) {
+        Get-CommandParameterArgument `
+            -Command $invokeStartHarnessCalls[0] `
+            -Name 'ScenarioSlug'
+    }
+$startAdditionalArguments =
+    if ($startGetHarnessArgumentsCalls.Count -eq 1) {
+        Get-CommandParameterArgument `
+            -Command $startGetHarnessArgumentsCalls[0] `
+            -Name 'AdditionalArguments'
+    }
+$startHarnessAssignments = if ($startHarnessFunctions.Count -eq 1) {
+    @($startHarnessFunctions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            (Get-VariableExpressionName -Node $node.Left) -in @('runName', 'stdoutPath', 'stderrPath')
+    }, $true))
+} else {
+    @()
+}
+$startHarnessVariableNames = @('runName', 'stdoutPath', 'stderrPath')
+$startHarnessAssignmentContract = @(
+    foreach ($startHarnessVariableName in $startHarnessVariableNames) {
+        $assignments = @($startHarnessAssignments | Where-Object {
+            (Get-VariableExpressionName -Node $_.Left) -eq
+                $startHarnessVariableName
+        })
+        if ($assignments.Count -ne 1) { $false; continue }
+        if ($startHarnessVariableName -eq 'runName') {
+            Test-InjectiveHarnessRunNameExpression -Node $assignments[0].Right
+            continue
+        }
+        $suffix = if ($startHarnessVariableName -eq 'stdoutPath') {
+            '.stdout.log'
+        } else {
+            '.stderr.log'
+        }
+        Test-DirectJoinPathNameExpression `
+            -Node $assignments[0].Right `
+            -ParentVariable 'suiteLogDir' `
+            -ChildVariable 'runName' `
+            -ChildSuffix $suffix `
+            -Style Format
+    }
+)
+if ($invokeHarnessFunctions.Count -ne 1 -or
+    $startHarnessFunctions.Count -ne 1 -or
+    $getHarnessArgumentsFunctions.Count -ne 1 -or
+    $invokeStartHarnessCalls.Count -ne 1 -or
+    $startGetHarnessArgumentsCalls.Count -ne 1 -or
+    -not (Test-DirectNamedBlockChild `
+        -Node $invokeStartHarnessCalls[0] `
+        -NamedBlock $invokeHarnessFunctions[0].Body.EndBlock) -or
+    -not (Test-DirectNamedBlockChild `
+        -Node $startGetHarnessArgumentsCalls[0] `
+        -NamedBlock $startHarnessFunctions[0].Body.EndBlock) -or
+    (Get-VariableExpressionName -Node $invokeAdditionalArguments) -ne
+        'AdditionalArguments' -or
+    (Get-VariableExpressionName -Node $invokeScenarioSlug) -ne
+        'ScenarioSlug' -or
+    (Get-VariableExpressionName -Node $startAdditionalArguments) -ne
+        'AdditionalArguments' -or
+    @($startHarnessAssignments | Where-Object {
+        -not [object]::ReferenceEquals(
+            $_.Parent,
+            $startHarnessFunctions[0].Body.EndBlock
+        )
+    }).Count -ne 0 -or
+    $startHarnessAssignmentContract.Count -ne
+        $startHarnessVariableNames.Count -or
+    @($startHarnessAssignmentContract | Where-Object { -not $_ }).Count -ne
+        0) {
+    throw 'Composite log paths must derive from each run scenario slug.'
+}
+
+$nativeKeyFilters = @('VK_PACKET', 'deferred char')
+foreach ($nativeKeyFilter in $nativeKeyFilters) {
+    # Zig accepts a zero-match test filter. A narrow declaration check is
+    # appropriate here only to prove that the semantic runner below is nonempty.
+    $nativeKeyDeclarations = [regex]::Matches(
+        $win32RuntimeText,
+        '(?m)^test "win32 ' + [regex]::Escape($nativeKeyFilter) +
+            '[^"\r\n]*" \{$'
+    )
+    if ($nativeKeyDeclarations.Count -lt 1) {
+        throw "$nativeKeyFilter semantic fixture has no matching Zig test declaration."
+    }
+    $nativeKeyFilterArgument = "-Dtest-filter=$nativeKeyFilter"
+    & (Join-Path $repoRoot 'scripts\dev-windows.cmd') `
+        zig build test $nativeKeyFilterArgument
+    if ($LASTEXITCODE -ne 0) {
+        throw "$nativeKeyFilter semantic fixture failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ($termioRuntimeText.Contains('self.surface_mailbox.pushTerminalOutput(buf)') -or
+    -not $termioRuntimeText.Contains('self.terminal_stream.handler.semantic_output.begin(') -or
+    -not $termioRuntimeText.Contains('self.terminal_stream.handler.semantic_output.finish()') -or
+    -not $termioRuntimeText.Contains('self.terminal_output_transport.captureEpoch()') -or
+    -not $termioRuntimeText.Contains('self.terminal_output_transport.pushSemanticBatchForEpoch(') -or
+    -not $termioRuntimeText.Contains('decision.semantic_output.slice()')) {
+    throw 'Termio must publish parser-derived semantic batches instead of forwarding raw PTY bytes.'
+}
+if ($terminalAccessibilityText.Contains('OutputSanitizer') -or
+    $terminalAccessibilityText.Contains('sanitizeAnnouncementByte') -or
+    $surfaceRuntimeText.Contains('terminal output transport drains inactive split controls without speech')) {
+    throw 'Win32 accessibility cannot retain a second terminal parser or its fake transport parser fixture.'
+}
+$semanticOutputInterestPolicyMatches = [regex]::Matches(
+    $terminalAccessibilityText,
+    '(?ms)^fn semanticOutputInterestPolicy\(\r?\n\s+attached: bool,\r?\n\s+provider_ready: bool,\r?\n\s+focused: bool,\r?\n\) bool \{\r?\n(?<body>.*?)^\}'
+)
+if ($semanticOutputInterestPolicyMatches.Count -ne 1 -or
+    -not $semanticOutputInterestPolicyMatches[0].Groups['body'].Value.Contains(
+        'return attached and provider_ready and focused;'
+    ) -or
+    -not $terminalAccessibilityText.Contains('.emit_events = clients_listening,') -or
+    -not $terminalAccessibilityText.Contains('win32_uia.events.clientsAreListening(),')) {
+    throw 'Semantic output interest must require attachment, provider readiness, and focus while event emission remains listener-gated.'
+}
+
+$semanticPolicyTestMatch = [regex]::Match(
+    $terminalAccessibilityText,
+    '(?ms)^test "terminal accessibility refresh and query policies" \{\r?\n(?<body>.*?)^\}'
+)
+$semanticPolicyAssertions = @(
+    'try std.testing.expect(semanticOutputInterestPolicy(true, true, true));',
+    'try std.testing.expect(!semanticOutputInterestPolicy(true, true, false));',
+    'try std.testing.expect(!semanticOutputInterestPolicy(true, false, true));',
+    'try std.testing.expect(!semanticOutputInterestPolicy(false, true, true));',
+    'try std.testing.expect(!query_only.emit_events);',
+    'try std.testing.expect(subscribed.emit_events);'
+)
+if (-not $semanticPolicyTestMatch.Success) {
+    throw 'Semantic output interest policy has no exact Zig test declaration.'
+}
+foreach ($assertion in $semanticPolicyAssertions) {
+    if (-not $semanticPolicyTestMatch.Groups['body'].Value.Contains($assertion)) {
+        throw "Semantic output interest policy test is missing assertion: $assertion"
+    }
+}
+if (-not $terminalSemanticOutputText.Contains('pub const transport_chunk_bytes = 1_000;') -or
+    -not $terminalSemanticOutputText.Contains('pub const transport_max_chunks = 8;') -or
+    -not $terminalSemanticOutputText.Contains('pub const capacity = transport_chunk_bytes * transport_max_chunks;') -or
+    -not $terminalOutputCaptureText.Contains('pub const capacity = semantic_output.capacity;') -or
+    -not $surfaceRuntimeText.Contains('pub const capacity = semantic_output.capacity;') -or
+    $terminalOutputCaptureText.Contains('recordRepeat') -or
+    $terminalStreamHandlerText.Contains('recordRepeat')) {
+    throw 'Semantic capture and transport must share one 8000-byte capacity and no duplicate REP interface.'
+}
+
+$realParserSemanticFragments = @(
+    'stream.nextSlice("\x1b[3b");',
+    '\x1b[31mright',
+    '\x1b]8;;https://secret.example',
+    '\x1bPqDCS-SECRET',
+    '\x1b[1$}\r\n\thidden\x1b[0$}visible',
+    '\x1b(0`\x1b(B',
+    'before\x1bcafter',
+    'stream.nextSlice("\xcc\x81");'
+)
+foreach ($fragment in $realParserSemanticFragments) {
+    if (-not $terminalStreamHandlerText.Contains($fragment)) {
+        throw "Real-parser semantic fixture is missing executable coverage fragment: $fragment"
+    }
+}
+
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{
+        $terminalOutputCapture = $terminalOutputCaptureText
+        $terminalStreamHandler = $terminalStreamHandlerText
+    } `
+    -ExpectedNames @(
+        'semantic output capture uninterested fast path',
+        'semantic output capture preserves utf8 and control order',
+        'semantic output finished batch owns bytes across capture reuse',
+        'semantic output full reset discards prior bytes and omission',
+        'semantic output capture retains codepoint-aligned prefix before omission',
+        'semantic output capture explicit partial error omission retains prefix',
+        'semantic output capture follows real stream handler parser'
+    ) `
+    -Filter 'semantic output capture'
+
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $surfaceRuntime = $surfaceRuntimeText } `
+    -ExpectedNames @(
+        'terminal output transport saturation is nonblocking and ordered',
+        'terminal output transport keeps utf8 chunks before batch omission marker',
+        'terminal output transport reentrant callbacks preserve epochs and contention marker',
+        'terminal output transport rejects stale interest epoch without poisoning new epoch',
+        'terminal output transport orders silent reset before post reset data'
+    ) `
+    -Filter 'terminal output transport'
+
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $terminalAccessibility = $terminalAccessibilityText } `
+    -ExpectedNames @(
+        'terminal accessibility refresh and query policies'
+    ) `
+    -Filter 'terminal accessibility refresh and query policies'
+
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $terminalAccessibility = $terminalAccessibilityText } `
+    -ExpectedNames @(
+        'terminal output announcement normalization allocation failure becomes ordered omission'
+    ) `
+    -Filter 'normalization allocation failure becomes ordered omission'
+
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $win32UiaWidgets = $win32UiaWidgetsText } `
+    -ExpectedNames @(
+        'TerminalProvider legacy caret compatibility reports no mutable selection'
+    ) `
+    -Filter 'legacy caret compatibility reports no mutable selection'
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $win32UiaWidgets = $win32UiaWidgetsText } `
+    -ExpectedNames @(
+        'TerminalTextRangeProvider reports unsupported mutation and scrolling honestly'
+    ) `
+    -Filter 'unsupported mutation and scrolling honestly'
+
+if (-not $win32ThemeText.Contains('const DWMSBT_NONE: u32 = 1;')) {
+    throw 'Win32 theme policy must use the documented DWMSBT_NONE value 1.'
+}
+Assert-ZigTestsDiscoveredAndRun `
+    -RepoRoot $repoRoot `
+    -Sources @{ $win32Theme = $win32ThemeText } `
+    -ExpectedNames @(
+        'settings window policy explicitly disables system backdrop',
+        'DWM system backdrop constants match Win32 ABI'
+    ) `
+    -Filter 'system backdrop'
+
 $publishedReleaseVerifierTokens = $null
 $publishedReleaseVerifierErrors = $null
 [void][System.Management.Automation.Language.Parser]::ParseInput(
@@ -1034,11 +1980,7 @@ foreach ($file in $cleanupScriptFiles) {
             $text -match '(?i)(?:^|\s)-RequireLiveRoot(?:\s|$)'
             $text -match '(?i)(?:^|\s)-AllowAlreadyExited(?:\s|$)'
         ).Where({ $_ }).Count
-        # The composite validator is a byte-for-byte frozen baseline artifact.
-        # Mode omission uses Stop-InteractiveWin11Process's fail-closed live-root
-        # default; every mutable caller must state exactly one lifecycle mode.
-        $frozenValidatorDefault = $file.Name -eq 'interactive-win11-validate.ps1' -and $modeCount -eq 0
-        if ((-not $frozenValidatorDefault -and $modeCount -ne 1) -or
+        if ($modeCount -ne 1 -or
             ($text -match '(?i)(?:^|\s)-AllowAlreadyExited(?:\s|$)' -and $file.Name -ne 'vt-probe-win32-conformance.ps1')) {
             [void]$cleanupContractViolations.Add("$($file.Name):$($command.Extent.StartLineNumber): $text")
         }
@@ -1318,12 +2260,27 @@ $accessibilityUIntPtrConversions = @($accessibilityAst.FindAll({
 if ($accessibilityErrors.Count -ne 0 -or $accessibilityUIntPtrConversions.Count -ne 0) {
     throw 'Accessibility harness must parse and construct nonzero WPARAM values through UIntPtr::new([uint64] ...).'
 }
-$textRangeEndpointReferences = [regex]::Matches(
-    $accessibilityHarnessText,
-    '\[System\.Windows\.Automation\.Text\.TextPatternRangeEndpoint\]::(?:Start|End)'
-)
-if ($textRangeEndpointReferences.Count -ne 4 -or
-    $accessibilityHarnessText -match '\[System\.Windows\.Automation\.TextPatternRangeEndpoint\]') {
+$textRangeEndpointReferences = @($accessibilityHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.MemberExpressionAst] -and
+        $node.Static -and
+        (Get-MemberExpressionName -Node $node) -in @('Start', 'End') -and
+        $node.Expression -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        $node.Expression.TypeName.FullName -eq
+            'System.Windows.Automation.Text.TextPatternRangeEndpoint'
+}, $true))
+$wrongTextRangeEndpointReferences = @($accessibilityHarnessAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.MemberExpressionAst] -and
+        $node.Static -and
+        (Get-MemberExpressionName -Node $node) -in @('Start', 'End') -and
+        $node.Expression -is [System.Management.Automation.Language.TypeExpressionAst] -and
+        $node.Expression.TypeName.Name -eq 'TextPatternRangeEndpoint' -and
+        $node.Expression.TypeName.FullName -ne
+            'System.Windows.Automation.Text.TextPatternRangeEndpoint'
+}, $true))
+if ($textRangeEndpointReferences.Count -ne 6 -or
+    $wrongTextRangeEndpointReferences.Count -ne 0) {
     throw 'Accessibility caret assertions must use the installed UIAutomation Text.TextPatternRangeEndpoint type.'
 }
 if ($accessibilityHarnessText -match 'VkKeyScanW|SendAsciiText' -or
@@ -1331,56 +2288,1143 @@ if ($accessibilityHarnessText -match 'VkKeyScanW|SendAsciiText' -or
     ([regex]::Matches($accessibilityHarnessText, 'inputs\.Add\(Key\(0, value, KEYEVENTF_UNICODE(?: \| KEYEVENTF_KEYUP)?\)\);')).Count -ne 2) {
     throw 'Accessibility text injection must use layout-independent KEYEVENTF_UNICODE key down/up pairs.'
 }
-$queryOnlyTextPatternContract = [regex]::Match(
-    $accessibilityHarnessText,
-    '(?s)\$queryOnlyPreviousRange = \$textPattern\.DocumentRange.*?RemoveAutomationEventHandler\(.*?TextPattern\]::TextChangedEvent.*?Send-AccessibilityOutputMarker .*?-TextPattern \$textPattern .*?-Marker \$queryOnlyMarker.*?\$script:queryOnlyTextProbe = \$textPattern\.DocumentRange\.GetText\(-1\).*?\$queryOnlyPreviousRange\.GetText\(-1\)\.Contains\(\$queryOnlyMarker\).*?AddAutomationEventHandler\(.*?TextPattern\]::TextChangedEvent'
+$highContrastFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityHighContrastProof'
 )
-if (-not $queryOnlyTextPatternContract.Success) {
-    throw 'Accessibility query-only contract must remove this client handler, request fresh ranges through the retained TextPattern, preserve the prior immutable range, and restore the handler.'
-}
-if ($accessibilityHarnessText -notmatch '\$queryOnlyMarker = "whq\$\(\[Guid\]::NewGuid\(\)\.ToString\(''N''\)\.Substring\(0, 12\)\)"' -or
-    $accessibilityHarnessText -notmatch '\$coldQueryMarker = "whc\$\(\[Guid\]::NewGuid\(\)\.ToString\(''N''\)\.Substring\(0, 12\)\)"') {
-    throw 'Accessibility query-only markers must remain short enough to avoid viewport soft-wrap false negatives.'
-}
-$outputMarkerInputDrainContract = [regex]::Match(
-    $accessibilityHarnessText,
-    '(?s)function Send-AccessibilityOutputMarker\(.*?SendUnicodeText\(\$command\).*?Start-Sleep -Milliseconds 250.*?Assert-AccessibilityInputOwner .*?pre-Enter.*?\$preEnterText = \$TextPattern\.DocumentRange\.GetText\(-1\).*?Send-AccessibilityChord .*?Enter'
+$highContrastCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityHighContrastProof'
 )
-if (-not $outputMarkerInputDrainContract.Success) {
-    throw 'Accessibility output markers must drain queued Unicode input and reassert focus before the pre-Enter UIA check and Enter.'
+if ($highContrastFunctions.Count -ne 1 -or $highContrastCalls.Count -ne 2) {
+    throw 'Targeted and full accessibility evidence must share one High Contrast proof helper.'
 }
-if ($win32RuntimeText -notmatch 'WM_WINHOSTTY_UIA_QUERY_REFRESH = WM_APP \+ 6' -or
-    $win32RuntimeText -notmatch 'SendMessageTimeoutW\(\s*hwnd\.\?,\s*WM_WINHOSTTY_UIA_QUERY_REFRESH,\s*1,' -or
-    $win32RuntimeText -notmatch 'refreshTerminalUiaTextWithMode\(wParam != 0\)' -or
-    $win32RuntimeText -notmatch 'if \(!force and !terminalUiaRefreshDue' -or
-    $win32RuntimeText -notmatch 'query_refresh_post_pending\.cmpxchgStrong\(false, true' -or
-    $win32RuntimeText -notmatch 'PostMessageW\(hwnd\.\?, WM_WINHOSTTY_UIA_QUERY_REFRESH' -or
-    $win32RuntimeText -notmatch 'refresh_snapshot = clients_listening_for_events or query_recently_active') {
-    throw 'Terminal UIA polling must use a coalesced query-driven UI-thread refresh and stop snapshots when clients are idle.'
-}
-if ($accessibilityHarnessText -notmatch 'Send-AccessibilityBlindOutputMarker' -or
-    $accessibilityHarnessText -notmatch 'Start-Sleep -Milliseconds 1200' -or
-    $accessibilityHarnessText -notmatch '\$coldQueryFirstText = \$textPattern\.DocumentRange\.GetText\(-1\)' -or
-    $accessibilityHarnessText -notmatch 'cold_query_first_document_range_fresh') {
-    throw 'Accessibility evidence must prove the first TextPattern range after a cold query is fresh without pre-querying.'
-}
-$blindMarkerFunctions = @($accessibilityHarnessAst.FindAll({
+Assert-NoUnreachableStatements `
+    -Ast $highContrastFunctions[0].Body `
+    -Context 'Invoke-AccessibilityHighContrastProof'
+$highContrastRecoveryTries = @($highContrastFunctions[0].Body.FindAll({
     param($node)
-    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-        $node.Name -eq 'Send-AccessibilityBlindOutputMarker'
+    if ($node -isnot [System.Management.Automation.Language.TryStatementAst] -or
+        $null -eq $node.Finally) {
+        return $false
+    }
+    $commands = @($node.Finally.FindAll({
+        param($child)
+        $child -is [System.Management.Automation.Language.CommandAst]
+    }, $true) | ForEach-Object { $_.GetCommandName() })
+    return $commands -contains 'Set-HighContrastState' -and
+        $commands -contains 'Get-HighContrastState' -and
+        $commands -contains 'Write-HighContrastRestoreDiagnostic' -and
+        $commands -contains 'Wait-AccessibilityCondition'
 }, $true))
-if ($blindMarkerFunctions.Count -ne 1) {
-    throw 'Accessibility harness must define exactly one blind output-marker helper.'
+if ($highContrastRecoveryTries.Count -ne 1) {
+    throw 'High Contrast proof must have one fail-closed finally block that restores exact SPI state, verifies recovery boundedly, and writes diagnostics.'
 }
-$blindMarkerBody = $blindMarkerFunctions[0].Body.Extent.Text
-$blindTextPatternReads = @($blindMarkerFunctions[0].Body.FindAll({
+$dwmHighContrastDiagnosticFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $highContrastFunctions[0].Body `
+        -Name 'Get-DwmHighContrastResetDiagnostic'
+)
+if ($dwmHighContrastDiagnosticFunctions.Count -ne 1) {
+    throw 'High Contrast proof must define one pure DWM reset diagnostic.'
+}
+Assert-NoUnreachableStatements `
+    -Ast $dwmHighContrastDiagnosticFunctions[0].Body `
+    -Context 'Get-DwmHighContrastResetDiagnostic'
+. ([scriptblock]::Create($dwmHighContrastDiagnosticFunctions[0].Extent.Text))
+$dwmNames = @(
+    'immersive_dark_20',
+    'immersive_dark_19',
+    'caption_color',
+    'text_color',
+    'backdrop_type'
+)
+$dwmBeforeFixture = [ordered]@{}
+$dwmDuringSuccessFixture = [ordered]@{}
+$dwmDuringFailureFixture = [ordered]@{}
+for ($dwmIndex = 0; $dwmIndex -lt $dwmNames.Count; $dwmIndex++) {
+    $dwmName = $dwmNames[$dwmIndex]
+    $dwmExpected = [uint32]($dwmIndex + 10)
+    $dwmBeforeFixture[$dwmName] = [pscustomobject]@{
+        attribute = $dwmIndex + 19
+        supported = $true
+        hresult = '0x00000000'
+        value = [uint32]0
+        expected_high_contrast = $dwmExpected
+    }
+    $dwmDuringSuccessFixture[$dwmName] = [pscustomobject]@{
+        attribute = $dwmIndex + 19
+        supported = $true
+        hresult = '0x00000000'
+        value = $dwmExpected
+        expected_high_contrast = $dwmExpected
+    }
+    $dwmDuringFailureFixture[$dwmName] = [pscustomobject]@{
+        attribute = $dwmIndex + 19
+        supported = $true
+        hresult = '0x00000000'
+        value = if ($dwmName -eq 'caption_color') {
+            [uint32]($dwmExpected + 1)
+        } else {
+            $dwmExpected
+        }
+        expected_high_contrast = $dwmExpected
+    }
+}
+$dwmSuccessOutputs = @(
+    Get-DwmHighContrastResetDiagnostic `
+        -Before $dwmBeforeFixture `
+        -During $dwmDuringSuccessFixture
+)
+$dwmFailureOutputs = @(
+    Get-DwmHighContrastResetDiagnostic `
+        -Before $dwmBeforeFixture `
+        -During $dwmDuringFailureFixture
+)
+if ($dwmSuccessOutputs.Count -ne 1 -or
+    $dwmSuccessOutputs[0].exact -ne $true -or
+    @($dwmSuccessOutputs[0].failures).Count -ne 0 -or
+    $dwmFailureOutputs.Count -ne 1 -or
+    $dwmFailureOutputs[0].exact -ne $false -or
+    @($dwmFailureOutputs[0].failures).Count -ne 1 -or
+    [string]::IsNullOrWhiteSpace([string]$dwmFailureOutputs[0].failures[0])) {
+    throw 'High Contrast DWM diagnostic must emit one exact success or one shaped failure without stray output.'
+}
+$openSettingsLoops = @($accessibilityHarnessAst.FindAll({
     param($node)
-    $node -is [System.Management.Automation.Language.VariableExpressionAst] -and
-        $node.VariablePath.UserPath -eq 'TextPattern'
+    if ($node -isnot [System.Management.Automation.Language.DoWhileStatementAst]) {
+        return $false
+    }
+    $settingsClassReferences = @($node.Body.FindAll({
+        param($child)
+        $child -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+            $child.Value -eq 'winghostty.win32.settings'
+    }, $true))
+    return $settingsClassReferences.Count -gt 0 -and
+        (Get-NamedMemberExpressions `
+            -Ast $node.Body `
+            -Name 'TopLevelWindowsForProcess' `
+            -InvocationOnly).Count -ge 2 -and
+        (Get-NamedMemberExpressions `
+            -Ast $node.Body `
+            -Name 'VisibleTerminalChildren' `
+            -InvocationOnly).Count -ge 1 -and
+        (Get-NamedMemberExpressions `
+            -Ast $node.Body `
+            -Name 'SendChord' `
+            -InvocationOnly).Count -ge 1
 }, $true))
-if ($blindTextPatternReads.Count -ne 0 -or
-    $blindMarkerBody -notmatch '(?s)SendUnicodeText\(\$command\).*?Start-Sleep -Milliseconds 250.*?Assert-AccessibilityInputOwner .*?pre-Enter.*?Send-AccessibilityChord .*?Enter') {
-    throw 'Blind output validation must drain queued Unicode before Enter without warming TextPattern.'
+if ($openSettingsLoops.Count -ne 1) {
+    throw 'Settings open recovery must have one owned bounded discovery/recovery loop.'
+}
+$openSettingsLoop = $openSettingsLoops[0]
+$openSettingsFunction = $openSettingsLoop
+while ($null -ne $openSettingsFunction -and
+    $openSettingsFunction -isnot
+        [System.Management.Automation.Language.FunctionDefinitionAst]) {
+    $openSettingsFunction = $openSettingsFunction.Parent
+}
+if ($null -eq $openSettingsFunction) {
+    throw 'Settings open recovery loop must be owned by a function.'
+}
+Assert-NoUnreachableStatements `
+    -Ast $openSettingsFunction.Body `
+    -Context 'Settings open recovery'
+$openSettingsTopLevelQueries = @(
+    Get-NamedMemberExpressions `
+        -Ast $openSettingsLoop.Body `
+        -Name 'TopLevelWindowsForProcess' `
+        -InvocationOnly |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$openSettingsIsWindowCalls = @(
+    Get-NamedMemberExpressions `
+        -Ast $openSettingsLoop.Body `
+        -Name 'IsWindow' `
+        -InvocationOnly
+)
+$openSettingsSendChordCalls = @(
+    Get-NamedMemberExpressions `
+        -Ast $openSettingsLoop.Body `
+        -Name 'SendChord' `
+        -InvocationOnly
+)
+$openSettingsSetFocusCalls = @(
+    Get-NamedMemberExpressions `
+        -Ast $openSettingsLoop.Body `
+        -Name 'SetFocus' `
+        -InvocationOnly
+)
+$openSettingsReturns = @($openSettingsLoop.Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.ReturnStatementAst]
+}, $true))
+$openSettingsRecoveryBranches = @($openSettingsLoop.Body.FindAll({
+    param($node)
+    if ($node -isnot [System.Management.Automation.Language.IfStatementAst]) {
+        return $false
+    }
+    return (Get-NamedMemberExpressions `
+        -Ast $node `
+        -Name 'VisibleTerminalChildren' `
+        -InvocationOnly).Count -ge 1 -and
+        (Get-NamedMemberExpressions `
+        -Ast $node `
+        -Name 'SendChord' `
+        -InvocationOnly).Count -ge 1
+}, $true))
+if ($openSettingsTopLevelQueries.Count -lt 2 -or
+    $openSettingsIsWindowCalls.Count -lt 2 -or
+    (Get-NamedMemberExpressions -Ast $openSettingsLoop.Body -Name 'FindAll' -InvocationOnly).Count -lt 1 -or
+    (Get-NamedMemberExpressions -Ast $openSettingsLoop.Body -Name 'FocusedWindowFor' -InvocationOnly).Count -lt 2 -or
+    $openSettingsSetFocusCalls.Count -lt 1 -or
+    $openSettingsSendChordCalls.Count -lt 1 -or
+    $openSettingsReturns.Count -lt 1 -or
+    $openSettingsRecoveryBranches.Count -lt 1 -or
+    (Get-NamedCommands -Ast $openSettingsLoop.Body -Name 'Start-Sleep').Count -lt 1 -or
+    $openSettingsSetFocusCalls[0].Extent.StartOffset -gt
+        $openSettingsSendChordCalls[0].Extent.StartOffset) {
+    throw 'Settings open recovery must use one deadline, one chord per zero-window state, terminal focus restoration, and an atomic stable HWND/UIA/section return.'
+}
+$forbiddenThemeApiPattern = '\b(?:DwmSetWindowAttribute|SetWindowTheme)\s*\('
+$themeApiLeaks = @(
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot 'src\apprt') -Filter '*.zig' -File -Recurse |
+        Where-Object { $_.FullName -ne $win32Theme } |
+        ForEach-Object {
+            if ((Get-Content -LiteralPath $_.FullName -Raw) -match $forbiddenThemeApiPattern) {
+                $_.FullName
+            }
+        }
+)
+if ($themeApiLeaks.Count -ne 0) {
+    throw "DWM and native-control theme APIs must remain private to win32_theme.zig: $($themeApiLeaks -join ', ')"
+}
+if ($win32RuntimeText -notmatch '\bwin32_theme\.WindowThemeAdapter\.applyHost\s*\(' -or
+    $win32SettingsText -notmatch '\bwin32_theme\.WindowThemeAdapter\.applySettings\s*\(' -or
+    $win32SettingsText -notmatch '\bwin32_theme\.WindowThemeAdapter\.applyNativeControl\s*\(') {
+    throw 'Win32 host and Settings callers must use the shared WindowThemeAdapter interface.'
+}
+$queryOnlyMarkerCommands = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Send-AccessibilityOutputMarker' |
+        Where-Object {
+            Test-CommandHasStringArgument `
+                -Command $_ `
+                -Value 'query-only TextPattern marker'
+        }
+)
+if ($queryOnlyMarkerCommands.Count -ne 1) {
+    throw 'Accessibility query-only contract must have one marker command.'
+}
+$queryOnlyMarkerCommand = $queryOnlyMarkerCommands[0]
+$queryOnlyOwner = Get-ContainingStatementBlock -Node $queryOnlyMarkerCommand
+$queryOnlyTextPatternName = Get-VariableExpressionName -Node (
+    Get-CommandParameterArgument `
+        -Command $queryOnlyMarkerCommand `
+        -Name 'TextPattern'
+)
+$queryOnlyRemoveHandlers = @($queryOnlyOwner.FindAll({
+    param($node)
+    Test-TextChangedHandlerOperation -Node $node -Operation 'Remove'
+}, $true) |
+        Where-Object {
+            $_.Extent.StartOffset -lt $queryOnlyMarkerCommand.Extent.StartOffset -and
+                [object]::ReferenceEquals(
+                    (Get-ContainingStatementBlock -Node $_),
+                    $queryOnlyOwner
+                )
+        } |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$queryOnlyColdCalls = @(
+    Get-NamedCommands `
+        -Ast $queryOnlyOwner `
+        -Name 'Invoke-AccessibilityColdFirstReadProof' |
+        Where-Object {
+            $_.Extent.StartOffset -gt $queryOnlyMarkerCommand.Extent.StartOffset -and
+                [object]::ReferenceEquals(
+                    (Get-ContainingStatementBlock -Node $_),
+                    $queryOnlyOwner
+                ) -and
+                (Test-CommandHasStringArgument `
+                    -Command $_ `
+                    -Value 'cold first-read TextPattern marker')
+        } |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$queryOnlyInactiveCalls = if ($queryOnlyColdCalls.Count -eq 1) {
+    @(
+        Get-NamedCommands `
+            -Ast $queryOnlyOwner `
+            -Name 'Invoke-AccessibilityInactiveTabFirstReadProof' |
+            Where-Object {
+                $_.Extent.StartOffset -gt
+                    $queryOnlyColdCalls[0].Extent.StartOffset -and
+                    [object]::ReferenceEquals(
+                        (Get-ContainingStatementBlock -Node $_),
+                        $queryOnlyOwner
+                    )
+            } |
+            Sort-Object { $_.Extent.StartOffset }
+    )
+} else {
+    @()
+}
+$queryOnlyAddHandlers = if ($queryOnlyInactiveCalls.Count -eq 1) {
+    @($queryOnlyOwner.FindAll({
+        param($node)
+        Test-TextChangedHandlerOperation -Node $node -Operation 'Add'
+    }, $true) |
+            Where-Object {
+                $_.Extent.StartOffset -gt
+                    $queryOnlyInactiveCalls[0].Extent.StartOffset -and
+                    [object]::ReferenceEquals(
+                        (Get-ContainingStatementBlock -Node $_),
+                        $queryOnlyOwner
+                    )
+            } |
+            Sort-Object { $_.Extent.StartOffset }
+    )
+} else {
+    @()
+}
+$queryOnlyHandlerPairs = @(
+    foreach ($removeHandler in $queryOnlyRemoveHandlers) {
+        foreach ($addHandler in $queryOnlyAddHandlers) {
+            $removeArguments = @($removeHandler.Arguments)
+            $addArguments = @($addHandler.Arguments)
+            if ((Get-VariableExpressionName -Node $removeArguments[1]) -eq
+                    (Get-VariableExpressionName -Node $addArguments[1]) -and
+                (Get-VariableExpressionName -Node $removeArguments[-1]) -eq
+                    (Get-VariableExpressionName -Node $addArguments[-1])) {
+                [pscustomobject]@{
+                    Remove = $removeHandler
+                    Add = $addHandler
+                }
+            }
+        }
+    }
+)
+$queryOnlyPreviousRangeAssignments = if ($queryOnlyHandlerPairs.Count -eq 1) {
+    @(
+        $queryOnlyOwner.FindAll({
+            param($node)
+            if ($node -isnot
+                [System.Management.Automation.Language.AssignmentStatementAst] -or
+                $node.Extent.StartOffset -ge
+                    $queryOnlyHandlerPairs[0].Remove.Extent.StartOffset -or
+                -not [object]::ReferenceEquals(
+                    (Get-ContainingStatementBlock -Node $node),
+                    $queryOnlyOwner
+                )) {
+                return $false
+            }
+            return (Get-VariableExpressionName -Node $node.Left) -ne '' -and
+                @(
+                    Get-NamedMemberExpressions `
+                        -Ast $node.Right `
+                        -Name 'DocumentRange' |
+                        Where-Object {
+                            (Get-ExpressionRootVariableName -Node $_) -eq
+                                $queryOnlyTextPatternName
+                        }
+                ).Count -eq 1
+        }, $true) |
+            Sort-Object { $_.Extent.StartOffset } |
+            Select-Object -Last 1
+    )
+} else {
+    @()
+}
+$queryOnlyPreviousRangeName =
+    if ($queryOnlyPreviousRangeAssignments.Count -eq 1) {
+        Get-VariableExpressionName `
+            -Node $queryOnlyPreviousRangeAssignments[0].Left
+    } else {
+        ''
+    }
+$queryOnlyCurrentReads = if ($queryOnlyColdCalls.Count -eq 1) {
+    @(
+        Get-NamedMemberExpressions `
+            -Ast $queryOnlyOwner `
+            -Name 'GetText' `
+            -InvocationOnly |
+            Where-Object {
+                $_.Extent.StartOffset -gt
+                    $queryOnlyMarkerCommand.Extent.StartOffset -and
+                $_.Extent.StartOffset -lt
+                    $queryOnlyColdCalls[0].Extent.StartOffset -and
+                (Get-ExpressionRootVariableName -Node $_.Expression) -eq
+                    $queryOnlyTextPatternName -and
+                (Get-NamedMemberExpressions `
+                    -Ast $_.Expression `
+                    -Name 'DocumentRange').Count -eq 1
+            }
+    )
+} else {
+    @()
+}
+$queryOnlyPreviousReads = if ($queryOnlyColdCalls.Count -eq 1) {
+    @(
+        Get-NamedMemberExpressions `
+            -Ast $queryOnlyOwner `
+            -Name 'GetText' `
+            -InvocationOnly |
+            Where-Object {
+                $_.Extent.StartOffset -gt
+                    $queryOnlyMarkerCommand.Extent.StartOffset -and
+                $_.Extent.StartOffset -lt
+                    $queryOnlyColdCalls[0].Extent.StartOffset -and
+                (Get-ExpressionRootVariableName -Node $_.Expression) -eq
+                    $queryOnlyPreviousRangeName
+            }
+    )
+} else {
+    @()
+}
+if ($null -ne $queryOnlyOwner) {
+    Assert-NoUnreachableStatements `
+        -Ast $queryOnlyOwner `
+        -Context 'query-only TextChanged handler ownership'
+}
+if ($null -eq $queryOnlyOwner -or
+    [string]::IsNullOrWhiteSpace($queryOnlyTextPatternName) -or
+    $queryOnlyColdCalls.Count -ne 1 -or
+    $queryOnlyInactiveCalls.Count -ne 1 -or
+    $queryOnlyHandlerPairs.Count -ne 1 -or
+    $queryOnlyPreviousRangeAssignments.Count -ne 1 -or
+    $queryOnlyCurrentReads.Count -ne 1 -or
+    $queryOnlyPreviousReads.Count -ne 1 -or
+    -not (
+        $queryOnlyPreviousRangeAssignments[0].Extent.StartOffset -lt
+            $queryOnlyHandlerPairs[0].Remove.Extent.StartOffset -and
+        $queryOnlyHandlerPairs[0].Remove.Extent.StartOffset -lt
+            $queryOnlyMarkerCommand.Extent.StartOffset -and
+        $queryOnlyMarkerCommand.Extent.StartOffset -lt
+            $queryOnlyCurrentReads[0].Extent.StartOffset -and
+        $queryOnlyCurrentReads[0].Extent.StartOffset -lt
+            $queryOnlyPreviousReads[0].Extent.StartOffset -and
+        $queryOnlyPreviousReads[0].Extent.StartOffset -lt
+            $queryOnlyColdCalls[0].Extent.StartOffset -and
+        $queryOnlyColdCalls[0].Extent.StartOffset -lt
+            $queryOnlyInactiveCalls[0].Extent.StartOffset -and
+        $queryOnlyInactiveCalls[0].Extent.StartOffset -lt
+            $queryOnlyHandlerPairs[0].Add.Extent.StartOffset
+    )) {
+    throw 'Accessibility query-only contract must own one ordered proof, remove and restore the identical TextChanged event/document/handler triple, refresh the retained TextPattern, and preserve the prior immutable range.'
+}
+$outputMarkerFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Send-AccessibilityOutputMarker'
+)
+if ($outputMarkerFunctions.Count -ne 1) {
+    throw 'Accessibility evidence must define exactly one output-marker input helper.'
+}
+$outputMarkerFunction = $outputMarkerFunctions[0]
+Assert-NoUnreachableStatements `
+    -Ast $outputMarkerFunction.Body `
+    -Context 'Send-AccessibilityOutputMarker'
+$outputMarkerLaunchers = @(
+    Get-NamedCommands `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'New-AccessibilityTempCmdLauncher'
+)
+$outputMarkerOwnerAssertions = @(
+    Get-NamedCommands `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'Assert-AccessibilityInputOwner' |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$outputMarkerUnicodeSends = @(
+    Get-NamedMemberExpressions `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'SendUnicodeText' `
+        -InvocationOnly
+)
+$outputMarkerEchoWaits = @(
+    Get-NamedCommands `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'Wait-AccessibilityTerminalCommandEcho'
+)
+$outputMarkerTextReads = @(
+    Get-NamedMemberExpressions `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'GetText' `
+        -InvocationOnly |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$outputMarkerEnterSends = @(
+    Get-NamedCommands `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'Send-AccessibilityChord'
+)
+$outputMarkerOutputWaits = @(
+    Get-NamedCommands `
+        -Ast $outputMarkerFunction.Body `
+        -Name 'Wait-AccessibilityCondition'
+)
+$outputMarkerCleanupTries = @($outputMarkerFunction.Body.FindAll({
+    param($node)
+    if ($node -isnot [System.Management.Automation.Language.TryStatementAst] -or
+        $null -eq $node.Finally) {
+        return $false
+    }
+    return (Get-NamedMemberExpressions `
+        -Ast $node.Finally `
+        -Name 'Delete' `
+        -InvocationOnly).Count -eq 1
+}, $true))
+if ($outputMarkerLaunchers.Count -ne 1 -or
+    $outputMarkerOwnerAssertions.Count -ne 2 -or
+    $outputMarkerUnicodeSends.Count -ne 1 -or
+    $outputMarkerEchoWaits.Count -ne 1 -or
+    $outputMarkerTextReads.Count -ne 2 -or
+    $outputMarkerEnterSends.Count -ne 1 -or
+    $outputMarkerOutputWaits.Count -ne 1 -or
+    $outputMarkerCleanupTries.Count -ne 1 -or
+    -not (
+        $outputMarkerLaunchers[0].Extent.StartOffset -lt
+            $outputMarkerOwnerAssertions[0].Extent.StartOffset -and
+        $outputMarkerOwnerAssertions[0].Extent.StartOffset -lt
+            $outputMarkerUnicodeSends[0].Extent.StartOffset -and
+        $outputMarkerUnicodeSends[0].Extent.StartOffset -lt
+            $outputMarkerEchoWaits[0].Extent.StartOffset -and
+        $outputMarkerEchoWaits[0].Extent.StartOffset -lt
+            $outputMarkerTextReads[0].Extent.StartOffset -and
+        $outputMarkerTextReads[0].Extent.StartOffset -lt
+            $outputMarkerOwnerAssertions[1].Extent.StartOffset -and
+        $outputMarkerOwnerAssertions[1].Extent.StartOffset -lt
+            $outputMarkerEnterSends[0].Extent.StartOffset -and
+        $outputMarkerEnterSends[0].Extent.StartOffset -lt
+            $outputMarkerOutputWaits[0].Extent.StartOffset -and
+        $outputMarkerOutputWaits[0].Extent.StartOffset -lt
+            $outputMarkerTextReads[1].Extent.StartOffset
+    )) {
+    throw 'Accessibility output markers must observe the full command, record/recover exact owner immediately before one Enter, and retain diagnostics.'
+}
+$notificationDiagnosticFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Get-AccessibilityOutputNotificationDiagnostic'
+)
+if ($notificationDiagnosticFunctions.Count -ne 1) {
+    throw 'Accessibility output notification evidence must define one pure diagnostic.'
+}
+Assert-NoUnreachableStatements `
+    -Ast $notificationDiagnosticFunctions[0].Body `
+    -Context 'Get-AccessibilityOutputNotificationDiagnostic'
+. ([scriptblock]::Create($notificationDiagnosticFunctions[0].Extent.Text))
+$notificationRawSuccessFixture = @()
+$notificationRawSuccessFixture += ,([object[]]@(
+    'Other',
+    'ignored',
+    0,
+    'OtherActivity'
+))
+$notificationRawSuccessFixture += ,([object[]]@(
+    'ActionCompleted',
+    'prefix-',
+    2,
+    'TerminalTextOutput'
+))
+$notificationRawSuccessFixture += ,([object[]]@(
+    'ActionCompleted',
+    'MARKER',
+    2,
+    'TerminalTextOutput'
+))
+$notificationSuccessOutputs = @(
+    Get-AccessibilityOutputNotificationDiagnostic `
+        -RawNotificationHistory $notificationRawSuccessFixture `
+        -Marker 'MARKER' `
+        -FocusMismatchPolls 2 `
+        -FocusRecoveryCount 1 `
+        -StolenForegroundHwnds @(41, 42) `
+        -LastForegroundHwnd 43 `
+        -LastFocusedHwnd 44
+)
+$notificationRawFailureFixture = @()
+$notificationRawFailureFixture += ,([object[]]@(
+    'ActionCompleted',
+    'different',
+    2,
+    'TerminalTextOutput'
+))
+$notificationRawFailureFixture += ,([object[]]@(
+    'Other',
+    'MARKER',
+    0,
+    'OtherActivity'
+))
+$notificationFailureOutputs = @(
+    Get-AccessibilityOutputNotificationDiagnostic `
+        -RawNotificationHistory $notificationRawFailureFixture `
+        -Marker 'MARKER'
+)
+$notificationRequiredProperties = @(
+    'raw_notification_history',
+    'notification_history',
+    'notification_text',
+    'matched',
+    'history',
+    'text',
+    'count',
+    'focus_mismatch_polls',
+    'focus_recovery_count',
+    'stolen_foreground_hwnds',
+    'last_foreground_hwnd',
+    'last_focused_hwnd'
+)
+if ($notificationSuccessOutputs.Count -ne 1 -or
+    @($notificationRequiredProperties | Where-Object {
+        $notificationSuccessOutputs[0].PSObject.Properties.Name -notcontains $_
+    }).Count -ne 0 -or
+    @($notificationSuccessOutputs[0].raw_notification_history).Count -ne 3 -or
+    @($notificationSuccessOutputs[0].notification_history).Count -ne 2 -or
+    $notificationSuccessOutputs[0].notification_text -cne 'prefix-MARKER' -or
+    $notificationSuccessOutputs[0].matched -ne $true -or
+    @($notificationSuccessOutputs[0].history).Count -ne 2 -or
+    $notificationSuccessOutputs[0].text -cne 'prefix-MARKER' -or
+    $notificationSuccessOutputs[0].count -ne 2 -or
+    $notificationSuccessOutputs[0].focus_mismatch_polls -ne 2 -or
+    $notificationSuccessOutputs[0].focus_recovery_count -ne 1 -or
+    @($notificationSuccessOutputs[0].stolen_foreground_hwnds).Count -ne 2 -or
+    $notificationSuccessOutputs[0].last_foreground_hwnd -ne 43 -or
+    $notificationSuccessOutputs[0].last_focused_hwnd -ne 44 -or
+    $notificationFailureOutputs.Count -ne 1 -or
+    @($notificationFailureOutputs[0].raw_notification_history).Count -ne 2 -or
+    @($notificationFailureOutputs[0].notification_history).Count -ne 1 -or
+    $notificationFailureOutputs[0].notification_text -cne 'different' -or
+    $notificationFailureOutputs[0].matched -ne $false) {
+    throw 'Accessibility output notification diagnostic must atomically shape raw, matching, text, focus, success, and failure evidence without stray output.'
+}
+$ownedWarmNotificationFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Wait-AccessibilityOwnedOutputNotification'
+)
+$ownedWarmNotificationCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Wait-AccessibilityOwnedOutputNotification'
+)
+$coldFirstReadFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityColdFirstReadProof'
+)
+$coldFirstReadCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityColdFirstReadProof'
+)
+$coldOwnedNotificationCalls = if ($coldFirstReadFunctions.Count -eq 1) {
+    @($coldFirstReadFunctions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -eq 'Wait-AccessibilityOwnedOutputNotification'
+    }, $true))
+} else {
+    @()
+}
+$coldCleanupTries = if ($coldFirstReadFunctions.Count -eq 1) {
+    @($coldFirstReadFunctions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.TryStatementAst] -and
+            $null -ne $node.Finally
+    }, $true))
+} else {
+    @()
+}
+if ($ownedWarmNotificationFunctions.Count -ne 1 -or
+    $ownedWarmNotificationCalls.Count -ne 3 -or
+    $coldFirstReadFunctions.Count -ne 1 -or
+    $coldFirstReadCalls.Count -ne 2 -or
+    $coldOwnedNotificationCalls.Count -ne 1 -or
+    $coldCleanupTries.Count -lt 1) {
+    throw 'Warm and cold accessibility evidence must share one owner-aware notification wait, one cold proof, and fail-closed cleanup.'
+}
+. ([scriptblock]::Create($ownedWarmNotificationFunctions[0].Extent.Text))
+function Wait-AccessibilityCondition {
+    param(
+        $Deadline,
+        [string] $Description,
+        [scriptblock] $Condition
+    )
+}
+try {
+    $notificationWaitFixtureProcess =
+        [System.Diagnostics.Process]::GetCurrentProcess()
+    $notificationWaitWithoutDiagnostic = @(
+        Wait-AccessibilityOwnedOutputNotification `
+            -Process $notificationWaitFixtureProcess `
+            -ExpectedFocusedHwnd ([IntPtr]::Zero) `
+            -Marker 'MARKER' `
+            -Description 'optional diagnostic omitted fixture'
+    )
+    $notificationWaitDiagnosticValue = $null
+    $notificationWaitWithDiagnostic = @(
+        Wait-AccessibilityOwnedOutputNotification `
+            -Process $notificationWaitFixtureProcess `
+            -ExpectedFocusedHwnd ([IntPtr]::Zero) `
+            -Marker 'MARKER' `
+            -Description 'optional diagnostic reference fixture' `
+            -Diagnostic ([ref] $notificationWaitDiagnosticValue)
+    )
+    $notificationWaitRejectedScalar = $false
+    try {
+        $null = Wait-AccessibilityOwnedOutputNotification `
+            -Process $notificationWaitFixtureProcess `
+            -ExpectedFocusedHwnd ([IntPtr]::Zero) `
+            -Marker 'MARKER' `
+            -Description 'invalid diagnostic scalar fixture' `
+            -Diagnostic 'not-a-reference'
+    }
+    catch {
+        if ($_.Exception.Message -cne
+            'Diagnostic must be a [ref] value when supplied.') {
+            throw
+        }
+        $notificationWaitRejectedScalar = $true
+    }
+    if ($notificationWaitWithoutDiagnostic.Count -ne 1 -or
+        $notificationWaitWithoutDiagnostic[0].matched -ne $false -or
+        $notificationWaitWithDiagnostic.Count -ne 1 -or
+        $notificationWaitWithDiagnostic[0].matched -ne $false -or
+        $null -eq $notificationWaitDiagnosticValue -or
+        $notificationWaitDiagnosticValue.matched -ne $false -or
+        -not $notificationWaitRejectedScalar) {
+        throw 'Owner-aware notification wait must support omitted and [ref] diagnostics while rejecting scalar diagnostics.'
+    }
+}
+finally {
+    Remove-Item `
+        -LiteralPath Function:\Wait-AccessibilityOwnedOutputNotification `
+        -ErrorAction SilentlyContinue
+    Remove-Item `
+        -LiteralPath Function:\Wait-AccessibilityCondition `
+        -ErrorAction SilentlyContinue
+}
+Assert-NoUnreachableStatements `
+    -Ast $ownedWarmNotificationFunctions[0].Body `
+    -Context 'Wait-AccessibilityOwnedOutputNotification'
+Assert-NoUnreachableStatements `
+    -Ast $coldFirstReadFunctions[0].Body `
+    -Context 'Invoke-AccessibilityColdFirstReadProof'
+$coldReadyWaits = @(
+    Get-NamedCommands `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'Wait-AccessibilityCondition'
+)
+$coldInactivitySleeps = @(
+    Get-NamedCommands `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'Start-Sleep'
+)
+$coldStartCaptures = @(
+    Get-NamedMemberExpressions `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'StartNotificationCapture' `
+        -InvocationOnly
+)
+$coldStopCaptures = @(
+    Get-NamedMemberExpressions `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'StopNotificationCapture' `
+        -InvocationOnly
+)
+$coldFinalReads = @(
+    Get-NamedMemberExpressions `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'GetText' `
+        -InvocationOnly
+)
+$coldTriggerWrites = @(
+    Get-NamedMemberExpressions `
+        -Ast $coldFirstReadFunctions[0].Body `
+        -Name 'WriteAllText' `
+        -InvocationOnly |
+        Where-Object {
+            $_.Arguments.Count -gt 0 -and
+            $_.Arguments[0] -is
+                [System.Management.Automation.Language.VariableExpressionAst] -and
+            ($_.Arguments[0].VariablePath.UserPath -split ':')[-1] -eq
+                'triggerPath' -and
+            $_.Extent.StartOffset -lt
+                $coldOwnedNotificationCalls[0].Extent.StartOffset
+        }
+)
+$coldFailClosedCleanupTries = @(
+    $coldCleanupTries |
+        Where-Object {
+            (Get-NamedMemberExpressions `
+                -Ast $_.Finally `
+                -Name 'StopNotificationCapture' `
+                -InvocationOnly).Count -eq 1 -and
+            (Get-NamedMemberExpressions `
+                -Ast $_.Finally `
+                -Name 'Delete' `
+                -InvocationOnly).Count -eq 1
+        }
+)
+if ($coldReadyWaits.Count -ne 1 -or
+    $coldInactivitySleeps.Count -ne 1 -or
+    $coldStartCaptures.Count -ne 1 -or
+    $coldStopCaptures.Count -ne 1 -or
+    $coldFinalReads.Count -ne 1 -or
+    (Get-ExpressionRootVariableName -Node $coldFinalReads[0].Expression) -ne
+        'TextPattern' -or
+    (Get-NamedMemberExpressions -Ast $coldFinalReads[0].Expression -Name 'DocumentRange').Count -ne 1 -or
+    $coldTriggerWrites.Count -ne 1 -or
+    $coldFailClosedCleanupTries.Count -ne 1 -or
+    -not (
+        $coldStartCaptures[0].Extent.StartOffset -lt
+            $coldReadyWaits[0].Extent.StartOffset -and
+        $coldReadyWaits[0].Extent.StartOffset -lt
+            $coldInactivitySleeps[0].Extent.StartOffset -and
+        $coldInactivitySleeps[0].Extent.StartOffset -lt
+            $coldTriggerWrites[0].Extent.StartOffset -and
+        $coldTriggerWrites[0].Extent.StartOffset -lt
+            $coldOwnedNotificationCalls[0].Extent.StartOffset -and
+        $coldOwnedNotificationCalls[0].Extent.StartOffset -lt
+            $coldFinalReads[0].Extent.StartOffset
+    )) {
+    throw 'Cold first-read proof must establish readiness and query inactivity, trigger output, observe owned notification evidence, then perform its sole TextPattern read with fail-closed capture cleanup.'
+}
+$ownedDiagnosticCalls = @(
+    Get-NamedCommands `
+        -Ast $ownedWarmNotificationFunctions[0].Body `
+        -Name 'Get-AccessibilityOutputNotificationDiagnostic'
+)
+$ownedRawHistorySnapshots = @(
+    Get-NamedMemberExpressions `
+        -Ast $ownedWarmNotificationFunctions[0].Body `
+        -Name 'NotificationHistorySnapshot'
+)
+$ownedDiagnosticValueAssignments = @(
+    Get-NamedMemberExpressions `
+        -Ast $ownedWarmNotificationFunctions[0].Body `
+        -Name 'Value' |
+        Where-Object {
+            (Get-ExpressionRootVariableName -Node $_) -eq 'diagnosticState' -and
+            $_.Parent -is
+                [System.Management.Automation.Language.AssignmentStatementAst] -and
+            [object]::ReferenceEquals($_.Parent.Left, $_)
+        }
+)
+if ($ownedDiagnosticCalls.Count -ne 3 -or
+    $ownedRawHistorySnapshots.Count -ne 2 -or
+    $ownedDiagnosticValueAssignments.Count -ne 2 -or
+    (Get-NamedCommands -Ast $ownedWarmNotificationFunctions[0].Body -Name 'Wait-AccessibilityCondition').Count -ne 1 -or
+    (Get-NamedCommands -Ast $ownedWarmNotificationFunctions[0].Body -Name 'Where-Object').Count -ne 0) {
+    throw 'Owner-aware output notification wait must recompute one atomic diagnostic from raw capture history on every poll and failure.'
+}
+$inactiveTabFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityInactiveTabFirstReadProof'
+)
+$inactiveTabCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Invoke-AccessibilityInactiveTabFirstReadProof'
+)
+$inactiveCleanupTries = if ($inactiveTabFunctions.Count -eq 1) {
+    @($inactiveTabFunctions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.TryStatementAst] -and
+            $null -ne $node.Finally
+    }, $true))
+} else {
+    @()
+}
+if ($inactiveTabFunctions.Count -ne 1 -or
+    $inactiveTabCalls.Count -ne 2 -or
+    $inactiveCleanupTries.Count -lt 1) {
+    throw 'Targeted and full evidence must share one inactive-tab proof with fail-closed cleanup.'
+}
+Assert-NoUnreachableStatements `
+    -Ast $inactiveTabFunctions[0].Body `
+    -Context 'Invoke-AccessibilityInactiveTabFirstReadProof'
+$inactiveAckWaits = @(
+    Get-NamedCommands `
+        -Ast $inactiveTabFunctions[0].Body `
+        -Name 'Wait-AccessibilityCondition' |
+        Where-Object {
+            Test-CommandHasStringArgument `
+                -Command $_ `
+                -Value 'inactive-output external ack'
+        }
+)
+$inactiveQuietLoops = @($inactiveTabFunctions[0].Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.DoWhileStatementAst] -and
+        (Get-NamedMemberExpressions `
+            -Ast $node.Body `
+            -Name 'IsWindowResponsive' `
+            -InvocationOnly).Count -eq 1 -and
+        (Get-NamedCommands `
+            -Ast $node.Body `
+            -Name 'Get-AccessibilityOutputNotificationDiagnostic').Count -eq 1
+}, $true))
+$inactiveStartCaptures = @(
+    Get-NamedMemberExpressions `
+        -Ast $inactiveTabFunctions[0].Body `
+        -Name 'StartNotificationCapture' `
+        -InvocationOnly
+)
+$inactiveStopCaptures = @(
+    Get-NamedMemberExpressions `
+        -Ast $inactiveTabFunctions[0].Body `
+        -Name 'StopNotificationCapture' `
+        -InvocationOnly |
+        Sort-Object { $_.Extent.StartOffset }
+)
+$inactiveFirstReads = @(
+    Get-NamedMemberExpressions `
+        -Ast $inactiveTabFunctions[0].Body `
+        -Name 'GetText' `
+        -InvocationOnly |
+        Sort-Object { $_.Extent.StartOffset }
+)
+if ($inactiveAckWaits.Count -ne 1 -or
+    $inactiveQuietLoops.Count -ne 1 -or
+    $inactiveStartCaptures.Count -ne 1 -or
+    $inactiveStopCaptures.Count -ne 2 -or
+    $inactiveFirstReads.Count -ne 1) {
+    throw 'Inactive-tab proof must define one ACK, quiet loop, capture lifetime, and first refocused TextPattern read.'
+}
+$inactiveNormalStop = @(
+    $inactiveStopCaptures |
+        Where-Object {
+            $_.Extent.StartOffset -gt $inactiveQuietLoops[0].Extent.EndOffset -and
+            $_.Extent.StartOffset -lt $inactiveFirstReads[0].Extent.StartOffset
+        }
+)
+$inactiveQuietBody = $inactiveQuietLoops[0].Body
+$inactiveFinalDiagnosticAssignments = if ($inactiveNormalStop.Count -eq 1) {
+    @($inactiveTabFunctions[0].Body.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Extent.StartOffset -gt $inactiveQuietLoops[0].Extent.EndOffset -and
+            $node.Extent.StartOffset -lt $inactiveNormalStop[0].Extent.StartOffset -and
+            (Get-NamedCommands `
+                -Ast $node.Right `
+                -Name 'Get-AccessibilityOutputNotificationDiagnostic').Count -eq 1 -and
+            (Get-NamedMemberExpressions `
+                -Ast $node.Right `
+                -Name 'NotificationHistorySnapshot').Count -eq 1
+    }, $true))
+} else {
+    @()
+}
+$inactiveFinalDiagnosticName =
+    if ($inactiveFinalDiagnosticAssignments.Count -eq 1) {
+        Get-VariableExpressionName `
+            -Node $inactiveFinalDiagnosticAssignments[0].Left
+    } else {
+        ''
+    }
+$inactiveFinalMatchedGuards = if ($inactiveNormalStop.Count -eq 1 -and
+    -not [string]::IsNullOrWhiteSpace($inactiveFinalDiagnosticName)) {
+    @(
+        Get-NamedMemberExpressions `
+            -Ast $inactiveTabFunctions[0].Body `
+            -Name 'matched' |
+            Where-Object {
+                if ((Get-ExpressionRootVariableName -Node $_) -ne
+                    $inactiveFinalDiagnosticName -or
+                    $_.Extent.StartOffset -le
+                        $inactiveFinalDiagnosticAssignments[0].Extent.EndOffset -or
+                    $_.Extent.StartOffset -ge
+                        $inactiveNormalStop[0].Extent.StartOffset) {
+                    return $false
+                }
+                $guard = $_
+                while ($null -ne $guard -and
+                    $guard -isnot
+                        [System.Management.Automation.Language.IfStatementAst]) {
+                    $guard = $guard.Parent
+                }
+                return $null -ne $guard -and
+                    @($guard.FindAll({
+                        param($node)
+                        $node -is
+                            [System.Management.Automation.Language.ThrowStatementAst]
+                    }, $true)).Count -ge 1
+            }
+    )
+} else {
+    @()
+}
+$inactiveBoundaryConsecutive = $false
+if ($inactiveFinalDiagnosticAssignments.Count -eq 1 -and
+    $inactiveFinalMatchedGuards.Count -eq 1 -and
+    $inactiveNormalStop.Count -eq 1) {
+    $inactiveBoundaryOwner =
+        Get-ContainingStatementBlock `
+            -Node $inactiveFinalDiagnosticAssignments[0]
+    $inactiveBoundaryAssignmentStatement =
+        Get-DirectStatementBlockChild `
+            -Node $inactiveFinalDiagnosticAssignments[0] `
+            -StatementBlock $inactiveBoundaryOwner
+    $inactiveBoundaryGuardStatement =
+        $inactiveFinalMatchedGuards[0]
+    while ($null -ne $inactiveBoundaryGuardStatement -and
+        $inactiveBoundaryGuardStatement -isnot
+            [System.Management.Automation.Language.IfStatementAst]) {
+        $inactiveBoundaryGuardStatement =
+            $inactiveBoundaryGuardStatement.Parent
+    }
+    $inactiveBoundaryStopStatement =
+        Get-DirectStatementBlockChild `
+            -Node $inactiveNormalStop[0] `
+            -StatementBlock $inactiveBoundaryOwner
+    $inactiveBoundaryStatements = @($inactiveBoundaryOwner.Statements)
+    $inactiveBoundaryAssignmentIndex = -1
+    $inactiveBoundaryGuardIndex = -1
+    $inactiveBoundaryStopIndex = -1
+    for ($index = 0; $index -lt $inactiveBoundaryStatements.Count; $index++) {
+        if ([object]::ReferenceEquals(
+            $inactiveBoundaryStatements[$index],
+            $inactiveBoundaryAssignmentStatement
+        )) {
+            $inactiveBoundaryAssignmentIndex = $index
+        }
+        if ([object]::ReferenceEquals(
+            $inactiveBoundaryStatements[$index],
+            $inactiveBoundaryGuardStatement
+        )) {
+            $inactiveBoundaryGuardIndex = $index
+        }
+        if ([object]::ReferenceEquals(
+            $inactiveBoundaryStatements[$index],
+            $inactiveBoundaryStopStatement
+        )) {
+            $inactiveBoundaryStopIndex = $index
+        }
+    }
+    $inactiveBoundaryConsecutive =
+        $inactiveBoundaryAssignmentIndex -ge 0 -and
+        $inactiveBoundaryGuardIndex -eq
+            ($inactiveBoundaryAssignmentIndex + 1) -and
+        $inactiveBoundaryStopIndex -eq
+            ($inactiveBoundaryGuardIndex + 1)
+}
+if ($inactiveNormalStop.Count -ne 1 -or
+    $inactiveFinalDiagnosticAssignments.Count -ne 1 -or
+    $inactiveFinalMatchedGuards.Count -ne 1 -or
+    -not $inactiveBoundaryConsecutive -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'Refresh' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'IsWindowResponsive' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'NotificationHistorySnapshot').Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'FocusedWindowFor' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'matched').Count -ne 1 -or
+    (Get-NamedCommands -Ast $inactiveQuietBody -Name 'Start-Sleep').Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'GetText' -InvocationOnly).Count -ne 0 -or
+    (Get-NamedMemberExpressions -Ast $inactiveQuietBody -Name 'DocumentRange').Count -ne 0 -or
+    -not (
+        $inactiveStartCaptures[0].Extent.StartOffset -lt
+            $inactiveAckWaits[0].Extent.StartOffset -and
+        $inactiveAckWaits[0].Extent.StartOffset -lt
+            $inactiveQuietLoops[0].Extent.StartOffset -and
+        $inactiveQuietLoops[0].Extent.EndOffset -lt
+            $inactiveFinalDiagnosticAssignments[0].Extent.StartOffset -and
+        $inactiveFinalDiagnosticAssignments[0].Extent.StartOffset -lt
+            $inactiveFinalMatchedGuards[0].Extent.StartOffset -and
+        $inactiveFinalMatchedGuards[0].Extent.StartOffset -lt
+            $inactiveNormalStop[0].Extent.StartOffset -and
+        $inactiveNormalStop[0].Extent.StartOffset -lt
+            $inactiveFirstReads[0].Extent.StartOffset
+    )) {
+    throw 'Inactive-tab proof must keep capture active through a bounded marker-free responsive quiet interval, reject one final fresh snapshot immediately before capture stop, and perform zero TextPattern reads before the first refocused read.'
+}
+$tempLauncherFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'New-AccessibilityTempCmdLauncher'
+)
+$tempLauncherCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'New-AccessibilityTempCmdLauncher'
+)
+if ($tempLauncherFunctions.Count -ne 1 -or $tempLauncherCalls.Count -ne 3) {
+    throw 'Warm, cold, and inactive evidence must share one temporary CMD launcher factory.'
+}
+$commandEchoFunctions = @(
+    Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Wait-AccessibilityTerminalCommandEcho'
+)
+if ($commandEchoFunctions.Count -ne 1) {
+    throw 'Terminal command echo gating must define one helper.'
+}
+$commandEchoFunction = $commandEchoFunctions[0]
+Assert-NoUnreachableStatements `
+    -Ast $commandEchoFunction.Body `
+    -Context 'Wait-AccessibilityTerminalCommandEcho'
+$commandEchoLoops = @($commandEchoFunction.Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.DoWhileStatementAst]
+}, $true))
+$commandEchoGetTextCalls = @(
+    Get-NamedMemberExpressions `
+        -Ast $commandEchoFunction.Body `
+        -Name 'GetText' `
+        -InvocationOnly
+)
+$commandEchoFullCommandContains = @(
+    Get-NamedMemberExpressions `
+        -Ast $commandEchoFunction.Body `
+        -Name 'Contains' `
+        -InvocationOnly |
+        Where-Object {
+            @($_.Arguments | Where-Object {
+                $_ -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                    ($_.VariablePath.UserPath -split ':')[-1] -eq 'Command'
+            }).Count -eq 1
+        }
+)
+$commandEchoForbiddenInputCalls = @(
+    @(
+        Get-NamedMemberExpressions `
+            -Ast $commandEchoFunction.Body `
+            -Name 'SendUnicodeText' `
+            -InvocationOnly
+    ) + @(
+        Get-NamedMemberExpressions `
+            -Ast $commandEchoFunction.Body `
+            -Name 'SendChord' `
+            -InvocationOnly
+    ) + @(
+        Get-NamedCommands `
+            -Ast $commandEchoFunction.Body `
+            -Name 'Send-AccessibilityChord'
+    )
+)
+if ($commandEchoLoops.Count -ne 1 -or
+    $commandEchoGetTextCalls.Count -ne 1 -or
+    $commandEchoGetTextCalls[0].Extent.StartOffset -lt
+        $commandEchoLoops[0].Extent.StartOffset -or
+    $commandEchoGetTextCalls[0].Extent.EndOffset -gt
+        $commandEchoLoops[0].Extent.EndOffset -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'GetForegroundWindow' -InvocationOnly).Count -lt 2 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'FocusedWindowFor' -InvocationOnly).Count -lt 2 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'ForceForeground' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'FromHandle' -InvocationOnly).Count -ne 2 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'SetFocus' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'TryGetCurrentPattern' -InvocationOnly).Count -ne 1 -or
+    (Get-NamedMemberExpressions -Ast $commandEchoFunction.Body -Name 'Replace' -InvocationOnly).Count -lt 4 -or
+    $commandEchoFullCommandContains.Count -ne 1 -or
+    (Get-NamedCommands -Ast $commandEchoFunction.Body -Name 'Get-AccessibilityExceptionHResults').Count -ne 1 -or
+    (Get-NamedCommands -Ast $commandEchoFunction.Body -Name 'Test-AccessibilityTransientHResult').Count -ne 1 -or
+    $commandEchoForbiddenInputCalls.Count -ne 0) {
+    throw 'Terminal command echo gating must require the full normalized command, recover exact host/terminal focus without resending input, poll TextPattern, and reacquire transient providers.'
 }
 $stressBoundaryContract = [regex]::Match(
     $accessibilityHarnessText,
@@ -1417,11 +3461,147 @@ if ($accessibilityHarnessText -notmatch 'docked search query UIA focus''[\s\S]*?
     $accessibilityHarnessText -match 'docked search query UIA focus''[\s\S]{0,1200}?\$searchQueryEdit\.SetFocus\(\)') {
     throw 'Accessibility docked-search recovery must prove native query focus before restoring only foreground ownership.'
 }
-if ($accessibilityHarnessText -notmatch 'settings section focus and selection ownership''[\s\S]*?\$sectionNativeFocusBeforeRecovery -ne \$focusSectionHwnd[\s\S]*?ForceForeground\(\$settingsHwnd\)' -or
-    $accessibilityHarnessText -match 'settings section focus and selection ownership''[\s\S]{0,1200}?\$focusSection\.SetFocus\(\)' -or
+$settingsFocusWaits = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Wait-AccessibilityCondition' |
+        Where-Object {
+            Test-CommandHasStringArgument `
+                -Command $_ `
+                -Value 'settings section focus and selection ownership'
+        }
+)
+$settingsFocusContract = $false
+if ($settingsFocusWaits.Count -eq 1) {
+    $settingsFocusCondition =
+        Get-CommandParameterArgument `
+            -Command $settingsFocusWaits[0] `
+            -Name 'Condition'
+    if ($settingsFocusCondition -is
+        [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+        $settingsFocusBody = $settingsFocusCondition.ScriptBlock.EndBlock
+        $settingsFocusWaitOwner =
+            Get-ContainingStatementBlock -Node $settingsFocusWaits[0]
+        $settingsFocusForegroundBranches = @($settingsFocusBody.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.IfStatementAst] -and
+                (Get-NamedMemberExpressions `
+                    -Ast $node.Clauses[0].Item1 `
+                    -Name 'GetForegroundWindow' `
+                    -InvocationOnly).Count -ge 1 -and
+                (Get-NamedMemberExpressions `
+                    -Ast $node.Clauses[0].Item2 `
+                    -Name 'ForceForeground' `
+                    -InvocationOnly).Count -ge 1
+        }, $true))
+        $settingsFocusSetFocusCalls = @(
+            Get-NamedMemberExpressions `
+                -Ast $settingsFocusBody `
+                -Name 'SetFocus' `
+                -InvocationOnly |
+                Where-Object {
+                    [object]::ReferenceEquals(
+                        (Get-ContainingStatementBlock -Node $_),
+                        $settingsFocusWaitOwner
+                    )
+                }
+        )
+        $settingsFocusSelectCalls = @(
+            Get-NamedMemberExpressions `
+                -Ast $settingsFocusBody `
+                -Name 'Select' `
+                -InvocationOnly |
+                Where-Object {
+                    [object]::ReferenceEquals(
+                        (Get-ContainingStatementBlock -Node $_),
+                        $settingsFocusWaitOwner
+                    )
+                }
+        )
+        if ($settingsFocusForegroundBranches.Count -eq 1 -and
+            $settingsFocusSetFocusCalls.Count -eq 1 -and
+            $settingsFocusSelectCalls.Count -eq 1) {
+            $settingsFocusForegroundBranch =
+                $settingsFocusForegroundBranches[0]
+            $settingsFocusForceCalls = @(
+                Get-NamedMemberExpressions `
+                    -Ast $settingsFocusForegroundBranch.Clauses[0].Item2 `
+                    -Name 'ForceForeground' `
+                    -InvocationOnly
+            )
+            $settingsFocusFalseReturns =
+                @($settingsFocusForegroundBranch.Clauses[0].Item2.FindAll({
+                    param($node)
+                    $node -is
+                        [System.Management.Automation.Language.ReturnStatementAst] -and
+                        @($node.FindAll({
+                            param($child)
+                            $child -is
+                                [System.Management.Automation.Language.VariableExpressionAst] -and
+                                (Get-VariableExpressionName -Node $child) -eq
+                                    'false'
+                        }, $true)).Count -eq 1
+                }, $true))
+            $settingsFocusPostconditions = @(
+                Get-NamedMemberExpressions `
+                    -Ast $settingsFocusBody `
+                    -Name 'FocusedWindowFor' `
+                    -InvocationOnly |
+                    Where-Object {
+                        $_.Extent.StartOffset -gt
+                            $settingsFocusSelectCalls[0].Extent.StartOffset -and
+                            [object]::ReferenceEquals(
+                                (Get-ContainingStatementBlock -Node $_),
+                                $settingsFocusWaitOwner
+                            )
+                    }
+            )
+            $settingsFocusHwndName =
+                if ($settingsFocusForceCalls.Count -eq 1 -and
+                    $settingsFocusForceCalls[0].Arguments.Count -eq 1) {
+                    Get-VariableExpressionName `
+                        -Node $settingsFocusForceCalls[0].Arguments[0]
+                } else {
+                    ''
+                }
+            $settingsFocusConditionVariableNames = @(
+                $settingsFocusForegroundBranch.Clauses[0].Item1.FindAll({
+                    param($node)
+                    $node -is
+                        [System.Management.Automation.Language.VariableExpressionAst]
+                }, $true) |
+                    ForEach-Object { Get-VariableExpressionName -Node $_ }
+            )
+            $settingsFocusPostconditionHwndName =
+                if ($settingsFocusPostconditions.Count -eq 1 -and
+                    $settingsFocusPostconditions[0].Arguments.Count -eq 1) {
+                    Get-VariableExpressionName `
+                        -Node $settingsFocusPostconditions[0].Arguments[0]
+                } else {
+                    ''
+                }
+            $settingsFocusContract =
+                $settingsFocusFalseReturns.Count -eq 1 -and
+                -not [string]::IsNullOrWhiteSpace($settingsFocusHwndName) -and
+                $settingsFocusConditionVariableNames -contains
+                    $settingsFocusHwndName -and
+                $settingsFocusPostconditionHwndName -eq
+                    $settingsFocusHwndName -and
+                $settingsFocusForceCalls[0].Extent.StartOffset -lt
+                    $settingsFocusFalseReturns[0].Extent.StartOffset -and
+                $settingsFocusForegroundBranch.Extent.EndOffset -lt
+                    $settingsFocusSetFocusCalls[0].Extent.StartOffset -and
+                $settingsFocusSetFocusCalls[0].Extent.StartOffset -lt
+                    $settingsFocusSelectCalls[0].Extent.StartOffset -and
+                $settingsFocusSelectCalls[0].Extent.StartOffset -lt
+                    $settingsFocusPostconditions[0].Extent.StartOffset
+        }
+    }
+}
+if (-not $settingsFocusContract -or
     $accessibilityHarnessText -notmatch 'ForceForeground\(\$ownerSettingsHwnd\)[\s\S]*?PostMessageW\(\s*\$ownerSettingsHwnd[\s\S]*?settings conservative dirty-close focus' -or
     $accessibilityHarnessText -match 'settings conservative dirty-close focus''[\s\S]{0,900}?(ForceForeground|SetFocus)\(') {
-    throw 'Accessibility settings evidence must validate focus without repairing the exact target under test.'
+    throw 'Accessibility settings focus evidence must restore only foreground ownership before retrying UIA target focus and selection.'
 }
 if ($accessibilityHarnessText -notmatch 'settings destruction and terminal focus restoration after idle soak''[\s\S]*?\$script:idleRestoreForegroundHwnd -eq \$idleTerminalHostHwnd[\s\S]*?\$script:idleRestoreFocusedHwnd -eq \$leftPane\.Hwnd' -or
     $accessibilityHarnessText -match 'settings destruction and terminal focus restoration after idle soak''[\s\S]{0,1000}?ForceForeground\(') {
@@ -1452,6 +3632,21 @@ Assert-TextContract `
     -Pattern '(?s)fn sendButtonClicked\(hwnd: com\.HWND\).*?SendMessageTimeoutW\(.*?SMTO_BLOCK \| SMTO_ABORTIFHUNG.*?settings_selection_timeout_ms.*?UIA_E_ELEMENTNOTAVAILABLE.*?fn Select\(p: \*com\.ISelectionItemProvider\).*?const result = sendButtonClicked\(self\.hwnd\).*?if \(!self\.available\(\)\).*?self\.isSelected\(\)' `
     -Description 'settings section selection is synchronous, bounded, and postcondition checked' `
     -Context $win32UiaWidgets
+Assert-TextContract `
+    -Content $win32UiaWidgetsText `
+    -Pattern '(?s)fn sendButtonClicked\(hwnd: com\.HWND\).*?SendMessageTimeoutW\(.*?WM_COMMAND.*?@bitCast\(@intFromPtr\(hwnd\)\).*?fn Select\(p: \*com\.ISelectionItemProvider\).*?sendButtonClicked\(self\.hwnd\)' `
+    -Description 'settings SelectionItem Select routes the real child source HWND synchronously to the UI thread' `
+    -Context $win32UiaWidgets
+Assert-TextContract `
+    -Content $win32SettingsText `
+    -Pattern '(?s)fn validatedSectionClickFocusTarget\(source: \?HWND, expected: \?HWND\).*?source_hwnd == expected_hwnd.*?if \(clickedSection\(id, notify\)\) \|section\|.*?validatedSectionClickFocusTarget\(.*?o\.sectionButton\(section\).*?_ = SetFocus\(button\);.*?o\.setActiveSection\(section\);' `
+    -Description 'validated section clicks focus the real child on the UI thread before activation' `
+    -Context $win32Settings
+Assert-TextContract `
+    -Content $win32SettingsText `
+    -Pattern '(?s)fn settingsSectionButtonProc.*?if \(msg == WM_SETFOCUS\).*?provider\.raiseFocusChanged\(\)' `
+    -Description 'real section child WM_SETFOCUS publishes the matching UIA focus event' `
+    -Context $win32Settings
 Assert-TextContract `
     -Content $win32UiaWidgetsText `
     -Pattern '(?s)fn hwndHasKeyboardFocus\(hwnd: com\.HWND\).*?GetWindowThreadProcessId\(hwnd, null\).*?GetGUIThreadInfo\(thread_id, &info\).*?IsChild\(hwnd, focused\).*?pub fn raiseFocusChanged\(self: \*SettingsControlProvider\).*?events\.raiseFocusChanged\(&self\.base\).*?UIA_HasKeyboardFocusPropertyId.*?hwndHasKeyboardFocus\(self\.hwnd\).*?pub fn raiseFocusChanged\(self: \*SettingsSectionProvider\)' `
@@ -1532,6 +3727,103 @@ Assert-TextContract `
     -Pattern '(?s)Invoke-AccessibilitySettingsCloseAction.*?-ActionName ''Save and close''.*?settings save-and-close completion.*?settings persisted config bytes.*?settings persistence verifier.*?Save and close did not survive a same-sandbox process relaunch.*?settings persistence baseline restoration.*?save_and_close_invoked.*?persisted_after_process_relaunch.*?original_value_restored' `
     -Description 'accessibility evidence invokes Save and close, proves same-sandbox process persistence, and restores the baseline' `
     -Context $accessibilityHarness
+$themePersistenceFunctionNames = @(
+    'Get-AccessibilityThemeProbe',
+    'Set-AccessibilityThemeIndex',
+    'Get-AccessibilityDwmUInt'
+)
+foreach ($functionName in $themePersistenceFunctionNames) {
+    if (@(Get-NamedFunctionDefinitions `
+        -Ast $accessibilityHarnessAst `
+        -Name $functionName).Count -ne 1) {
+        throw "Theme persistence evidence must define exactly one $functionName helper."
+    }
+}
+$themePersistenceVerifierCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Get-AccessibilityThemeProbe' |
+        Where-Object {
+            Test-CommandHasStringArgument `
+                -Command $_ `
+                -Value 'settings persistence verifier'
+        }
+)
+$themePersistenceSelectionCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Set-AccessibilityThemeIndex' |
+        Where-Object {
+            Test-CommandHasStringArgument `
+                -Command $_ `
+                -Value 'settings save probe Dark selection'
+        }
+)
+$themePersistenceDwmCalls = @(
+    Get-NamedCommands `
+        -Ast $accessibilityHarnessAst `
+        -Name 'Get-AccessibilityDwmUInt' |
+        Where-Object {
+            $description = Get-CommandParameterArgument `
+                -Command $_ `
+                -Name 'Description'
+            $description -is
+                    [System.Management.Automation.Language.StringConstantExpressionAst] -and
+                $description.Value -in @('fresh Dark host', 'fresh Dark Settings')
+        }
+)
+$themePersistenceDwmAttributes = @(
+    $themePersistenceDwmCalls |
+        ForEach-Object {
+            $argument = Get-CommandParameterArgument -Command $_ -Name 'Attribute'
+            if ($argument -isnot
+                [System.Management.Automation.Language.ConstantExpressionAst]) {
+                throw 'Fresh Dark DWM persistence attributes must be static integers.'
+            }
+            [int]$argument.Value
+        } |
+        Sort-Object
+)
+$themePersistenceStringValues = @(
+    $accessibilityHarnessAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.StringConstantExpressionAst]
+    }, $true) |
+        ForEach-Object { $_.Value }
+)
+$themePersistenceEvidenceKeys = @(
+    'persistence_theme_config_dark',
+    'persistence_theme_fresh_process_index',
+    'persistence_theme_dark_settings_pixel',
+    'persistence_theme_dark_host_pixel',
+    'persistence_theme_host_dwm_dark',
+    'persistence_theme_settings_dwm_dark',
+    'persistence_theme_host_backdrop',
+    'persistence_theme_settings_backdrop',
+    'persistence_theme_restored'
+)
+$themeSelectionIndex = if ($themePersistenceSelectionCalls.Count -eq 1) {
+    Get-CommandParameterArgument `
+        -Command $themePersistenceSelectionCalls[0] `
+        -Name 'Index'
+}
+if ($themePersistenceVerifierCalls.Count -ne 1 -or
+    $themePersistenceSelectionCalls.Count -ne 1 -or
+    $themeSelectionIndex -isnot
+        [System.Management.Automation.Language.ConstantExpressionAst] -or
+    [int]$themeSelectionIndex.Value -ne 3 -or
+    $themePersistenceDwmCalls.Count -ne 4 -or
+    (Compare-Object `
+        -ReferenceObject @(20, 20, 38, 38) `
+        -DifferenceObject $themePersistenceDwmAttributes `
+        -SyncWindow 0).Count -ne 0 -or
+    $themePersistenceStringValues -notcontains
+        '(?m)^window-theme\s*=\s*dark\s*$' -or
+    @($themePersistenceEvidenceKeys | Where-Object {
+        $themePersistenceStringValues -notcontains $_
+    }).Count -ne 0) {
+    throw 'Theme persistence evidence must save Dark, relaunch, verify exact visual/DWM state, and restore its baseline.'
+}
 Assert-TextContract `
     -Content $accessibilityHarnessText `
     -Pattern '(?s)function Start-AccessibilityProcessWithEnvironment.*?\$baseline = \[ordered\]@\{\}.*?SetEnvironmentVariable\(.*?try \{.*?Start-Process.*?finally \{.*?\$baseline\.GetEnumerator\(\).*?SetEnvironmentVariable\(.*?settingsPersistenceLayout = Get-InteractiveWin11SandboxLayout.*?settingsProbeEnvironment = Get-InteractiveWin11Environment.*?sandboxConfigPath = Join-Path \$settingsPersistenceLayout\.LocalAppData.*?Start-AccessibilityProcessWithEnvironment.*?-ArgumentList \$saveProbeArguments.*?-EnvironmentVariables \$settingsProbeEnvironment.*?Start-AccessibilityProcessWithEnvironment.*?-ArgumentList \$saveVerifyArguments.*?-EnvironmentVariables \$settingsProbeEnvironment' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -99,9 +99,9 @@ function Assert-ZigTestsDiscoveredAndRun {
         }
     }
     foreach ($expectedName in $ExpectedNames) {
-        $matches = @($declarations | Where-Object { $_.Name -ceq $expectedName })
-        if ($matches.Count -ne 1) {
-            throw "Expected exactly one Zig test declaration '$expectedName'; found $($matches.Count)."
+        $declMatches = @($declarations | Where-Object { $_.Name -ceq $expectedName })
+        if ($declMatches.Count -ne 1) {
+            throw "Expected exactly one Zig test declaration '$expectedName'; found $($declMatches.Count)."
         }
     }
 

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -105,12 +105,9 @@ function Assert-ZigTestsDiscoveredAndRun {
         }
     }
 
-    $filterArgument = "-Dtest-filter=$Filter"
-    & (Join-Path $RepoRoot 'scripts\dev-windows.cmd') `
-        zig build test $filterArgument
-    if ($LASTEXITCODE -ne 0) {
-        throw "Zig semantic fixture '$Filter' failed with exit code $LASTEXITCODE."
-    }
+    Invoke-ZigFixture `
+        -RepoRoot $RepoRoot `
+        -Filter $Filter
 }
 
 function Get-YamlJobText {
@@ -137,6 +134,70 @@ function Get-YamlStepText {
     $match = [regex]::Match($Content, $pattern)
     if (-not $match.Success) { throw "Workflow step not found: $Name ($Source)" }
     $match.Value
+}
+
+function Assert-DeferredZigFixtureExecution {
+    param(
+        [Parameter(Mandatory)] [string] $WorkflowText,
+        [Parameter(Mandatory)] [string] $Source
+    )
+
+    $windowsJob = Get-YamlJobText `
+        -Content $WorkflowText `
+        -Name 'windows' `
+        -Source $Source
+    $flagshipStep = Get-YamlStepText `
+        -Content $windowsJob `
+        -Name 'Flagship verification contract checks' `
+        -Source "$Source :: windows"
+    $setupStep = Get-YamlStepText `
+        -Content $windowsJob `
+        -Name 'Setup Zig' `
+        -Source "$Source :: windows"
+    $fullSuiteStep = Get-YamlStepText `
+        -Content $windowsJob `
+        -Name 'Full Zig test suite' `
+        -Source "$Source :: windows"
+    $conditionalStepPattern = '(?m)^        (?:if|continue-on-error):'
+    $flagshipIndex = $windowsJob.IndexOf($flagshipStep, [StringComparison]::Ordinal)
+    $setupIndex = $windowsJob.IndexOf($setupStep, [StringComparison]::Ordinal)
+    $fullSuiteIndex = $windowsJob.IndexOf($fullSuiteStep, [StringComparison]::Ordinal)
+
+    if ($flagshipStep -notmatch
+            '(?m)^        run: \./test/windows/flagship/Test-VerificationContracts\.ps1\s*$' -or
+        $setupStep -notmatch
+            '(?m)^        uses: mlugg/setup-zig@[^\s]+(?:\s+#.*)?\s*$' -or
+        $setupStep -match $conditionalStepPattern -or
+        $fullSuiteStep -notmatch
+            '(?m)^        run: zig build test -Demit-test-exe=true\s*$' -or
+        $fullSuiteStep -match $conditionalStepPattern -or
+        $flagshipIndex -lt 0 -or
+        $setupIndex -le $flagshipIndex -or
+        $fullSuiteIndex -le $setupIndex) {
+        throw 'The early flagship contract must defer unavailable fixture execution to the same Windows job''s mandatory Setup Zig and full Zig test suite.'
+    }
+}
+
+function Test-FlagshipZigFixtureExecutionEnabled {
+    return $env:GITHUB_ACTIONS -ne 'true'
+}
+
+function Invoke-ZigFixture {
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot,
+        [Parameter(Mandatory)] [string] $Filter
+    )
+
+    if (-not (Test-FlagshipZigFixtureExecutionEnabled)) {
+        Write-Host "ZIG-FIXTURE-EXECUTION-SKIPPED [$Filter]: deferred to mandatory full Zig suite in the same Windows job."
+        return
+    }
+    $filterArgument = "-Dtest-filter=$Filter"
+    & (Join-Path $RepoRoot 'scripts\dev-windows.cmd') `
+        zig build test $filterArgument
+    if ($LASTEXITCODE -ne 0) {
+        throw "Zig semantic fixture '$Filter' failed with exit code $LASTEXITCODE."
+    }
 }
 
 function Get-YamlLiteralRunScript {
@@ -1397,6 +1458,10 @@ if ($invokeHarnessFunctions.Count -ne 1 -or
     throw 'Composite log paths must derive from each run scenario slug.'
 }
 
+Assert-DeferredZigFixtureExecution `
+    -WorkflowText $testWorkflowText `
+    -Source $testWorkflow
+
 $nativeKeyFilters = @('VK_PACKET', 'deferred char')
 foreach ($nativeKeyFilter in $nativeKeyFilters) {
     # Zig accepts a zero-match test filter. A narrow declaration check is
@@ -1409,12 +1474,9 @@ foreach ($nativeKeyFilter in $nativeKeyFilters) {
     if ($nativeKeyDeclarations.Count -lt 1) {
         throw "$nativeKeyFilter semantic fixture has no matching Zig test declaration."
     }
-    $nativeKeyFilterArgument = "-Dtest-filter=$nativeKeyFilter"
-    & (Join-Path $repoRoot 'scripts\dev-windows.cmd') `
-        zig build test $nativeKeyFilterArgument
-    if ($LASTEXITCODE -ne 0) {
-        throw "$nativeKeyFilter semantic fixture failed with exit code $LASTEXITCODE."
-    }
+    Invoke-ZigFixture `
+        -RepoRoot $repoRoot `
+        -Filter $nativeKeyFilter
 }
 
 if ($termioRuntimeText.Contains('self.surface_mailbox.pushTerminalOutput(buf)') -or

--- a/test/windows/flagship/baselines/origin-main.json
+++ b/test/windows/flagship/baselines/origin-main.json
@@ -21,13 +21,6 @@
       "path": "test/windows/package-portable-cli.ps1",
       "sha256": "269f010e479c78720b3649ded80199039d89a779e109a720675f640d42d4a518",
       "scenario_id": "windows.portable-cli.x64"
-    },
-    {
-      "id": "interactive-win11-harness",
-      "kind": "contract",
-      "path": "test/windows/interactive-win11-validate.ps1",
-      "sha256": "3ae33710432f4ab97cad69297b26f77e0a53581c7de5c2c3759e0f22ef0d0068",
-      "scenario_id": "windows.interactive-win11.composite"
     }
   ]
 }

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -2,6 +2,8 @@
 param(
     [switch] $Rebuild,
     [switch] $ResetState,
+    [switch] $ThemeDiagnosticOnly,
+    [switch] $ColdDiagnosticOnly,
     [int] $TimeoutSeconds = 20,
     [int] $IdleSoakSeconds = 60
 )
@@ -9,6 +11,9 @@ param(
 $ErrorActionPreference = 'Stop'
 if ($TimeoutSeconds -le 0) { throw 'TimeoutSeconds must be positive.' }
 if ($IdleSoakSeconds -lt 0) { throw 'IdleSoakSeconds must be non-negative.' }
+if ($ThemeDiagnosticOnly -and $ColdDiagnosticOnly) {
+    throw 'ThemeDiagnosticOnly and ColdDiagnosticOnly are mutually exclusive.'
+}
 $launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 . (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
@@ -65,6 +70,8 @@ if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_ACCESSIBILITY_BOOTSTRAPPED) {
     $forwarded = @('-TimeoutSeconds', $TimeoutSeconds.ToString(), '-IdleSoakSeconds', $IdleSoakSeconds.ToString())
     if ($Rebuild) { $forwarded += '-Rebuild' }
     if ($ResetState) { $forwarded += '-ResetState' }
+    if ($ThemeDiagnosticOnly) { $forwarded += '-ThemeDiagnosticOnly' }
+    if ($ColdDiagnosticOnly) { $forwarded += '-ColdDiagnosticOnly' }
     $code = 0
     Invoke-InteractiveWin11Bootstrap -RepoRoot $repoRoot -LauncherPath $launcherPath `
         -EnvironmentVariable 'WINGHOSTTY_INTERACTIVE_WIN11_ACCESSIBILITY_BOOTSTRAPPED' `
@@ -82,6 +89,10 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 public static class WinghosttyAccessibilityNative {
+    private static int lastSendInputRequested;
+    private static int lastSendInputReturned;
+    public static int LastSendInputRequested { get { return Volatile.Read(ref lastSendInputRequested); } }
+    public static int LastSendInputReturned { get { return Volatile.Read(ref lastSendInputReturned); } }
     public delegate bool EnumProc(IntPtr hwnd, IntPtr data);
     [StructLayout(LayoutKind.Sequential)] public struct POINT {
         public int x; public int y;
@@ -114,8 +125,12 @@ public static class WinghosttyAccessibilityNative {
     [StructLayout(LayoutKind.Sequential)] public struct INPUT {
         public uint type; public INPUTUNION value;
     }
-    [DllImport("user32.dll", SetLastError=true)]
+    [DllImport("user32.dll", EntryPoint="SystemParametersInfoW", CharSet=CharSet.Unicode, SetLastError=true)]
     public static extern bool SystemParametersInfo(uint action, uint parameter, ref HIGHCONTRAST value, uint flags);
+    [DllImport("user32.dll")]
+    public static extern uint GetSysColor(int index);
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, uint attribute, out uint value, uint size);
     [DllImport("user32.dll")]
     public static extern bool SetForegroundWindow(IntPtr hwnd);
     [DllImport("user32.dll")]
@@ -152,12 +167,29 @@ public static class WinghosttyAccessibilityNative {
     public static extern bool IsWindow(IntPtr hwnd);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool PostMessageW(IntPtr hwnd, uint message, UIntPtr wParam, IntPtr lParam);
+    [DllImport("user32.dll")]
+    public static extern IntPtr SendMessageW(IntPtr hwnd, uint message, UIntPtr wParam, IntPtr lParam);
+    [DllImport("user32.dll", SetLastError=true)]
+    static extern IntPtr SendMessageTimeoutW(
+        IntPtr hwnd,
+        uint message,
+        UIntPtr wParam,
+        IntPtr lParam,
+        uint flags,
+        uint timeout,
+        out UIntPtr result);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool ClientToScreen(IntPtr hwnd, ref POINT point);
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern IntPtr GetDC(IntPtr hwnd);
+    [DllImport("user32.dll")]
+    public static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+    [DllImport("gdi32.dll")]
+    public static extern uint GetPixel(IntPtr hdc, int x, int y);
     [DllImport("user32.dll", SetLastError=true)]
     public static extern bool GetGUIThreadInfo(uint threadId, ref GUITHREADINFO info);
 
@@ -185,6 +217,9 @@ public static class WinghosttyAccessibilityNative {
     private static readonly object notificationSync = new object();
     private static string notificationKind = "";
     private static string notificationDisplayString = "";
+    private static int notificationProcessing;
+    private static string notificationActivityId = "";
+    private static readonly List<object[]> notificationHistory = new List<object[]>();
     private static IntPtr notificationAutomation = IntPtr.Zero;
     private static IntPtr notificationElement = IntPtr.Zero;
     private static IntPtr notificationHandlerInterface = IntPtr.Zero;
@@ -212,13 +247,22 @@ public static class WinghosttyAccessibilityNative {
             int processing,
             string displayString,
             string activityId) {
-            RecordNotification(NotificationKindName(kind), displayString ?? "");
+            RecordNotification(
+                NotificationKindName(kind),
+                processing,
+                displayString ?? "",
+                activityId ?? "");
             return 0;
         }
     }
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int ElementFromHandleDelegate(IntPtr self, IntPtr hwnd, out IntPtr element);
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetCurrentPropertyValueDelegate(
+        IntPtr self,
+        int propertyId,
+        [MarshalAs(UnmanagedType.Struct)] out object value);
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int AddNotificationEventHandlerDelegate(
         IntPtr self,
@@ -364,17 +408,33 @@ public static class WinghosttyAccessibilityNative {
             default: return "Unknown(" + kind.ToString() + ")";
         }
     }
-    private static void RecordNotification(string kind, string displayString) {
+    private static void RecordNotification(
+        string kind,
+        int processing,
+        string displayString,
+        string activityId) {
         lock (notificationSync) {
             notificationKind = kind ?? "";
+            notificationProcessing = processing;
             notificationDisplayString = displayString ?? "";
+            notificationActivityId = activityId ?? "";
+            if (notificationHistory.Count == 256) notificationHistory.RemoveAt(0);
+            notificationHistory.Add(new object[] {
+                notificationKind,
+                notificationDisplayString,
+                notificationProcessing,
+                notificationActivityId
+            });
             Interlocked.Increment(ref notificationCount);
         }
     }
     public static void ResetNotificationCount() {
         lock (notificationSync) {
             notificationKind = "";
+            notificationProcessing = 0;
             notificationDisplayString = "";
+            notificationActivityId = "";
+            notificationHistory.Clear();
             Interlocked.Exchange(ref notificationCount, 0);
         }
     }
@@ -390,7 +450,13 @@ public static class WinghosttyAccessibilityNative {
     public static object[] NotificationSnapshot {
         get {
             lock (notificationSync) {
-                return new object[] { notificationCount, notificationKind, notificationDisplayString };
+                return new object[] {
+                    notificationCount,
+                    notificationKind,
+                    notificationDisplayString,
+                    notificationProcessing,
+                    notificationActivityId
+                };
             }
         }
     }
@@ -398,6 +464,37 @@ public static class WinghosttyAccessibilityNative {
         IntPtr vtable = Marshal.ReadIntPtr(instance);
         IntPtr function = Marshal.ReadIntPtr(vtable, slot * IntPtr.Size);
         return (T)(object)Marshal.GetDelegateForFunctionPointer(function, typeof(T));
+    }
+    public static int GetCurrentIntProperty(IntPtr hwnd, int propertyId) {
+        if (hwnd == IntPtr.Zero) throw new ArgumentException("Element HWND is null.", "hwnd");
+        Guid classId = new Guid("E22AD333-B25F-460C-83D0-0581107395C9");
+        Guid interfaceId = new Guid("25F700C8-D816-4057-A9DC-3CBDEE77E256");
+        IntPtr automation = IntPtr.Zero;
+        IntPtr element = IntPtr.Zero;
+        int hr = CoCreateInstance(ref classId, IntPtr.Zero, 1, ref interfaceId, out automation);
+        if (hr < 0) Marshal.ThrowExceptionForHR(hr);
+        try {
+            ElementFromHandleDelegate elementFromHandle = VtableDelegate<ElementFromHandleDelegate>(automation, 6);
+            hr = elementFromHandle(automation, hwnd, out element);
+            if (hr < 0) Marshal.ThrowExceptionForHR(hr);
+            GetCurrentPropertyValueDelegate getProperty =
+                VtableDelegate<GetCurrentPropertyValueDelegate>(element, 10);
+            object value;
+            hr = getProperty(element, propertyId, out value);
+            if (hr < 0) Marshal.ThrowExceptionForHR(hr);
+            return Convert.ToInt32(value);
+        }
+        finally {
+            if (element != IntPtr.Zero) Marshal.Release(element);
+            if (automation != IntPtr.Zero) Marshal.Release(automation);
+        }
+    }
+    public static object[][] NotificationHistorySnapshot {
+        get {
+            lock (notificationSync) {
+                return notificationHistory.ToArray();
+            }
+        }
     }
     public static void StartNotificationCapture(IntPtr hwnd) {
         if (hwnd == IntPtr.Zero) throw new ArgumentException("Palette HWND is null.", "hwnd");
@@ -468,7 +565,11 @@ public static class WinghosttyAccessibilityNative {
         return input;
     }
     private static bool Submit(INPUT[] inputs) {
-        return SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT))) == inputs.Length;
+        int requested = inputs.Length;
+        int returned = unchecked((int)SendInput((uint)requested, inputs, Marshal.SizeOf(typeof(INPUT))));
+        Volatile.Write(ref lastSendInputRequested, requested);
+        Volatile.Write(ref lastSendInputReturned, returned);
+        return returned == requested;
     }
     public static bool SendUnicodeText(string text) {
         System.Collections.Generic.List<INPUT> inputs = new System.Collections.Generic.List<INPUT>();
@@ -504,6 +605,28 @@ public static class WinghosttyAccessibilityNative {
             StringBuilder name = new StringBuilder(128);
             GetClassNameW(hwnd, name, name.Capacity);
             if (IsWindowVisible(hwnd) && name.ToString() == "winghostty.win32") children.Add(hwnd);
+            return true;
+        };
+        EnumChildWindows(parent, callback, IntPtr.Zero);
+        return children.ToArray();
+    }
+    public static IntPtr[] TerminalChildren(IntPtr parent) {
+        System.Collections.Generic.List<IntPtr> children = new System.Collections.Generic.List<IntPtr>();
+        EnumProc callback = delegate(IntPtr hwnd, IntPtr data) {
+            StringBuilder name = new StringBuilder(128);
+            GetClassNameW(hwnd, name, name.Capacity);
+            if (name.ToString() == "winghostty.win32") children.Add(hwnd);
+            return true;
+        };
+        EnumChildWindows(parent, callback, IntPtr.Zero);
+        return children.ToArray();
+    }
+    public static IntPtr[] VisibleChildrenByClass(IntPtr parent, string expectedClass) {
+        System.Collections.Generic.List<IntPtr> children = new System.Collections.Generic.List<IntPtr>();
+        EnumProc callback = delegate(IntPtr hwnd, IntPtr data) {
+            StringBuilder name = new StringBuilder(128);
+            GetClassNameW(hwnd, name, name.Capacity);
+            if (IsWindowVisible(hwnd) && name.ToString() == expectedClass) children.Add(hwnd);
             return true;
         };
         EnumChildWindows(parent, callback, IntPtr.Zero);
@@ -559,6 +682,62 @@ public static class WinghosttyAccessibilityNative {
         rect.right = bottomRight.x;
         rect.bottom = bottomRight.y;
         return rect;
+    }
+    public static bool TrySampleWindowClientPixel(IntPtr hwnd, int x, int y, out uint color) {
+        color = 0xFFFFFFFF;
+        IntPtr hdc = GetDC(hwnd);
+        if (hdc == IntPtr.Zero) return false;
+        try {
+            color = GetPixel(hdc, x, y);
+        }
+        finally {
+            ReleaseDC(hwnd, hdc);
+        }
+        return color != 0xFFFFFFFF;
+    }
+    public static uint SampleClientPixel(IntPtr hwnd, int x, int y) {
+        uint color;
+        if (TrySampleWindowClientPixel(hwnd, x, y, out color)) return color;
+
+        POINT point = new POINT();
+        point.x = x;
+        point.y = y;
+        if (!ClientToScreen(hwnd, ref point)) throw new System.ComponentModel.Win32Exception();
+        IntPtr screen = GetDC(IntPtr.Zero);
+        if (screen == IntPtr.Zero) throw new System.ComponentModel.Win32Exception();
+        try {
+            color = GetPixel(screen, point.x, point.y);
+            if (color == 0xFFFFFFFF) {
+                throw new InvalidOperationException(
+                    "GetPixel returned CLR_INVALID for both window and screen DCs.");
+            }
+            return color;
+        }
+        finally {
+            ReleaseDC(IntPtr.Zero, screen);
+        }
+    }
+    public static uint GetDwmUInt(IntPtr hwnd, uint attribute) {
+        uint value;
+        int hr = DwmGetWindowAttribute(hwnd, attribute, out value, sizeof(uint));
+        if (hr < 0) Marshal.ThrowExceptionForHR(hr);
+        return value;
+    }
+    public static bool TryGetDwmUInt(IntPtr hwnd, uint attribute, out uint value, out int hresult) {
+        hresult = DwmGetWindowAttribute(hwnd, attribute, out value, sizeof(uint));
+        return hresult >= 0;
+    }
+    public static bool IsWindowResponsive(IntPtr hwnd, uint timeoutMs) {
+        if (!IsWindow(hwnd)) return false;
+        UIntPtr result;
+        return SendMessageTimeoutW(
+            hwnd,
+            0,
+            UIntPtr.Zero,
+            IntPtr.Zero,
+            0x0002,
+            timeoutMs,
+            out result) != IntPtr.Zero;
     }
     public static bool ForceForeground(IntPtr hwnd) {
         // A synthetic Alt press temporarily satisfies the Win32 foreground-lock
@@ -666,6 +845,103 @@ function Send-AccessibilityChord(
     Assert-AccessibilityInputOwner -Process $Process -Description "post-$Description" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
 }
 
+function Get-AccessibilityClientPixelGrid {
+    param(
+        [Parameter(Mandatory)][IntPtr] $Hwnd,
+        [Parameter(Mandatory)][int] $MinX,
+        [Parameter(Mandatory)][int] $MaxX,
+        [Parameter(Mandatory)][int] $MinY,
+        [Parameter(Mandatory)][int] $MaxY,
+        [int] $Step = 16
+    )
+
+    $grid = [ordered]@{}
+    for ($y = $MinY; $y -le $MaxY; $y += $Step) {
+        for ($x = $MinX; $x -le $MaxX; $x += $Step) {
+            [uint32]$color = 0
+            if ([WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                $Hwnd,
+                $x,
+                $y,
+                [ref]$color
+            )) {
+                $grid["$x,$y"] = [ordered]@{ x = $x; y = $y; color = $color }
+            }
+        }
+    }
+    return $grid
+}
+
+function Find-AccessibilityClientPixel {
+    param(
+        [Parameter(Mandatory)][IntPtr] $Hwnd,
+        [Parameter(Mandatory)][System.Collections.IDictionary] $OriginalGrid,
+        [Parameter(Mandatory)][uint32] $TargetColor
+    )
+
+    foreach ($entry in $OriginalGrid.Values) {
+        [uint32]$color = 0
+        if ([WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+            $Hwnd,
+            [int]$entry.x,
+            [int]$entry.y,
+            [ref]$color
+        ) -and $color -eq $TargetColor) {
+            return [ordered]@{
+                x = [int]$entry.x
+                y = [int]$entry.y
+                original_color = [uint32]$entry.color
+                color = $color
+            }
+        }
+    }
+    return $null
+}
+
+function New-AccessibilityTempCmdLauncher(
+    [Parameter(Mandatory)][string[]] $Lines,
+    [Parameter(Mandatory)][string] $Description
+) {
+    if ([string]::IsNullOrWhiteSpace($env:TEMP)) {
+        throw "TEMP is unavailable for $Description launcher."
+    }
+    foreach ($line in $Lines) {
+        if ($null -eq $line -or $line.Contains("`r") -or $line.Contains("`n")) {
+            throw "$Description launcher lines must be non-null single lines."
+        }
+    }
+
+    $name = "wgh$([Guid]::NewGuid().ToString('N').Substring(0, 8)).cmd"
+    $path = Join-Path $env:TEMP $name
+    $command = "%TEMP%\$name"
+    $expanded = [System.Environment]::ExpandEnvironmentVariables($command)
+    if ($command -notmatch '^%TEMP%\\wgh[0-9a-f]{8}\.cmd$' -or
+        -not [string]::Equals(
+            $expanded,
+            $path,
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw "$Description launcher path mismatch: command='$command' expanded='$expanded' expected='$path'."
+    }
+
+    try {
+        [System.IO.File]::WriteAllText(
+            $path,
+            (@('@echo off') + $Lines) -join "`r`n",
+            [System.Text.UTF8Encoding]::new($false)
+        )
+    }
+    catch {
+        try { [System.IO.File]::Delete($path) } catch {}
+        throw
+    }
+    return [pscustomobject][ordered]@{
+        path = $path
+        command = $command
+        command_length = $command.Length
+    }
+}
+
 function Send-AccessibilityOutputMarker(
     [System.Diagnostics.Process] $Process,
     $TextPattern,
@@ -676,54 +952,798 @@ function Send-AccessibilityOutputMarker(
     if ($Marker -notmatch '^[A-Za-z0-9_]{12,}$') {
         throw "Output marker for $Description must be at least 12 command-safe alphanumeric/underscore characters."
     }
-    $split = [int][Math]::Floor($Marker.Length / 2)
-    $command = 'cmd.exe /d /c "echo ' + $Marker.Substring(0, $split) + '^' + $Marker.Substring($split) + '"'
-    if ($command.Contains($Marker)) {
-        throw "Output marker command for $Description contains its literal marker."
-    }
+    $launcher = New-AccessibilityTempCmdLauncher `
+        -Lines @("@echo $Marker") `
+        -Description $Description
+    $command = $launcher.command
 
-    Assert-AccessibilityInputOwner -Process $Process -Description "$Description text" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
-    if (-not [WinghosttyAccessibilityNative]::SendUnicodeText($command)) {
-        throw "SendInput failed for ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    try {
+        if ($command.Contains($Marker)) {
+            throw "Output marker command for $Description contains its literal marker."
+        }
+        Assert-AccessibilityInputOwner -Process $Process -Description "$Description text" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        if (-not [WinghosttyAccessibilityNative]::SendUnicodeText($command)) {
+            throw "SendInput failed for ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        $sendInputRequested = [WinghosttyAccessibilityNative]::LastSendInputRequested
+        $sendInputReturned = [WinghosttyAccessibilityNative]::LastSendInputReturned
+        $commandEchoEvidence = Wait-AccessibilityTerminalCommandEcho `
+            -Process $Process `
+            -TextPattern $TextPattern `
+            -Command $command `
+            -Description $Description `
+            -ExpectedFocusedHwnd $ExpectedFocusedHwnd `
+            -SendInputRequested $sendInputRequested `
+            -SendInputReturned $sendInputReturned
+        $preEnterText = $TextPattern.DocumentRange.GetText(-1)
+        if ($preEnterText.Contains($Marker)) {
+            throw "Terminal exposed output marker for $Description before Enter."
+        }
+        $preEnterForegroundBefore = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+        $preEnterFocusBefore =
+            [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+        $preEnterRecoveryCount = if (
+            $preEnterForegroundBefore -ne $Process.MainWindowHandle -or
+            $preEnterFocusBefore -ne $ExpectedFocusedHwnd
+        ) { 1 } else { 0 }
+        Assert-AccessibilityInputOwner `
+            -Process $Process `
+            -Description "$Description pre-Enter" `
+            -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        $preEnterForegroundAfter = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+        $preEnterFocusAfter =
+            [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+        Send-AccessibilityChord -Keys @([uint16]0x0D) -Description "$Description Enter" -Process $Process -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "$Description launcher output" -Condition {
+            $script:outputMarkerLauncherText = $TextPattern.DocumentRange.GetText(-1)
+            return $script:outputMarkerLauncherText.Contains($Marker)
+        }
+        return [pscustomobject][ordered]@{
+            short_command = $command
+            short_command_length = $launcher.command_length
+            send_input_requested = $sendInputRequested
+            send_input_returned = $sendInputReturned
+            command_echo = $commandEchoEvidence
+            pre_enter_foreground_before = $preEnterForegroundBefore.ToInt64()
+            pre_enter_focus_before = $preEnterFocusBefore.ToInt64()
+            pre_enter_recovery_count = $preEnterRecoveryCount
+            pre_enter_foreground_after = $preEnterForegroundAfter.ToInt64()
+            pre_enter_focus_after = $preEnterFocusAfter.ToInt64()
+            marker_visible_before_launcher_cleanup = $true
+        }
     }
-    # SendInput queues packets; a busy Debug UI thread may not have consumed
-    # the full command yet. Keep Enter behind the same drain/focus boundary as
-    # the blind helper, then prove the marker is still absent before execution.
-    Start-Sleep -Milliseconds 250
-    Assert-AccessibilityInputOwner -Process $Process -Description "$Description pre-Enter" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
-    $preEnterText = $TextPattern.DocumentRange.GetText(-1)
-    if ($preEnterText.Contains($Marker)) {
-        throw "Terminal exposed output marker for $Description before Enter."
+    finally {
+        try { [System.IO.File]::Delete($launcher.path) } catch {}
     }
-    Send-AccessibilityChord -Keys @([uint16]0x0D) -Description "$Description Enter" -Process $Process -ExpectedFocusedHwnd $ExpectedFocusedHwnd
 }
 
-function Send-AccessibilityBlindOutputMarker(
+function Get-AccessibilityOutputNotificationDiagnostic(
+    [object[]] $RawNotificationHistory,
+    [string] $Marker,
+    [int] $FocusMismatchPolls = 0,
+    [int] $FocusRecoveryCount = 0,
+    [long[]] $StolenForegroundHwnds = @(),
+    [long] $LastForegroundHwnd = 0,
+    [long] $LastFocusedHwnd = 0
+) {
+    $rawHistory = @($RawNotificationHistory)
+    $matchingHistory = @(
+        $rawHistory | Where-Object {
+            $_ -is [System.Array] -and
+            $_.Count -ge 4 -and
+            [string]$_[0] -eq 'ActionCompleted' -and
+            [int]$_[2] -eq 2 -and
+            [string]$_[3] -eq 'TerminalTextOutput'
+        }
+    )
+    $notificationText = (
+        $matchingHistory | ForEach-Object { [string]$_[1] }
+    ) -join ''
+    return [pscustomobject][ordered]@{
+        raw_notification_history = $rawHistory
+        notification_history = $matchingHistory
+        notification_text = $notificationText
+        matched = $matchingHistory.Count -gt 0 -and
+            $notificationText.Contains($Marker)
+        history = $matchingHistory
+        text = $notificationText
+        count = $matchingHistory.Count
+        focus_mismatch_polls = $FocusMismatchPolls
+        focus_recovery_count = $FocusRecoveryCount
+        stolen_foreground_hwnds = @($StolenForegroundHwnds)
+        last_foreground_hwnd = $LastForegroundHwnd
+        last_focused_hwnd = $LastFocusedHwnd
+    }
+}
+
+function Wait-AccessibilityOwnedOutputNotification(
     [System.Diagnostics.Process] $Process,
+    [IntPtr] $ExpectedFocusedHwnd,
     [string] $Marker,
     [string] $Description,
-    [IntPtr] $ExpectedFocusedHwnd
+    $Diagnostic = $null
+) {
+    if ($null -ne $Diagnostic -and
+        $Diagnostic -isnot [System.Management.Automation.PSReference]) {
+        throw 'Diagnostic must be a [ref] value when supplied.'
+    }
+    $state = [ordered]@{
+        focus_mismatch_polls = 0
+        focus_recovery_count = 0
+        stolen_foreground_hwnds = [System.Collections.Generic.List[long]]::new()
+        last_foreground_hwnd = 0
+        last_focused_hwnd = 0
+    }
+    $diagnosticValue = Get-AccessibilityOutputNotificationDiagnostic `
+        -RawNotificationHistory @() `
+        -Marker $Marker
+    $diagnosticState = [ref] $diagnosticValue
+    if ($null -ne $Diagnostic) {
+        $Diagnostic.Value = $diagnosticState.Value
+    }
+    try {
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description $Description -Condition {
+            $foregroundHwnd = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+            $focusedHwnd =
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+            $state.last_foreground_hwnd = $foregroundHwnd.ToInt64()
+            $state.last_focused_hwnd = $focusedHwnd.ToInt64()
+            $focusMismatch = $foregroundHwnd -ne $Process.MainWindowHandle -or
+                $focusedHwnd -ne $ExpectedFocusedHwnd
+            if ($focusMismatch) {
+                $state.focus_mismatch_polls++
+                if ($foregroundHwnd -ne $Process.MainWindowHandle -and
+                    -not $state.stolen_foreground_hwnds.Contains(
+                        $foregroundHwnd.ToInt64()
+                    )) {
+                    [void] $state.stolen_foreground_hwnds.Add(
+                        $foregroundHwnd.ToInt64()
+                    )
+                }
+                $state.focus_recovery_count++
+            }
+            $rawHistory = @(
+                [WinghosttyAccessibilityNative]::NotificationHistorySnapshot
+            )
+            $diagnosticState.Value =
+                Get-AccessibilityOutputNotificationDiagnostic `
+                    -RawNotificationHistory $rawHistory `
+                    -Marker $Marker `
+                    -FocusMismatchPolls $state.focus_mismatch_polls `
+                    -FocusRecoveryCount $state.focus_recovery_count `
+                    -StolenForegroundHwnds @($state.stolen_foreground_hwnds) `
+                    -LastForegroundHwnd $state.last_foreground_hwnd `
+                    -LastFocusedHwnd $state.last_focused_hwnd
+            if ($null -ne $Diagnostic) {
+                $Diagnostic.Value = $diagnosticState.Value
+            }
+            if ($focusMismatch) {
+                Assert-AccessibilityInputOwner `
+                    -Process $Process `
+                    -Description "$Description owner recovery" `
+                    -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+                return $false
+            }
+            return $diagnosticState.Value.matched
+        }
+    }
+    catch {
+        $rawHistory = @(
+            [WinghosttyAccessibilityNative]::NotificationHistorySnapshot
+        )
+        $diagnosticState.Value =
+            Get-AccessibilityOutputNotificationDiagnostic `
+                -RawNotificationHistory $rawHistory `
+                -Marker $Marker `
+                -FocusMismatchPolls $state.focus_mismatch_polls `
+                -FocusRecoveryCount $state.focus_recovery_count `
+                -StolenForegroundHwnds @($state.stolen_foreground_hwnds) `
+                -LastForegroundHwnd $state.last_foreground_hwnd `
+                -LastFocusedHwnd $state.last_focused_hwnd
+        if ($null -ne $Diagnostic) {
+            $Diagnostic.Value = $diagnosticState.Value
+        }
+        throw "$($_.Exception.Message) Diagnostic=$($diagnosticState.Value | ConvertTo-Json -Depth 5 -Compress)"
+    }
+    return $diagnosticState.Value
+}
+
+function Invoke-AccessibilityColdFirstReadProof(
+    [System.Diagnostics.Process] $Process,
+    $TextPattern,
+    [string] $Marker,
+    [string] $Description,
+    [IntPtr] $ExpectedFocusedHwnd,
+    [string] $HelperDirectory,
+    [switch] $NotificationCaptureActive
 ) {
     if ($Marker -notmatch '^[A-Za-z0-9_]{12,}$') {
-        throw "Blind output marker for $Description must be at least 12 command-safe alphanumeric/underscore characters."
+        throw "Cold output marker for $Description must be at least 12 command-safe alphanumeric/underscore characters."
     }
-    $split = [int][Math]::Floor($Marker.Length / 2)
-    $command = 'cmd.exe /d /c "echo ' + $Marker.Substring(0, $split) + '^' + $Marker.Substring($split) + '"'
-    if ($command.Contains($Marker)) {
-        throw "Blind output marker command for $Description contains its literal marker."
+    $token = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+    $helperPath = Join-Path $HelperDirectory "cold-output-$token.ps1"
+    $readyPath = Join-Path $HelperDirectory "cold-output-$token.ready"
+    $triggerPath = Join-Path $HelperDirectory "cold-output-$token.trigger"
+    $ackPath = Join-Path $HelperDirectory "cold-output-$token.ack"
+    $readyLiteral = $readyPath.Replace("'", "''")
+    $triggerLiteral = $triggerPath.Replace("'", "''")
+    $ackLiteral = $ackPath.Replace("'", "''")
+    $markerLiteral = $Marker.Replace("'", "''")
+    $helperText = @(
+        '$ErrorActionPreference = ''Stop'''
+        "[System.IO.File]::WriteAllText('$readyLiteral', 'ready')"
+        '$deadline = [DateTime]::UtcNow.AddSeconds(15)'
+        "while (-not [System.IO.File]::Exists('$triggerLiteral')) {"
+        "    if ([DateTime]::UtcNow -ge `$deadline) { throw 'cold output trigger timeout' }"
+        '    Start-Sleep -Milliseconds 25'
+        '}'
+        "[Console]::Out.WriteLine('$markerLiteral')"
+        '[Console]::Out.Flush()'
+        "[System.IO.File]::WriteAllText('$ackLiteral', 'ack')"
+    ) -join "`r`n"
+    [System.IO.File]::WriteAllText(
+        $helperPath,
+        $helperText,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $launcherPath = $null
+    $captureCreated = $false
+    try {
+        $helperInvocation =
+            'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' +
+            $helperPath.Replace('"', '""') +
+            '"'
+        $launcher = New-AccessibilityTempCmdLauncher `
+            -Lines @($helperInvocation) `
+            -Description $Description
+        $launcherPath = $launcher.path
+        $command = $launcher.command
+        if ($command.Contains($Marker)) {
+            throw "Cold output helper command for $Description contains its literal marker."
+        }
+        [WinghosttyAccessibilityNative]::ResetNotificationCount()
+        if (-not $NotificationCaptureActive) {
+            [WinghosttyAccessibilityNative]::StartNotificationCapture($ExpectedFocusedHwnd)
+            $captureCreated = $true
+        }
+
+        Assert-AccessibilityInputOwner -Process $Process -Description "$Description text" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        if (-not [WinghosttyAccessibilityNative]::SendUnicodeText($command)) {
+            throw "SendInput failed for ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        $sendInputRequested = [WinghosttyAccessibilityNative]::LastSendInputRequested
+        $sendInputReturned = [WinghosttyAccessibilityNative]::LastSendInputReturned
+        $echoEvidence = Wait-AccessibilityTerminalCommandEcho `
+            -Process $Process `
+            -TextPattern $TextPattern `
+            -Command $command `
+            -Description $Description `
+            -ExpectedFocusedHwnd $ExpectedFocusedHwnd `
+            -SendInputRequested $sendInputRequested `
+            -SendInputReturned $sendInputReturned
+        Assert-AccessibilityInputOwner -Process $Process -Description "$Description pre-Enter" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        Send-AccessibilityChord -Keys @([uint16]0x0D) -Description "$Description Enter" -Process $Process -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+
+        # From ready-file observation through the final read, readiness and
+        # output completion are proved without querying TextPattern.
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "$Description helper ready file" -Condition {
+            return [System.IO.File]::Exists($readyPath)
+        }
+        $queryInactivityMilliseconds = 1200
+        Start-Sleep -Milliseconds $queryInactivityMilliseconds
+        $postExpiryTextPatternReadsBeforeFinal = 0
+        $preTriggerForegroundBefore = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+        $preTriggerFocusBefore =
+            [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+        $preTriggerRecoveryCount = if (
+            $preTriggerForegroundBefore -ne $Process.MainWindowHandle -or
+            $preTriggerFocusBefore -ne $ExpectedFocusedHwnd
+        ) { 1 } else { 0 }
+        Assert-AccessibilityInputOwner `
+            -Process $Process `
+            -Description "$Description pre-trigger owner" `
+            -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+        $preTriggerForegroundAfter = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+        $preTriggerFocusAfter =
+            [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+        [WinghosttyAccessibilityNative]::ResetNotificationCount()
+        [System.IO.File]::WriteAllText($triggerPath, 'trigger')
+        $coldNotificationDiagnostic = $null
+        try {
+            $coldOutputNotification = Wait-AccessibilityOwnedOutputNotification `
+                -Process $Process `
+                -ExpectedFocusedHwnd $ExpectedFocusedHwnd `
+                -Marker $Marker `
+                -Description "$Description direct output notification" `
+                -Diagnostic ([ref] $coldNotificationDiagnostic)
+        }
+        catch {
+            $diagnostic = [ordered]@{
+                ready_exists = [System.IO.File]::Exists($readyPath)
+                trigger_exists = [System.IO.File]::Exists($triggerPath)
+                ack_exists = [System.IO.File]::Exists($ackPath)
+                notification_count = [WinghosttyAccessibilityNative]::NotificationCount
+                raw_notification_history =
+                    $coldNotificationDiagnostic.raw_notification_history
+                notification_history =
+                    $coldNotificationDiagnostic.notification_history
+                notification_text = $coldNotificationDiagnostic.notification_text
+                foreground_hwnd = [WinghosttyAccessibilityNative]::GetForegroundWindow().ToInt64()
+                focused_hwnd = [WinghosttyAccessibilityNative]::FocusedWindowFor(
+                    $Process.MainWindowHandle
+                ).ToInt64()
+                expected_focused_hwnd = $ExpectedFocusedHwnd.ToInt64()
+                capture_reused = [bool]$NotificationCaptureActive
+                pre_trigger_foreground_before = $preTriggerForegroundBefore.ToInt64()
+                pre_trigger_focus_before = $preTriggerFocusBefore.ToInt64()
+                pre_trigger_recovery_count = $preTriggerRecoveryCount
+                pre_trigger_foreground_after = $preTriggerForegroundAfter.ToInt64()
+                pre_trigger_focus_after = $preTriggerFocusAfter.ToInt64()
+                notification_focus_mismatch_count = $coldNotificationDiagnostic.focus_mismatch_polls
+                notification_focus_recovery_count = $coldNotificationDiagnostic.focus_recovery_count
+                notification_stolen_foreground_hwnds =
+                    $coldNotificationDiagnostic.stolen_foreground_hwnds
+                command_echo = $echoEvidence
+            }
+            throw "$($_.Exception.Message) Diagnostic=$($diagnostic | ConvertTo-Json -Depth 6 -Compress)"
+        }
+
+        $finalTextPatternReads = 1
+        $finalText = $TextPattern.DocumentRange.GetText(-1)
+        if (-not $finalText.Contains($Marker)) {
+            throw "Cold first TextPattern read did not contain $Description marker (text='$($finalText.Replace("`r", '\r').Replace("`n", '\n'))')."
+        }
+
+        return [pscustomobject][ordered]@{
+            marker = $Marker
+            marker_visible = $true
+            short_command = $command
+            short_command_length = $launcher.command_length
+            send_input_requested = $sendInputRequested
+            send_input_returned = $sendInputReturned
+            command_echo = $echoEvidence
+            ready_observed_without_uia = $true
+            query_inactivity_milliseconds = $queryInactivityMilliseconds
+            notification_history_cleared_before_trigger = $true
+            notification_capture_reused = [bool]$NotificationCaptureActive
+            output_ack_observed = [System.IO.File]::Exists($ackPath)
+            pre_trigger_foreground_before = $preTriggerForegroundBefore.ToInt64()
+            pre_trigger_focus_before = $preTriggerFocusBefore.ToInt64()
+            pre_trigger_recovery_count = $preTriggerRecoveryCount
+            pre_trigger_foreground_after = $preTriggerForegroundAfter.ToInt64()
+            pre_trigger_focus_after = $preTriggerFocusAfter.ToInt64()
+            notification_focus_mismatch_count = $coldOutputNotification.focus_mismatch_polls
+            notification_focus_recovery_count = $coldOutputNotification.focus_recovery_count
+            notification_stolen_foreground_hwnds =
+                $coldOutputNotification.stolen_foreground_hwnds
+            output_raw_notification_history =
+                $coldOutputNotification.raw_notification_history
+            output_notification_history =
+                $coldOutputNotification.notification_history
+            output_notification_count = $coldOutputNotification.count
+            output_notification_text = $coldOutputNotification.text
+            post_expiry_text_pattern_reads_before_final = $postExpiryTextPatternReadsBeforeFinal
+            final_text_pattern_reads = $finalTextPatternReads
+            final_text_length = $finalText.Length
+            final_text_tail = $finalText.Substring(
+                [Math]::Max(0, $finalText.Length - 160)
+            ).Replace("`r", '\r').Replace("`n", '\n')
+        }
     }
-    Assert-AccessibilityInputOwner -Process $Process -Description "$Description text" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
-    if (-not [WinghosttyAccessibilityNative]::SendUnicodeText($command)) {
-        throw "SendInput failed for ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    finally {
+        if ($captureCreated) {
+            [WinghosttyAccessibilityNative]::StopNotificationCapture()
+        }
+        if ([System.IO.File]::Exists($readyPath) -and
+            -not [System.IO.File]::Exists($triggerPath)) {
+            [System.IO.File]::WriteAllText($triggerPath, 'cleanup')
+        }
+        foreach ($path in @($launcherPath, $helperPath, $readyPath, $triggerPath, $ackPath)) {
+            if ($null -eq $path) { continue }
+            try { [System.IO.File]::Delete($path) } catch {}
+        }
     }
-    # SendInput returning means the keyboard packets entered the system queue,
-    # not that the terminal child consumed the full command. Keep this blind
-    # (no TextPattern query) while giving the UI thread time to drain all
-    # Unicode packets before Enter, or a busy Debug build can execute only
-    # the leading `cmd` and launch a nested shell.
-    Start-Sleep -Milliseconds 250
-    Assert-AccessibilityInputOwner -Process $Process -Description "$Description pre-Enter" -ExpectedFocusedHwnd $ExpectedFocusedHwnd
-    Send-AccessibilityChord -Keys @([uint16]0x0D) -Description "$Description Enter" -Process $Process -ExpectedFocusedHwnd $ExpectedFocusedHwnd
+}
+
+function Invoke-AccessibilityInactiveTabFirstReadProof(
+    [System.Diagnostics.Process] $Process,
+    [IntPtr] $TabAHwnd,
+    [string] $HelperDirectory
+) {
+    # Background output belongs in the retained terminal snapshot but must not
+    # be spoken from an inactive tab. Acquire tab B's provider while active,
+    # emit only after switching to A, then make one first read after returning.
+    $inactiveTabMarker = "whi$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
+    $inactiveToken = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+    $inactiveHelperPath = Join-Path $HelperDirectory "inactive-output-$inactiveToken.ps1"
+    $inactiveReadyPath = Join-Path $HelperDirectory "inactive-output-$inactiveToken.ready"
+    $inactiveTriggerPath = Join-Path $HelperDirectory "inactive-output-$inactiveToken.trigger"
+    $inactiveAckPath = Join-Path $HelperDirectory "inactive-output-$inactiveToken.ack"
+    $inactiveLauncherPath = $null
+    $inactiveCaptureStarted = $false
+    $inactiveTabEvidence = $null
+    try {
+        Send-AccessibilityChord `
+            -Keys @([uint16]0x11, [uint16]0x10, [uint16]0x54) `
+            -Description 'inactive-output new tab B' `
+            -Process $Process
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output tab B creation' -Condition {
+            $script:inactiveAllTerminals = @(
+                [WinghosttyAccessibilityNative]::TerminalChildren($Process.MainWindowHandle)
+            )
+            $script:inactiveVisibleTerminals = @(
+                [WinghosttyAccessibilityNative]::VisibleTerminalChildren($Process.MainWindowHandle)
+            )
+            return $script:inactiveAllTerminals.Count -eq 2 -and
+                $script:inactiveVisibleTerminals.Count -eq 1 -and
+                $script:inactiveVisibleTerminals[0] -ne $TabAHwnd
+        }
+        $inactiveTabHwnd = @(
+            $script:inactiveAllTerminals | Where-Object { $_ -ne $TabAHwnd }
+        )[0]
+        $inactiveTabDocument =
+            [System.Windows.Automation.AutomationElement]::FromHandle($inactiveTabHwnd)
+        $inactiveTabTextPattern = $null
+        if ($null -eq $inactiveTabDocument -or -not $inactiveTabDocument.TryGetCurrentPattern(
+            [System.Windows.Automation.TextPattern]::Pattern,
+            [ref]$inactiveTabTextPattern
+        )) {
+            throw 'Inactive-output tab B does not expose TextPattern.'
+        }
+
+        $inactiveReadyLiteral = $inactiveReadyPath.Replace("'", "''")
+        $inactiveTriggerLiteral = $inactiveTriggerPath.Replace("'", "''")
+        $inactiveAckLiteral = $inactiveAckPath.Replace("'", "''")
+        $inactiveMarkerLiteral = $inactiveTabMarker.Replace("'", "''")
+        $inactiveHelperText = @(
+            '$ErrorActionPreference = ''Stop'''
+            "[System.IO.File]::WriteAllText('$inactiveReadyLiteral', 'ready')"
+            '$deadline = [DateTime]::UtcNow.AddSeconds(15)'
+            "while (-not [System.IO.File]::Exists('$inactiveTriggerLiteral')) {"
+            "    if ([DateTime]::UtcNow -ge `$deadline) { throw 'inactive output trigger timeout' }"
+            '    Start-Sleep -Milliseconds 25'
+            '}'
+            "[Console]::Out.WriteLine('$inactiveMarkerLiteral')"
+            '[Console]::Out.Flush()'
+            'Start-Sleep -Milliseconds 250'
+            "[System.IO.File]::WriteAllText('$inactiveAckLiteral', 'ack')"
+        ) -join "`r`n"
+        [System.IO.File]::WriteAllText(
+            $inactiveHelperPath,
+            $inactiveHelperText,
+            [System.Text.UTF8Encoding]::new($false)
+        )
+        $inactiveHelperInvocation =
+            'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' +
+            $inactiveHelperPath.Replace('"', '""') +
+            '"'
+        $inactiveLauncher = New-AccessibilityTempCmdLauncher `
+            -Lines @($inactiveHelperInvocation) `
+            -Description 'inactive-output helper command'
+        $inactiveLauncherPath = $inactiveLauncher.path
+        $inactiveCommand = $inactiveLauncher.command
+        if ($inactiveCommand.Contains($inactiveTabMarker)) {
+            throw 'Inactive-output typed command contains its literal marker.'
+        }
+        Assert-AccessibilityInputOwner `
+            -Process $Process `
+            -Description 'inactive-output helper command' `
+            -ExpectedFocusedHwnd $inactiveTabHwnd
+        if (-not [WinghosttyAccessibilityNative]::SendUnicodeText($inactiveCommand)) {
+            throw "SendInput failed for inactive-output helper command: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        $inactiveSendInputRequested =
+            [WinghosttyAccessibilityNative]::LastSendInputRequested
+        $inactiveSendInputReturned =
+            [WinghosttyAccessibilityNative]::LastSendInputReturned
+        $inactiveEchoEvidence = Wait-AccessibilityTerminalCommandEcho `
+            -Process $Process `
+            -TextPattern $inactiveTabTextPattern `
+            -Command $inactiveCommand `
+            -Description 'inactive-output helper command' `
+            -ExpectedFocusedHwnd $inactiveTabHwnd `
+            -SendInputRequested $inactiveSendInputRequested `
+            -SendInputReturned $inactiveSendInputReturned
+        Send-AccessibilityChord `
+            -Keys @([uint16]0x0D) `
+            -Description 'inactive-output helper Enter' `
+            -Process $Process `
+            -ExpectedFocusedHwnd $inactiveTabHwnd
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output helper ready' -Condition {
+            return [System.IO.File]::Exists($inactiveReadyPath)
+        }
+
+        [WinghosttyAccessibilityNative]::ResetNotificationCount()
+        [WinghosttyAccessibilityNative]::StartNotificationCapture($inactiveTabHwnd)
+        $inactiveCaptureStarted = $true
+        Send-AccessibilityChord `
+            -Keys @([uint16]0x11, [uint16]0x21) `
+            -Description 'inactive-output switch to tab A' `
+            -Process $Process
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output tab A focus' -Condition {
+            $script:inactiveTabAVisible = @(
+                [WinghosttyAccessibilityNative]::VisibleTerminalChildren($Process.MainWindowHandle)
+            )
+            return $script:inactiveTabAVisible.Count -eq 1 -and
+                $script:inactiveTabAVisible[0] -eq $TabAHwnd -and
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle) -eq
+                    $TabAHwnd
+        }
+        [WinghosttyAccessibilityNative]::ResetNotificationCount()
+        $inactivePostSwitchTextPatternReads = 0
+        [System.IO.File]::WriteAllText($inactiveTriggerPath, 'trigger')
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output external ack' -Condition {
+            return [System.IO.File]::Exists($inactiveAckPath)
+        }
+        $inactiveQuietIntervalMilliseconds = 750
+        $inactiveQuietPollMilliseconds = 50
+        $inactiveQuietPollCount = 0
+        $inactiveQuietLivenessPollCount = 0
+        $inactiveQuietStarted = [DateTime]::UtcNow
+        $inactiveQuietDeadline =
+            $inactiveQuietStarted.AddMilliseconds($inactiveQuietIntervalMilliseconds)
+        $inactiveNotificationDiagnostic = $null
+        do {
+            $Process.Refresh()
+            if ($Process.HasExited -or
+                -not [WinghosttyAccessibilityNative]::IsWindowResponsive(
+                    $Process.MainWindowHandle,
+                    250
+                )) {
+                throw "Inactive-output app/UI thread became unresponsive during quiet proof after $inactiveQuietLivenessPollCount successful liveness polls."
+            }
+            $inactiveQuietLivenessPollCount++
+            $inactiveNotificationDiagnostic =
+                Get-AccessibilityOutputNotificationDiagnostic `
+                    -RawNotificationHistory @(
+                        [WinghosttyAccessibilityNative]::NotificationHistorySnapshot
+                    ) `
+                    -Marker $inactiveTabMarker
+            if ($inactiveNotificationDiagnostic.matched) {
+                throw "Inactive tab B emitted a marker speech notification during quiet proof. Diagnostic=$($inactiveNotificationDiagnostic | ConvertTo-Json -Depth 5 -Compress)"
+            }
+            if ([WinghosttyAccessibilityNative]::FocusedWindowFor(
+                $Process.MainWindowHandle
+            ) -ne $TabAHwnd) {
+                throw 'Inactive-output tab A lost focus during quiet proof.'
+            }
+            $inactiveQuietPollCount++
+            if ([DateTime]::UtcNow -lt $inactiveQuietDeadline) {
+                Start-Sleep -Milliseconds $inactiveQuietPollMilliseconds
+            }
+        } while ([DateTime]::UtcNow -lt $inactiveQuietDeadline)
+        $inactiveQuietElapsedMilliseconds =
+            [int]([DateTime]::UtcNow - $inactiveQuietStarted).TotalMilliseconds
+        if ($inactiveQuietPollCount -lt 2 -or
+            $inactiveQuietLivenessPollCount -ne $inactiveQuietPollCount -or
+            $inactivePostSwitchTextPatternReads -ne 0) {
+            throw "Inactive-output quiet proof was incomplete: polls=$inactiveQuietPollCount liveness=$inactiveQuietLivenessPollCount text_reads=$inactivePostSwitchTextPatternReads."
+        }
+        $inactiveFinalNotificationDiagnostic =
+            Get-AccessibilityOutputNotificationDiagnostic `
+                -RawNotificationHistory @(
+                    [WinghosttyAccessibilityNative]::NotificationHistorySnapshot
+                ) `
+                -Marker $inactiveTabMarker
+        if ($inactiveFinalNotificationDiagnostic.matched) {
+            throw "Inactive tab B emitted a marker speech notification at the capture boundary. Diagnostic=$($inactiveFinalNotificationDiagnostic | ConvertTo-Json -Depth 5 -Compress)"
+        }
+        [WinghosttyAccessibilityNative]::StopNotificationCapture()
+        $inactiveCaptureStarted = $false
+        $inactiveNotificationDiagnostic = $inactiveFinalNotificationDiagnostic
+        $inactiveRawNotificationHistory =
+            @($inactiveNotificationDiagnostic.raw_notification_history)
+        $inactiveNotificationHistory =
+            @($inactiveNotificationDiagnostic.notification_history)
+        $inactiveNotificationText =
+            $inactiveNotificationDiagnostic.notification_text
+
+        Send-AccessibilityChord `
+            -Keys @([uint16]0x11, [uint16]0x22) `
+            -Description 'inactive-output return to tab B' `
+            -Process $Process
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output tab B refocus' -Condition {
+            $script:inactiveTabBVisible = @(
+                [WinghosttyAccessibilityNative]::VisibleTerminalChildren($Process.MainWindowHandle)
+            )
+            return $script:inactiveTabBVisible.Count -eq 1 -and
+                $script:inactiveTabBVisible[0] -eq $inactiveTabHwnd -and
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle) -eq
+                    $inactiveTabHwnd
+        }
+        $inactiveFirstReadCount = 1
+        $inactiveFirstText = $inactiveTabTextPattern.DocumentRange.GetText(-1)
+        if (-not $inactiveFirstText.Contains($inactiveTabMarker)) {
+            throw "Inactive tab B first refocused TextPattern read missed its marker (text='$($inactiveFirstText.Replace("`r", '\r').Replace("`n", '\n'))')."
+        }
+        $inactiveTabEvidence = [ordered]@{
+            marker = $inactiveTabMarker
+            tab_a_hwnd = $TabAHwnd.ToInt64()
+            tab_b_hwnd = $inactiveTabHwnd.ToInt64()
+            command_echo = $inactiveEchoEvidence
+            short_command = $inactiveCommand
+            short_command_length = $inactiveLauncher.command_length
+            send_input_requested = $inactiveSendInputRequested
+            send_input_returned = $inactiveSendInputReturned
+            post_switch_text_pattern_reads_before_final = $inactivePostSwitchTextPatternReads
+            first_refocused_text_pattern_reads = $inactiveFirstReadCount
+            first_refocused_text_contains_marker = $true
+            inactive_raw_notification_count = $inactiveRawNotificationHistory.Count
+            inactive_notification_count = $inactiveNotificationHistory.Count
+            inactive_notification_contains_marker = $false
+            ack_observed = $true
+            quiet_interval_milliseconds = $inactiveQuietIntervalMilliseconds
+            quiet_elapsed_milliseconds = $inactiveQuietElapsedMilliseconds
+            quiet_poll_count = $inactiveQuietPollCount
+            quiet_liveness_poll_count = $inactiveQuietLivenessPollCount
+            quiet_text_pattern_reads = $inactivePostSwitchTextPatternReads
+            final_capture_snapshot_rejected_marker = $true
+        }
+
+        Send-AccessibilityChord `
+            -Keys @([uint16]0x11, [uint16]0x10, [uint16]0x57) `
+            -Description 'inactive-output close tab B' `
+            -Process $Process
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'inactive-output tab A restoration' -Condition {
+            $script:inactiveRestoredAll = @(
+                [WinghosttyAccessibilityNative]::TerminalChildren($Process.MainWindowHandle)
+            )
+            $script:inactiveRestoredVisible = @(
+                [WinghosttyAccessibilityNative]::VisibleTerminalChildren($Process.MainWindowHandle)
+            )
+            return $script:inactiveRestoredAll.Count -eq 1 -and
+                $script:inactiveRestoredVisible.Count -eq 1 -and
+                $script:inactiveRestoredVisible[0] -eq $TabAHwnd -and
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle) -eq
+                    $TabAHwnd
+        }
+    }
+    finally {
+        if ($inactiveCaptureStarted) {
+            [WinghosttyAccessibilityNative]::StopNotificationCapture()
+        }
+        if ([System.IO.File]::Exists($inactiveReadyPath) -and
+            -not [System.IO.File]::Exists($inactiveTriggerPath)) {
+            [System.IO.File]::WriteAllText($inactiveTriggerPath, 'cleanup')
+        }
+        foreach ($path in @(
+            $inactiveLauncherPath,
+            $inactiveHelperPath,
+            $inactiveReadyPath,
+            $inactiveTriggerPath,
+            $inactiveAckPath
+        )) {
+            if ($null -eq $path) { continue }
+            try { [System.IO.File]::Delete($path) } catch {}
+        }
+    }
+    return $inactiveTabEvidence
+}
+
+function Wait-AccessibilityTerminalCommandEcho(
+    [System.Diagnostics.Process] $Process,
+    $TextPattern,
+    [string] $Command,
+    [string] $Description,
+    [IntPtr] $ExpectedFocusedHwnd,
+    [int] $SendInputRequested,
+    [int] $SendInputReturned,
+    [string] $InputTransport = 'send-input'
+) {
+    $commandTail = $Command.Substring([Math]::Max(0, $Command.Length - 24))
+    $diagnostic = [ordered]@{
+        command_length = $Command.Length
+        command_tail = $commandTail
+        input_transport = $InputTransport
+        send_input_requested = $SendInputRequested
+        send_input_returned = $SendInputReturned
+        polls = 0
+        focus_mismatch_polls = 0
+        focus_recovery_count = 0
+        stolen_foreground_hwnds = [System.Collections.Generic.List[long]]::new()
+        text_reads = 0
+        transient_errors = 0
+        provider_reacquires = 0
+        max_text_length = 0
+        longest_command_prefix = 0
+        longest_command_suffix = 0
+        last_foreground_hwnd = 0
+        last_focused_hwnd = 0
+        last_text_tail = ''
+        full_echo_observed = $false
+    }
+    $effectiveDeadline = [DateTime]::UtcNow.AddSeconds(5)
+    if ($null -ne $script:accessibilityOverallDeadline -and
+        $script:accessibilityOverallDeadline -lt $effectiveDeadline) {
+        $effectiveDeadline = $script:accessibilityOverallDeadline
+    }
+    do {
+        $diagnostic.polls++
+        $foregroundHwnd = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+        $focusedHwnd = [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+        $diagnostic.last_foreground_hwnd = $foregroundHwnd.ToInt64()
+        $diagnostic.last_focused_hwnd = $focusedHwnd.ToInt64()
+        if ($foregroundHwnd -ne $Process.MainWindowHandle -or
+            $focusedHwnd -ne $ExpectedFocusedHwnd) {
+            $diagnostic.focus_mismatch_polls++
+            if ($foregroundHwnd -ne $Process.MainWindowHandle -and
+                -not $diagnostic.stolen_foreground_hwnds.Contains($foregroundHwnd.ToInt64())) {
+                [void] $diagnostic.stolen_foreground_hwnds.Add(
+                    $foregroundHwnd.ToInt64()
+                )
+            }
+            $diagnostic.focus_recovery_count++
+            [void][WinghosttyAccessibilityNative]::ForceForeground($Process.MainWindowHandle)
+            $recoveredForegroundHwnd = [WinghosttyAccessibilityNative]::GetForegroundWindow()
+            $recoveredFocusedHwnd =
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($Process.MainWindowHandle)
+            if ($recoveredForegroundHwnd -eq $Process.MainWindowHandle -and
+                $recoveredFocusedHwnd -ne $ExpectedFocusedHwnd) {
+                $recoveredDocument =
+                    [System.Windows.Automation.AutomationElement]::FromHandle($ExpectedFocusedHwnd)
+                if ($null -ne $recoveredDocument) {
+                    $recoveredDocument.SetFocus()
+                }
+            }
+            Start-Sleep -Milliseconds 100
+            continue
+        }
+        try {
+            $script:terminalCommandEchoText = $TextPattern.DocumentRange.GetText(-1)
+        }
+        catch {
+            $transient = $false
+            foreach ($hresult in (Get-AccessibilityExceptionHResults -Exception $_.Exception)) {
+                if (Test-AccessibilityTransientHResult -HResult $hresult) {
+                    $transient = $true
+                    break
+                }
+            }
+            if (-not $transient) { throw }
+            $diagnostic.transient_errors++
+            $currentDocument =
+                [System.Windows.Automation.AutomationElement]::FromHandle($ExpectedFocusedHwnd)
+            $currentPattern = $null
+            if ($null -eq $currentDocument -or -not $currentDocument.TryGetCurrentPattern(
+                [System.Windows.Automation.TextPattern]::Pattern,
+                [ref]$currentPattern
+            )) {
+                Start-Sleep -Milliseconds 100
+                continue
+            }
+            $TextPattern = $currentPattern
+            $diagnostic.provider_reacquires++
+            Start-Sleep -Milliseconds 100
+            continue
+        }
+        $diagnostic.text_reads++
+        $text = $script:terminalCommandEchoText
+        $diagnostic.max_text_length = [Math]::Max($diagnostic.max_text_length, $text.Length)
+        $tailLength = [Math]::Min(160, $text.Length)
+        $diagnostic.last_text_tail = $text.Substring($text.Length - $tailLength).
+            Replace("`r", '\r').Replace("`n", '\n')
+        $normalizedText = $text.Replace("`r", '').Replace("`n", '')
+        for ($length = $Command.Length; $length -gt $diagnostic.longest_command_prefix; $length--) {
+            if ($normalizedText.Contains($Command.Substring(0, $length))) {
+                $diagnostic.longest_command_prefix = $length
+                break
+            }
+        }
+        for ($length = $Command.Length; $length -gt $diagnostic.longest_command_suffix; $length--) {
+            if ($normalizedText.Contains($Command.Substring($Command.Length - $length))) {
+                $diagnostic.longest_command_suffix = $length
+                break
+            }
+        }
+        if ($normalizedText.Contains($Command)) {
+            $diagnostic.full_echo_observed = $true
+            return [pscustomobject]$diagnostic
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $effectiveDeadline)
+
+    throw "Timed out waiting for $Description full command echo. Diagnostic=$($diagnostic | ConvertTo-Json -Compress)"
 }
 
 function Wait-AccessibilityCondition([scriptblock] $Condition, [DateTime] $Deadline, [string] $Description) {
@@ -738,27 +1758,201 @@ function Wait-AccessibilityCondition([scriptblock] $Condition, [DateTime] $Deadl
     throw "Timed out waiting for $Description."
 }
 
+function Wait-AccessibilityWindowElement(
+    [Parameter(Mandatory)][IntPtr] $Hwnd,
+    [Parameter(Mandatory)][string] $Description
+) {
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "$Description UIA Window root" -Condition {
+        try {
+            $script:accessibilityWindowElementProbe =
+                [System.Windows.Automation.AutomationElement]::FromHandle($Hwnd)
+            return $null -ne $script:accessibilityWindowElementProbe -and
+                $script:accessibilityWindowElementProbe.Current.ControlType -eq
+                    [System.Windows.Automation.ControlType]::Window
+        }
+        catch {
+            foreach ($hresult in (Get-AccessibilityExceptionHResults -Exception $_.Exception)) {
+                if (Test-AccessibilityTransientHResult -HResult $hresult) {
+                    $script:accessibilityWindowElementProbe = $null
+                    return $false
+                }
+            }
+            throw
+        }
+    }
+    return $script:accessibilityWindowElementProbe
+}
+
+function Wait-AccessibilitySettingsProbe(
+    [Parameter(Mandatory)][System.Diagnostics.Process] $Process,
+    [Parameter(Mandatory)][string] $Description
+) {
+    try {
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "$Description HWND and UIA Window root" -Condition {
+            $script:settingsProbeWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                [uint32]$Process.Id,
+                'winghostty.win32.settings'
+            ))
+            if ($script:settingsProbeWindows.Count -ne 1) { return $false }
+            $script:settingsProbeHwnd = $script:settingsProbeWindows[0]
+            try {
+                $script:settingsProbeElement =
+                    [System.Windows.Automation.AutomationElement]::FromHandle($script:settingsProbeHwnd)
+                return $null -ne $script:settingsProbeElement -and
+                    $script:settingsProbeElement.Current.ControlType -eq
+                        [System.Windows.Automation.ControlType]::Window
+            }
+            catch {
+                foreach ($hresult in (Get-AccessibilityExceptionHResults -Exception $_.Exception)) {
+                    if (Test-AccessibilityTransientHResult -HResult $hresult) { return $false }
+                }
+                throw
+            }
+        }
+    }
+    catch {
+        $probeAlive = if ($null -eq $script:settingsProbeHwnd) {
+            $false
+        } else {
+            [WinghosttyAccessibilityNative]::IsWindow($script:settingsProbeHwnd)
+        }
+        $probeType = if ($null -eq $script:settingsProbeElement) {
+            '<none>'
+        } else {
+            try { $script:settingsProbeElement.Current.ControlType.ProgrammaticName } catch { '<unavailable>' }
+        }
+        throw "$($_.Exception.Message) count=$(@($script:settingsProbeWindows).Count) hwnd=$($script:settingsProbeHwnd) alive=$probeAlive root_type=$probeType."
+    }
+    return [pscustomobject]@{
+        Hwnd = $script:settingsProbeHwnd
+        Element = $script:settingsProbeElement
+    }
+}
+
 function Open-AccessibilitySettingsProbe {
     param(
         [Parameter(Mandatory)][System.Diagnostics.Process] $Process,
         [Parameter(Mandatory)][string] $Description
     )
 
-    Assert-AccessibilityInputOwner -Process $Process -Description "$Description open"
-    if (-not [WinghosttyAccessibilityNative]::SendChord(@([uint16]0x11, [uint16]0xBC))) {
-        throw "SendInput failed while opening ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
-    }
-    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "$Description HWND" -Condition {
-        $script:settingsProbeWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+    $deadline = [DateTime]::UtcNow.AddSeconds(5)
+    $sectionNames = @('Appearance', 'Terminal', 'Shell', 'Privacy', 'Updates', 'Keybindings', 'Advanced')
+    $sentForCurrentNoWindowState = $false
+    $lastWindows = @()
+    $lastHwnd = [IntPtr]::Zero
+    $lastRootType = '<none>'
+    $lastSectionCount = 0
+    do {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            throw "$Description process exited while opening Settings."
+        }
+        $lastWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
             [uint32]$Process.Id,
             'winghostty.win32.settings'
         ))
-        return $script:settingsProbeWindows.Count -eq 1
+        if ($lastWindows.Count -gt 0) {
+            $sentForCurrentNoWindowState = $false
+            if ($lastWindows.Count -eq 1) {
+                $lastHwnd = $lastWindows[0]
+                $element = $null
+                try {
+                    if ([WinghosttyAccessibilityNative]::IsWindow($lastHwnd)) {
+                        $element =
+                            [System.Windows.Automation.AutomationElement]::FromHandle($lastHwnd)
+                    }
+                    if ($null -ne $element) {
+                        $lastRootType = $element.Current.ControlType.ProgrammaticName
+                        if ($element.Current.ControlType -eq
+                            [System.Windows.Automation.ControlType]::Window) {
+                            $descendants = @($element.FindAll(
+                                [System.Windows.Automation.TreeScope]::Descendants,
+                                [System.Windows.Automation.Condition]::TrueCondition
+                            ) | ForEach-Object { $_ })
+                            $sections = @($descendants | Where-Object {
+                                $_.Current.ControlType -eq
+                                    [System.Windows.Automation.ControlType]::RadioButton -and
+                                $sectionNames -contains $_.Current.Name
+                            })
+                            $observedSectionNames = @($sections | ForEach-Object { $_.Current.Name })
+                            $lastSectionCount = $sections.Count
+                            $stableWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                                [uint32]$Process.Id,
+                                'winghostty.win32.settings'
+                            ))
+                            if ($sections.Count -eq $sectionNames.Count -and
+                                @($sectionNames | Where-Object {
+                                    $observedSectionNames -notcontains $_
+                                }).Count -eq 0 -and
+                                $stableWindows.Count -eq 1 -and
+                                $stableWindows[0] -eq $lastHwnd -and
+                                [WinghosttyAccessibilityNative]::IsWindow($lastHwnd)) {
+                                return [pscustomobject]@{
+                                    Hwnd = $lastHwnd
+                                    Element = $element
+                                }
+                            }
+                        }
+                    }
+                }
+                catch {
+                    $transient = $false
+                    foreach ($hresult in (Get-AccessibilityExceptionHResults -Exception $_.Exception)) {
+                        if (Test-AccessibilityTransientHResult -HResult $hresult) {
+                            $transient = $true
+                            break
+                        }
+                    }
+                    if (-not $transient -and [WinghosttyAccessibilityNative]::IsWindow($lastHwnd)) {
+                        throw
+                    }
+                }
+            }
+        }
+        elseif (-not $sentForCurrentNoWindowState) {
+            [void][WinghosttyAccessibilityNative]::ForceForeground($Process.MainWindowHandle)
+            $terminalHwnds = @([WinghosttyAccessibilityNative]::VisibleTerminalChildren(
+                $Process.MainWindowHandle
+            ))
+            $focusedHwnd = [WinghosttyAccessibilityNative]::FocusedWindowFor(
+                $Process.MainWindowHandle
+            )
+            $terminalHwnd = if ($terminalHwnds -contains $focusedHwnd) {
+                $focusedHwnd
+            } elseif ($terminalHwnds.Count -gt 0) {
+                $terminalHwnds[0]
+            } else {
+                [IntPtr]::Zero
+            }
+            if ($terminalHwnd -ne [IntPtr]::Zero) {
+                if ($focusedHwnd -ne $terminalHwnd) {
+                    $terminalElement =
+                        [System.Windows.Automation.AutomationElement]::FromHandle($terminalHwnd)
+                    if ($null -ne $terminalElement) { $terminalElement.SetFocus() }
+                }
+                if ([WinghosttyAccessibilityNative]::GetForegroundWindow() -eq
+                        $Process.MainWindowHandle -and
+                    [WinghosttyAccessibilityNative]::FocusedWindowFor(
+                        $Process.MainWindowHandle
+                    ) -eq $terminalHwnd) {
+                    if (-not [WinghosttyAccessibilityNative]::SendChord(
+                        @([uint16]0x11, [uint16]0xBC)
+                    )) {
+                        throw "SendInput failed while opening ${Description}: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+                    }
+                    $sentForCurrentNoWindowState = $true
+                }
+            }
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    $alive = if ($lastHwnd -eq [IntPtr]::Zero) {
+        $false
+    } else {
+        [WinghosttyAccessibilityNative]::IsWindow($lastHwnd)
     }
-    $hwnd = $script:settingsProbeWindows[0]
-    $element = [System.Windows.Automation.AutomationElement]::FromHandle($hwnd)
-    if ($null -eq $element) { throw "$Description exposes no UIA root." }
-    return [pscustomobject]@{ Hwnd = $hwnd; Element = $element }
+    throw "Timed out opening $Description with one stable Settings HWND/UIA root/section set. count=$($lastWindows.Count) hwnd=$lastHwnd alive=$alive root_type=$lastRootType sections=$lastSectionCount chord_sent_for_zero_state=$sentForCurrentNoWindowState."
 }
 
 function Get-AccessibilityScrollbackProbe {
@@ -807,6 +2001,871 @@ function Get-AccessibilityScrollbackProbe {
     }) | Select-Object -First 1
     if ($null -eq $save) { throw "$Description exposes no Save button." }
     return [pscustomobject]@{ Edit = $edit; Value = $value; Save = $save }
+}
+
+function Get-AccessibilityThemeProbe {
+    param(
+        [Parameter(Mandatory)] $SettingsProbe,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    $elements = @($SettingsProbe.Element.FindAll(
+        [System.Windows.Automation.TreeScope]::Descendants,
+        [System.Windows.Automation.Condition]::TrueCondition
+    ) | ForEach-Object { $_ })
+    $appearance = @($elements | Where-Object {
+        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::RadioButton -and
+        $_.Current.Name -eq 'Appearance'
+    }) | Select-Object -First 1
+    $appearanceSelection = $null
+    if ($null -eq $appearance -or -not $appearance.TryGetCurrentPattern(
+        [System.Windows.Automation.SelectionItemPattern]::Pattern,
+        [ref]$appearanceSelection
+    )) {
+        throw "$Description cannot select the Appearance settings section."
+    }
+    $appearanceSelection.Select()
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description "$Description Appearance section" -Condition {
+        return $appearanceSelection.Current.IsSelected
+    }
+    $elements = @($SettingsProbe.Element.FindAll(
+        [System.Windows.Automation.TreeScope]::Descendants,
+        [System.Windows.Automation.Condition]::TrueCondition
+    ) | ForEach-Object { $_ })
+    $combo = @($elements | Where-Object {
+        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::ComboBox -and
+        $_.Current.Name -eq 'Window theme'
+    }) | Select-Object -First 1
+    $save = @($elements | Where-Object {
+        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::Button -and
+        $_.Current.Name -eq 'Save'
+    }) | Select-Object -First 1
+    if ($null -eq $combo -or $null -eq $save) {
+        throw "$Description exposes no Window theme combo and Save button."
+    }
+    $hwnd = [IntPtr]$combo.Current.NativeWindowHandle
+    $index = [WinghosttyAccessibilityNative]::SendMessageW(
+        $hwnd,
+        0x0147,
+        [UIntPtr]::Zero,
+        [IntPtr]::Zero
+    ).ToInt64()
+    return [pscustomobject]@{
+        Combo = $combo
+        Hwnd = $hwnd
+        Index = $index
+        Save = $save
+    }
+}
+
+function Set-AccessibilityThemeIndex {
+    param(
+        [Parameter(Mandatory)] $SettingsProbe,
+        [Parameter(Mandatory)] $ThemeProbe,
+        [Parameter(Mandatory)][int] $Index,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    [void][WinghosttyAccessibilityNative]::SendMessageW(
+        $ThemeProbe.Hwnd,
+        0x014E,
+        [UIntPtr]::new([uint32]$Index),
+        [IntPtr]::Zero
+    )
+    [void][WinghosttyAccessibilityNative]::SendMessageW(
+        $SettingsProbe.Hwnd,
+        0x0111,
+        [UIntPtr]::new(0x00010195),
+        $ThemeProbe.Hwnd
+    )
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description $Description -Condition {
+        return [WinghosttyAccessibilityNative]::SendMessageW(
+            $ThemeProbe.Hwnd,
+            0x0147,
+            [UIntPtr]::Zero,
+            [IntPtr]::Zero
+        ).ToInt64() -eq $Index
+    }
+}
+
+function Get-AccessibilityDwmUInt {
+    param(
+        [Parameter(Mandatory)][IntPtr] $Hwnd,
+        [Parameter(Mandatory)][uint32] $Attribute,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    [uint32]$value = 0
+    [int]$hresult = 0
+    if (-not [WinghosttyAccessibilityNative]::TryGetDwmUInt(
+        $Hwnd,
+        $Attribute,
+        [ref]$value,
+        [ref]$hresult
+    )) {
+        $unsignedHresult = [BitConverter]::ToUInt32(
+            [BitConverter]::GetBytes($hresult),
+            0
+        )
+        throw "$Description DWM attribute $Attribute is unavailable (HRESULT=0x$($unsignedHresult.ToString('X8')))."
+    }
+    return $value
+}
+
+function Invoke-AccessibilityHighContrastProof(
+    [Parameter(Mandatory)][System.Diagnostics.Process] $Process,
+    [Parameter(Mandatory)][string] $DiagnosticDirectory
+) {
+    function Get-HighContrastState {
+        $value = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
+        $value.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($value)
+        if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(
+            0x42,
+            $value.cbSize,
+            [ref]$value,
+            0
+        )) {
+            throw "SPI_GETHIGHCONTRAST failed: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        $scheme = if ($value.lpszDefaultScheme -eq [IntPtr]::Zero) {
+            $null
+        } else {
+            [Runtime.InteropServices.Marshal]::PtrToStringUni($value.lpszDefaultScheme)
+        }
+        return [pscustomobject]@{ flags = [uint32]$value.dwFlags; scheme = $scheme }
+    }
+
+    function Set-HighContrastState {
+        param([Parameter(Mandatory)] $State)
+
+        $schemePointer = [IntPtr]::Zero
+        try {
+            if ($null -ne $State.scheme) {
+                $schemePointer = [Runtime.InteropServices.Marshal]::StringToHGlobalUni(
+                    [string]$State.scheme
+                )
+            }
+            $value = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
+            $value.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($value)
+            $value.dwFlags = [uint32]$State.flags
+            $value.lpszDefaultScheme = $schemePointer
+            if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(
+                0x43,
+                $value.cbSize,
+                [ref]$value,
+                2
+            )) {
+                throw "SPI_SETHIGHCONTRAST failed: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+            }
+        }
+        finally {
+            if ($schemePointer -ne [IntPtr]::Zero) {
+                [Runtime.InteropServices.Marshal]::FreeHGlobal($schemePointer)
+            }
+        }
+    }
+
+    function Get-DwmProbe {
+        param([Parameter(Mandatory)][IntPtr] $Hwnd)
+
+        if (-not [WinghosttyAccessibilityNative]::IsWindow($Hwnd)) {
+            throw "DWM probe HWND is no longer alive: $Hwnd."
+        }
+        $probe = [ordered]@{}
+        foreach ($entry in @(
+            @{ Name = 'immersive_dark_20'; Attribute = 20; Expected = 0 },
+            @{ Name = 'immersive_dark_19'; Attribute = 19; Expected = 0 },
+            @{ Name = 'caption_color'; Attribute = 35; Expected = [uint32]::MaxValue },
+            @{ Name = 'text_color'; Attribute = 36; Expected = [uint32]::MaxValue },
+            @{ Name = 'backdrop_type'; Attribute = 38; Expected = 1 }
+        )) {
+            [uint32]$value = 0
+            [int]$hresult = 0
+            $supported = [WinghosttyAccessibilityNative]::TryGetDwmUInt(
+                $Hwnd,
+                [uint32]$entry.Attribute,
+                [ref]$value,
+                [ref]$hresult
+            )
+            $probe[$entry.Name] = [ordered]@{
+                attribute = $entry.Attribute
+                supported = $supported
+                hresult = ('0x{0:X8}' -f [BitConverter]::ToUInt32([BitConverter]::GetBytes($hresult), 0))
+                value = if ($supported) { $value } else { $null }
+                expected_high_contrast = $entry.Expected
+            }
+        }
+        return $probe
+    }
+
+    function Get-DwmHighContrastResetDiagnostic {
+        param(
+            [Parameter(Mandatory)] $Before,
+            [Parameter(Mandatory)] $During
+        )
+
+        $failures = [System.Collections.Generic.List[string]]::new()
+        foreach ($name in @(
+            'immersive_dark_20',
+            'immersive_dark_19',
+            'caption_color',
+            'text_color',
+            'backdrop_type'
+        )) {
+            $beforeValue = $Before[$name]
+            $duringValue = $During[$name]
+            if ($beforeValue.supported -and -not $duringValue.supported) {
+                [void] $failures.Add(
+                    "DWM attribute $($duringValue.attribute) became unreadable under High Contrast ($($duringValue.hresult))."
+                )
+            }
+            if ($duringValue.supported -and
+                [uint32]$duringValue.value -ne [uint32]$duringValue.expected_high_contrast) {
+                [void] $failures.Add(
+                    "DWM attribute $($duringValue.attribute) High Contrast reset mismatch: actual=0x$(([uint32]$duringValue.value).ToString('X8')) expected=0x$(([uint32]$duringValue.expected_high_contrast).ToString('X8'))."
+                )
+            }
+            if (-not $beforeValue.supported -and -not $duringValue.supported -and
+                $beforeValue.hresult -ne $duringValue.hresult) {
+                [void] $failures.Add(
+                    "DWM attribute $($duringValue.attribute) unsupported result changed across High Contrast: before=$($beforeValue.hresult) during=$($duringValue.hresult)."
+                )
+            }
+        }
+        if (-not $During.immersive_dark_20.supported -and
+            -not $During.immersive_dark_19.supported -and
+            ($During.immersive_dark_20.hresult -ne '0x80070057' -or
+                $During.immersive_dark_19.hresult -ne '0x80070057')) {
+            [void] $failures.Add(
+                'Both immersive-dark DWM reads are unavailable without the expected E_INVALIDARG capability result.'
+            )
+        }
+        return [pscustomobject][ordered]@{
+            exact = $failures.Count -eq 0
+            failures = @($failures)
+        }
+    }
+
+    function Get-DwmExactDiagnostic {
+        param(
+            [Parameter(Mandatory)] $Expected,
+            [Parameter(Mandatory)] $Actual
+        )
+
+        $attributes = [ordered]@{}
+        $exact = $true
+        foreach ($name in @(
+            'immersive_dark_20',
+            'immersive_dark_19',
+            'caption_color',
+            'text_color',
+            'backdrop_type'
+        )) {
+            $expectedValue = $Expected[$name]
+            $actualValue = $Actual[$name]
+            $supportedExact = [bool]$expectedValue.supported -eq
+                [bool]$actualValue.supported
+            $hresultExact = [string]$expectedValue.hresult -ceq
+                [string]$actualValue.hresult
+            $valueExact = if ($expectedValue.supported -and $actualValue.supported) {
+                [uint32]$expectedValue.value -eq [uint32]$actualValue.value
+            } else {
+                $true
+            }
+            $attributeExact = $supportedExact -and $hresultExact -and $valueExact
+            $attributes[$name] = [ordered]@{
+                exact = $attributeExact
+                supported_exact = $supportedExact
+                hresult_exact = $hresultExact
+                value_exact = $valueExact
+                expected = $expectedValue
+                actual = $actualValue
+            }
+            $exact = $exact -and $attributeExact
+        }
+        return [ordered]@{
+            exact = $exact
+            attributes = $attributes
+        }
+    }
+
+    function Get-SettingsProbeDiagnostic {
+        param([Parameter(Mandatory)] $Probe)
+
+        $diagnostic = [ordered]@{
+            top_level_count_exact = $false
+            original_hwnd_exact = $false
+            hwnd_alive = [WinghosttyAccessibilityNative]::IsWindow($Probe.Hwnd)
+            uia_window_root = $false
+            section_count_exact = $false
+            section_names_exact = $false
+            observed_section_names = @()
+            stable = $false
+            error = $null
+        }
+        try {
+            $windows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                [uint32]$Process.Id,
+                'winghostty.win32.settings'
+            ))
+            $diagnostic.top_level_hwnds = @($windows | ForEach-Object { $_.ToInt64() })
+            $diagnostic.top_level_count_exact = $windows.Count -eq 1
+            $diagnostic.original_hwnd_exact = $windows.Count -eq 1 -and
+                $windows[0] -eq $Probe.Hwnd
+            if (-not $diagnostic.original_hwnd_exact -or -not $diagnostic.hwnd_alive) {
+                return $diagnostic
+            }
+            $root = [System.Windows.Automation.AutomationElement]::FromHandle($Probe.Hwnd)
+            $diagnostic.uia_window_root = $null -ne $root -and
+                $root.Current.ControlType -eq [System.Windows.Automation.ControlType]::Window
+            if (-not $diagnostic.uia_window_root) { return $diagnostic }
+            $sectionNames = @(
+                'Appearance',
+                'Terminal',
+                'Shell',
+                'Privacy',
+                'Updates',
+                'Keybindings',
+                'Advanced'
+            )
+            $sections = @($root.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.Condition]::TrueCondition
+            ) | Where-Object {
+                $_.Current.ControlType -eq
+                    [System.Windows.Automation.ControlType]::RadioButton -and
+                $sectionNames -contains $_.Current.Name
+            })
+            $observedNames = @($sections | ForEach-Object { $_.Current.Name })
+            $diagnostic.observed_section_names = $observedNames
+            $diagnostic.section_count_exact = $sections.Count -eq $sectionNames.Count
+            $diagnostic.section_names_exact =
+                @($sectionNames | Where-Object { $observedNames -notcontains $_ }).Count -eq 0
+            $diagnostic.stable = $diagnostic.top_level_count_exact -and
+                $diagnostic.original_hwnd_exact -and
+                $diagnostic.hwnd_alive -and
+                $diagnostic.uia_window_root -and
+                $diagnostic.section_count_exact -and
+                $diagnostic.section_names_exact
+            return $diagnostic
+        }
+        catch {
+            $diagnostic.error = $_.Exception.Message
+            $diagnostic.hwnd_alive =
+                [WinghosttyAccessibilityNative]::IsWindow($Probe.Hwnd)
+            return $diagnostic
+        }
+    }
+
+    function Get-SettingsSemanticSnapshots {
+        param([Parameter(Mandatory)][IntPtr] $SettingsHwnd)
+
+        $targets = @(
+            @($SettingsHwnd) + @([WinghosttyAccessibilityNative]::VisibleChildrenByClass(
+                $SettingsHwnd,
+                'Static'
+            ))
+        )
+        $snapshots = [System.Collections.Generic.List[object]]::new()
+        foreach ($targetHwnd in $targets) {
+            $targetClass = [WinghosttyAccessibilityNative]::WindowClass($targetHwnd)
+            if ($targetClass -ne 'Static' -and $targetHwnd -ne $SettingsHwnd) { continue }
+            $targetRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen($targetHwnd)
+            $width = $targetRect.right - $targetRect.left
+            $height = $targetRect.bottom - $targetRect.top
+            if ($width -le 8 -or $height -le 8) { continue }
+            foreach ($yOrdinal in 1..5) {
+                $y = [Math]::Min($height - 5, [Math]::Max(4, [int]($height * $yOrdinal / 6)))
+                foreach ($xOrdinal in 1..5) {
+                    $x = [Math]::Min($width - 5, [Math]::Max(4, [int]($width * $xOrdinal / 6)))
+                    [uint32]$color = 0
+                    if (-not [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                        $targetHwnd,
+                        $x,
+                        $y,
+                        [ref]$color
+                    )) {
+                        continue
+                    }
+                    $screenPoint = [WinghosttyAccessibilityNative+POINT]::new()
+                    $screenPoint.x = $targetRect.left + $x
+                    $screenPoint.y = $targetRect.top + $y
+                    if ([WinghosttyAccessibilityNative]::WindowFromPoint($screenPoint) -ne
+                        $targetHwnd) {
+                        continue
+                    }
+                    $snapshots.Add([pscustomobject]@{
+                        hwnd = $targetHwnd
+                        class_name = $targetClass
+                        client_x = $x
+                        client_y = $y
+                        screen_x = $screenPoint.x
+                        screen_y = $screenPoint.y
+                        baseline_color = $color
+                    })
+                }
+            }
+        }
+        return @($snapshots)
+    }
+
+    function Get-SettingsSemanticPixelDiagnostic {
+        param(
+            [Parameter(Mandatory)] $Pixel,
+            [Parameter(Mandatory)][uint32] $ExpectedColor
+        )
+
+        $diagnostic = [ordered]@{
+            hwnd = $Pixel.hwnd.ToInt64()
+            hwnd_alive = [WinghosttyAccessibilityNative]::IsWindow($Pixel.hwnd)
+            expected_class = $Pixel.class_name
+            actual_class = $null
+            class_exact = $false
+            client_x = [int]$Pixel.client_x
+            client_y = [int]$Pixel.client_y
+            client_coordinate_in_bounds = $false
+            baseline_screen_x = [int]$Pixel.screen_x
+            baseline_screen_y = [int]$Pixel.screen_y
+            current_screen_x = $null
+            current_screen_y = $null
+            client_rect = $null
+            window_from_point_hwnd = 0
+            window_from_point_exact = $false
+            expected_color = [uint32]$ExpectedColor
+            actual_color = $null
+            color_sample_valid = $false
+            color_exact = $false
+            exact = $false
+            error = $null
+        }
+        if (-not $diagnostic.hwnd_alive) { return $diagnostic }
+        try {
+            $diagnostic.actual_class =
+                [WinghosttyAccessibilityNative]::WindowClass($Pixel.hwnd)
+            $diagnostic.class_exact =
+                $diagnostic.actual_class -ceq $Pixel.class_name
+            $rect = [WinghosttyAccessibilityNative]::ClientRectOnScreen($Pixel.hwnd)
+            $diagnostic.client_rect = [ordered]@{
+                left = $rect.left
+                top = $rect.top
+                right = $rect.right
+                bottom = $rect.bottom
+            }
+            $width = $rect.right - $rect.left
+            $height = $rect.bottom - $rect.top
+            $diagnostic.client_coordinate_in_bounds =
+                $Pixel.client_x -ge 0 -and $Pixel.client_x -lt $width -and
+                $Pixel.client_y -ge 0 -and $Pixel.client_y -lt $height
+            $point = [WinghosttyAccessibilityNative+POINT]::new()
+            $point.x = $rect.left + [int]$Pixel.client_x
+            $point.y = $rect.top + [int]$Pixel.client_y
+            $diagnostic.current_screen_x = $point.x
+            $diagnostic.current_screen_y = $point.y
+            $hitHwnd = [WinghosttyAccessibilityNative]::WindowFromPoint($point)
+            $diagnostic.window_from_point_hwnd = $hitHwnd.ToInt64()
+            $diagnostic.window_from_point_exact = $hitHwnd -eq $Pixel.hwnd
+            [uint32]$color = 0
+            $diagnostic.color_sample_valid =
+                [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                    $Pixel.hwnd,
+                    [int]$Pixel.client_x,
+                    [int]$Pixel.client_y,
+                    [ref]$color
+                )
+            if ($diagnostic.color_sample_valid) {
+                $diagnostic.actual_color = $color
+                $diagnostic.color_exact = $color -eq $ExpectedColor
+            }
+            $diagnostic.exact = $diagnostic.hwnd_alive -and
+                $diagnostic.class_exact -and
+                $diagnostic.client_coordinate_in_bounds -and
+                $diagnostic.window_from_point_exact -and
+                $diagnostic.color_sample_valid -and
+                $diagnostic.color_exact
+            return $diagnostic
+        }
+        catch {
+            $diagnostic.error = $_.Exception.Message
+            return $diagnostic
+        }
+    }
+
+    function Write-HighContrastRestoreDiagnostic {
+        param(
+            [Parameter(Mandatory)] $Diagnostic,
+            [Parameter(Mandatory)][string] $Path
+        )
+
+        $json = $Diagnostic | ConvertTo-Json -Depth 12
+        [System.IO.File]::WriteAllText(
+            $Path,
+            $json,
+            [System.Text.UTF8Encoding]::new($false)
+        )
+    }
+
+    $before = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
+    $before.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($before)
+    if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(
+        0x42,
+        $before.cbSize,
+        [ref]$before,
+        0
+    )) {
+        throw "SPI_GETHIGHCONTRAST targeted preflight failed: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    }
+    $beforeScheme = if ($before.lpszDefaultScheme -eq [IntPtr]::Zero) {
+        $null
+    } else {
+        [Runtime.InteropServices.Marshal]::PtrToStringUni($before.lpszDefaultScheme)
+    }
+    $beforeState = [pscustomobject]@{
+        flags = [uint32]$before.dwFlags
+        scheme = $beforeScheme
+    }
+    $hostWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+        [uint32]$Process.Id,
+        'winghostty.win32.host'
+    ))
+    if ($hostWindows.Count -ne 1) {
+        throw "High Contrast proof requires one native host HWND; found $($hostWindows.Count)."
+    }
+    $hostHwnd = $hostWindows[0]
+    $settings = Open-AccessibilitySettingsProbe `
+        -Process $Process `
+        -Description 'High Contrast baseline Settings'
+    $settingsHwnd = $settings.Hwnd
+    $beforeHostDwm = Get-DwmProbe -Hwnd $hostHwnd
+    $beforeSettingsDwm = Get-DwmProbe -Hwnd $settingsHwnd
+    $semanticSnapshots = @(Get-SettingsSemanticSnapshots -SettingsHwnd $settingsHwnd)
+    if ($semanticSnapshots.Count -eq 0) {
+        throw 'High Contrast baseline Settings exposed no stable Static/parent semantic snapshots.'
+    }
+    $recoveryPath = Join-Path (
+        [System.IO.Path]::GetTempPath()
+    ) ("winghostty-high-contrast-recovery-$PID-$([Guid]::NewGuid().ToString('N')).json")
+    $restoreDiagnosticPath = Join-Path `
+        $DiagnosticDirectory `
+        'high-contrast-restore-diagnostic.json'
+    $beforeState | ConvertTo-Json | Set-Content -LiteralPath $recoveryPath -Encoding utf8
+    if (-not [System.IO.File]::Exists($recoveryPath)) {
+        throw 'High Contrast recovery snapshot was not persisted.'
+    }
+    $result = [ordered]@{ restored = $false }
+    $toggleAttempted = $false
+    $semanticPixel = $null
+    $semanticHitCount = 0
+    $changedSemanticHitCount = 0
+    try {
+        $toggleAttempted = $true
+        Set-HighContrastState -State ([pscustomobject]@{
+            flags = [uint32]($beforeState.flags -bor 1)
+            scheme = $beforeState.scheme
+        })
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'targeted High Contrast activation' -Condition {
+            $script:targetedHcActive = Get-HighContrastState
+            return [bool]($script:targetedHcActive.flags -band 1)
+        }
+        $script:duringDwm = $null
+        try {
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'host High Contrast DWM convergence' -Condition {
+                $Process.Refresh()
+                $currentHostWindows = @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                    [uint32]$Process.Id,
+                    'winghostty.win32.host'
+                ))
+                if ($Process.HasExited -or $currentHostWindows.Count -ne 1 -or
+                    $currentHostWindows[0] -ne $hostHwnd -or
+                    -not [WinghosttyAccessibilityNative]::IsWindow($hostHwnd)) {
+                    return $false
+                }
+                $script:duringDwm = Get-DwmProbe -Hwnd $hostHwnd
+                return (Get-DwmHighContrastResetDiagnostic `
+                    -Before $beforeHostDwm `
+                    -During $script:duringDwm).exact
+            }
+        }
+        catch {
+            $finalDwm = if ($null -eq $script:duringDwm) {
+                '<unavailable>'
+            } else {
+                $script:duringDwm | ConvertTo-Json -Depth 4 -Compress
+            }
+            throw "Host High Contrast DWM state did not converge on stable HWND $hostHwnd. final=$finalDwm. $($_.Exception.Message)"
+        }
+        $duringDwm = $script:duringDwm
+        $dwmResetDiagnostic = Get-DwmHighContrastResetDiagnostic `
+            -Before $beforeHostDwm `
+            -During $duringDwm
+        if (-not $dwmResetDiagnostic.exact) {
+            throw ($dwmResetDiagnostic.failures -join ' ')
+        }
+        $buttonFace = [WinghosttyAccessibilityNative]::GetSysColor(15)
+        $script:semanticHitCount = 0
+        $script:changedSemanticHitCount = 0
+        $script:semanticPixel = $null
+        try {
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'same Settings HWND High Contrast semantic system-role pixel' -Condition {
+                if (-not (Get-SettingsProbeDiagnostic -Probe $settings).stable) {
+                    return $false
+                }
+                $hits = @($semanticSnapshots | Where-Object {
+                    (Get-SettingsSemanticPixelDiagnostic `
+                        -Pixel $_ `
+                        -ExpectedColor $buttonFace).exact
+                })
+                $changedHits = @($hits | Where-Object {
+                    [uint32]$_.baseline_color -ne $buttonFace
+                })
+                $script:semanticHitCount = $hits.Count
+                $script:changedSemanticHitCount = $changedHits.Count
+                $script:semanticPixel = if ($changedHits.Count -gt 0) {
+                    $changedHits[0]
+                } elseif ($hits.Count -gt 0) {
+                    $hits[0]
+                } else {
+                    $null
+                }
+                return $null -ne $script:semanticPixel
+            }
+        }
+        catch {
+            throw "High Contrast semantic pixel selection failed: candidates=$($semanticSnapshots.Count) hits=$($script:semanticHitCount) changed_hits=$($script:changedSemanticHitCount). $($_.Exception.Message)"
+        }
+        $semanticPixel = $script:semanticPixel
+        $semanticHitCount = $script:semanticHitCount
+        $changedSemanticHitCount = $script:changedSemanticHitCount
+        $result = [ordered]@{
+            os_build = [Environment]::OSVersion.Version.Build
+            host_hwnd = $hostHwnd.ToInt64()
+            settings_hwnd = $settingsHwnd.ToInt64()
+            dwm_before = $beforeHostDwm
+            settings_dwm_before = $beforeSettingsDwm
+            dwm_high_contrast = $duringDwm
+            settings_system_color = $buttonFace
+            settings_sample_hwnd = $semanticPixel.hwnd.ToInt64()
+            settings_sample_class = $semanticPixel.class_name
+            settings_sample_x = $semanticPixel.client_x
+            settings_sample_y = $semanticPixel.client_y
+            settings_sample_screen_x = $semanticPixel.screen_x
+            settings_sample_screen_y = $semanticPixel.screen_y
+            settings_semantic_candidate_count = $semanticSnapshots.Count
+            settings_semantic_hit_count = $semanticHitCount
+            settings_changed_semantic_hit_count = $changedSemanticHitCount
+            settings_normal_color = $semanticPixel.baseline_color
+            restore_diagnostic_path = $restoreDiagnosticPath
+            restored = $false
+        }
+    }
+    finally {
+        try {
+            Set-HighContrastState -State $beforeState
+            $verifyState = Get-HighContrastState
+            if ($verifyState.flags -ne $beforeState.flags -or
+                $verifyState.scheme -cne $beforeState.scheme) {
+                $stateDiagnostic = [ordered]@{
+                    captured_utc = [DateTime]::UtcNow.ToString('o')
+                    phase = 'exact-spi-restore'
+                    recovery_path = $recoveryPath
+                    expected_state = $beforeState
+                    actual_state = $verifyState
+                    exact_spi_state = $false
+                }
+                Write-HighContrastRestoreDiagnostic `
+                    -Diagnostic $stateDiagnostic `
+                    -Path $restoreDiagnosticPath
+                throw "Targeted High Contrast state was not restored exactly. diagnostic=$restoreDiagnosticPath recovery=$recoveryPath"
+            }
+            if ($toggleAttempted -and $null -ne $semanticPixel) {
+                $compoundRestoreDeadline = [DateTime]::UtcNow.AddSeconds(10)
+                $script:hcRestorePollCount = 0
+                $script:hcRestoreDiagnostic = $null
+                try {
+                    Wait-AccessibilityCondition -Deadline $compoundRestoreDeadline -Description 'compound post-High Contrast app reversal' -Condition {
+                        $script:hcRestorePollCount++
+                        $Process.Refresh()
+                        $currentHostWindows = @(
+                            [WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                                [uint32]$Process.Id,
+                                'winghostty.win32.host'
+                            )
+                        )
+                        $hostCountExact = $currentHostWindows.Count -eq 1
+                        $hostOriginalExact = $hostCountExact -and
+                            $currentHostWindows[0] -eq $hostHwnd
+                        $hostAlive = [WinghosttyAccessibilityNative]::IsWindow($hostHwnd)
+                        $hostDwm = $null
+                        $hostDwmError = $null
+                        $hostDwmExact = $false
+                        $hostDwmDiagnostic = $null
+                        if ($hostAlive) {
+                            try {
+                                $hostDwm = Get-DwmProbe -Hwnd $hostHwnd
+                                $hostDwmDiagnostic = Get-DwmExactDiagnostic `
+                                    -Expected $beforeHostDwm `
+                                    -Actual $hostDwm
+                                $hostDwmExact = [bool]$hostDwmDiagnostic.exact
+                            }
+                            catch {
+                                $hostDwmError = $_.Exception.Message
+                            }
+                        }
+
+                        $settingsDiagnostic =
+                            Get-SettingsProbeDiagnostic -Probe $settings
+                        $settingsDwm = $null
+                        $settingsDwmError = $null
+                        $settingsDwmExact = $false
+                        $settingsDwmDiagnostic = $null
+                        if ($settingsDiagnostic.hwnd_alive) {
+                            try {
+                                $settingsDwm = Get-DwmProbe -Hwnd $settingsHwnd
+                                $settingsDwmDiagnostic = Get-DwmExactDiagnostic `
+                                    -Expected $beforeSettingsDwm `
+                                    -Actual $settingsDwm
+                                $settingsDwmExact =
+                                    [bool]$settingsDwmDiagnostic.exact
+                            }
+                            catch {
+                                $settingsDwmError = $_.Exception.Message
+                            }
+                        }
+
+                        $semanticDiagnostic =
+                            Get-SettingsSemanticPixelDiagnostic `
+                                -Pixel $semanticPixel `
+                                -ExpectedColor (
+                                    [uint32]$semanticPixel.baseline_color
+                                )
+                        $foregroundHwnd =
+                            [WinghosttyAccessibilityNative]::GetForegroundWindow()
+                        $hostFocusedHwnd = if ($hostAlive) {
+                            [WinghosttyAccessibilityNative]::FocusedWindowFor($hostHwnd)
+                        } else {
+                            [IntPtr]::Zero
+                        }
+                        $settingsFocusedHwnd = if ($settingsDiagnostic.hwnd_alive) {
+                            [WinghosttyAccessibilityNative]::FocusedWindowFor(
+                                $settingsHwnd
+                            )
+                        } else {
+                            [IntPtr]::Zero
+                        }
+                        $compoundExact = -not $Process.HasExited -and
+                            $hostCountExact -and
+                            $hostOriginalExact -and
+                            $hostAlive -and
+                            $settingsDiagnostic.stable -and
+                            $hostDwmExact -and
+                            $settingsDwmExact -and
+                            $semanticDiagnostic.exact
+                        $script:hcRestoreDiagnostic = [ordered]@{
+                            captured_utc = [DateTime]::UtcNow.ToString('o')
+                            phase = 'compound-app-restore'
+                            poll = $script:hcRestorePollCount
+                            timed_out = $false
+                            deadline_utc = $compoundRestoreDeadline.ToString('o')
+                            budget_seconds = 10
+                            recovery_path = $recoveryPath
+                            diagnostic_path = $restoreDiagnosticPath
+                            process_alive = -not $Process.HasExited
+                            exact_spi_state = $true
+                            host = [ordered]@{
+                                expected_hwnd = $hostHwnd.ToInt64()
+                                top_level_hwnds = @(
+                                    $currentHostWindows |
+                                        ForEach-Object { $_.ToInt64() }
+                                )
+                                top_level_count_exact = $hostCountExact
+                                original_hwnd_exact = $hostOriginalExact
+                                hwnd_alive = $hostAlive
+                                dwm_exact = $hostDwmExact
+                                dwm_error = $hostDwmError
+                                dwm_actual = $hostDwm
+                                dwm = $hostDwmDiagnostic
+                            }
+                            settings = $settingsDiagnostic
+                            settings_dwm_exact = $settingsDwmExact
+                            settings_dwm_error = $settingsDwmError
+                            settings_dwm_actual = $settingsDwm
+                            settings_dwm = $settingsDwmDiagnostic
+                            semantic_pixel = $semanticDiagnostic
+                            foreground_hwnd = $foregroundHwnd.ToInt64()
+                            host_focused_hwnd = $hostFocusedHwnd.ToInt64()
+                            settings_focused_hwnd =
+                                $settingsFocusedHwnd.ToInt64()
+                            compound_exact = $compoundExact
+                        }
+                        Write-HighContrastRestoreDiagnostic `
+                            -Diagnostic $script:hcRestoreDiagnostic `
+                            -Path $restoreDiagnosticPath
+                        return $compoundExact
+                    }
+                    $compoundRestoreCompleted = $true
+                }
+                catch {
+                    if ($null -ne $script:hcRestoreDiagnostic) {
+                        $script:hcRestoreDiagnostic.timed_out = $true
+                        $script:hcRestoreDiagnostic.timeout_error =
+                            $_.Exception.Message
+                        $script:hcRestoreDiagnostic.captured_utc =
+                            [DateTime]::UtcNow.ToString('o')
+                        Write-HighContrastRestoreDiagnostic `
+                            -Diagnostic $script:hcRestoreDiagnostic `
+                            -Path $restoreDiagnosticPath
+                    }
+                    $finalRestore = if ($null -eq $script:hcRestoreDiagnostic) {
+                        '<unavailable>'
+                    } else {
+                        $script:hcRestoreDiagnostic |
+                            ConvertTo-Json -Depth 12 -Compress
+                    }
+                    throw "Compound High Contrast app reversal failed. diagnostic=$restoreDiagnosticPath recovery=$recoveryPath final=$finalRestore. $($_.Exception.Message)"
+                }
+                $result['dwm_restored'] =
+                    $script:hcRestoreDiagnostic.host.dwm_actual
+                $result['settings_dwm_restored'] =
+                    $script:hcRestoreDiagnostic.settings_dwm_actual
+                $result['settings_reversed_color'] =
+                    [uint32]$script:hcRestoreDiagnostic.semantic_pixel.actual_color
+            }
+            else {
+                $compoundRestoreCompleted = $false
+                $unavailableDiagnostic = [ordered]@{
+                    captured_utc = [DateTime]::UtcNow.ToString('o')
+                    phase = 'compound-app-restore-unavailable'
+                    recovery_path = $recoveryPath
+                    diagnostic_path = $restoreDiagnosticPath
+                    exact_spi_state = $true
+                    toggle_attempted = $toggleAttempted
+                    semantic_pixel_available = $null -ne $semanticPixel
+                    compound_exact = $false
+                }
+                Write-HighContrastRestoreDiagnostic `
+                    -Diagnostic $unavailableDiagnostic `
+                    -Path $restoreDiagnosticPath
+            }
+            if ($compoundRestoreCompleted) {
+                $result.restored = $true
+                [System.IO.File]::Delete($recoveryPath)
+                if ([System.IO.File]::Exists($recoveryPath)) {
+                    throw "High Contrast recovery snapshot could not be deleted after verified compound restore: $recoveryPath"
+                }
+            }
+        }
+        finally {
+            [void][WinghosttyAccessibilityNative]::PostMessageW(
+                $settingsHwnd,
+                0x0010,
+                [UIntPtr]::Zero,
+                [IntPtr]::Zero
+            )
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'same Settings HWND close after High Contrast proof' -Condition {
+                return -not [WinghosttyAccessibilityNative]::IsWindow($settingsHwnd)
+            }
+        }
+    }
+    return $result
 }
 
 function Invoke-AccessibilitySettingsCloseAction {
@@ -1113,9 +3172,31 @@ if ($LASTEXITCODE -ne 0) { throw 'Unable to establish accessibility worktree pro
 $stdout = Join-Path $layout.Logs 'interactive-win11-accessibility-stdout.log'
 $stderr = Join-Path $layout.Logs 'interactive-win11-accessibility-stderr.log'
 $artifact = Join-Path $layout.Logs 'uia-tree.json'
+$themePreviewConfigPath = Join-Path $layout.LocalAppData 'winghostty\config.ghostty'
+$themePreviewConfigDirectory = Split-Path -Parent $themePreviewConfigPath
+[void][System.IO.Directory]::CreateDirectory($themePreviewConfigDirectory)
+$themePreviewConfigText = if (Test-Path -LiteralPath $themePreviewConfigPath) {
+    Get-Content -LiteralPath $themePreviewConfigPath -Raw
+}
+else {
+    ''
+}
+$themePreviewConfigText = [regex]::Replace(
+    $themePreviewConfigText,
+    '(?m)^[ \t]*window-theme[ \t]*=.*(?:\r?\n|$)',
+    ''
+)
+if ($themePreviewConfigText.Length -ne 0 -and -not $themePreviewConfigText.EndsWith("`n")) {
+    $themePreviewConfigText += "`r`n"
+}
+$themePreviewConfigText += "window-theme = system`r`n"
+$themePreviewUtf8 = [System.Text.UTF8Encoding]::new($false)
+[System.IO.File]::WriteAllText($themePreviewConfigPath, $themePreviewConfigText, $themePreviewUtf8)
+[byte[]]$themePreviewConfigBaselineBytes = [System.IO.File]::ReadAllBytes($themePreviewConfigPath)
 $document = $null
 $textChangedHandler = $null
 $textChangedRegistered = $false
+$terminalNotificationCaptureStarted = $false
 $paletteSelectionHandler = $null
 $paletteSelectionRegistered = $false
 $settingsFocusHandler = $null
@@ -1147,7 +3228,7 @@ $terminalRectCount = 0
 $queryOnlyMarker = "whq$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
 $queryOnlyRangeRefreshed = $false
 $coldQueryMarker = "whc$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
-$coldQueryFirstRangeFresh = $false
+$coldQueryPostEchoRangeFresh = $false
 $splitBaseline = 0
 $splitAfterRight = 0
 $splitAfterDown = 0
@@ -1171,6 +3252,7 @@ $paletteUnavailableQuery = "zzzzwinghosttynomatch$([Guid]::NewGuid().ToString('N
 $settingsLifecycle = $null
 $settingsOwnerLifecycle = $null
 $sustainedOutputEvidence = $null
+$inactiveTabEvidence = $null
 $evidence = $null
 $runFailure = $null
 $cleanupFailures = [System.Collections.Generic.List[string]]::new()
@@ -1208,12 +3290,265 @@ try {
     if ($root.Current.ControlType -ne [System.Windows.Automation.ControlType]::Window) {
         throw "UIA root control type is $($root.Current.ControlType.ProgrammaticName), expected Window."
     }
+    if ($ThemeDiagnosticOnly) {
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'theme diagnostic terminal Text element' -Condition {
+            $script:themeDiagnosticDocuments = @($root.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.PropertyCondition]::new(
+                    [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                    [System.Windows.Automation.ControlType]::Text
+                )
+            ) | Where-Object {
+                $_.Current.ProcessId -eq $process.Id -and
+                $_.Current.LocalizedControlType -eq 'terminal'
+            })
+            return $script:themeDiagnosticDocuments.Count -gt 0
+        }
+        $themeDiagnosticDocument = $script:themeDiagnosticDocuments[0]
+        $themeDiagnosticTerminalHwnd = [IntPtr]$themeDiagnosticDocument.Current.NativeWindowHandle
+        [void][WinghosttyAccessibilityNative]::ForceForeground($process.MainWindowHandle)
+        $themeDiagnosticDocument.SetFocus()
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'theme diagnostic terminal focus' -Condition {
+            return [WinghosttyAccessibilityNative]::FocusedWindowFor($process.MainWindowHandle) -eq
+                $themeDiagnosticTerminalHwnd
+        }
+        Assert-AccessibilityInputOwner `
+            -Process $process `
+            -Description 'theme diagnostic Settings open' `
+            -ExpectedFocusedHwnd $themeDiagnosticTerminalHwnd
+        if (-not [WinghosttyAccessibilityNative]::SendChord(@([uint16]0x11, [uint16]0xBC))) {
+            throw "SendInput failed while opening theme diagnostic Settings: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        $themeDiagnosticProbe = Wait-AccessibilitySettingsProbe `
+            -Process $process `
+            -Description 'theme diagnostic Settings'
+        $themeDiagnosticHwnd = $themeDiagnosticProbe.Hwnd
+        $themeDiagnosticElement = $themeDiagnosticProbe.Element
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'theme diagnostic Window theme combo' -Condition {
+            $script:themeDiagnosticElements = @($themeDiagnosticElement.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.Condition]::TrueCondition
+            ) | ForEach-Object { $_ })
+            $script:themeDiagnosticCombo = @($script:themeDiagnosticElements | Where-Object {
+                $_.Current.Name -eq 'Window theme' -and
+                $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::ComboBox
+            }) | Select-Object -First 1
+            return $null -ne $script:themeDiagnosticCombo
+        }
+        $themeDiagnosticComboHwnd = [IntPtr]$script:themeDiagnosticCombo.Current.NativeWindowHandle
+        $themeDiagnosticInitialIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+            $themeDiagnosticComboHwnd,
+            0x0147,
+            [UIntPtr]::Zero,
+            [IntPtr]::Zero
+        ).ToInt64()
+        if ($themeDiagnosticInitialIndex -ne 1) {
+            throw "Theme diagnostic expected seeded System index 1; found $themeDiagnosticInitialIndex."
+        }
+        $themeDiagnosticSettingsRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen($themeDiagnosticHwnd)
+        $themeDiagnosticHostRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen($process.MainWindowHandle)
+        $themeDiagnosticSettingsGrid = Get-AccessibilityClientPixelGrid `
+            -Hwnd $themeDiagnosticHwnd -MinX 24 `
+            -MaxX ([Math]::Max(24, ($themeDiagnosticSettingsRect.right - $themeDiagnosticSettingsRect.left) - 24)) `
+            -MinY 24 -MaxY ([Math]::Max(24, ($themeDiagnosticSettingsRect.bottom - $themeDiagnosticSettingsRect.top) - 24)) -Step 16
+        $themeDiagnosticHostGrid = Get-AccessibilityClientPixelGrid `
+            -Hwnd $process.MainWindowHandle -MinX 24 `
+            -MaxX ([Math]::Max(24, ($themeDiagnosticHostRect.right - $themeDiagnosticHostRect.left) - 24)) `
+            -MinY 8 -MaxY ([Math]::Max(8, [Math]::Min(48, ($themeDiagnosticHostRect.bottom - $themeDiagnosticHostRect.top) - 8))) -Step 8
+        foreach ($target in @(
+            @{ Index = 3; Name = 'Dark'; Color = [uint32]0x00202020 },
+            @{ Index = 2; Name = 'Light'; Color = [uint32]0x00F3F3F3 }
+        )) {
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $themeDiagnosticComboHwnd,
+                0x014E,
+                [UIntPtr]::new([uint64]$target.Index),
+                [IntPtr]::Zero
+            )
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $themeDiagnosticHwnd,
+                0x0111,
+                [UIntPtr]::new(0x00010195),
+                $themeDiagnosticComboHwnd
+            )
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "theme diagnostic $($target.Name) pixels" -Condition {
+                $script:themeDiagnosticIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+                    $themeDiagnosticComboHwnd,
+                    0x0147,
+                    [UIntPtr]::Zero,
+                    [IntPtr]::Zero
+                ).ToInt64()
+                $script:themeDiagnosticSettingsPixel = Find-AccessibilityClientPixel `
+                    -Hwnd $themeDiagnosticHwnd -OriginalGrid $themeDiagnosticSettingsGrid -TargetColor $target.Color
+                $script:themeDiagnosticHostPixel = Find-AccessibilityClientPixel `
+                    -Hwnd $process.MainWindowHandle -OriginalGrid $themeDiagnosticHostGrid -TargetColor $target.Color
+                return $script:themeDiagnosticIndex -eq $target.Index -and
+                    $null -ne $script:themeDiagnosticSettingsPixel -and
+                    $null -ne $script:themeDiagnosticHostPixel
+            }
+        }
+        $themeDiagnosticLightSettingsColor = $script:themeDiagnosticSettingsPixel.color
+        $themeDiagnosticLightHostColor = $script:themeDiagnosticHostPixel.color
+        [void][WinghosttyAccessibilityNative]::SendMessageW(
+            $themeDiagnosticComboHwnd,
+            0x014E,
+            [UIntPtr]::new(1),
+            [IntPtr]::Zero
+        )
+        [void][WinghosttyAccessibilityNative]::SendMessageW(
+            $themeDiagnosticHwnd,
+            0x0111,
+            [UIntPtr]::new(0x00010195),
+            $themeDiagnosticComboHwnd
+        )
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'theme diagnostic System revert' -Condition {
+            return [WinghosttyAccessibilityNative]::SendMessageW(
+                $themeDiagnosticComboHwnd,
+                0x0147,
+                [UIntPtr]::Zero,
+                [IntPtr]::Zero
+            ).ToInt64() -eq 1
+        }
+        [void][WinghosttyAccessibilityNative]::PostMessageW(
+            $themeDiagnosticHwnd,
+            0x0010,
+            [UIntPtr]::Zero,
+            [IntPtr]::Zero
+        )
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'theme diagnostic Settings close' -Condition {
+            return -not [WinghosttyAccessibilityNative]::IsWindow($themeDiagnosticHwnd)
+        }
+        [byte[]]$themeDiagnosticConfigBytes = [System.IO.File]::ReadAllBytes($themePreviewConfigPath)
+        if ([Convert]::ToBase64String($themePreviewConfigBaselineBytes) -ne
+            [Convert]::ToBase64String($themeDiagnosticConfigBytes)) {
+            throw 'Targeted theme preview changed config.ghostty bytes.'
+        }
+        [void][WinghosttyAccessibilityNative]::ForceForeground($process.MainWindowHandle)
+        $themeDiagnosticDocument.SetFocus()
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'theme diagnostic pre-HC terminal focus' -Condition {
+            return [WinghosttyAccessibilityNative]::FocusedWindowFor($process.MainWindowHandle) -eq
+                $themeDiagnosticTerminalHwnd
+        }
+        $themeDiagnosticHighContrast = Invoke-AccessibilityHighContrastProof `
+            -Process $process `
+            -DiagnosticDirectory $layout.Logs
+        $evidence = [ordered]@{
+            schema_version = 1
+            outcome = 'pass'
+            mode = 'theme-diagnostic'
+            system_index = $themeDiagnosticInitialIndex
+            final_index = 1
+            settings_hwnd_closed = -not [WinghosttyAccessibilityNative]::IsWindow($themeDiagnosticHwnd)
+            host_hwnd_alive = [WinghosttyAccessibilityNative]::IsWindow($process.MainWindowHandle)
+            exact_light_settings_color = $themeDiagnosticLightSettingsColor
+            exact_light_host_color = $themeDiagnosticLightHostColor
+            config_bytes_unchanged = $true
+            high_contrast = $themeDiagnosticHighContrast
+            provenance = [ordered]@{
+                source_commit = $sourceCommit
+                executable_path = $resolvedExe
+                executable_sha256 = $binaryHash
+                validation_started_utc = $validationStartedAt.ToString('o')
+            }
+        }
+    }
+    elseif ($ColdDiagnosticOnly) {
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'cold diagnostic terminal Text element' -Condition {
+            $script:coldDiagnosticDocuments = @($root.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.PropertyCondition]::new(
+                    [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                    [System.Windows.Automation.ControlType]::Text
+                )
+            ) | Where-Object {
+                $_.Current.ProcessId -eq $process.Id -and
+                $_.Current.LocalizedControlType -eq 'terminal'
+            })
+            return $script:coldDiagnosticDocuments.Count -gt 0
+        }
+        $document = $script:coldDiagnosticDocuments[0]
+        $coldDiagnosticTerminalHwnd = [IntPtr]$document.Current.NativeWindowHandle
+        $coldDiagnosticTextPattern = $null
+        if (-not $document.TryGetCurrentPattern(
+            [System.Windows.Automation.TextPattern]::Pattern,
+            [ref]$coldDiagnosticTextPattern
+        )) {
+            throw 'Cold diagnostic terminal Text element does not expose TextPattern.'
+        }
+        [void][WinghosttyAccessibilityNative]::ForceForeground($process.MainWindowHandle)
+        $document.SetFocus()
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'cold diagnostic terminal focus' -Condition {
+            return [WinghosttyAccessibilityNative]::GetForegroundWindow() -eq $process.MainWindowHandle -and
+                [WinghosttyAccessibilityNative]::FocusedWindowFor($process.MainWindowHandle) -eq
+                    $coldDiagnosticTerminalHwnd
+        }
+
+        # Exercise the same continuous native notification subscription as the
+        # full flow: prove one warm notification, retain that exact handler and
+        # provider, then reset only its local history for the true-cold marker.
+        [WinghosttyAccessibilityNative]::ResetNotificationCount()
+        [WinghosttyAccessibilityNative]::StartNotificationCapture($coldDiagnosticTerminalHwnd)
+        $terminalNotificationCaptureStarted = $true
+        $coldDiagnosticWarmMarker = "whw$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
+        $coldDiagnosticWarmInput = Send-AccessibilityOutputMarker `
+            -Process $process `
+            -TextPattern $coldDiagnosticTextPattern `
+            -Marker $coldDiagnosticWarmMarker `
+            -Description 'cold diagnostic warm notification marker' `
+            -ExpectedFocusedHwnd $coldDiagnosticTerminalHwnd
+        $coldDiagnosticWarmNotification =
+            Wait-AccessibilityOwnedOutputNotification `
+                -Process $process `
+                -ExpectedFocusedHwnd $coldDiagnosticTerminalHwnd `
+                -Marker $coldDiagnosticWarmMarker `
+                -Description 'cold diagnostic warm output notification'
+        $script:coldDiagnosticWarmHistory =
+            @($coldDiagnosticWarmNotification.history)
+
+        $coldDiagnosticProof = Invoke-AccessibilityColdFirstReadProof `
+            -Process $process `
+            -TextPattern $coldDiagnosticTextPattern `
+            -Marker $coldQueryMarker `
+            -Description 'cold diagnostic first-read TextPattern marker' `
+            -ExpectedFocusedHwnd $coldDiagnosticTerminalHwnd `
+            -HelperDirectory $layout.Logs `
+            -NotificationCaptureActive
+        [WinghosttyAccessibilityNative]::StopNotificationCapture()
+        $terminalNotificationCaptureStarted = $false
+        $coldDiagnosticInactiveTabProof =
+            Invoke-AccessibilityInactiveTabFirstReadProof `
+                -Process $process `
+                -TabAHwnd $coldDiagnosticTerminalHwnd `
+                -HelperDirectory $layout.Logs
+        $evidence = [ordered]@{
+            schema_version = 1
+            outcome = 'pass'
+            mode = 'cold-diagnostic'
+            marker = $coldQueryMarker
+            marker_visible = $true
+            terminal_hwnd = $coldDiagnosticTerminalHwnd.ToInt64()
+            warm_notification_marker = $coldDiagnosticWarmMarker
+            warm_notification_count = $script:coldDiagnosticWarmHistory.Count
+            warm_input = $coldDiagnosticWarmInput
+            warm_notification = $coldDiagnosticWarmNotification
+            cold_first_read = $coldDiagnosticProof
+            inactive_tab = $coldDiagnosticInactiveTabProof
+            provenance = [ordered]@{
+                source_commit = $sourceCommit
+                executable_path = $resolvedExe
+                executable_sha256 = $binaryHash
+                validation_started_utc = $validationStartedAt.ToString('o')
+            }
+        }
+    }
+    else {
     $documents = @($elements | Where-Object {
         $_.Current.ProcessId -eq $process.Id -and
-        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::Document
+        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::Text -and
+        $_.Current.LocalizedControlType -eq 'terminal'
     })
     if ($documents.Count -eq 0) {
-        throw 'UIA tree contains no terminal Document element.'
+        throw 'UIA tree contains no terminal Text element.'
     }
     $document = $documents[0]
     $textPattern = $null
@@ -1221,7 +3556,7 @@ try {
         [System.Windows.Automation.TextPattern]::Pattern,
         [ref] $textPattern
     )) {
-        throw 'Terminal Document does not expose the UIA Text pattern.'
+        throw 'Terminal Text element does not expose the UIA Text pattern.'
     }
     $documentFocusError = $null
     try { $document.SetFocus() } catch { $documentFocusError = $_.Exception.Message }
@@ -1353,6 +3688,9 @@ try {
     }
 
     [WinghosttyAccessibilityNative]::ResetTextChangedCount()
+    [WinghosttyAccessibilityNative]::ResetNotificationCount()
+    [WinghosttyAccessibilityNative]::StartNotificationCapture($focusedHwnd)
+    $terminalNotificationCaptureStarted = $true
     $textChangedHandler = [Delegate]::CreateDelegate(
         [System.Windows.Automation.AutomationEventHandler],
         [WinghosttyAccessibilityNative].GetMethod('OnTextChanged')
@@ -1366,7 +3704,7 @@ try {
     $textChangedRegistered = $true
 
     $textChangedObservationStart = [DateTime]::UtcNow
-    Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $marker -Description 'terminal marker' -ExpectedFocusedHwnd $focusedHwnd
+    $terminalWarmInput = Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $marker -Description 'terminal marker' -ExpectedFocusedHwnd $focusedHwnd
     try {
         Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'terminal marker through TextPattern' -Condition {
             $script:terminalTextProbe = $textPattern.DocumentRange.GetText(-1)
@@ -1388,14 +3726,65 @@ try {
     if ($textChangedCount -gt $textChangedLimit) {
         throw "Terminal emitted $textChangedCount TextChanged events in $([Math]::Round($textChangedElapsedSeconds, 2))s; limit=$textChangedLimit."
     }
+    $terminalWarmNotification = Wait-AccessibilityOwnedOutputNotification `
+        -Process $process `
+        -ExpectedFocusedHwnd $focusedHwnd `
+        -Marker $marker `
+        -Description 'terminal marker output notification'
+    $script:terminalOutputHistory = @($terminalWarmNotification.history)
+    $script:terminalOutputSpoken = $terminalWarmNotification.text
+    $oversizedTerminalOutput = @($script:terminalOutputHistory | Where-Object {
+        ([System.Text.Encoding]::UTF8.GetByteCount([string]$_[1])) -gt 1000
+    })
+    if ($oversizedTerminalOutput.Count -ne 0) {
+        throw "Terminal output notification exceeded the 1000-byte speech chunk ceiling."
+    }
+    $terminalOutputNotification = @(
+        $script:terminalOutputHistory.Count,
+        'ActionCompleted',
+        $script:terminalOutputSpoken,
+        2,
+        'TerminalTextOutput'
+    )
+    if ($terminalOutputNotification[1] -ne 'ActionCompleted' -or
+        [string]::IsNullOrWhiteSpace([string]$terminalOutputNotification[2]) -or
+        -not ([string]$terminalOutputNotification[2]).Contains($marker) -or
+        $terminalOutputNotification[3] -ne 2 -or
+        $terminalOutputNotification[4] -ne 'TerminalTextOutput') {
+        throw "Terminal output notification metadata mismatch: count=$($terminalOutputNotification[0]) kind='$($terminalOutputNotification[1])' display='$($terminalOutputNotification[2])' processing=$($terminalOutputNotification[3]) activity='$($terminalOutputNotification[4])'."
+    }
+
+    $liveSettingValue = [WinghosttyAccessibilityNative]::GetCurrentIntProperty(
+        $focusedHwnd,
+        30135
+    )
+    if ($liveSettingValue -ne 1) {
+        throw "Terminal live setting is '$liveSettingValue'; expected Polite (1)."
+    }
+    $liveSetting = 'Polite'
 
     $supportedTextSelection = $textPattern.SupportedTextSelection
     if ($supportedTextSelection -ne [System.Windows.Automation.SupportedTextSelection]::None) {
-        throw "Terminal TextPattern unexpectedly advertises selection support: $supportedTextSelection."
+        throw "Terminal TextPattern advertises '$supportedTextSelection'; expected None."
     }
+    # Compatibility path for legacy clients. TextPattern2.GetCaretRange is
+    # canonical; this range remains readable but is not a mutable selection.
     $selection = @($textPattern.GetSelection())
-    if ($selection.Count -ne 0) {
-        throw "Terminal TextPattern returned $($selection.Count) legacy selection ranges despite reporting None."
+    if ($selection.Count -ne 1) {
+        throw "Terminal TextPattern returned $($selection.Count) legacy selection ranges; expected one caret."
+    }
+    if ($selection[0].CompareEndpoints(
+        [System.Windows.Automation.Text.TextPatternRangeEndpoint]::Start,
+        $selection[0],
+        [System.Windows.Automation.Text.TextPatternRangeEndpoint]::End
+    ) -ne 0) {
+        throw 'Terminal legacy selection is not a degenerate caret range.'
+    }
+    $selectionLine = $selection[0].Clone()
+    $selectionLine.ExpandToEnclosingUnit([System.Windows.Automation.Text.TextUnit]::Line)
+    $selectionLineText = $selectionLine.GetText(-1)
+    if ([string]::IsNullOrWhiteSpace($selectionLineText)) {
+        throw 'Terminal legacy caret could not expand/read its current line.'
     }
     $markerRange = $textPattern.DocumentRange.FindText($marker, $true, $false)
     if ($null -eq $markerRange) { throw 'Terminal FindText did not return the visible marker range.' }
@@ -1426,7 +3815,7 @@ try {
     )
     $textChangedRegistered = $false
     [WinghosttyAccessibilityNative]::ResetTextChangedCount()
-    Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $queryOnlyMarker -Description 'query-only TextPattern marker' -ExpectedFocusedHwnd $focusedHwnd
+    [void](Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $queryOnlyMarker -Description 'query-only TextPattern marker' -ExpectedFocusedHwnd $focusedHwnd)
     try {
         Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'already-acquired query-only TextPattern refresh' -Condition {
             $script:queryOnlyTextProbe = $textPattern.DocumentRange.GetText(-1)
@@ -1445,24 +3834,30 @@ try {
     }
     $queryOnlyRangeRefreshed = $true
 
-    # Prove the first read after UIA inactivity is fresh. Do not touch the
-    # TextPattern while the query window expires or while output is emitted.
-    Start-Sleep -Milliseconds 1200
+    # Type and echo-gate the helper while UIA is hot. After its ready file, the
+    # proof waits out query activity and uses only direct notification history
+    # until one final DocumentRange read.
     [WinghosttyAccessibilityNative]::ResetTextChangedCount()
-    Send-AccessibilityBlindOutputMarker `
+    $coldQueryProof = Invoke-AccessibilityColdFirstReadProof `
         -Process $process `
+        -TextPattern $textPattern `
         -Marker $coldQueryMarker `
         -Description 'cold first-read TextPattern marker' `
-        -ExpectedFocusedHwnd $focusedHwnd
-    Start-Sleep -Milliseconds 500
-    $coldQueryFirstText = $textPattern.DocumentRange.GetText(-1)
-    if (-not $coldQueryFirstText.Contains($coldQueryMarker)) {
-        throw "First cold TextPattern DocumentRange was stale after output (text='$($coldQueryFirstText.Replace("`r", '\r').Replace("`n", '\n'))')."
-    }
+        -ExpectedFocusedHwnd $focusedHwnd `
+        -HelperDirectory $layout.Logs `
+        -NotificationCaptureActive
+    [WinghosttyAccessibilityNative]::StopNotificationCapture()
+    $terminalNotificationCaptureStarted = $false
     if ([WinghosttyAccessibilityNative]::TextChangedCount -ne 0) {
         throw 'TextChanged callback ran during cold-query validation after listener removal.'
     }
-    $coldQueryFirstRangeFresh = $true
+    $coldQueryPostEchoRangeFresh = $true
+
+    $inactiveTabEvidence = Invoke-AccessibilityInactiveTabFirstReadProof `
+        -Process $process `
+        -TabAHwnd $focusedHwnd `
+        -HelperDirectory $layout.Logs
+
     [System.Windows.Automation.Automation]::AddAutomationEventHandler(
         [System.Windows.Automation.TextPattern]::TextChangedEvent,
         $document,
@@ -2040,7 +4435,7 @@ try {
         $script:paletteDismissTerminalHwnds = @([WinghosttyAccessibilityNative]::VisibleTerminalChildren($process.MainWindowHandle))
         return $null -ne $script:paletteDismissFocused -and
             $script:paletteDismissFocused.Current.ProcessId -eq $process.Id -and
-            $script:paletteDismissFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Document -and
+            $script:paletteDismissFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Text -and
             $script:paletteDismissTerminalHwnds -contains $script:paletteDismissFocusedHwnd
     }
 
@@ -2070,7 +4465,7 @@ try {
         $script:paletteToggleTerminalHwnds = @([WinghosttyAccessibilityNative]::VisibleTerminalChildren($process.MainWindowHandle))
         return $null -ne $script:paletteToggleFocused -and
             $script:paletteToggleFocused.Current.ProcessId -eq $process.Id -and
-            $script:paletteToggleFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Document -and
+            $script:paletteToggleFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Text -and
             $script:paletteToggleTerminalHwnds -contains $script:paletteToggleFocusedHwnd
     }
 
@@ -2186,7 +4581,7 @@ try {
         return -not [WinghosttyAccessibilityNative]::IsWindowVisible($searchNativeHwnd) -and
             $null -ne $script:searchDismissFocused -and
             $script:searchDismissFocused.Current.ProcessId -eq $process.Id -and
-            $script:searchDismissFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Document -and
+            $script:searchDismissFocused.Current.ControlType -eq [System.Windows.Automation.ControlType]::Text -and
             $script:searchDismissTerminalHwnds -contains $script:searchDismissFocusedHwnd
     }
     $hiddenSearchElement = [System.Windows.Automation.AutomationElement]::FromHandle($searchNativeHwnd)
@@ -2197,7 +4592,20 @@ try {
     }
 
     $settingsCycles = @()
+    $themePreviewEvidence = $null
+    $themeHighContrast = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
+    $themeHighContrast.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($themeHighContrast)
+    if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(
+        0x42,
+        $themeHighContrast.cbSize,
+        [ref]$themeHighContrast,
+        0
+    )) {
+        throw "SPI_GETHIGHCONTRAST failed before theme preview: $([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    }
+    $themeHighContrastActive = [bool]($themeHighContrast.dwFlags -band 1)
     for ($settingsCycle = 1; $settingsCycle -le 2; $settingsCycle++) {
+        $settingsClosedByThemeDiscard = $false
         Assert-AccessibilityInputOwner -Process $process -Description "settings lifecycle open $settingsCycle"
         $settingsOpenFocusedHwnd = [WinghosttyAccessibilityNative]::FocusedWindowFor($process.MainWindowHandle)
         $settingsOpenTerminalHwnds = @([WinghosttyAccessibilityNative]::VisibleTerminalChildren($process.MainWindowHandle))
@@ -2230,10 +4638,9 @@ try {
         if ($settingsRect.right -le $settingsRect.left -or $settingsRect.bottom -le $settingsRect.top) {
             throw "Settings cycle $settingsCycle has empty native bounds."
         }
-        $settingsElement = [System.Windows.Automation.AutomationElement]::FromHandle($settingsHwnd)
-        if ($null -eq $settingsElement -or $settingsElement.Current.ControlType -ne [System.Windows.Automation.ControlType]::Window) {
-            throw "Settings cycle $settingsCycle exposes no UIA Window root."
-        }
+        $settingsElement = Wait-AccessibilityWindowElement `
+            -Hwnd $settingsHwnd `
+            -Description "Settings cycle $settingsCycle"
         if ($settingsElement.Current.Name -ne 'winghostty settings') {
             throw "Settings cycle $settingsCycle root name is '$($settingsElement.Current.Name)'; expected 'winghostty settings'."
         }
@@ -2289,10 +4696,73 @@ try {
                 @{ Name = 'Save'; Type = [System.Windows.Automation.ControlType]::Button }
             )
         }
-        $settingsElements = @($settingsElement.FindAll(
-            [System.Windows.Automation.TreeScope]::Descendants,
-            [System.Windows.Automation.Condition]::TrueCondition
-        ) | ForEach-Object { $_ })
+        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "Settings cycle $settingsCycle section UIA tree" -Condition {
+            $script:settingsElementsProbe = @($settingsElement.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.Condition]::TrueCondition
+            ) | ForEach-Object { $_ })
+            $script:settingsSectionButtonsProbe = @($script:settingsElementsProbe | Where-Object {
+                $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::RadioButton -and
+                $settingsSectionNames -contains $_.Current.Name
+            })
+            return $script:settingsSectionButtonsProbe.Count -eq $settingsSectionNames.Count
+        }
+        $settingsElements = @($script:settingsElementsProbe)
+        if ($settingsCycle -eq 2 -and $null -ne $themePreviewEvidence) {
+            if ($themePreviewEvidence.skipped) {
+                $themePreviewEvidence.rollback_verified = $false
+            }
+            else {
+                $restoredWindowTheme = @($settingsElements | Where-Object {
+                    $_.Current.Name -eq 'Window theme' -and
+                    $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::ComboBox
+                }) | Select-Object -First 1
+                if ($null -eq $restoredWindowTheme) {
+                    throw 'Reopened Settings exposes no Window theme combo for discard verification.'
+                }
+                $restoredThemeHwnd = [IntPtr]$restoredWindowTheme.Current.NativeWindowHandle
+                Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'Settings theme preview rollback on reopen' -Condition {
+                    $script:restoredIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+                        $restoredThemeHwnd,
+                        0x0147,
+                        [UIntPtr]::Zero,
+                        [IntPtr]::Zero
+                    ).ToInt64()
+                    [uint32]$restoredSettingsColorProbe = 0
+                    [uint32]$restoredHostColorProbe = 0
+                    $restoredSettingsPixelValid = [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                        $settingsHwnd,
+                        $themePreviewEvidence.settings_sample_x,
+                        $themePreviewEvidence.settings_sample_y,
+                        [ref]$restoredSettingsColorProbe
+                    )
+                    $restoredHostPixelValid = [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                        $process.MainWindowHandle,
+                        $themePreviewEvidence.host_sample_x,
+                        $themePreviewEvidence.host_sample_y,
+                        [ref]$restoredHostColorProbe
+                    )
+                    $script:restoredSettingsColor = $restoredSettingsColorProbe
+                    $script:restoredHostColor = $restoredHostColorProbe
+                    return $restoredSettingsPixelValid -and $restoredHostPixelValid -and
+                        $script:restoredIndex -eq $themePreviewEvidence.original_index -and
+                        $script:restoredSettingsColor -eq $themePreviewEvidence.original_settings_color -and
+                        $script:restoredHostColor -eq $themePreviewEvidence.original_host_color
+                }
+                $themePreviewEvidence.restored_settings_color = $script:restoredSettingsColor
+                $themePreviewEvidence.restored_host_color = $script:restoredHostColor
+                $themePreviewEvidence.restored_index = $script:restoredIndex
+                [byte[]]$themePreviewConfigRestoredBytes = [System.IO.File]::ReadAllBytes(
+                    $themePreviewConfigPath
+                )
+                if ([Convert]::ToBase64String($themePreviewConfigBaselineBytes) -ne
+                    [Convert]::ToBase64String($themePreviewConfigRestoredBytes)) {
+                    throw 'Discarded Settings theme preview changed config.ghostty bytes.'
+                }
+                $themePreviewEvidence.config_bytes_unchanged = $true
+                $themePreviewEvidence.rollback_verified = $true
+            }
+        }
         $sectionButtons = @($settingsElements | Where-Object {
             $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::RadioButton -and
             $settingsSectionNames -contains $_.Current.Name
@@ -2511,18 +4981,14 @@ try {
         )) {
             throw "Settings focus probe section '$($focusSection.Current.Name)' exposes no SelectionItemPattern."
         }
-        $focusSection.SetFocus()
-        $focusSectionSelection.Select()
         try {
             Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'settings section focus and selection ownership' -Condition {
                 if ([WinghosttyAccessibilityNative]::GetForegroundWindow() -ne $settingsHwnd) {
-                    $sectionNativeFocusBeforeRecovery = [WinghosttyAccessibilityNative]::FocusedWindowFor($settingsHwnd)
-                    if ($sectionNativeFocusBeforeRecovery -ne $focusSectionHwnd) {
-                        throw "Settings section lost native focus before foreground recovery (focused=$sectionNativeFocusBeforeRecovery expected=$focusSectionHwnd)."
-                    }
                     [void][WinghosttyAccessibilityNative]::ForceForeground($settingsHwnd)
                     return $false
                 }
+                $focusSection.SetFocus()
+                $focusSectionSelection.Select()
                 $script:settingsFocusedElement = [System.Windows.Automation.AutomationElement]::FocusedElement
                 $script:settingsSelectedAfterFocus = @($sectionButtons | Where-Object {
                     $candidateSelection = $null
@@ -2562,6 +5028,269 @@ try {
             }) -join ', '
             throw "Settings focus/selection probe failed for '$($focusSection.Current.Name)': focused=$focusedSummary; native_focused_hwnd=$nativeFocusedHwnd; expected_hwnd=$focusSectionHwnd; selected=$selectedSummary; headers=$headerSummary. $($_.Exception.Message)"
         }
+        if ($settingsCycle -eq 1 -and $themeHighContrastActive) {
+            $themePreviewEvidence = [ordered]@{
+                skipped = $true
+                skip_reason = 'High Contrast active; explicit app-theme pixel preview is intentionally bypassed'
+                rollback_verified = $false
+            }
+        }
+        elseif ($settingsCycle -eq 1) {
+            $appearanceButton = @($sectionButtons | Where-Object { $_.Current.Name -eq 'Appearance' })[0]
+            $appearanceSelection = $null
+            if (-not $appearanceButton.TryGetCurrentPattern(
+                [System.Windows.Automation.SelectionItemPattern]::Pattern,
+                [ref]$appearanceSelection
+            )) {
+                throw 'Settings Appearance section exposes no SelectionItemPattern for theme preview.'
+            }
+            $appearanceSelection.Select()
+            $windowTheme = @($settingsElements | Where-Object {
+                $_.Current.Name -eq 'Window theme' -and
+                $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::ComboBox
+            }) | Select-Object -First 1
+            if ($null -eq $windowTheme) { throw 'Settings exposes no Window theme combo.' }
+            $windowThemeHwnd = [IntPtr]$windowTheme.Current.NativeWindowHandle
+            $originalThemeIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+                $windowThemeHwnd,
+                0x0147,
+                [UIntPtr]::Zero,
+                [IntPtr]::Zero
+            ).ToInt64()
+            if ($originalThemeIndex -ne 1) {
+                throw "Seeded window-theme=system resolved to Settings index $originalThemeIndex instead of 1."
+            }
+            $settingsClientWidth = $settingsClientRect.right - $settingsClientRect.left
+            $settingsClientHeight = $settingsClientRect.bottom - $settingsClientRect.top
+            $hostClientRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen(
+                $process.MainWindowHandle
+            )
+            $hostClientWidth = $hostClientRect.right - $hostClientRect.left
+            $hostClientHeight = $hostClientRect.bottom - $hostClientRect.top
+            $originalSettingsGrid = Get-AccessibilityClientPixelGrid `
+                -Hwnd $settingsHwnd `
+                -MinX 24 `
+                -MaxX ([Math]::Max(24, $settingsClientWidth - 24)) `
+                -MinY 24 `
+                -MaxY ([Math]::Max(24, $settingsClientHeight - 24)) `
+                -Step 16
+            $originalHostGrid = Get-AccessibilityClientPixelGrid `
+                -Hwnd $process.MainWindowHandle `
+                -MinX 24 `
+                -MaxX ([Math]::Max(24, $hostClientWidth - 24)) `
+                -MinY 8 `
+                -MaxY ([Math]::Max(8, [Math]::Min(48, $hostClientHeight - 8))) `
+                -Step 8
+            if ($originalSettingsGrid.Count -eq 0 -or $originalHostGrid.Count -eq 0) {
+                throw "Theme preview could not sample initial Settings/host client grids (settings=$($originalSettingsGrid.Count), host=$($originalHostGrid.Count))."
+            }
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $windowThemeHwnd,
+                0x014E,
+                [UIntPtr]::new(3),
+                [IntPtr]::Zero
+            )
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $settingsHwnd,
+                0x0111,
+                [UIntPtr]::new(0x00010195),
+                $windowThemeHwnd
+            )
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'Settings and host System-to-Dark preview pixels' -Condition {
+                $script:systemDarkIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+                    $windowThemeHwnd,
+                    0x0147,
+                    [UIntPtr]::Zero,
+                    [IntPtr]::Zero
+                ).ToInt64()
+                $script:systemDarkSettingsPixel = Find-AccessibilityClientPixel `
+                    -Hwnd $settingsHwnd `
+                    -OriginalGrid $originalSettingsGrid `
+                    -TargetColor ([uint32]0x00202020)
+                $script:systemDarkHostPixel = Find-AccessibilityClientPixel `
+                    -Hwnd $process.MainWindowHandle `
+                    -OriginalGrid $originalHostGrid `
+                    -TargetColor ([uint32]0x00202020)
+                return $script:systemDarkIndex -eq 3 -and
+                    $null -ne $script:systemDarkSettingsPixel -and
+                    $null -ne $script:systemDarkHostPixel
+            }
+            $systemSettingsColor = $script:systemDarkSettingsPixel.original_color
+            $systemHostColor = $script:systemDarkHostPixel.original_color
+            $systemAlreadyResolvedDark = (
+                $systemSettingsColor -eq [uint32]0x00202020 -and
+                $systemHostColor -eq [uint32]0x00202020
+            )
+            $systemToDarkVisualTransition = -not $systemAlreadyResolvedDark
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $windowThemeHwnd,
+                0x014E,
+                [UIntPtr]::new(2),
+                [IntPtr]::Zero
+            )
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $settingsHwnd,
+                0x0111,
+                [UIntPtr]::new(0x00010195),
+                $windowThemeHwnd
+            )
+            try {
+                Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'Settings and host forced-Light preview pixels' -Condition {
+                    $script:lightSettingsPixel = Find-AccessibilityClientPixel `
+                        -Hwnd $settingsHwnd `
+                        -OriginalGrid $originalSettingsGrid `
+                        -TargetColor ([uint32]0x00F3F3F3)
+                    $script:lightHostPixel = Find-AccessibilityClientPixel `
+                        -Hwnd $process.MainWindowHandle `
+                        -OriginalGrid $originalHostGrid `
+                        -TargetColor ([uint32]0x00F3F3F3)
+                    return $null -ne $script:lightSettingsPixel -and
+                        $null -ne $script:lightHostPixel
+                }
+            }
+            catch {
+                $lightDiagnosticIndex = [WinghosttyAccessibilityNative]::SendMessageW(
+                    $windowThemeHwnd,
+                    0x0147,
+                    [UIntPtr]::Zero,
+                    [IntPtr]::Zero
+                ).ToInt64()
+                $lightSettingsColors = @(Get-AccessibilityClientPixelGrid `
+                    -Hwnd $settingsHwnd -MinX 24 -MaxX ([Math]::Max(24, $settingsClientWidth - 24)) `
+                    -MinY 24 -MaxY ([Math]::Max(24, $settingsClientHeight - 24)) -Step 16 |
+                    ForEach-Object { $_.Values } | ForEach-Object { $_.color } |
+                    Group-Object | Sort-Object Count -Descending | Select-Object -First 8 |
+                    ForEach-Object { "$($_.Name):$($_.Count)" })
+                $lightHostColors = @(Get-AccessibilityClientPixelGrid `
+                    -Hwnd $process.MainWindowHandle -MinX 24 -MaxX ([Math]::Max(24, $hostClientWidth - 24)) `
+                    -MinY 8 -MaxY ([Math]::Max(8, [Math]::Min(48, $hostClientHeight - 8))) -Step 8 |
+                    ForEach-Object { $_.Values } | ForEach-Object { $_.color } |
+                    Group-Object | Sort-Object Count -Descending | Select-Object -First 8 |
+                    ForEach-Object { "$($_.Name):$($_.Count)" })
+                throw "$($_.Exception.Message) settings_alive=$([WinghosttyAccessibilityNative]::IsWindow($settingsHwnd)) host_alive=$([WinghosttyAccessibilityNative]::IsWindow($process.MainWindowHandle)) combo_index=$lightDiagnosticIndex settings_colors=$($lightSettingsColors -join ',') host_colors=$($lightHostColors -join ',')."
+            }
+            $settingsSampleX = $script:lightSettingsPixel.x
+            $settingsSampleY = $script:lightSettingsPixel.y
+            $hostSampleX = $script:lightHostPixel.x
+            $hostSampleY = $script:lightHostPixel.y
+            $originalSettingsColor = $script:lightSettingsPixel.original_color
+            $originalHostColor = $script:lightHostPixel.original_color
+            $script:lightSettingsColor = $script:lightSettingsPixel.color
+            $script:lightHostColor = $script:lightHostPixel.color
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $windowThemeHwnd,
+                0x014E,
+                [UIntPtr]::new(3),
+                [IntPtr]::Zero
+            )
+            [void][WinghosttyAccessibilityNative]::SendMessageW(
+                $settingsHwnd,
+                0x0111,
+                [UIntPtr]::new(0x00010195),
+                $windowThemeHwnd
+            )
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'Settings and host Light-to-Dark preview pixels' -Condition {
+                [uint32]$darkSettingsColorProbe = 0
+                [uint32]$darkHostColorProbe = 0
+                $darkSettingsPixelValid = [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                    $settingsHwnd,
+                    $settingsSampleX,
+                    $settingsSampleY,
+                    [ref]$darkSettingsColorProbe
+                )
+                $darkHostPixelValid = [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                    $process.MainWindowHandle,
+                    $hostSampleX,
+                    $hostSampleY,
+                    [ref]$darkHostColorProbe
+                )
+                $script:darkSettingsColor = $darkSettingsColorProbe
+                $script:darkHostColor = $darkHostColorProbe
+                return $darkSettingsPixelValid -and $darkHostPixelValid -and
+                    $script:darkSettingsColor -eq [uint32]0x00202020 -and
+                    $script:darkHostColor -eq [uint32]0x00202020 -and
+                    $script:darkSettingsColor -ne $script:lightSettingsColor -and
+                    $script:darkHostColor -ne $script:lightHostColor
+            }
+            $themePreviewEvidence = [ordered]@{
+                skipped = $false
+                original_index = $originalThemeIndex
+                light_index = 2
+                dark_index = 3
+                original_settings_color = $originalSettingsColor
+                settings_sample_x = $settingsSampleX
+                settings_sample_y = $settingsSampleY
+                light_settings_color = $script:lightSettingsColor
+                dark_settings_color = $script:darkSettingsColor
+                original_host_color = $originalHostColor
+                host_sample_x = $hostSampleX
+                host_sample_y = $hostSampleY
+                light_host_color = $script:lightHostColor
+                dark_host_color = $script:darkHostColor
+                system_to_dark_covered = $true
+                system_to_dark_selected_index = $script:systemDarkIndex
+                system_settings_color = $systemSettingsColor
+                system_settings_sample_x = $script:systemDarkSettingsPixel.x
+                system_settings_sample_y = $script:systemDarkSettingsPixel.y
+                system_dark_settings_color = $script:systemDarkSettingsPixel.color
+                system_host_color = $systemHostColor
+                system_host_sample_x = $script:systemDarkHostPixel.x
+                system_host_sample_y = $script:systemDarkHostPixel.y
+                system_dark_host_color = $script:systemDarkHostPixel.color
+                system_already_resolved_dark = $systemAlreadyResolvedDark
+                system_to_dark_visual_transition = $systemToDarkVisualTransition
+                system_to_dark_visual_transition_status = if ($systemAlreadyResolvedDark) {
+                    'not applicable: System already resolved exact Dark'
+                } else {
+                    'observed'
+                }
+                light_settings_expected = [uint32]0x00F3F3F3
+                dark_settings_expected = [uint32]0x00202020
+                restored_index = $null
+                restored_settings_color = $null
+                restored_host_color = $null
+                config_bytes_unchanged = $false
+                rollback_verified = $false
+            }
+            [void](Invoke-InteractiveWin11Message `
+                -Hwnd $settingsHwnd `
+                -Message 0x0010 `
+                -WParam ([UIntPtr]::Zero) `
+                -LParam ([IntPtr]::Zero) `
+                -Deadline ([DateTime]::UtcNow.AddSeconds(5)) `
+                -Process $process `
+                -Description 'close Settings with Dark preview pending')
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'Settings Dark preview discard action' -Condition {
+                $script:themeDiscardButton = @($settingsElement.FindAll(
+                    [System.Windows.Automation.TreeScope]::Descendants,
+                    [System.Windows.Automation.Condition]::TrueCondition
+                ) | Where-Object {
+                    $_.Current.Name -eq 'Discard changes' -and -not $_.Current.IsOffscreen
+                }) | Select-Object -First 1
+                return $null -ne $script:themeDiscardButton
+            }
+            $discardInvoke = $null
+            if (-not $script:themeDiscardButton.TryGetCurrentPattern(
+                [System.Windows.Automation.InvokePattern]::Pattern,
+                [ref]$discardInvoke
+            )) {
+                throw 'Settings Dark preview discard action exposes no InvokePattern.'
+            }
+            $discardInvoke.Invoke()
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'Settings Dark preview discard close' -Condition {
+                return -not [WinghosttyAccessibilityNative]::IsWindow($settingsHwnd)
+            }
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'host pixel restore after Dark preview discard' -Condition {
+                [uint32]$discardHostColorProbe = 0
+                return [WinghosttyAccessibilityNative]::TrySampleWindowClientPixel(
+                    $process.MainWindowHandle,
+                    $hostSampleX,
+                    $hostSampleY,
+                    [ref]$discardHostColorProbe
+                ) -and $discardHostColorProbe -eq $originalHostColor
+            }
+            $settingsClosedByThemeDiscard = $true
+        }
         $settingsCycles += [ordered]@{
             cycle = $settingsCycle
             hwnd = $settingsHwnd.ToInt64()
@@ -2580,22 +5309,28 @@ try {
                 height = $settingsRect.bottom - $settingsRect.top
             }
         }
-        [void](Invoke-InteractiveWin11Message `
-            -Hwnd $settingsHwnd `
-            -Message 0x0010 `
-            -WParam ([UIntPtr]::Zero) `
-            -LParam ([IntPtr]::Zero) `
-            -Deadline ([DateTime]::UtcNow.AddSeconds(5)) `
-            -Process $process `
-            -Description "close settings lifecycle cycle $settingsCycle")
-        Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "settings destruction cycle $settingsCycle" -Condition {
-            return @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
-                [uint32]$process.Id,
-                'winghostty.win32.settings'
-            )).Count -eq 0
+        if (-not $settingsClosedByThemeDiscard) {
+            [void](Invoke-InteractiveWin11Message `
+                -Hwnd $settingsHwnd `
+                -Message 0x0010 `
+                -WParam ([UIntPtr]::Zero) `
+                -LParam ([IntPtr]::Zero) `
+                -Deadline ([DateTime]::UtcNow.AddSeconds(5)) `
+                -Process $process `
+                -Description "close settings lifecycle cycle $settingsCycle")
+            Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description "settings destruction cycle $settingsCycle" -Condition {
+                return @([WinghosttyAccessibilityNative]::TopLevelWindowsForProcess(
+                    [uint32]$process.Id,
+                    'winghostty.win32.settings'
+                )).Count -eq 0
+            }
         }
     }
-    $settingsLifecycle = [ordered]@{ cycles = $settingsCycles; reopened = $true }
+    $settingsLifecycle = [ordered]@{
+        cycles = $settingsCycles
+        reopened = $true
+        theme_preview = $themePreviewEvidence
+    }
 
     $ownerProbeStdout = Join-Path $layout.Logs 'interactive-win11-accessibility-settings-owner-stdout.log'
     $ownerProbeStderr = Join-Path $layout.Logs 'interactive-win11-accessibility-settings-owner-stderr.log'
@@ -2625,17 +5360,22 @@ try {
         return $script:ownerSettingsWindowsProbe.Count -eq 1
     }
     $ownerSettingsHwnd = $script:ownerSettingsWindowsProbe[0]
-    $ownerSettingsElement = [System.Windows.Automation.AutomationElement]::FromHandle($ownerSettingsHwnd)
-    if ($null -eq $ownerSettingsElement) { throw 'Settings owner probe exposes no UIA root.' }
-    $ownerSettingsElements = @($ownerSettingsElement.FindAll(
-        [System.Windows.Automation.TreeScope]::Descendants,
-        [System.Windows.Automation.Condition]::TrueCondition
-    ) | ForEach-Object { $_ })
-    $ownerTerminalSection = @($ownerSettingsElements | Where-Object {
-        $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::RadioButton -and
-        $_.Current.Name -eq 'Terminal'
-    }) | Select-Object -First 1
-    if ($null -eq $ownerTerminalSection) { throw 'Settings owner probe cannot find the Terminal section.' }
+    $ownerSettingsElement = Wait-AccessibilityWindowElement `
+        -Hwnd $ownerSettingsHwnd `
+        -Description 'Settings owner probe'
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'settings owner probe Terminal UIA section' -Condition {
+        $script:ownerSettingsElements = @($ownerSettingsElement.FindAll(
+            [System.Windows.Automation.TreeScope]::Descendants,
+            [System.Windows.Automation.Condition]::TrueCondition
+        ) | ForEach-Object { $_ })
+        $script:ownerTerminalSection = @($script:ownerSettingsElements | Where-Object {
+            $_.Current.ControlType -eq [System.Windows.Automation.ControlType]::RadioButton -and
+            $_.Current.Name -eq 'Terminal'
+        }) | Select-Object -First 1
+        return $null -ne $script:ownerTerminalSection
+    }
+    $ownerSettingsElements = @($script:ownerSettingsElements)
+    $ownerTerminalSection = $script:ownerTerminalSection
     $ownerTerminalSelection = $null
     if (-not $ownerTerminalSection.TryGetCurrentPattern(
         [System.Windows.Automation.SelectionItemPattern]::Pattern,
@@ -2925,6 +5665,12 @@ try {
     }
     $saveProbe = Open-AccessibilitySettingsProbe -Process $saveProbeProcess -Description 'settings save probe'
     $saveScrollback = Get-AccessibilityScrollbackProbe -SettingsProbe $saveProbe -Description 'settings save probe'
+    $saveTheme = Get-AccessibilityThemeProbe -SettingsProbe $saveProbe -Description 'settings save probe'
+    $settingsPersistenceOriginalThemeIndex = [int]$saveTheme.Index
+    if ($settingsPersistenceOriginalThemeIndex -lt 0 -or
+        $settingsPersistenceOriginalThemeIndex -gt 4) {
+        throw "Settings persistence sandbox exposed invalid Window theme index $settingsPersistenceOriginalThemeIndex."
+    }
     [uint64]$settingsPersistenceOriginalScrollback = 0
     if (-not [uint64]::TryParse(
         $saveScrollback.Value.Current.Value,
@@ -2944,19 +5690,33 @@ try {
         [Globalization.CultureInfo]::InvariantCulture
     )
     $saveScrollback.Value.SetValue($settingsPersistenceDraftText)
+    Set-AccessibilityThemeIndex `
+        -SettingsProbe $saveProbe `
+        -ThemeProbe $saveTheme `
+        -Index 3 `
+        -Description 'settings save probe Dark selection'
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'settings save probe dirty draft' -Condition {
-        return $saveScrollback.Value.Current.Value -eq $settingsPersistenceDraftText -and $saveScrollback.Save.Current.IsEnabled
+        return $saveScrollback.Value.Current.Value -eq $settingsPersistenceDraftText -and
+            [WinghosttyAccessibilityNative]::SendMessageW(
+                $saveTheme.Hwnd,
+                0x0147,
+                [UIntPtr]::Zero,
+                [IntPtr]::Zero
+            ).ToInt64() -eq 3 -and
+            $saveScrollback.Save.Current.IsEnabled
     }
     Invoke-AccessibilitySettingsCloseAction `
         -SettingsProbe $saveProbe `
         -ActionName 'Save and close' `
         -Description 'settings save probe'
-    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'settings save-and-close completion' -Condition {
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds($TimeoutSeconds)) -Description 'settings save-and-close completion' -Condition {
         return -not [WinghosttyAccessibilityNative]::IsWindow($saveProbe.Hwnd)
     }
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(5)) -Description 'settings persisted config bytes' -Condition {
         if (-not (Test-Path -LiteralPath $sandboxConfigPath -PathType Leaf)) { return $false }
-        return (Get-Content -LiteralPath $sandboxConfigPath -Raw) -match "(?m)^scrollback-limit\s*=\s*$([regex]::Escape($settingsPersistenceDraftText))\s*$"
+        $persistedConfig = Get-Content -LiteralPath $sandboxConfigPath -Raw
+        return $persistedConfig -match "(?m)^scrollback-limit\s*=\s*$([regex]::Escape($settingsPersistenceDraftText))\s*$" -and
+            $persistedConfig -match '(?m)^window-theme\s*=\s*dark\s*$'
     }
     Stop-InteractiveWin11Process -Process $saveProbeProcess -Contained
     $saveProbeProcess = $null
@@ -2980,10 +5740,72 @@ try {
     }
     $saveVerifyProbe = Open-AccessibilitySettingsProbe -Process $saveVerifyProcess -Description 'settings persistence verifier'
     $verifyScrollback = Get-AccessibilityScrollbackProbe -SettingsProbe $saveVerifyProbe -Description 'settings persistence verifier'
+    $verifyTheme = Get-AccessibilityThemeProbe -SettingsProbe $saveVerifyProbe -Description 'settings persistence verifier'
     if ($verifyScrollback.Value.Current.Value -ne $settingsPersistenceDraftText) {
         throw "Save and close did not survive a same-sandbox process relaunch; expected=$settingsPersistenceDraftText actual=$($verifyScrollback.Value.Current.Value)."
     }
+    if ($verifyTheme.Index -ne 3) {
+        throw "Saved Dark theme did not survive a same-sandbox process relaunch; expected index 3, actual=$($verifyTheme.Index)."
+    }
+
+    $verifySettingsRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen(
+        $saveVerifyProbe.Hwnd
+    )
+    $verifyHostRect = [WinghosttyAccessibilityNative]::ClientRectOnScreen(
+        $saveVerifyProcess.MainWindowHandle
+    )
+    $verifySettingsGrid = Get-AccessibilityClientPixelGrid `
+        -Hwnd $saveVerifyProbe.Hwnd `
+        -MinX 24 `
+        -MaxX ([Math]::Max(24, ($verifySettingsRect.right - $verifySettingsRect.left) - 24)) `
+        -MinY 24 `
+        -MaxY ([Math]::Max(24, ($verifySettingsRect.bottom - $verifySettingsRect.top) - 24)) `
+        -Step 16
+    $verifyHostGrid = Get-AccessibilityClientPixelGrid `
+        -Hwnd $saveVerifyProcess.MainWindowHandle `
+        -MinX 24 `
+        -MaxX ([Math]::Max(24, ($verifyHostRect.right - $verifyHostRect.left) - 24)) `
+        -MinY 8 `
+        -MaxY ([Math]::Max(8, [Math]::Min(48, ($verifyHostRect.bottom - $verifyHostRect.top) - 8))) `
+        -Step 8
+    $verifySettingsDarkPixel = @($verifySettingsGrid.Values | Where-Object {
+        [uint32]$_.color -eq [uint32]0x00202020
+    }) | Select-Object -First 1
+    $verifyHostDarkPixel = @($verifyHostGrid.Values | Where-Object {
+        [uint32]$_.color -eq [uint32]0x00202020
+    }) | Select-Object -First 1
+    if ($null -eq $verifySettingsDarkPixel -or $null -eq $verifyHostDarkPixel) {
+        throw "Fresh Dark process exposes no exact 0x00202020 Settings/host pixels (settings=$($verifySettingsGrid.Count), host=$($verifyHostGrid.Count))."
+    }
+    $verifyHostDwmDark = Get-AccessibilityDwmUInt `
+        -Hwnd $saveVerifyProcess.MainWindowHandle `
+        -Attribute 20 `
+        -Description 'fresh Dark host'
+    $verifySettingsDwmDark = Get-AccessibilityDwmUInt `
+        -Hwnd $saveVerifyProbe.Hwnd `
+        -Attribute 20 `
+        -Description 'fresh Dark Settings'
+    $verifyHostBackdrop = Get-AccessibilityDwmUInt `
+        -Hwnd $saveVerifyProcess.MainWindowHandle `
+        -Attribute 38 `
+        -Description 'fresh Dark host'
+    $verifySettingsBackdrop = Get-AccessibilityDwmUInt `
+        -Hwnd $saveVerifyProbe.Hwnd `
+        -Attribute 38 `
+        -Description 'fresh Dark Settings'
+    if ($verifyHostDwmDark -ne 1 -or
+        $verifySettingsDwmDark -ne 1 -or
+        $verifyHostBackdrop -ne 1 -or
+        $verifySettingsBackdrop -ne 1) {
+        throw "Fresh Dark DWM state mismatch: host_dark=$verifyHostDwmDark settings_dark=$verifySettingsDwmDark host_backdrop=$verifyHostBackdrop settings_backdrop=$verifySettingsBackdrop."
+    }
+
     $verifyScrollback.Value.SetValue($settingsPersistenceOriginalScrollbackText)
+    Set-AccessibilityThemeIndex `
+        -SettingsProbe $saveVerifyProbe `
+        -ThemeProbe $verifyTheme `
+        -Index $settingsPersistenceOriginalThemeIndex `
+        -Description 'settings persistence original theme restore'
     $restoreInvoke = $null
     if (-not $verifyScrollback.Save.TryGetCurrentPattern(
         [System.Windows.Automation.InvokePattern]::Pattern,
@@ -3006,6 +5828,16 @@ try {
     if ($restoredAssignments.Count -ne 1 -or
         $restoredAssignments[0].Groups['value'].Value -cne $settingsPersistenceOriginalScrollbackText) {
         throw "Settings persistence restore left ambiguous scrollback assignments (count=$($restoredAssignments.Count))."
+    }
+    $settingsThemeNames = @('auto', 'system', 'light', 'dark', 'ghostty')
+    $restoredThemeAssignments = [regex]::Matches(
+        (Get-Content -LiteralPath $sandboxConfigPath -Raw),
+        '(?m)^window-theme\s*=\s*(?<value>\S+)\s*$'
+    )
+    if ($restoredThemeAssignments.Count -ne 1 -or
+        $restoredThemeAssignments[0].Groups['value'].Value -cne
+            $settingsThemeNames[$settingsPersistenceOriginalThemeIndex]) {
+        throw "Settings persistence restore left ambiguous Window theme assignments (count=$($restoredThemeAssignments.Count))."
     }
     [void](Invoke-InteractiveWin11Message `
         -Hwnd $saveVerifyProbe.Hwnd `
@@ -3030,6 +5862,17 @@ try {
     $settingsOwnerLifecycle['original_value_restored'] = $true
     $settingsOwnerLifecycle['persistence_original_value'] = $settingsPersistenceOriginalScrollbackText
     $settingsOwnerLifecycle['persistence_dirty_value'] = $settingsPersistenceDraftText
+    $settingsOwnerLifecycle['persistence_theme_original_index'] = $settingsPersistenceOriginalThemeIndex
+    $settingsOwnerLifecycle['persistence_theme_saved_index'] = 3
+    $settingsOwnerLifecycle['persistence_theme_config_dark'] = $true
+    $settingsOwnerLifecycle['persistence_theme_fresh_process_index'] = [int]$verifyTheme.Index
+    $settingsOwnerLifecycle['persistence_theme_dark_settings_pixel'] = $verifySettingsDarkPixel
+    $settingsOwnerLifecycle['persistence_theme_dark_host_pixel'] = $verifyHostDarkPixel
+    $settingsOwnerLifecycle['persistence_theme_host_dwm_dark'] = $verifyHostDwmDark
+    $settingsOwnerLifecycle['persistence_theme_settings_dwm_dark'] = $verifySettingsDwmDark
+    $settingsOwnerLifecycle['persistence_theme_host_backdrop'] = $verifyHostBackdrop
+    $settingsOwnerLifecycle['persistence_theme_settings_backdrop'] = $verifySettingsBackdrop
+    $settingsOwnerLifecycle['persistence_theme_restored'] = $true
 
     Send-AccessibilityChord -Keys @([uint16]0x12, [uint16]0x25) -Description 'Alt+Left before sustained output' -Process $process
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(3)) -Description 'left pane focus before sustained output' -Condition {
@@ -3094,7 +5937,7 @@ try {
     if ($stressEventCount -lt 1 -or $stressEventCount -gt 300) {
         throw "Sustained output emitted $stressEventCount TextChanged events; expected 1..300 for $stressLineCount lines."
     }
-    Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $stressResponsiveMarker -Description 'post-stress responsiveness marker' -ExpectedFocusedHwnd $leftPane.Hwnd
+    [void](Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $stressResponsiveMarker -Description 'post-stress responsiveness marker' -ExpectedFocusedHwnd $leftPane.Hwnd)
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'post-stress responsiveness marker through TextPattern' -Condition {
         foreach ($candidateDocument in $documents) {
             $candidatePattern = $null
@@ -3214,7 +6057,7 @@ try {
     }
 
     $idleMarker = "whi$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
-    Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $idleMarker -Description 'post-idle liveness marker' -ExpectedFocusedHwnd $leftPane.Hwnd
+    [void](Send-AccessibilityOutputMarker -Process $process -TextPattern $textPattern -Marker $idleMarker -Description 'post-idle liveness marker' -ExpectedFocusedHwnd $leftPane.Hwnd)
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'post-idle marker through TextPattern' -Condition {
         $script:idleMarkerVisible = $false
         foreach ($candidateDocument in $documents) {
@@ -3227,6 +6070,10 @@ try {
         }
         return $script:idleMarkerVisible
     }
+    $hcTransitionEvidence = Invoke-AccessibilityHighContrastProof `
+        -Process $process `
+        -DiagnosticDirectory $layout.Logs
+
     $hc = [WinghosttyAccessibilityNative+HIGHCONTRAST]::new()
     $hc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($hc)
     if (-not [WinghosttyAccessibilityNative]::SystemParametersInfo(0x42, $hc.cbSize, [ref]$hc, 0)) {
@@ -3244,6 +6091,7 @@ try {
             source_worktree_dirty = $sourceWorktreeDirty
         }
         high_contrast = [bool]($hc.dwFlags -band 1)
+        high_contrast_transition = $hcTransitionEvidence
         focused = $focused.Current.Name
         terminal = [ordered]@{
             marker = $marker
@@ -3253,11 +6101,23 @@ try {
             rectangle_count = $terminalRectCount
             selection_range_count = $selection.Count
             supported_text_selection = $supportedTextSelection.ToString()
-            selection_is_degenerate = $false
+            selection_is_degenerate = $true
+            selection_line_text = $selectionLineText
+            live_setting = $liveSetting.ToString()
+            output_notification_count = $terminalOutputNotification[0]
+            output_notification_kind = $terminalOutputNotification[1]
+            output_notification_display_string = $terminalOutputNotification[2]
+            output_notification_processing = $terminalOutputNotification[3]
+            output_notification_activity_id = $terminalOutputNotification[4]
+            warm_input = $terminalWarmInput
+            warm_notification = $terminalWarmNotification
             query_only_marker = $queryOnlyMarker
             query_only_acquired_text_pattern_refreshed = $queryOnlyRangeRefreshed
             cold_query_marker = $coldQueryMarker
-            cold_query_first_document_range_fresh = $coldQueryFirstRangeFresh
+            cold_query_command_echo = $coldQueryProof.command_echo
+            cold_query_first_read = $coldQueryProof
+            cold_query_post_echo_document_range_fresh = $coldQueryPostEchoRangeFresh
+            inactive_tab = $inactiveTabEvidence
             text_pattern2_client_available = $false
             text_pattern2_client_limitation = 'Windows PowerShell UIAutomationClient 4.0 exposes no TextPattern2 type or registered pattern ID 10024.'
             sustained_output = $sustainedOutputEvidence
@@ -3368,12 +6228,12 @@ try {
     $relaunchRoot = [System.Windows.Automation.AutomationElement]::FromHandle($relaunchProcess.MainWindowHandle)
     if ($null -eq $relaunchRoot) { throw 'UI Automation returned no root for relaunched winghostty.' }
     $relaunchDocuments = @()
-    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'relaunch terminal Document' -Condition {
+    Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'relaunch terminal Text element' -Condition {
         $script:relaunchDocumentsProbe = @($relaunchRoot.FindAll(
             [System.Windows.Automation.TreeScope]::Descendants,
             [System.Windows.Automation.PropertyCondition]::new(
                 [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
-                [System.Windows.Automation.ControlType]::Document
+                [System.Windows.Automation.ControlType]::Text
             )
         ) | ForEach-Object { $_ })
         return $script:relaunchDocumentsProbe.Count -gt 0
@@ -3384,16 +6244,17 @@ try {
         [System.Windows.Automation.TextPattern]::Pattern,
         [ref]$relaunchTextPattern
     )) {
-        throw 'Relaunched terminal Document does not expose TextPattern.'
+        throw 'Relaunched terminal Text element does not expose TextPattern.'
     }
     Assert-AccessibilityInputOwner -Process $relaunchProcess -Description 'relaunch liveness text'
     $relaunchMarker = "whr$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
     $relaunchDocumentHwnd = [IntPtr]$relaunchDocuments[0].Current.NativeWindowHandle
-    Send-AccessibilityOutputMarker -Process $relaunchProcess -TextPattern $relaunchTextPattern -Marker $relaunchMarker -Description 'relaunch liveness marker' -ExpectedFocusedHwnd $relaunchDocumentHwnd
+    [void](Send-AccessibilityOutputMarker -Process $relaunchProcess -TextPattern $relaunchTextPattern -Marker $relaunchMarker -Description 'relaunch liveness marker' -ExpectedFocusedHwnd $relaunchDocumentHwnd)
     Wait-AccessibilityCondition -Deadline ([DateTime]::UtcNow.AddSeconds(8)) -Description 'relaunch marker through TextPattern' -Condition {
         return $relaunchTextPattern.DocumentRange.GetText(-1).Contains($relaunchMarker)
     }
     $evidence['relaunch'] = [ordered]@{ marker = $relaunchMarker; visible = $true; process_id = $relaunchProcess.Id }
+    }
 }
 catch {
     $runFailure = $_
@@ -3433,6 +6294,15 @@ finally {
         }
         catch {
             $cleanupFailures.Add("failed to remove palette Notification handler: $($_.Exception.Message)")
+        }
+    }
+    if ($terminalNotificationCaptureStarted) {
+        try {
+            [WinghosttyAccessibilityNative]::StopNotificationCapture()
+            $terminalNotificationCaptureStarted = $false
+        }
+        catch {
+            $cleanupFailures.Add("failed to remove terminal Notification handler: $($_.Exception.Message)")
         }
     }
     if ($textChangedRegistered -and $null -ne $textChangedHandler -and $null -ne $document) {

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -1536,8 +1536,6 @@ function Invoke-AccessibilityInactiveTabFirstReadProof(
             @($inactiveNotificationDiagnostic.raw_notification_history)
         $inactiveNotificationHistory =
             @($inactiveNotificationDiagnostic.notification_history)
-        $inactiveNotificationText =
-            $inactiveNotificationDiagnostic.notification_text
 
         Send-AccessibilityChord `
             -Keys @([uint16]0x11, [uint16]0x22) `

--- a/test/windows/interactive-win11-key-input.ps1
+++ b/test/windows/interactive-win11-key-input.ps1
@@ -1,8 +1,18 @@
 param(
     [switch] $Rebuild,
     [switch] $ResetState,
-    [ValidateSet('a', 'space')] [string] $Key = 'a',
-    [ValidateSet('surface', 'host')] [string] $Route = 'surface',
+    [ValidateSet(
+        'a',
+        'space',
+        'unicode-bmp',
+        'unicode-supplementary',
+        'unicode-burst',
+        'unicode-cr',
+        'unicode-lf',
+        'unicode-tab',
+        'unicode-backspace',
+        'unicode-escape'
+    )] [string] $Key = 'a',
     [switch] $RunBooFirst,
     [int] $TimeoutSeconds = 15
 )
@@ -18,8 +28,47 @@ $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $libPath = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
 . $libPath
 
+function Get-KeyInputScenarioSlug {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet(
+            'a',
+            'space',
+            'unicode-bmp',
+            'unicode-supplementary',
+            'unicode-burst',
+            'unicode-cr',
+            'unicode-lf',
+            'unicode-tab',
+            'unicode-backspace',
+            'unicode-escape'
+        )]
+        [string] $Key,
+        [switch] $PostBoo
+    )
+
+    $slug = switch ($Key) {
+        'a' { 'classic-a' }
+        'space' { 'classic-space' }
+        'unicode-bmp' { 'bmp' }
+        'unicode-supplementary' { 'supplementary' }
+        'unicode-burst' { 'burst' }
+        'unicode-cr' { 'control-cr' }
+        'unicode-lf' { 'control-lf' }
+        'unicode-tab' { 'control-tab' }
+        'unicode-backspace' { 'control-backspace' }
+        'unicode-escape' { 'control-escape' }
+    }
+    if ($PostBoo) {
+        return "$slug-post-boo"
+    }
+    return $slug
+}
+
+$scenarioSlug = Get-KeyInputScenarioSlug -Key $Key -PostBoo:$RunBooFirst
+
 if (-not $env:WINGHOSTTY_INTERACTIVE_WIN11_KEY_INPUT_BOOTSTRAPPED) {
-    $forwardedArgs = @('-Key', $Key, '-Route', $Route, '-TimeoutSeconds', $TimeoutSeconds.ToString())
+    $forwardedArgs = @('-Key', $Key, '-TimeoutSeconds', $TimeoutSeconds.ToString())
     if ($RunBooFirst) { $forwardedArgs += '-RunBooFirst' }
     if ($Rebuild) { $forwardedArgs += '-Rebuild' }
     if ($ResetState) { $forwardedArgs += '-ResetState' }
@@ -63,6 +112,39 @@ public static class Win11KeyInputNative {
         public RECT rcCaret;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KEYBDINPUT {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MOUSEINPUT {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct INPUTUNION {
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+        [FieldOffset(0)]
+        public MOUSEINPUT mi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct INPUT {
+        public uint type;
+        public INPUTUNION U;
+    }
+
     [DllImport("user32.dll")]
     public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
@@ -89,6 +171,49 @@ public static class Win11KeyInputNative {
 
     [DllImport("user32.dll")]
     public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint cInputs, INPUT[] pInputs, int cbSize);
+
+    public static uint SendUnicodeInput(ushort[] codeUnits) {
+        const uint INPUT_KEYBOARD = 1;
+        const uint KEYEVENTF_KEYUP = 0x0002;
+        const uint KEYEVENTF_UNICODE = 0x0004;
+        INPUT[] inputs = new INPUT[codeUnits.Length * 2];
+        for (int i = 0; i < codeUnits.Length; i++) {
+            KEYBDINPUT down = new KEYBDINPUT {
+                wVk = 0,
+                wScan = codeUnits[i],
+                dwFlags = KEYEVENTF_UNICODE,
+                time = 0,
+                dwExtraInfo = UIntPtr.Zero
+            };
+            KEYBDINPUT up = down;
+            up.dwFlags |= KEYEVENTF_KEYUP;
+            inputs[i * 2] = new INPUT {
+                type = INPUT_KEYBOARD,
+                U = new INPUTUNION { ki = down }
+            };
+            inputs[(i * 2) + 1] = new INPUT {
+                type = INPUT_KEYBOARD,
+                U = new INPUTUNION { ki = up }
+            };
+        }
+
+        uint inserted = SendInput(
+            (uint)inputs.Length,
+            inputs,
+            Marshal.SizeOf(typeof(INPUT))
+        );
+        if (inserted != (uint)inputs.Length) {
+            throw new System.ComponentModel.Win32Exception(
+                Marshal.GetLastWin32Error(),
+                String.Format("SendInput inserted {0} of {1} Unicode keyboard events", inserted, inputs.Length)
+            );
+        }
+        return inserted;
+    }
+
 }
 '@
 
@@ -100,6 +225,7 @@ $VK_SPACE = 0x20
 $WM_KEYDOWN = 0x0100
 $WM_KEYUP = 0x0101
 $WM_CHAR = 0x0102
+$UNICODE_SENTINEL = [uint16]0xE000
 
 function Get-WindowClassName {
     param(
@@ -241,27 +367,86 @@ function Send-VirtualKeyMessage {
         -Description "WM_KEYUP vk=$VirtualKey")
 }
 
-$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'key-input' -ResetState:$ResetState -IncludeResourcesDir
+function Send-UnicodeInput {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [UInt16[]] $CodeUnits
+    )
+
+    [uint16[]] $terminated = @($CodeUnits + $UNICODE_SENTINEL)
+    $inserted = [Win11KeyInputNative]::SendUnicodeInput($terminated)
+    $expectedEvents = [uint32]($terminated.Length * 2)
+    if ($inserted -ne $expectedEvents) {
+        throw "SendInput inserted $inserted of $expectedEvents Unicode keyboard events"
+    }
+}
+
+$artifactPrefix = "interactive-win11-key-input-$scenarioSlug"
+$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName "key-input-$scenarioSlug" -ResetState:$ResetState -IncludeResourcesDir
 $repoRoot = $harness.RepoRoot
 $layout = $harness.Layout
 
 $exePath = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
 $buildInputs = Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot
 $launchAction = Get-InteractiveWin11LaunchAction -ExePath $exePath -Rebuild:$Rebuild -BuildInputs $buildInputs
-$stdoutPath = Join-Path $layout.Logs 'interactive-win11-key-input-stdout.log'
-$stderrPath = Join-Path $layout.Logs 'interactive-win11-key-input-stderr.log'
-$resultPath = Join-Path $layout.Temp 'interactive-win11-key-input-result.json'
-$preReadKeyReadyPath = Join-Path $layout.Temp 'interactive-win11-key-input-ready.txt'
-$preReadKeyStatePath = Join-Path $layout.Temp 'interactive-win11-key-input-state.json'
-$preReadKeyTracePath = Join-Path $layout.Temp 'interactive-win11-key-input-boo-trace.txt'
-$payloadPath = Join-Path $layout.Temp 'interactive-win11-key-input-payload.ps1'
+$stdoutPath = Join-Path $layout.Logs "$artifactPrefix-stdout.log"
+$stderrPath = Join-Path $layout.Logs "$artifactPrefix-stderr.log"
+$resultPath = Join-Path $layout.Temp "$artifactPrefix-result.json"
+$deliveryTracePath = Join-Path $layout.Temp "$artifactPrefix-delivery.json"
+$inputReadyPath = Join-Path $layout.Temp "$artifactPrefix-read-ready.txt"
+$preReadKeyReadyPath = Join-Path $layout.Temp "$artifactPrefix-boo-ready.txt"
+$preReadKeyStatePath = Join-Path $layout.Temp "$artifactPrefix-boo-state.json"
+$preReadKeyTracePath = Join-Path $layout.Temp "$artifactPrefix-boo-trace.txt"
+$payloadPath = Join-Path $layout.Temp "$artifactPrefix-payload.ps1"
 
 if ($launchAction -eq 'build') {
     Invoke-InteractiveWin11Build -RepoRoot $repoRoot
 }
 
 Assert-InteractiveWin11ExeExists -ExePath $exePath
-Remove-Item -LiteralPath $stdoutPath, $stderrPath, $resultPath -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $stdoutPath, $stderrPath, $resultPath, $deliveryTracePath, $inputReadyPath -ErrorAction SilentlyContinue
+
+[uint16[]] $unicodeInputUnits = @()
+switch ($Key) {
+    'unicode-bmp' {
+        $unicodeInputUnits = [uint16[]] @(0x03A9)
+    }
+    'unicode-supplementary' {
+        $unicodeInputUnits = [uint16[]] @(0xD83D, 0xDE42)
+    }
+    'unicode-burst' {
+        # Native coverage proves exact sequential delivery. The Zig
+        # 256-authorization test owns deferred backlog capacity proof.
+        $burstText = 'abcdefghijklmnopqrstuvwxyz012345' * 8
+        if ($burstText.Length -ne 256) {
+            throw "Unicode burst fixture must contain exactly 256 UTF-16 units; got $($burstText.Length)"
+        }
+        $unicodeInputUnits = [uint16[]] @(
+            $burstText.ToCharArray() | ForEach-Object { [uint16][char] $_ }
+        )
+    }
+    'unicode-cr' {
+        $unicodeInputUnits = [uint16[]] @(0x000D)
+    }
+    'unicode-lf' {
+        $unicodeInputUnits = [uint16[]] @(0x000A)
+    }
+    'unicode-tab' {
+        $unicodeInputUnits = [uint16[]] @(0x0009)
+    }
+    'unicode-backspace' {
+        $unicodeInputUnits = [uint16[]] @(0x0008)
+    }
+    'unicode-escape' {
+        $unicodeInputUnits = [uint16[]] @(0x001B)
+    }
+}
+$useUnicodeInput = $unicodeInputUnits.Length -ne 0
+$useSequentialRead = $unicodeInputUnits.Length -ne 0
+[uint16[]] $expectedReadUnits = @($unicodeInputUnits)
+if ($Key -eq 'unicode-backspace') {
+    # Terminal Backspace is encoded as DEL by the default terminal protocol.
+    $expectedReadUnits = [uint16[]] @(0x007F)
+}
 
 $commandPrelude = ''
 if ($RunBooFirst) {
@@ -300,16 +485,42 @@ finally {
         Replace('__READY_PATH__', $preReadKeyReadyPathLiteral)
 }
 
-$resultPathLiteral = $resultPath.Replace("'", "''")
+$payloadBody = if ($useSequentialRead) {
+    @'
+'ready' | Set-Content -LiteralPath '__INPUT_READY_PATH__' -Encoding ASCII
+$receivedUnits = New-Object 'System.Collections.Generic.List[int]'
+while ($true) {
+    $key = [Console]::ReadKey($true)
+    $unit = [int][char]$key.KeyChar
+    if ($unit -eq __UNICODE_SENTINEL__) {
+        break
+    }
+    [void] $receivedUnits.Add($unit)
+}
+[ordered]@{
+    utf16Units = @($receivedUnits.ToArray())
+} | ConvertTo-Json -Compress | Set-Content -LiteralPath '__RESULT_PATH__' -Encoding ASCII
+'@
+}
+else {
+    @'
+'ready' | Set-Content -LiteralPath '__INPUT_READY_PATH__' -Encoding ASCII
+$key = [Console]::ReadKey($true)
+[ordered]@{
+    keyCharCode = [int][char]$key.KeyChar
+    keyChar = [string]$key.KeyChar
+    key = $key.Key.ToString()
+    modifiers = $key.Modifiers.ToString()
+} | ConvertTo-Json -Compress | Set-Content -LiteralPath '__RESULT_PATH__' -Encoding ASCII
+'@
+}
+$payloadBody = $payloadBody.
+    Replace('__INPUT_READY_PATH__', $inputReadyPath.Replace("'", "''")).
+    Replace('__RESULT_PATH__', $resultPath.Replace("'", "''")).
+    Replace('__UNICODE_SENTINEL__', ([int] $UNICODE_SENTINEL).ToString())
 @"
 $commandPrelude
-`$key = [Console]::ReadKey(`$true)
-[ordered]@{
-    keyCharCode = [int][char]`$key.KeyChar
-    keyChar = [string]`$key.KeyChar
-    key = `$key.Key.ToString()
-    modifiers = `$key.Modifiers.ToString()
-} | ConvertTo-Json -Compress | Set-Content -LiteralPath '$resultPathLiteral' -Encoding ASCII
+$payloadBody
 "@ | Set-Content -LiteralPath $payloadPath -Encoding UTF8
 
 $launchArgs = @(
@@ -324,9 +535,15 @@ $launchArgs = @(
     $payloadPath
 )
 
-$expectedKeyCharCode, $expectedKeyName, $virtualKey, $charCode = switch ($Key) {
-    'a' { 97, 'A', $VK_A, 97 }
-    'space' { 32, 'Spacebar', $VK_SPACE, 32 }
+$expectedKeyCharCode = $null
+$expectedKeyName = $null
+$virtualKey = $null
+$charCode = $null
+if (-not $useSequentialRead) {
+    $expectedKeyCharCode, $expectedKeyName, $virtualKey, $charCode = switch ($Key) {
+        'a' { 97, 'A', $VK_A, 97 }
+        'space' { 32, 'Spacebar', $VK_SPACE, 32 }
+    }
 }
 
 $process = Start-Process -FilePath $exePath `
@@ -352,8 +569,12 @@ try {
     }
 
     $surfaceHwnd = Find-SurfaceWindow -Parent $hostHwnd
-    $messageTargetHwnd = if ($Route -eq 'host') { $hostHwnd } else { $surfaceHwnd }
-    $deliveryMode = 'message'
+    $deliveryMode = if ($useUnicodeInput) {
+        'sendinput-unicode'
+    }
+    else {
+        'message'
+    }
     Start-Sleep -Milliseconds 300
 
     if ($RunBooFirst) {
@@ -389,7 +610,28 @@ try {
         Start-Sleep -Milliseconds 300
     }
 
-    Send-VirtualKeyMessage -Hwnd $messageTargetHwnd -VirtualKey $virtualKey -CharCode ([uint16] $charCode) -Deadline $deadline -Process $process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'child input readiness' -Process $process -Condition {
+        Test-Path -LiteralPath $inputReadyPath
+    }
+
+    $inputSentAtUtc = [DateTime]::UtcNow
+    $inputStopwatch = [Diagnostics.Stopwatch]::StartNew()
+    if ($useSequentialRead) {
+        [void] [Win11KeyInputNative]::SetForegroundWindow($hostHwnd)
+        Wait-InteractiveWin11Until -Deadline $deadline -Description 'focused terminal surface' -Process $process -Condition {
+            if ([Win11KeyInputNative]::GetForegroundWindow() -ne $hostHwnd) {
+                return $false
+            }
+            $info = Get-GuiThreadInfo -Hwnd $hostHwnd
+            return $null -ne $info -and
+                $info.FocusHwnd -ne [IntPtr]::Zero -and
+                (Get-WindowClassName -Hwnd $info.FocusHwnd) -eq 'winghostty.win32'
+        }
+        Send-UnicodeInput -CodeUnits $unicodeInputUnits
+    }
+    else {
+        Send-VirtualKeyMessage -Hwnd $surfaceHwnd -VirtualKey $virtualKey -CharCode ([uint16] $charCode) -Deadline $deadline -Process $process
+    }
 
     $resultRef = [ref]$null
     $lastResultReadError = [ref]'result file has not appeared'
@@ -427,9 +669,49 @@ try {
     }
 
     $result = $resultRef.Value
-    if ($result.keyCharCode -ne $expectedKeyCharCode -or $result.key -ne $expectedKeyName) {
+    $inputStopwatch.Stop()
+    $inputObservedAtUtc = [DateTime]::UtcNow
+    if ($useSequentialRead) {
+        [int[]] $actualUnits = @($result.utf16Units | ForEach-Object { [int] $_ })
+        $mismatchIndex = -1
+        $comparedLength = [Math]::Min($expectedReadUnits.Length, $actualUnits.Length)
+        for ($i = 0; $i -lt $comparedLength; $i++) {
+            if ($actualUnits[$i] -ne $expectedReadUnits[$i]) {
+                $mismatchIndex = $i
+                break
+            }
+        }
+        if ($mismatchIndex -lt 0 -and $actualUnits.Length -ne $expectedReadUnits.Length) {
+            $mismatchIndex = $comparedLength
+        }
+        if ($mismatchIndex -ge 0) {
+            $expectedAtMismatch = if ($mismatchIndex -lt $expectedReadUnits.Length) {
+                [int] $expectedReadUnits[$mismatchIndex]
+            } else {
+                '<end>'
+            }
+            $actualAtMismatch = if ($mismatchIndex -lt $actualUnits.Length) {
+                $actualUnits[$mismatchIndex]
+            } else {
+                '<end>'
+            }
+            throw "unexpected Unicode input result (mode=$deliveryMode key=$Key expected-units=$($expectedReadUnits.Length) actual-units=$($actualUnits.Length) mismatch-index=$mismatchIndex expected=$expectedAtMismatch actual=$actualAtMismatch)"
+        }
+    }
+    elseif ($result.keyCharCode -ne $expectedKeyCharCode -or $result.key -ne $expectedKeyName) {
         throw "unexpected key input result (mode=$deliveryMode): $($result | ConvertTo-Json -Compress)"
     }
+
+    [ordered]@{
+        scenario = $scenarioSlug
+        deliveryMode = $deliveryMode
+        sentAtUtc = $inputSentAtUtc.ToString('o')
+        observedAtUtc = $inputObservedAtUtc.ToString('o')
+        elapsedMs = [int] $inputStopwatch.ElapsedMilliseconds
+        injectedUtf16Units = if ($useSequentialRead) { @($unicodeInputUnits) } else { $null }
+        expectedReadUtf16Units = if ($useSequentialRead) { @($expectedReadUnits) } else { @([int] $expectedKeyCharCode) }
+        utf16Units = if ($useSequentialRead) { @($actualUnits) } else { @([int] $result.keyCharCode) }
+    } | ConvertTo-Json -Compress | Set-Content -LiteralPath $deliveryTracePath -Encoding ASCII
 
     $guiThreadInfo = Get-GuiThreadInfo -Hwnd $hostHwnd
     $focusClass = if ($null -ne $guiThreadInfo -and $guiThreadInfo.FocusHwnd -ne [IntPtr]::Zero) {
@@ -446,7 +728,7 @@ try {
     else {
         ''
     }
-    Write-Host ("interactive-win11 key-input validation: PASS (scenario={0}, key={1}, route={2}, mode={3}, focus-class={4}, stdout={5}, stderr={6}, result={7}{8})" -f $scenario, $Key, $Route, $deliveryMode, $focusClass, $stdoutPath, $stderrPath, $resultPath, $extra)
+    Write-Host ("interactive-win11 key-input validation: PASS (scenario={0}, input-scenario={1}, key={2}, mode={3}, input-elapsed-ms={4}, focus-class={5}, stdout={6}, stderr={7}, result={8}, delivery-trace={9}{10})" -f $scenario, $scenarioSlug, $Key, $deliveryMode, $inputStopwatch.ElapsedMilliseconds, $focusClass, $stdoutPath, $stderrPath, $resultPath, $deliveryTracePath, $extra)
 }
 finally {
     Stop-InteractiveWin11Process -Process $process -Contained

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -57,7 +57,8 @@ function Get-HarnessArguments {
     param(
         [Parameter(Mandatory)] [string] $ScriptName,
         [int] $TimeoutSeconds = 0,
-        [switch] $IncludeResetState
+        [switch] $IncludeResetState,
+        [string[]] $AdditionalArguments = @()
     )
 
     $scriptPath = Join-Path $PSScriptRoot $ScriptName
@@ -76,6 +77,7 @@ function Get-HarnessArguments {
         )
     }
     if ($ResetState -and $IncludeResetState) { $argumentList += '-ResetState' }
+    if ($AdditionalArguments.Count -ne 0) { $argumentList += $AdditionalArguments }
 
     return $argumentList
 }
@@ -98,15 +100,17 @@ function Invoke-Harness {
 function Invoke-HarnessWithPassSentinel {
     param(
         [Parameter(Mandatory)] [string] $ScriptName,
-        [Parameter(Mandatory)] [int] $TimeoutSeconds
+        [Parameter(Mandatory)] [int] $TimeoutSeconds,
+        [string[]] $AdditionalArguments = @(),
+        [string] $ScenarioSlug = ''
     )
 
-    $run = Start-Harness -ScriptName $ScriptName -TimeoutSeconds $TimeoutSeconds
+    $run = Start-Harness -ScriptName $ScriptName -TimeoutSeconds $TimeoutSeconds -AdditionalArguments $AdditionalArguments -ScenarioSlug $ScenarioSlug
     $waitMilliseconds = [int][Math]::Ceiling(($TimeoutSeconds + 5) * 1000)
     if (-not $run.Process.WaitForExit($waitMilliseconds)) {
-        Stop-InteractiveWin11Process -Process $run.Process
+        Stop-InteractiveWin11Process -Process $run.Process -RequireLiveRoot
         throw @"
-$ScriptName timed out after ${TimeoutSeconds}s
+$($run.Script) timed out after ${TimeoutSeconds}s
 stdout ($($run.Stdout)):
 $(Get-HarnessLog -Path $run.Stdout)
 
@@ -122,7 +126,7 @@ $(Get-HarnessLog -Path $run.Stderr)
 
     if (($null -ne $exitCode) -and ($exitCode -ne 0)) {
         throw @"
-$ScriptName exited with code $exitCode
+$($run.Script) exited with code $exitCode
 stdout:
 $stdout
 
@@ -133,7 +137,7 @@ $stderr
 
     if ($summary -notlike '*PASS*') {
         throw @"
-$ScriptName did not report PASS
+$($run.Script) did not report PASS
 stdout:
 $stdout
 
@@ -150,12 +154,20 @@ $stderr
 function Start-Harness {
     param(
         [Parameter(Mandatory)] [string] $ScriptName,
-        [Parameter(Mandatory)] [int] $TimeoutSeconds
+        [Parameter(Mandatory)] [int] $TimeoutSeconds,
+        [string[]] $AdditionalArguments = @(),
+        [string] $ScenarioSlug = ''
     )
 
-    $stdoutPath = Join-Path $suiteLogDir ("{0}.stdout.log" -f $ScriptName)
-    $stderrPath = Join-Path $suiteLogDir ("{0}.stderr.log" -f $ScriptName)
-    $argumentList = Get-HarnessArguments -ScriptName $ScriptName -TimeoutSeconds $TimeoutSeconds -IncludeResetState
+    $runName = if ([string]::IsNullOrWhiteSpace($ScenarioSlug)) {
+        $ScriptName
+    }
+    else {
+        "{0}-{1}" -f [System.IO.Path]::GetFileNameWithoutExtension($ScriptName), $ScenarioSlug
+    }
+    $stdoutPath = Join-Path $suiteLogDir ("{0}.stdout.log" -f $runName)
+    $stderrPath = Join-Path $suiteLogDir ("{0}.stderr.log" -f $runName)
+    $argumentList = Get-HarnessArguments -ScriptName $ScriptName -TimeoutSeconds $TimeoutSeconds -IncludeResetState -AdditionalArguments $AdditionalArguments
 
     $process = Start-Process `
         -FilePath 'powershell.exe' `
@@ -165,7 +177,7 @@ function Start-Harness {
         -RedirectStandardError $stderrPath `
         -PassThru
 
-    return [InteractiveWin11HarnessRun]::new($ScriptName, $process, $stdoutPath, $stderrPath, $TimeoutSeconds)
+    return [InteractiveWin11HarnessRun]::new($runName, $process, $stdoutPath, $stderrPath, $TimeoutSeconds)
 }
 
 function Get-HarnessLog {
@@ -211,7 +223,15 @@ if ($env:WINGHOSTTY_INTERACTIVE_RUN_FOREGROUND_HARNESS -eq '1') {
 else {
     Write-Host 'interactive-win11 shell command live validation: SKIP (set WINGHOSTTY_INTERACTIVE_RUN_FOREGROUND_HARNESS=1 to require the foreground-sensitive harness in the composite suite)'
 }
-Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -ScenarioSlug 'classic-a'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-bmp') -ScenarioSlug 'bmp'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-supplementary') -ScenarioSlug 'supplementary'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 25 -AdditionalArguments @('-Key', 'unicode-burst') -ScenarioSlug 'burst'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-cr') -ScenarioSlug 'control-cr'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-lf') -ScenarioSlug 'control-lf'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-tab') -ScenarioSlug 'control-tab'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-backspace') -ScenarioSlug 'control-backspace'
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-escape') -ScenarioSlug 'control-escape'
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-ime-candidate.ps1' -TimeoutSeconds 20
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-new-tab.ps1' -TimeoutSeconds 20
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-resize.ps1' -TimeoutSeconds 15
@@ -232,7 +252,7 @@ foreach ($run in $parallelRuns) {
     if (-not $run.Process.WaitForExit($remainingMilliseconds)) {
         foreach ($other in $parallelRuns) {
             if (-not $other.Process.HasExited) {
-                Stop-InteractiveWin11Process -Process $other.Process
+                Stop-InteractiveWin11Process -Process $other.Process -RequireLiveRoot
             }
         }
         throw @"


### PR DESCRIPTION
## Summary

- Route committed terminal output through an authoritative semantic pipeline into Win32 UIA, with ordered bounded notifications, echo suppression, coherent caret/provider state, and focused-provider capture across listener transitions.
- Apply live theme preview and persistence across terminal chrome, Settings, native controls, and DWM while preserving exact High Contrast system colors and rollback behavior.
- Fix native Unicode/control-key delivery plus renderer wake and blink-reset behavior found by executable Windows verification.

## Architecture

Semantic output originates at the authoritative `StreamHandler`/terminal parser seam after committed parser effects. An allocation-free, nonblocking, bounded Surface transport carries ordered output, reset, and omission records to the Win32 UI thread; Win32 no longer maintains a second VT parser.

`TerminalAccessibilitySession` is the deep UIA ownership module for cached snapshots, caret/provider lifetime, focus, echo suppression, notification ordering, and query/event policy. Locality remains explicit: parser semantics stay in terminal/termio, transport stays on Surface, UIA stays in Win32, and Settings retains local GDI brush/reentry/teardown ownership behind the shared window-theme adapter.

## Validation

- `scripts/dev-windows.cmd zig build -Demit-exe=true` — PASS.
- `scripts/dev-windows.cmd zig build test -Demit-test-exe=true` — PASS.
- `scripts/dev-windows.cmd zig build test '-Dtest-filter=semantic output'` — PASS.
- `scripts/dev-windows.cmd zig build test '-Dtest-filter=terminal output transport'` — PASS.
- `scripts/dev-windows.cmd zig build test '-Dtest-filter=terminal output announcement'` — PASS.
- `scripts/dev-windows.cmd zig build test '-Dtest-filter=terminal accessibility'` — PASS.
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` — `flagship verification contracts: PASS (2 scenarios)`.
- `pwsh -NoProfile -File test/windows/interactive-win11-accessibility.ps1 -ResetState -TimeoutSeconds 20 -IdleSoakSeconds 60` — PASS in 119.962 seconds, including UIA/text-pattern behavior, inactive-pane silence, theme/High Contrast/scaling checks, and a 60-second idle soak with no event or resource growth.
- Fable semantic/deslop re-audit — PASS; no actionable findings.
- Sol independent source/architecture audit — PASS; no actionable findings.

## Remaining human risk

Actual Narrator and NVDA Speech Recap behavior is not automated. Human acceptance remains required for speech ordering, first-output behavior, caret narration, and native visual polish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows terminal accessibility so screen readers can follow focused text, caret movement, and terminal output announcements.
  * Added polite terminal output notifications compatible with Windows accessibility tools.
  * Settings theme changes now preview immediately and can be reverted, with improved dark, light, system, and High Contrast support.
  * Improved Unicode keyboard input handling, including supplementary characters and control keys.

* **Bug Fixes**
  * Improved focus handling, theme repainting, text selection behavior, and cursor blinking.

* **Tests**
  * Expanded automated and interactive coverage for accessibility, themes, Unicode input, and High Contrast behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->