### PR TITLE
site: automate verified Cloudflare deployment

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,284 @@
+name: Deploy Site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-site.yml"
+      - "README.md"
+      - "docs/getting-started.md"
+      - "docs/status.md"
+      - "scripts/build-site-bundle.mjs"
+      - "scripts/build-site-payload.ps1"
+      - "scripts/check-release-copy.ps1"
+      - "scripts/check-site-bundle.ps1"
+      - "scripts/check-site-copy.ps1"
+      - "scripts/verify-cloudflare-pages.ps1"
+      - "site/**"
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: cloudflare-pages-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Canary, verify, and publish
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: windows-latest
+    timeout-minutes: 20
+    environment: cloudflare-pages-production
+    env:
+      CLOUDFLARE_PAGES_PROJECT: winghostty
+      CLOUDFLARE_PAGES_PRODUCTION_BRANCH: main
+
+    steps:
+      - name: Checkout exact event commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve exact deployment commit
+        id: source
+        shell: pwsh
+        run: |
+          $sha = (git rev-parse HEAD).Trim()
+          if ($sha -cnotmatch '^[0-9a-f]{40}$') {
+            throw 'Deployment source did not resolve to a full Git SHA.'
+          }
+          "sha=$sha" >> $env:GITHUB_OUTPUT
+
+      - name: Validate committed site bundle and copy
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          npm ci --prefix site --ignore-scripts
+          if ($LASTEXITCODE -ne 0) { throw 'Site dependency installation failed.' }
+          ./scripts/check-site-bundle.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./scripts/check-site-copy.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($env:GITHUB_EVENT_NAME -eq 'release') {
+            if ($env:RELEASE_TAG -cnotmatch '^v(?<version>\d+\.\d+\.\d+)$') {
+              throw 'Published release tag must be plain v<major>.<minor>.<patch> semver.'
+            }
+            ./scripts/check-release-copy.ps1 `
+              -ExpectedVersion $Matches.version `
+              -CheckRemoteLatest
+          } else {
+            ./scripts/check-release-copy.ps1 -CheckRemoteLatest
+          }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Build deterministic deploy payload twice
+        id: payload
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP "winghostty-site-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          $first = Join-Path $root 'payload'
+          $second = Join-Path $root 'payload-repeat'
+          $firstManifest = Join-Path $root 'payload.sha256'
+          $secondManifest = Join-Path $root 'payload-repeat.sha256'
+          $evidence = Join-Path $env:RUNNER_TEMP "winghostty-site-evidence-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          $wrangler = Join-Path $env:RUNNER_TEMP "winghostty-wrangler-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+
+          ./scripts/build-site-payload.ps1 -OutputDirectory $first -ManifestPath $firstManifest
+          ./scripts/build-site-payload.ps1 -OutputDirectory $second -ManifestPath $secondManifest
+
+          $firstBytes = [IO.File]::ReadAllBytes($firstManifest)
+          $secondBytes = [IO.File]::ReadAllBytes($secondManifest)
+          if (-not [Linq.Enumerable]::SequenceEqual[byte]($firstBytes, $secondBytes)) {
+            throw 'Repeated site builds produced different sorted SHA-256 manifests.'
+          }
+
+          New-Item -ItemType Directory -Path $evidence -Force | Out-Null
+          New-Item -ItemType Directory -Path $wrangler -Force | Out-Null
+          Copy-Item -LiteralPath $firstManifest -Destination (Join-Path $evidence 'payload.sha256')
+          "directory=$($first.Replace('\', '/'))" >> $env:GITHUB_OUTPUT
+          "manifest=$($firstManifest.Replace('\', '/'))" >> $env:GITHUB_OUTPUT
+          "evidence_directory=$($evidence.Replace('\', '/'))" >> $env:GITHUB_OUTPUT
+          "wrangler_directory=$($wrangler.Replace('\', '/'))" >> $env:GITHUB_OUTPUT
+
+      - name: Require exact origin main before canary
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty' -or
+              $env:DEFAULT_BRANCH -cne 'main') {
+            throw 'Site deployment is restricted to amanthanvi/winghostty main.'
+          }
+          $origin = (git remote get-url origin).Trim()
+          if ($origin -cnotin @(
+              'https://github.com/amanthanvi/winghostty',
+              'https://github.com/amanthanvi/winghostty.git'
+          )) {
+            throw 'Unexpected origin remote for production site deployment.'
+          }
+          git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'
+          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch exact origin/main.' }
+          $head = (git rev-parse HEAD).Trim()
+          $originMain = (git rev-parse refs/remotes/origin/main).Trim()
+          if ($head -cne $env:DEPLOY_SHA -or $head -cne $originMain) {
+            throw 'Resolved deployment SHA is not the exact current origin/main commit.'
+          }
+          if (git status --porcelain=v1 --untracked-files=all) {
+            throw 'Repository became dirty before the canary deployment.'
+          }
+
+      - name: Resolve canary branch
+        id: canary_meta
+        shell: pwsh
+        run: |
+          $sha = '${{ steps.source.outputs.sha }}'
+          $branch = "canary-$($sha.Substring(0, 12))-$env:GITHUB_RUN_ATTEMPT"
+          "branch=$branch" >> $env:GITHUB_OUTPUT
+
+      - name: Deploy exact payload to canary
+        id: canary
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          wranglerVersion: 4.114.0
+          packageManager: npm
+          workingDirectory: ${{ steps.payload.outputs.wrangler_directory }}
+          quiet: true
+          command: >-
+            pages deploy "${{ steps.payload.outputs.directory }}"
+            --project-name=winghostty
+            --branch="${{ steps.canary_meta.outputs.branch }}"
+            --commit-hash="${{ steps.source.outputs.sha }}"
+            --commit-dirty=false
+
+      - name: Verify canary provenance and bytes
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOYMENT_ID: ${{ steps.canary.outputs.pages-deployment-id }}
+          DEPLOYMENT_URL: ${{ steps.canary.outputs.deployment-url }}
+          CANARY_BRANCH: ${{ steps.canary_meta.outputs.branch }}
+          PAYLOAD_DIRECTORY: ${{ steps.payload.outputs.directory }}
+          PAYLOAD_MANIFEST: ${{ steps.payload.outputs.manifest }}
+          PROVENANCE_DIRECTORY: ${{ steps.payload.outputs.evidence_directory }}
+        run: |
+          $provenancePath = Join-Path $env:PROVENANCE_DIRECTORY 'canary-provenance.json'
+          ./scripts/verify-cloudflare-pages.ps1 `
+            -Mode Deployment `
+            -DeploymentId $env:DEPLOYMENT_ID `
+            -ExpectedEnvironment preview `
+            -ExpectedBranch $env:CANARY_BRANCH `
+            -ExpectedCommit '${{ steps.source.outputs.sha }}' `
+            -BaseUrl $env:DEPLOYMENT_URL `
+            -PayloadDirectory $env:PAYLOAD_DIRECTORY `
+            -ManifestPath $env:PAYLOAD_MANIFEST `
+            -ProvenancePath $provenancePath
+
+      - name: Require the zone-owned www redirect before production
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOYMENT_ID: ${{ steps.canary.outputs.pages-deployment-id }}
+        run: |
+          ./scripts/verify-cloudflare-pages.ps1 `
+            -Mode Redirect `
+            -DeploymentId $env:DEPLOYMENT_ID `
+            -ExpectedCommit '${{ steps.source.outputs.sha }}'
+
+      - name: Require exact origin main before production
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty' -or
+              $env:DEFAULT_BRANCH -cne 'main') {
+            throw 'Site deployment is restricted to amanthanvi/winghostty main.'
+          }
+          $origin = (git remote get-url origin).Trim()
+          if ($origin -cnotin @(
+              'https://github.com/amanthanvi/winghostty',
+              'https://github.com/amanthanvi/winghostty.git'
+          )) {
+            throw 'Unexpected origin remote for production site deployment.'
+          }
+          git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'
+          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch exact origin/main.' }
+          $head = (git rev-parse HEAD).Trim()
+          $originMain = (git rev-parse refs/remotes/origin/main).Trim()
+          if ($head -cne $env:DEPLOY_SHA -or $head -cne $originMain) {
+            throw 'Resolved deployment SHA is not the exact current origin/main commit.'
+          }
+          if (git status --porcelain=v1 --untracked-files=all) {
+            throw 'Repository became dirty before the production deployment.'
+          }
+
+      - name: Deploy identical payload to production
+        id: production
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          wranglerVersion: 4.114.0
+          packageManager: npm
+          workingDirectory: ${{ steps.payload.outputs.wrangler_directory }}
+          quiet: true
+          command: >-
+            pages deploy "${{ steps.payload.outputs.directory }}"
+            --project-name=winghostty
+            --branch=main
+            --commit-hash="${{ steps.source.outputs.sha }}"
+            --commit-dirty=false
+
+      - name: Verify production provenance, domain, and bytes
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOYMENT_ID: ${{ steps.production.outputs.pages-deployment-id }}
+          DEPLOYMENT_URL: ${{ steps.production.outputs.deployment-url }}
+          PAYLOAD_DIRECTORY: ${{ steps.payload.outputs.directory }}
+          PAYLOAD_MANIFEST: ${{ steps.payload.outputs.manifest }}
+          PROVENANCE_DIRECTORY: ${{ steps.payload.outputs.evidence_directory }}
+        run: |
+          $provenancePath = Join-Path $env:PROVENANCE_DIRECTORY 'production-provenance.json'
+          ./scripts/verify-cloudflare-pages.ps1 `
+            -Mode Deployment `
+            -DeploymentId $env:DEPLOYMENT_ID `
+            -ExpectedEnvironment production `
+            -ExpectedBranch main `
+            -ExpectedCommit '${{ steps.source.outputs.sha }}' `
+            -BaseUrl $env:DEPLOYMENT_URL `
+            -CanonicalBaseUrl 'https://winghostty.com/' `
+            -PayloadDirectory $env:PAYLOAD_DIRECTORY `
+            -ManifestPath $env:PAYLOAD_MANIFEST `
+            -ProvenancePath $provenancePath `
+            -RequireCanonical `
+            -VerifyWwwRedirect
+
+      - name: Upload redacted deployment provenance
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: site-deployment-provenance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/winghostty-site-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          include-hidden-files: false
+          retention-days: 30

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,20 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/deploy-site.yml"
-      - "README.md"
-      - "docs/getting-started.md"
-      - "docs/status.md"
-      - "scripts/build-site-bundle.mjs"
-      - "scripts/build-site-payload.ps1"
-      - "scripts/check-release-copy.ps1"
-      - "scripts/check-site-bundle.ps1"
-      - "scripts/check-site-copy.ps1"
-      - "scripts/get-site-header-contract.ps1"
-      - "scripts/require-site-deployment-head.ps1"
-      - "scripts/verify-cloudflare-pages.ps1"
-      - "site/**"
   release:
     types:
       - published

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -14,6 +14,8 @@ on:
       - "scripts/check-release-copy.ps1"
       - "scripts/check-site-bundle.ps1"
       - "scripts/check-site-copy.ps1"
+      - "scripts/get-site-header-contract.ps1"
+      - "scripts/require-site-deployment-head.ps1"
       - "scripts/verify-cloudflare-pages.ps1"
       - "site/**"
   release:
@@ -70,6 +72,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./scripts/check-site-copy.ps1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./scripts/get-site-header-contract.ps1 | Out-Null
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if ($env:GITHUB_EVENT_NAME -eq 'release') {
             if ($env:RELEASE_TAG -cnotmatch '^v(?<version>\d+\.\d+\.\d+)$') {
               throw 'Published release tag must be plain v<major>.<minor>.<patch> semver.'
@@ -117,27 +121,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DEPLOY_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty' -or
-              $env:DEFAULT_BRANCH -cne 'main') {
-            throw 'Site deployment is restricted to amanthanvi/winghostty main.'
-          }
-          $origin = (git remote get-url origin).Trim()
-          if ($origin -cnotin @(
-              'https://github.com/amanthanvi/winghostty',
-              'https://github.com/amanthanvi/winghostty.git'
-          )) {
-            throw 'Unexpected origin remote for production site deployment.'
-          }
-          git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'
-          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch exact origin/main.' }
-          $head = (git rev-parse HEAD).Trim()
-          $originMain = (git rev-parse refs/remotes/origin/main).Trim()
-          if ($head -cne $env:DEPLOY_SHA -or $head -cne $originMain) {
-            throw 'Resolved deployment SHA is not the exact current origin/main commit.'
-          }
-          if (git status --porcelain=v1 --untracked-files=all) {
-            throw 'Repository became dirty before the canary deployment.'
-          }
+          ./scripts/require-site-deployment-head.ps1 `
+            -ExpectedSha $env:DEPLOY_SHA `
+            -DefaultBranch $env:DEFAULT_BRANCH `
+            -Phase canary
 
       - name: Resolve canary branch
         id: canary_meta
@@ -207,27 +194,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DEPLOY_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty' -or
-              $env:DEFAULT_BRANCH -cne 'main') {
-            throw 'Site deployment is restricted to amanthanvi/winghostty main.'
-          }
-          $origin = (git remote get-url origin).Trim()
-          if ($origin -cnotin @(
-              'https://github.com/amanthanvi/winghostty',
-              'https://github.com/amanthanvi/winghostty.git'
-          )) {
-            throw 'Unexpected origin remote for production site deployment.'
-          }
-          git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'
-          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch exact origin/main.' }
-          $head = (git rev-parse HEAD).Trim()
-          $originMain = (git rev-parse refs/remotes/origin/main).Trim()
-          if ($head -cne $env:DEPLOY_SHA -or $head -cne $originMain) {
-            throw 'Resolved deployment SHA is not the exact current origin/main commit.'
-          }
-          if (git status --porcelain=v1 --untracked-files=all) {
-            throw 'Repository became dirty before the production deployment.'
-          }
+          ./scripts/require-site-deployment-head.ps1 `
+            -ExpectedSha $env:DEPLOY_SHA `
+            -DefaultBranch $env:DEFAULT_BRANCH `
+            -Phase production
 
       - name: Deploy identical payload to production
         id: production

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,7 +40,11 @@ jobs:
         id: source
         shell: pwsh
         run: |
-          $sha = (git rev-parse HEAD).Trim()
+          $sha = git rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not resolve the deployment source SHA.'
+          }
+          $sha = ([string]($sha -join "`n")).Trim()
           if ($sha -cnotmatch '^[0-9a-f]{40}$') {
             throw 'Deployment source did not resolve to a full Git SHA.'
           }
@@ -52,11 +56,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          ./scripts/check-site-copy.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npm ci --prefix site --ignore-scripts
           if ($LASTEXITCODE -ne 0) { throw 'Site dependency installation failed.' }
           ./scripts/check-site-bundle.ps1
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          ./scripts/check-site-copy.ps1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./scripts/get-site-header-contract.ps1 | Out-Null
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -115,8 +119,10 @@ jobs:
       - name: Resolve canary branch
         id: canary_meta
         shell: pwsh
+        env:
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          $sha = '${{ steps.source.outputs.sha }}'
+          $sha = $env:DEPLOY_SHA
           $branch = "canary-$($sha.Substring(0, 12))-$env:GITHUB_RUN_ATTEMPT"
           "branch=$branch" >> $env:GITHUB_OUTPUT
 
@@ -145,6 +151,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOYMENT_ID: ${{ steps.canary.outputs.pages-deployment-id }}
           DEPLOYMENT_URL: ${{ steps.canary.outputs.deployment-url }}
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
           CANARY_BRANCH: ${{ steps.canary_meta.outputs.branch }}
           PAYLOAD_DIRECTORY: ${{ steps.payload.outputs.directory }}
           PAYLOAD_MANIFEST: ${{ steps.payload.outputs.manifest }}
@@ -156,7 +163,7 @@ jobs:
             -DeploymentId $env:DEPLOYMENT_ID `
             -ExpectedEnvironment preview `
             -ExpectedBranch $env:CANARY_BRANCH `
-            -ExpectedCommit '${{ steps.source.outputs.sha }}' `
+            -ExpectedCommit $env:DEPLOY_SHA `
             -BaseUrl $env:DEPLOYMENT_URL `
             -PayloadDirectory $env:PAYLOAD_DIRECTORY `
             -ManifestPath $env:PAYLOAD_MANIFEST `
@@ -168,11 +175,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOYMENT_ID: ${{ steps.canary.outputs.pages-deployment-id }}
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
         run: |
           ./scripts/verify-cloudflare-pages.ps1 `
             -Mode Redirect `
             -DeploymentId $env:DEPLOYMENT_ID `
-            -ExpectedCommit '${{ steps.source.outputs.sha }}'
+            -ExpectedCommit $env:DEPLOY_SHA
 
       - name: Require exact origin main before production
         shell: pwsh
@@ -210,6 +218,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOYMENT_ID: ${{ steps.production.outputs.pages-deployment-id }}
           DEPLOYMENT_URL: ${{ steps.production.outputs.deployment-url }}
+          DEPLOY_SHA: ${{ steps.source.outputs.sha }}
           PAYLOAD_DIRECTORY: ${{ steps.payload.outputs.directory }}
           PAYLOAD_MANIFEST: ${{ steps.payload.outputs.manifest }}
           PROVENANCE_DIRECTORY: ${{ steps.payload.outputs.evidence_directory }}
@@ -220,7 +229,7 @@ jobs:
             -DeploymentId $env:DEPLOYMENT_ID `
             -ExpectedEnvironment production `
             -ExpectedBranch main `
-            -ExpectedCommit '${{ steps.source.outputs.sha }}' `
+            -ExpectedCommit $env:DEPLOY_SHA `
             -BaseUrl $env:DEPLOYMENT_URL `
             -CanonicalBaseUrl 'https://winghostty.com/' `
             -PayloadDirectory $env:PAYLOAD_DIRECTORY `

--- a/scripts/build-site-payload.ps1
+++ b/scripts/build-site-payload.ps1
@@ -1,0 +1,142 @@
+#requires -Version 7.3
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $OutputDirectory,
+
+    [Parameter(Mandatory)]
+    [string] $ManifestPath,
+
+    [string] $SourceDirectory = (Join-Path (Split-Path -Parent $PSScriptRoot) 'site')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sourceRoot = [IO.Path]::GetFullPath($SourceDirectory).TrimEnd('\', '/')
+$outputRoot = [IO.Path]::GetFullPath($OutputDirectory).TrimEnd('\', '/')
+$manifestFullPath = [IO.Path]::GetFullPath($ManifestPath)
+$pathComparison = if ($IsWindows) {
+    [StringComparison]::OrdinalIgnoreCase
+} else {
+    [StringComparison]::Ordinal
+}
+$separator = [IO.Path]::DirectorySeparatorChar
+$sourcePrefix = "$sourceRoot$separator"
+$outputPrefix = "$outputRoot$separator"
+
+if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
+    throw "Site source directory does not exist: $sourceRoot"
+}
+if ($outputRoot.Equals($sourceRoot, $pathComparison) -or
+    $outputRoot.StartsWith($sourcePrefix, $pathComparison) -or
+    $sourceRoot.StartsWith($outputPrefix, $pathComparison)) {
+    throw 'Payload output must be outside the site source tree and cannot contain it.'
+}
+$outputDriveRoot = [IO.Path]::GetPathRoot($outputRoot).TrimEnd('\', '/')
+if ($outputRoot.Equals($outputDriveRoot, $pathComparison) -or
+    $outputRoot.Length -le ($outputDriveRoot.Length + 8)) {
+    throw 'Refusing to clean an unsafe payload output path.'
+}
+if ($manifestFullPath.StartsWith($outputPrefix, $pathComparison) -or
+    $manifestFullPath.Equals($outputRoot, $pathComparison)) {
+    throw 'The SHA-256 manifest must be outside the deploy payload.'
+}
+
+# Deliberately exact: source JSX, package metadata, build notes, and local tooling
+# cannot silently become production files.
+$allowlist = [string[]] @(
+    '404.html'
+    '_headers'
+    'app.js'
+    'assets/favicon.svg'
+    'assets/winghostty-app-icon.svg'
+    'assets/winghostty-flag-light.svg'
+    'assets/winghostty-flag.svg'
+    'assets/winghostty-icon.svg'
+    'assets/winghostty-social.png'
+    'assets/winghostty-wordmark.svg'
+    'bundle.js'
+    'icons/ghostty-official.png'
+    'index.html'
+    'styles.css'
+    'vendor/react-dom.production.min.js'
+    'vendor/react.production.min.js'
+)
+[Array]::Sort($allowlist, [StringComparer]::Ordinal)
+
+$sourceFiles = [Collections.Generic.List[object]]::new()
+foreach ($relativePath in $allowlist) {
+    if ($relativePath.Contains('\')) {
+        throw "Payload allowlist paths must use forward slashes: $relativePath"
+    }
+    $sourcePath = [IO.Path]::GetFullPath(
+        (Join-Path $sourceRoot ($relativePath.Replace('/', $separator)))
+    )
+    if (-not $sourcePath.StartsWith($sourcePrefix, $pathComparison)) {
+        throw "Payload allowlist path escapes the source directory: $relativePath"
+    }
+    if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+        throw "Required site payload file is missing: $relativePath"
+    }
+    $sourceItem = Get-Item -LiteralPath $sourcePath -Force
+    if (($sourceItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Site payload cannot contain a reparse point: $relativePath"
+    }
+    [void]$sourceFiles.Add([pscustomobject]@{
+        RelativePath = $relativePath
+        SourcePath = $sourcePath
+    })
+}
+
+if (Test-Path -LiteralPath $outputRoot) {
+    $outputItem = Get-Item -LiteralPath $outputRoot -Force
+    if (($outputItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw 'Refusing to clean a payload output directory that is a reparse point.'
+    }
+    Remove-Item -LiteralPath $outputRoot -Recurse -Force
+}
+[void](New-Item -ItemType Directory -Path $outputRoot)
+
+$manifestLines = [Collections.Generic.List[string]]::new()
+foreach ($sourceFile in $sourceFiles) {
+    $destinationPath = Join-Path $outputRoot (
+        $sourceFile.RelativePath.Replace('/', $separator)
+    )
+    $destinationParent = Split-Path -Parent $destinationPath
+    [void](New-Item -ItemType Directory -Path $destinationParent -Force)
+    [IO.File]::Copy($sourceFile.SourcePath, $destinationPath, $false)
+    $hash = (Get-FileHash -LiteralPath $destinationPath -Algorithm SHA256).
+        Hash.ToLowerInvariant()
+    [void]$manifestLines.Add("$hash  $($sourceFile.RelativePath)")
+}
+
+$actualRelativePaths = [string[]] @(
+    Get-ChildItem -LiteralPath $outputRoot -File -Recurse -Force |
+        ForEach-Object {
+            $_.FullName.Substring($outputPrefix.Length).Replace('\', '/')
+        }
+)
+[Array]::Sort($actualRelativePaths, [StringComparer]::Ordinal)
+if ($actualRelativePaths.Count -ne $allowlist.Count) {
+    throw 'Payload output contains an unexpected number of files.'
+}
+for ($index = 0; $index -lt $allowlist.Count; $index++) {
+    if ($actualRelativePaths[$index] -cne $allowlist[$index]) {
+        throw "Payload output escaped the allowlist: $($actualRelativePaths[$index])"
+    }
+}
+
+$manifestParent = Split-Path -Parent $manifestFullPath
+if ($manifestParent) {
+    [void](New-Item -ItemType Directory -Path $manifestParent -Force)
+}
+$utf8NoBom = [Text.UTF8Encoding]::new($false)
+[IO.File]::WriteAllText(
+    $manifestFullPath,
+    (($manifestLines -join "`n") + "`n"),
+    $utf8NoBom
+)
+
+Write-Host "Built deterministic site payload: $($allowlist.Count) files."

--- a/scripts/build-site-payload.ps1
+++ b/scripts/build-site-payload.ps1
@@ -29,6 +29,8 @@ $outputPrefix = "$outputRoot$separator"
 if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
     throw "Site source directory does not exist: $sourceRoot"
 }
+[void](& (Join-Path $PSScriptRoot 'get-site-header-contract.ps1') `
+    -SiteDirectory $sourceRoot)
 if ($outputRoot.Equals($sourceRoot, $pathComparison) -or
     $outputRoot.StartsWith($sourcePrefix, $pathComparison) -or
     $sourceRoot.StartsWith($outputPrefix, $pathComparison)) {

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -51,37 +51,41 @@ foreach ($line in [IO.File]::ReadAllLines($headersPath)) {
     }
 }
 
-foreach ($requiredPath in @('/*', '/bundle.js')) {
+foreach ($requiredPath in @('/*', '/', '/bundle.js')) {
     if (-not $blocks.ContainsKey($requiredPath)) {
         throw "Site header contract is missing $requiredPath."
     }
 }
-$root = $blocks['/*']
+$security = $blocks['/*']
+$root = $blocks['/']
 $bundle = $blocks['/bundle.js']
 foreach ($requiredHeader in @(
-    'Cache-Control',
     'Content-Security-Policy',
     'X-Content-Type-Options',
     'X-Frame-Options',
     'Referrer-Policy',
     'Permissions-Policy'
 )) {
-    if (-not $root.ContainsKey($requiredHeader)) {
-        throw "Root site header contract is missing $requiredHeader."
+    if (-not $security.ContainsKey($requiredHeader)) {
+        throw "Catch-all site security contract is missing $requiredHeader."
     }
 }
-if (-not $bundle.ContainsKey('Cache-Control')) {
-    throw 'Bundle site header contract is missing Cache-Control.'
+if (-not $root.ContainsKey('Cache-Control') -or
+    -not $bundle.ContainsKey('Cache-Control')) {
+    throw 'Root or bundle site header contract is missing Cache-Control.'
+}
+if ($security.ContainsKey('Cache-Control')) {
+    throw 'Catch-all security headers cannot overlap path-specific cache policy.'
 }
 if ($root['Cache-Control'] -cne 'public, max-age=0, must-revalidate' -or
     $bundle['Cache-Control'] -cne 'public, max-age=3600, must-revalidate' -or
-    $root['X-Content-Type-Options'] -cne 'nosniff' -or
-    $root['X-Frame-Options'] -cne 'DENY' -or
-    $root['Referrer-Policy'] -cne 'strict-origin-when-cross-origin') {
+    $security['X-Content-Type-Options'] -cne 'nosniff' -or
+    $security['X-Frame-Options'] -cne 'DENY' -or
+    $security['Referrer-Policy'] -cne 'strict-origin-when-cross-origin') {
     throw 'Site cache or browser security header contract changed unexpectedly.'
 }
 
-$permissions = $root['Permissions-Policy']
+$permissions = $security['Permissions-Policy']
 foreach ($permission in @(
     'camera=()',
     'geolocation=()',
@@ -128,7 +132,7 @@ foreach ($htmlName in @('index.html', '404.html')) {
 }
 [void]$expectedHashes.Add((Get-CspSha256Source -Value "this.media='all'"))
 
-$csp = $root['Content-Security-Policy']
+$csp = $security['Content-Security-Policy']
 if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
     throw 'Site CSP cannot broadly allow inline scripts.'
 }
@@ -162,9 +166,9 @@ if ($declaredHashes.Count -ne $expectedHashes.Count -or
     root = [ordered]@{
         cache_control = $root['Cache-Control']
         content_security_policy = $csp
-        x_content_type_options = $root['X-Content-Type-Options']
-        x_frame_options = $root['X-Frame-Options']
-        referrer_policy = $root['Referrer-Policy']
+        x_content_type_options = $security['X-Content-Type-Options']
+        x_frame_options = $security['X-Frame-Options']
+        referrer_policy = $security['Referrer-Policy']
         permissions_policy = $permissions
     }
     bundle = [ordered]@{

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -75,16 +75,40 @@ if ($security['Cache-Control'] -cne 'public, max-age=0, must-revalidate' -or
 }
 
 $permissions = $security['Permissions-Policy']
+$expectedPermissions = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
 foreach ($permission in @(
+    'accelerometer=()',
+    'autoplay=()',
     'camera=()',
     'geolocation=()',
+    'gyroscope=()',
+    'magnetometer=()',
     'microphone=()',
     'payment=()',
     'usb=()'
 )) {
-    if (-not $permissions.Contains($permission, [StringComparison]::Ordinal)) {
-        throw "Site permissions policy is missing $permission."
+    [void]$expectedPermissions.Add($permission)
+}
+$declaredPermissionTokens = @(
+    $permissions.Split(',') | ForEach-Object { $_.Trim() }
+)
+$declaredPermissions = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+foreach ($permission in $declaredPermissionTokens) {
+    if (-not $permission) {
+        throw 'Site permissions policy contains an empty directive.'
     }
+    [void]$declaredPermissions.Add($permission)
+}
+if ($declaredPermissionTokens.Count -ne $declaredPermissions.Count -or
+    $declaredPermissions.Count -ne $expectedPermissions.Count -or
+    @($expectedPermissions | Where-Object {
+        -not $declaredPermissions.Contains($_)
+    }).Count -ne 0) {
+    throw 'Site permissions policy does not exactly match the denylist contract.'
 }
 
 function Get-CspSha256Source {
@@ -97,6 +121,9 @@ function Get-CspSha256Source {
 }
 
 $expectedScriptHashes = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+$expectedScriptAttributeHashes = [Collections.Generic.HashSet[string]]::new(
     [StringComparer]::Ordinal
 )
 foreach ($htmlName in @('index.html', '404.html')) {
@@ -118,13 +145,21 @@ foreach ($htmlName in @('index.html', '404.html')) {
     [void]$expectedScriptHashes.Add(
         (Get-CspSha256Source -Value $inlineScripts[0].Groups['body'].Value)
     )
+    $eventAttributeCount = [regex]::Matches(
+        $html,
+        '(?is)\s+on[a-z][a-z0-9_-]*\s*='
+    ).Count
+    $eventHandlers = @([regex]::Matches(
+        $html,
+        '(?is)\s+on[a-z][a-z0-9_-]*\s*=\s*(?<quote>["''])(?<body>.*?)\k<quote>'
+    ))
+    if ($eventAttributeCount -ne 1 -or $eventHandlers.Count -ne 1) {
+        throw "Expected exactly one quoted CSP-hashed event handler in $htmlName."
+    }
+    [void]$expectedScriptAttributeHashes.Add(
+        (Get-CspSha256Source -Value $eventHandlers[0].Groups['body'].Value)
+    )
 }
-$expectedScriptAttributeHashes = [Collections.Generic.HashSet[string]]::new(
-    [StringComparer]::Ordinal
-)
-[void]$expectedScriptAttributeHashes.Add(
-    (Get-CspSha256Source -Value "this.media='all'")
-)
 
 $csp = $security['Content-Security-Policy']
 function Get-CspDirectiveSources {

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -194,6 +194,16 @@ Assert-ExactCspDirectiveHashes `
     -DirectiveName 'script-src-attr' `
     -Expected $expectedScriptAttributeHashes
 
+foreach ($directive in $csp.Split(';')) {
+    $directive = $directive.Trim()
+    if (-not $directive) { continue }
+    $directiveName = [regex]::Split($directive, '\s+')[0]
+    if ($directiveName -notin @('script-src', 'script-src-attr') -and
+        $directive -match "'sha256-[A-Za-z0-9+/]+=*'") {
+        throw "Site CSP cannot declare hashes in unvalidated directive $directiveName."
+    }
+}
+
 $expectedHashes = [Collections.Generic.HashSet[string]]::new(
     $expectedScriptHashes,
     [StringComparer]::Ordinal

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -140,13 +140,18 @@ foreach ($token in @(
         throw "Site CSP is missing: $token"
     }
 }
-$declaredHashes = @(
-    [regex]::Matches($csp, "'(?<hash>sha256-[A-Za-z0-9+/]+=*)'") |
-        ForEach-Object { $_.Groups['hash'].Value }
+$declaredHashes = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
 )
+foreach ($match in [regex]::Matches(
+    $csp,
+    "'(?<hash>sha256-[A-Za-z0-9+/]+=*)'"
+)) {
+    [void]$declaredHashes.Add($match.Groups['hash'].Value)
+}
 if ($declaredHashes.Count -ne $expectedHashes.Count -or
-    @($declaredHashes | Where-Object {
-        -not $expectedHashes.Contains($_)
+    @($expectedHashes | Where-Object {
+        -not $declaredHashes.Contains($_)
     }).Count -ne 0) {
     throw 'Site CSP hashes do not exactly match the inline HTML scripts and handlers.'
 }

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -51,15 +51,12 @@ foreach ($line in [IO.File]::ReadAllLines($headersPath)) {
     }
 }
 
-foreach ($requiredPath in @('/*', '/', '/bundle.js')) {
-    if (-not $blocks.ContainsKey($requiredPath)) {
-        throw "Site header contract is missing $requiredPath."
-    }
+if ($blocks.Count -ne 1 -or -not $blocks.ContainsKey('/*')) {
+    throw 'Site header contract must use one catch-all response policy.'
 }
 $security = $blocks['/*']
-$root = $blocks['/']
-$bundle = $blocks['/bundle.js']
 foreach ($requiredHeader in @(
+    'Cache-Control',
     'Content-Security-Policy',
     'X-Content-Type-Options',
     'X-Frame-Options',
@@ -70,15 +67,7 @@ foreach ($requiredHeader in @(
         throw "Catch-all site security contract is missing $requiredHeader."
     }
 }
-if (-not $root.ContainsKey('Cache-Control') -or
-    -not $bundle.ContainsKey('Cache-Control')) {
-    throw 'Root or bundle site header contract is missing Cache-Control.'
-}
-if ($security.ContainsKey('Cache-Control')) {
-    throw 'Catch-all security headers cannot overlap path-specific cache policy.'
-}
-if ($root['Cache-Control'] -cne 'public, max-age=0, must-revalidate' -or
-    $bundle['Cache-Control'] -cne 'public, max-age=3600, must-revalidate' -or
+if ($security['Cache-Control'] -cne 'public, max-age=0, must-revalidate' -or
     $security['X-Content-Type-Options'] -cne 'nosniff' -or
     $security['X-Frame-Options'] -cne 'DENY' -or
     $security['Referrer-Policy'] -cne 'strict-origin-when-cross-origin') {
@@ -164,7 +153,7 @@ if ($declaredHashes.Count -ne $expectedHashes.Count -or
 
 [ordered]@{
     root = [ordered]@{
-        cache_control = $root['Cache-Control']
+        cache_control = $security['Cache-Control']
         content_security_policy = $csp
         x_content_type_options = $security['X-Content-Type-Options']
         x_frame_options = $security['X-Frame-Options']
@@ -172,6 +161,6 @@ if ($declaredHashes.Count -ne $expectedHashes.Count -or
         permissions_policy = $permissions
     }
     bundle = [ordered]@{
-        cache_control = $bundle['Cache-Control']
+        cache_control = $security['Cache-Control']
     }
 } | ConvertTo-Json -Depth 4 -Compress

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -1,0 +1,173 @@
+#requires -Version 7.3
+
+[CmdletBinding()]
+param(
+    [string] $SiteDirectory = (Join-Path (Split-Path -Parent $PSScriptRoot) 'site')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$siteRoot = [IO.Path]::GetFullPath($SiteDirectory).TrimEnd('\', '/')
+$headersPath = Join-Path $siteRoot '_headers'
+if (-not (Test-Path -LiteralPath $headersPath -PathType Leaf)) {
+    throw 'Site header contract is missing _headers.'
+}
+
+$blocks = [Collections.Generic.Dictionary[
+    string,
+    Collections.Generic.Dictionary[string, string]
+]]::new([StringComparer]::Ordinal)
+$currentPath = $null
+foreach ($line in [IO.File]::ReadAllLines($headersPath)) {
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.TrimStart().StartsWith('#')) {
+        continue
+    }
+    if (-not [char]::IsWhiteSpace($line[0])) {
+        $currentPath = $line.Trim()
+        if (-not $blocks.TryAdd(
+            $currentPath,
+            [Collections.Generic.Dictionary[string, string]]::new(
+                [StringComparer]::OrdinalIgnoreCase
+            )
+        )) {
+            throw "Duplicate site header path: $currentPath"
+        }
+        continue
+    }
+    if ($null -eq $currentPath) {
+        throw 'Site header appears before a path block.'
+    }
+    $separator = $line.IndexOf(':')
+    if ($separator -le 0) {
+        throw "Malformed site header in ${currentPath}: $line"
+    }
+    $name = $line.Substring(0, $separator).Trim()
+    $value = $line.Substring($separator + 1).Trim()
+    if ([string]::IsNullOrWhiteSpace($name) -or
+        [string]::IsNullOrWhiteSpace($value) -or
+        -not $blocks[$currentPath].TryAdd($name, $value)) {
+        throw "Invalid or duplicate site header in ${currentPath}: $name"
+    }
+}
+
+foreach ($requiredPath in @('/*', '/bundle.js')) {
+    if (-not $blocks.ContainsKey($requiredPath)) {
+        throw "Site header contract is missing $requiredPath."
+    }
+}
+$root = $blocks['/*']
+$bundle = $blocks['/bundle.js']
+foreach ($requiredHeader in @(
+    'Cache-Control',
+    'Content-Security-Policy',
+    'X-Content-Type-Options',
+    'X-Frame-Options',
+    'Referrer-Policy',
+    'Permissions-Policy'
+)) {
+    if (-not $root.ContainsKey($requiredHeader)) {
+        throw "Root site header contract is missing $requiredHeader."
+    }
+}
+if (-not $bundle.ContainsKey('Cache-Control')) {
+    throw 'Bundle site header contract is missing Cache-Control.'
+}
+if ($root['Cache-Control'] -cne 'public, max-age=0, must-revalidate' -or
+    $bundle['Cache-Control'] -cne 'public, max-age=3600, must-revalidate' -or
+    $root['X-Content-Type-Options'] -cne 'nosniff' -or
+    $root['X-Frame-Options'] -cne 'DENY' -or
+    $root['Referrer-Policy'] -cne 'strict-origin-when-cross-origin') {
+    throw 'Site cache or browser security header contract changed unexpectedly.'
+}
+
+$permissions = $root['Permissions-Policy']
+foreach ($permission in @(
+    'camera=()',
+    'geolocation=()',
+    'microphone=()',
+    'payment=()',
+    'usb=()'
+)) {
+    if (-not $permissions.Contains($permission, [StringComparison]::Ordinal)) {
+        throw "Site permissions policy is missing $permission."
+    }
+}
+
+function Get-CspSha256Source {
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Value)
+
+    $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Value)
+    return 'sha256-' + [Convert]::ToBase64String(
+        [Security.Cryptography.SHA256]::HashData($bytes)
+    )
+}
+
+$expectedHashes = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+foreach ($htmlName in @('index.html', '404.html')) {
+    $htmlPath = Join-Path $siteRoot $htmlName
+    if (-not (Test-Path -LiteralPath $htmlPath -PathType Leaf)) {
+        throw "Site header contract is missing $htmlName."
+    }
+    $html = [IO.File]::ReadAllText(
+        $htmlPath,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $inlineScripts = @(
+        [regex]::Matches($html, '(?is)<script(?<attrs>[^>]*)>(?<body>.*?)</script>') |
+            Where-Object { $_.Groups['attrs'].Value -notmatch '\bsrc\s*=' }
+    )
+    if ($inlineScripts.Count -ne 1) {
+        throw "Expected exactly one CSP-hashed inline script in $htmlName."
+    }
+    [void]$expectedHashes.Add(
+        (Get-CspSha256Source -Value $inlineScripts[0].Groups['body'].Value)
+    )
+}
+[void]$expectedHashes.Add((Get-CspSha256Source -Value "this.media='all'"))
+
+$csp = $root['Content-Security-Policy']
+if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
+    throw 'Site CSP cannot broadly allow inline scripts.'
+}
+foreach ($token in @(
+    "default-src 'self'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "script-src 'self'",
+    "script-src-attr 'unsafe-hashes'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "connect-src 'self' https://api.github.com"
+)) {
+    if (-not $csp.Contains($token, [StringComparison]::Ordinal)) {
+        throw "Site CSP is missing: $token"
+    }
+}
+$declaredHashes = @(
+    [regex]::Matches($csp, "'(?<hash>sha256-[A-Za-z0-9+/]+=*)'") |
+        ForEach-Object { $_.Groups['hash'].Value }
+)
+if ($declaredHashes.Count -ne $expectedHashes.Count -or
+    @($declaredHashes | Where-Object {
+        -not $expectedHashes.Contains($_)
+    }).Count -ne 0) {
+    throw 'Site CSP hashes do not exactly match the inline HTML scripts and handlers.'
+}
+
+[ordered]@{
+    root = [ordered]@{
+        cache_control = $root['Cache-Control']
+        content_security_policy = $csp
+        x_content_type_options = $root['X-Content-Type-Options']
+        x_frame_options = $root['X-Frame-Options']
+        referrer_policy = $root['Referrer-Policy']
+        permissions_policy = $permissions
+    }
+    bundle = [ordered]@{
+        cache_control = $bundle['Cache-Control']
+    }
+} | ConvertTo-Json -Depth 4 -Compress

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -96,7 +96,7 @@ function Get-CspSha256Source {
     )
 }
 
-$expectedHashes = [Collections.Generic.HashSet[string]]::new(
+$expectedScriptHashes = [Collections.Generic.HashSet[string]]::new(
     [StringComparer]::Ordinal
 )
 foreach ($htmlName in @('index.html', '404.html')) {
@@ -115,11 +115,16 @@ foreach ($htmlName in @('index.html', '404.html')) {
     if ($inlineScripts.Count -ne 1) {
         throw "Expected exactly one CSP-hashed inline script in $htmlName."
     }
-    [void]$expectedHashes.Add(
+    [void]$expectedScriptHashes.Add(
         (Get-CspSha256Source -Value $inlineScripts[0].Groups['body'].Value)
     )
 }
-[void]$expectedHashes.Add((Get-CspSha256Source -Value "this.media='all'"))
+$expectedScriptAttributeHashes = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+[void]$expectedScriptAttributeHashes.Add(
+    (Get-CspSha256Source -Value "this.media='all'")
+)
 
 $csp = $security['Content-Security-Policy']
 if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
@@ -140,6 +145,60 @@ foreach ($token in @(
         throw "Site CSP is missing: $token"
     }
 }
+function Get-CspDirectiveSources {
+    param(
+        [Parameter(Mandatory)] [string] $Policy,
+        [Parameter(Mandatory)] [string] $DirectiveName
+    )
+
+    $matches = @(
+        $Policy.Split(';') |
+            ForEach-Object { $_.Trim() } |
+            Where-Object {
+                $_ -match ('^' + [regex]::Escape($DirectiveName) + '(?:\s|$)')
+            }
+    )
+    if ($matches.Count -ne 1) {
+        throw "Site CSP must declare $DirectiveName exactly once."
+    }
+    return @([regex]::Split($matches[0], '\s+') | Select-Object -Skip 1)
+}
+
+function Assert-ExactCspDirectiveHashes {
+    param(
+        [Parameter(Mandatory)] [string] $DirectiveName,
+        [Parameter(Mandatory)]
+        [Collections.Generic.HashSet[string]] $Expected
+    )
+
+    $declaredTokens = @(
+        Get-CspDirectiveSources -Policy $csp -DirectiveName $DirectiveName |
+            Where-Object { $_ -match "^'sha256-[A-Za-z0-9+/]+=*'$" }
+    )
+    $declared = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::Ordinal
+    )
+    foreach ($token in $declaredTokens) {
+        [void]$declared.Add($token.Trim("'"))
+    }
+    if ($declaredTokens.Count -ne $declared.Count -or
+        $declared.Count -ne $Expected.Count -or
+        @($Expected | Where-Object { -not $declared.Contains($_) }).Count -ne 0) {
+        throw "Site CSP $DirectiveName hashes do not exactly match their HTML sources."
+    }
+}
+Assert-ExactCspDirectiveHashes `
+    -DirectiveName 'script-src' `
+    -Expected $expectedScriptHashes
+Assert-ExactCspDirectiveHashes `
+    -DirectiveName 'script-src-attr' `
+    -Expected $expectedScriptAttributeHashes
+
+$expectedHashes = [Collections.Generic.HashSet[string]]::new(
+    $expectedScriptHashes,
+    [StringComparer]::Ordinal
+)
+$expectedHashes.UnionWith($expectedScriptAttributeHashes)
 $declaredHashes = [Collections.Generic.HashSet[string]]::new(
     [StringComparer]::Ordinal
 )
@@ -153,7 +212,7 @@ if ($declaredHashes.Count -ne $expectedHashes.Count -or
     @($expectedHashes | Where-Object {
         -not $declaredHashes.Contains($_)
     }).Count -ne 0) {
-    throw 'Site CSP hashes do not exactly match the inline HTML scripts and handlers.'
+    throw 'Site CSP declares hashes outside the exact HTML source contract.'
 }
 
 [ordered]@{

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -156,8 +156,11 @@ foreach ($htmlName in @('index.html', '404.html')) {
     if ($eventAttributeCount -ne 1 -or $eventHandlers.Count -ne 1) {
         throw "Expected exactly one quoted CSP-hashed event handler in $htmlName."
     }
+    $decodedEventHandler = [Net.WebUtility]::HtmlDecode(
+        $eventHandlers[0].Groups['body'].Value
+    )
     [void]$expectedScriptAttributeHashes.Add(
-        (Get-CspSha256Source -Value $eventHandlers[0].Groups['body'].Value)
+        (Get-CspSha256Source -Value $decodedEventHandler)
     )
 }
 

--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -127,24 +127,6 @@ $expectedScriptAttributeHashes = [Collections.Generic.HashSet[string]]::new(
 )
 
 $csp = $security['Content-Security-Policy']
-if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
-    throw 'Site CSP cannot broadly allow inline scripts.'
-}
-foreach ($token in @(
-    "default-src 'self'",
-    "base-uri 'none'",
-    "object-src 'none'",
-    "frame-ancestors 'none'",
-    "script-src 'self'",
-    "script-src-attr 'unsafe-hashes'",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
-    "connect-src 'self' https://api.github.com"
-)) {
-    if (-not $csp.Contains($token, [StringComparison]::Ordinal)) {
-        throw "Site CSP is missing: $token"
-    }
-}
 function Get-CspDirectiveSources {
     param(
         [Parameter(Mandatory)] [string] $Policy,
@@ -164,44 +146,85 @@ function Get-CspDirectiveSources {
     return @([regex]::Split($matches[0], '\s+') | Select-Object -Skip 1)
 }
 
-function Assert-ExactCspDirectiveHashes {
+function Assert-ExactCspDirectiveSources {
     param(
         [Parameter(Mandatory)] [string] $DirectiveName,
-        [Parameter(Mandatory)]
-        [Collections.Generic.HashSet[string]] $Expected
+        [Parameter(Mandatory)] [AllowEmptyCollection()]
+        [string[]] $Expected
     )
 
     $declaredTokens = @(
-        Get-CspDirectiveSources -Policy $csp -DirectiveName $DirectiveName |
-            Where-Object { $_ -match "^'sha256-[A-Za-z0-9+/]+=*'$" }
+        Get-CspDirectiveSources -Policy $csp -DirectiveName $DirectiveName
     )
     $declared = [Collections.Generic.HashSet[string]]::new(
         [StringComparer]::Ordinal
     )
+    $expectedSet = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::Ordinal
+    )
     foreach ($token in $declaredTokens) {
-        [void]$declared.Add($token.Trim("'"))
+        [void]$declared.Add($token)
+    }
+    foreach ($token in $Expected) {
+        [void]$expectedSet.Add($token)
     }
     if ($declaredTokens.Count -ne $declared.Count -or
-        $declared.Count -ne $Expected.Count -or
-        @($Expected | Where-Object { -not $declared.Contains($_) }).Count -ne 0) {
-        throw "Site CSP $DirectiveName hashes do not exactly match their HTML sources."
+        $Expected.Count -ne $expectedSet.Count -or
+        $declared.Count -ne $expectedSet.Count -or
+        @($expectedSet | Where-Object { -not $declared.Contains($_) }).Count -ne 0) {
+        throw "Site CSP $DirectiveName sources do not exactly match the site contract."
     }
 }
-Assert-ExactCspDirectiveHashes `
-    -DirectiveName 'script-src' `
-    -Expected $expectedScriptHashes
-Assert-ExactCspDirectiveHashes `
-    -DirectiveName 'script-src-attr' `
-    -Expected $expectedScriptAttributeHashes
 
+$expectedScriptSources = @("'self'") + @(
+    $expectedScriptHashes | ForEach-Object { "'$_'" }
+)
+$expectedScriptAttributeSources = @("'unsafe-hashes'") + @(
+    $expectedScriptAttributeHashes | ForEach-Object { "'$_'" }
+)
+$expectedCspDirectives = [ordered]@{
+    'default-src' = @("'self'")
+    'base-uri' = @("'none'")
+    'object-src' = @("'none'")
+    'frame-ancestors' = @("'none'")
+    'form-action' = @("'self'")
+    'script-src' = $expectedScriptSources
+    'script-src-attr' = $expectedScriptAttributeSources
+    'style-src' = @(
+        "'self'",
+        "'unsafe-inline'",
+        'https://fonts.googleapis.com'
+    )
+    'style-src-attr' = @("'unsafe-inline'")
+    'font-src' = @("'self'", 'https://fonts.gstatic.com')
+    'connect-src' = @("'self'", 'https://api.github.com')
+    'img-src' = @("'self'", 'data:')
+    'frame-src' = @("'none'")
+    'worker-src' = @("'none'")
+    'manifest-src' = @("'self'")
+    'upgrade-insecure-requests' = @()
+}
+$declaredDirectiveNames = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
 foreach ($directive in $csp.Split(';')) {
     $directive = $directive.Trim()
     if (-not $directive) { continue }
     $directiveName = [regex]::Split($directive, '\s+')[0]
-    if ($directiveName -notin @('script-src', 'script-src-attr') -and
-        $directive -match "'sha256-[A-Za-z0-9+/]+=*'") {
-        throw "Site CSP cannot declare hashes in unvalidated directive $directiveName."
+    if (-not $declaredDirectiveNames.Add($directiveName)) {
+        throw "Site CSP declares duplicate directive $directiveName."
     }
+}
+if ($declaredDirectiveNames.Count -ne $expectedCspDirectives.Count -or
+    @($declaredDirectiveNames | Where-Object {
+        -not $expectedCspDirectives.Contains($_)
+    }).Count -ne 0) {
+    throw 'Site CSP does not declare the exact expected directive set.'
+}
+foreach ($directiveName in $expectedCspDirectives.Keys) {
+    Assert-ExactCspDirectiveSources `
+        -DirectiveName $directiveName `
+        -Expected $expectedCspDirectives[$directiveName]
 }
 
 $expectedHashes = [Collections.Generic.HashSet[string]]::new(

--- a/scripts/require-site-deployment-head.ps1
+++ b/scripts/require-site-deployment-head.ps1
@@ -21,8 +21,12 @@ $ErrorActionPreference = 'Stop'
 if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty') {
     throw 'Site deployment is restricted to amanthanvi/winghostty.'
 }
-$origin = (git remote get-url origin).Trim()
-if ($LASTEXITCODE -ne 0 -or $origin -cnotin @(
+$originOutput = git remote get-url origin
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to read the origin remote for production site deployment.'
+}
+$origin = ([string]($originOutput -join "`n")).Trim()
+if ($origin -cnotin @(
     'https://github.com/amanthanvi/winghostty',
     'https://github.com/amanthanvi/winghostty.git'
 )) {
@@ -32,14 +36,25 @@ git fetch --force --no-tags origin "refs/heads/${DefaultBranch}:refs/remotes/ori
 if ($LASTEXITCODE -ne 0) {
     throw "Failed to fetch exact origin/$DefaultBranch."
 }
-$head = (git rev-parse HEAD).Trim()
-$originHead = (git rev-parse "refs/remotes/origin/$DefaultBranch").Trim()
-if ($LASTEXITCODE -ne 0 -or
-    $head -cne $ExpectedSha -or
+$headOutput = git rev-parse HEAD
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to resolve the checked-out deployment commit.'
+}
+$head = ([string]($headOutput -join "`n")).Trim()
+$originHeadOutput = git rev-parse "refs/remotes/origin/$DefaultBranch"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to resolve exact origin/$DefaultBranch."
+}
+$originHead = ([string]($originHeadOutput -join "`n")).Trim()
+if ($head -cne $ExpectedSha -or
     $head -cne $originHead) {
     throw "Resolved deployment SHA is not the exact current origin/$DefaultBranch commit."
 }
-if (git status --porcelain=v1 --untracked-files=all) {
+$status = @(git status --porcelain=v1 --untracked-files=all)
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to inspect the working tree before the $Phase deployment."
+}
+if ($status.Count -ne 0) {
     throw "Repository became dirty before the $Phase deployment."
 }
 

--- a/scripts/require-site-deployment-head.ps1
+++ b/scripts/require-site-deployment-head.ps1
@@ -1,0 +1,46 @@
+#requires -Version 7.3
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-f]{40}$')]
+    [string] $ExpectedSha,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^main$')]
+    [string] $DefaultBranch,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('canary', 'production')]
+    [string] $Phase
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($env:GITHUB_REPOSITORY -cne 'amanthanvi/winghostty') {
+    throw 'Site deployment is restricted to amanthanvi/winghostty.'
+}
+$origin = (git remote get-url origin).Trim()
+if ($LASTEXITCODE -ne 0 -or $origin -cnotin @(
+    'https://github.com/amanthanvi/winghostty',
+    'https://github.com/amanthanvi/winghostty.git'
+)) {
+    throw 'Unexpected origin remote for production site deployment.'
+}
+git fetch --force --no-tags origin "refs/heads/${DefaultBranch}:refs/remotes/origin/${DefaultBranch}"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to fetch exact origin/$DefaultBranch."
+}
+$head = (git rev-parse HEAD).Trim()
+$originHead = (git rev-parse "refs/remotes/origin/$DefaultBranch").Trim()
+if ($LASTEXITCODE -ne 0 -or
+    $head -cne $ExpectedSha -or
+    $head -cne $originHead) {
+    throw "Resolved deployment SHA is not the exact current origin/$DefaultBranch commit."
+}
+if (git status --porcelain=v1 --untracked-files=all) {
+    throw "Repository became dirty before the $Phase deployment."
+}
+
+Write-Host "Verified clean exact origin/$DefaultBranch at $ExpectedSha before $Phase."

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -416,7 +416,7 @@ function Get-ResponseHeaderText {
     return ''
 }
 
-function Assert-PublicHeaderContract {
+function Test-PublicHeaderContractOnce {
     param(
         [Parameter(Mandatory)] [Uri] $Origin,
         [Parameter(Mandatory)] [string] $Id,
@@ -451,15 +451,13 @@ function Assert-PublicHeaderContract {
         try {
             $response = $publicClient.SendAsync($request).GetAwaiter().GetResult()
             if ([int]$response.StatusCode -ne $probe.ExpectedStatus) {
-                throw "Published header probe failed for $($probe.Path) at " +
-                    "$($Origin.DnsSafeHost)."
+                return $false
             }
             $cacheControl = Get-ResponseHeaderText `
                 -Response $response `
                 -Name 'Cache-Control'
             if ($cacheControl -cne $probe.ExpectedCache) {
-                throw "Published cache policy mismatch for $($probe.Path) at " +
-                    "$($Origin.DnsSafeHost)."
+                return $false
             }
             if ((Get-ResponseHeaderText -Response $response -Name 'X-Content-Type-Options') -cne
                     [string]$Contract.root.x_content_type_options -or
@@ -471,14 +469,37 @@ function Assert-PublicHeaderContract {
                     [string]$Contract.root.permissions_policy -or
                 (Get-ResponseHeaderText -Response $response -Name 'Content-Security-Policy') -cne
                     [string]$Contract.root.content_security_policy) {
-                throw "Published browser security headers are incomplete at $($Origin.DnsSafeHost)."
+                return $false
             }
+        }
+        catch {
+            return $false
         }
         finally {
             if ($response) { $response.Dispose() }
             $request.Dispose()
         }
     }
+    return $true
+}
+
+function Assert-PublicHeaderContract {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [object] $Contract
+    )
+
+    for ($attempt = 1; $attempt -le 6; $attempt++) {
+        if (Test-PublicHeaderContractOnce `
+                -Origin $Origin `
+                -Id $Id `
+                -Contract $Contract) {
+            return
+        }
+        if ($attempt -lt 6) { Start-Sleep -Seconds 2 }
+    }
+    throw "Published response headers did not converge at $($Origin.DnsSafeHost)."
 }
 
 function Assert-WwwRedirectContract {

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -1,0 +1,670 @@
+#requires -Version 7.3
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Deployment', 'Redirect')]
+    [string] $Mode,
+
+    [ValidatePattern('^winghostty$')]
+    [string] $ProjectName = 'winghostty',
+
+    [ValidatePattern('^main$')]
+    [string] $ProductionBranch = 'main',
+
+    [string] $DeploymentId,
+    [string] $ExpectedEnvironment,
+    [string] $ExpectedBranch,
+    [string] $ExpectedCommit,
+    [string] $BaseUrl,
+    [string] $CanonicalBaseUrl,
+    [string] $PayloadDirectory,
+    [string] $ManifestPath,
+    [string] $ProvenancePath,
+    [switch] $RequireCanonical,
+    [switch] $VerifyWwwRedirect,
+
+    [string] $ApiToken = $env:CLOUDFLARE_API_TOKEN,
+    [string] $AccountId = $env:CLOUDFLARE_ACCOUNT_ID
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($ApiToken)) {
+    throw 'CLOUDFLARE_API_TOKEN is required.'
+}
+if ($AccountId -cnotmatch '^[0-9a-f]{32}$') {
+    throw 'CLOUDFLARE_ACCOUNT_ID must be a 32-character lowercase hexadecimal identifier.'
+}
+
+function Assert-DeploymentId {
+    param(
+        [Parameter(Mandatory)] [string] $Value,
+        [Parameter(Mandatory)] [string] $Label
+    )
+
+    if ($Value -cnotmatch '^[0-9A-Za-z-]{8,64}$') {
+        throw "$Label has an invalid format."
+    }
+}
+
+function Write-RedactedJson {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [object] $Value
+    )
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $parent = Split-Path -Parent $fullPath
+    if ($parent) {
+        [void](New-Item -ItemType Directory -Path $parent -Force)
+    }
+    $json = (($Value | ConvertTo-Json -Depth 12) -replace "`r`n", "`n").
+        TrimEnd([char[]]"`n") + "`n"
+    if ($json.Contains($ApiToken, [StringComparison]::Ordinal) -or
+        $json.Contains($AccountId, [StringComparison]::Ordinal)) {
+        throw 'Refusing to write provenance containing Cloudflare credentials or account identifiers.'
+    }
+    [IO.File]::WriteAllText($fullPath, $json, [Text.UTF8Encoding]::new($false))
+}
+
+$apiHandler = [Net.Http.HttpClientHandler]::new()
+$apiHandler.AllowAutoRedirect = $false
+$apiClient = [Net.Http.HttpClient]::new($apiHandler)
+$apiClient.Timeout = [TimeSpan]::FromSeconds(30)
+$apiClient.DefaultRequestHeaders.Authorization =
+    [Net.Http.Headers.AuthenticationHeaderValue]::new('Bearer', $ApiToken)
+$apiClient.DefaultRequestHeaders.UserAgent.ParseAdd('winghostty-site-verifier/1')
+$apiRoot = 'https://api.cloudflare.com/client/v4/accounts/' +
+    [Uri]::EscapeDataString($AccountId) +
+    '/pages/projects/' +
+    [Uri]::EscapeDataString($ProjectName)
+
+function Invoke-CloudflareApi {
+    param(
+        [Parameter(Mandatory)] [Net.Http.HttpMethod] $Method,
+        [Parameter(Mandatory)] [string] $RelativePath
+    )
+
+    $request = [Net.Http.HttpRequestMessage]::new(
+        $Method,
+        "$apiRoot$RelativePath"
+    )
+    $response = $null
+    try {
+        try {
+            $response = $apiClient.SendAsync($request).GetAwaiter().GetResult()
+            $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+        }
+        catch {
+            throw 'Cloudflare API transport failed.'
+        }
+        if (-not $response.IsSuccessStatusCode) {
+            throw "Cloudflare API request failed with HTTP $([int]$response.StatusCode)."
+        }
+        try {
+            $envelope = ConvertFrom-Json -InputObject $body -Depth 64 -NoEnumerate
+        }
+        catch {
+            throw 'Cloudflare API returned invalid JSON.'
+        }
+        if ($envelope.GetType() -ne [Management.Automation.PSCustomObject] -or
+            $envelope.success -ne $true -or
+            $null -eq $envelope.result) {
+            throw 'Cloudflare API rejected the request.'
+        }
+        return $envelope.result
+    }
+    finally {
+        if ($response) { $response.Dispose() }
+        $request.Dispose()
+    }
+}
+
+function Get-Project {
+    Invoke-CloudflareApi -Method ([Net.Http.HttpMethod]::Get) -RelativePath ''
+}
+
+function Get-Deployment {
+    param([Parameter(Mandatory)] [string] $Id)
+
+    Assert-DeploymentId -Value $Id -Label 'Deployment ID'
+    Invoke-CloudflareApi `
+        -Method ([Net.Http.HttpMethod]::Get) `
+        -RelativePath "/deployments/$([Uri]::EscapeDataString($Id))"
+}
+
+function Assert-ProjectContract {
+    param([Parameter(Mandatory)] [object] $Project)
+
+    if ([string]$Project.name -cne $ProjectName) {
+        throw 'Cloudflare Pages project identity mismatch.'
+    }
+    if ([string]$Project.production_branch -cne $ProductionBranch) {
+        throw 'Cloudflare Pages production branch is not main.'
+    }
+}
+
+function Assert-DeploymentContract {
+    param(
+        [Parameter(Mandatory)] [object] $Deployment,
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Environment,
+        [Parameter(Mandatory)] [string] $Branch,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+
+    if ($Commit -cnotmatch '^[0-9a-f]{40}$') {
+        throw 'Expected commit must be a full lowercase Git SHA.'
+    }
+    if ([string]$Deployment.id -cne $Id -or
+        [string]$Deployment.project_name -cne $ProjectName) {
+        throw 'Cloudflare deployment identity mismatch.'
+    }
+    if ([string]$Deployment.environment -cne $Environment) {
+        throw 'Cloudflare deployment environment mismatch.'
+    }
+    if ($Deployment.is_skipped -eq $true -or
+        [string]$Deployment.latest_stage.status -cne 'success') {
+        throw 'Cloudflare deployment did not complete successfully.'
+    }
+    $metadata = $Deployment.deployment_trigger.metadata
+    if ([string]$metadata.branch -cne $Branch -or
+        [string]$metadata.commit_hash -cne $Commit -or
+        $metadata.commit_dirty -ne $false) {
+        throw 'Cloudflare deployment provenance does not match the clean exact commit.'
+    }
+}
+
+function Get-CanonicalDeploymentId {
+    param([Parameter(Mandatory)] [object] $Project)
+
+    if ($null -eq $Project.canonical_deployment) { return '' }
+    return [string]$Project.canonical_deployment.id
+}
+
+function Wait-CanonicalDeployment {
+    param([Parameter(Mandatory)] [string] $ExpectedId)
+
+    for ($attempt = 1; $attempt -le 10; $attempt++) {
+        $project = Get-Project
+        Assert-ProjectContract -Project $project
+        if ((Get-CanonicalDeploymentId -Project $project) -ceq $ExpectedId) {
+            return $project
+        }
+        if ($attempt -lt 10) { Start-Sleep -Seconds 2 }
+    }
+    throw 'Cloudflare canonical deployment did not converge to the expected deployment.'
+}
+
+function Get-ManifestEntries {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $PayloadRoot
+    )
+
+    $manifestFullPath = [IO.Path]::GetFullPath($Path)
+    $payloadFullPath = [IO.Path]::GetFullPath($PayloadRoot).TrimEnd('\', '/')
+    if (-not (Test-Path -LiteralPath $manifestFullPath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $payloadFullPath -PathType Container)) {
+        throw 'Site payload or SHA-256 manifest is missing.'
+    }
+    $payloadPrefix = "$payloadFullPath$([IO.Path]::DirectorySeparatorChar)"
+    $pathComparison = if ($IsWindows) {
+        [StringComparison]::OrdinalIgnoreCase
+    } else {
+        [StringComparison]::Ordinal
+    }
+    $entries = [Collections.Generic.List[object]]::new()
+    $previousPath = $null
+    foreach ($line in [IO.File]::ReadAllLines($manifestFullPath)) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            throw 'Site payload manifest cannot contain blank lines.'
+        }
+        $match = [regex]::Match(
+            $line,
+            '^(?<hash>[0-9a-f]{64})  (?<path>_headers|[A-Za-z0-9][A-Za-z0-9._/-]*)$',
+            [Text.RegularExpressions.RegexOptions]::CultureInvariant
+        )
+        if (-not $match.Success) {
+            throw 'Site payload manifest has an invalid line.'
+        }
+        $relativePath = $match.Groups['path'].Value
+        $segments = $relativePath.Split('/')
+        if ($relativePath.Contains('\') -or
+            $segments -contains '.' -or
+            $segments -contains '..' -or
+            ($null -ne $previousPath -and
+                [StringComparer]::Ordinal.Compare($previousPath, $relativePath) -ge 0)) {
+            throw 'Site payload manifest paths must be unique, safe, and ordinally sorted.'
+        }
+        $localPath = [IO.Path]::GetFullPath(
+            (Join-Path $payloadFullPath (
+                $relativePath.Replace('/', [IO.Path]::DirectorySeparatorChar)
+            ))
+        )
+        if (-not $localPath.StartsWith($payloadPrefix, $pathComparison) -or
+            -not (Test-Path -LiteralPath $localPath -PathType Leaf)) {
+            throw 'Site payload manifest references a missing or unsafe local file.'
+        }
+        $actualHash = (Get-FileHash -LiteralPath $localPath -Algorithm SHA256).
+            Hash.ToLowerInvariant()
+        if ($actualHash -cne $match.Groups['hash'].Value) {
+            throw 'Local site payload does not match its SHA-256 manifest.'
+        }
+        [void]$entries.Add([pscustomobject]@{
+            Hash = $actualHash
+            Path = $relativePath
+        })
+        $previousPath = $relativePath
+    }
+    if ($entries.Count -eq 0) {
+        throw 'Site payload manifest is empty.'
+    }
+    return $entries
+}
+
+function ConvertTo-PublicBaseUri {
+    param(
+        [Parameter(Mandatory)] [string] $Value,
+        [Parameter(Mandatory)] [ValidateSet('pages', 'canonical')] [string] $Kind
+    )
+
+    $uri = $null
+    if (-not [Uri]::TryCreate($Value, [UriKind]::Absolute, [ref]$uri) -or
+        $uri.Scheme -cne 'https' -or
+        -not [string]::IsNullOrEmpty($uri.UserInfo) -or
+        -not [string]::IsNullOrEmpty($uri.Query) -or
+        -not [string]::IsNullOrEmpty($uri.Fragment) -or
+        $uri.AbsolutePath -cne '/') {
+        throw 'Deployment verification URL must be an HTTPS origin.'
+    }
+    if ($Kind -eq 'pages' -and
+        $uri.DnsSafeHost -cnotmatch '^(?:[a-z0-9-]+\.)?winghostty\.pages\.dev$') {
+        throw 'Deployment URL is not a winghostty Pages origin.'
+    }
+    if ($Kind -eq 'canonical' -and $uri.DnsSafeHost -cne 'winghostty.com') {
+        throw 'Canonical URL must be https://winghostty.com/.'
+    }
+    return $uri
+}
+
+function New-PublicAssetUri {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [string] $RelativePath,
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+
+    if ($RelativePath -ceq 'index.html') {
+        $path = '/'
+    } elseif ($RelativePath -ceq '404.html') {
+        $path = "/__winghostty_missing_$($Commit.Substring(0, 12))/nested/page"
+    } else {
+        $escapedSegments = $RelativePath.Split('/') |
+            ForEach-Object { [Uri]::EscapeDataString($_) }
+        $path = '/' + ($escapedSegments -join '/')
+    }
+    $builder = [UriBuilder]::new($Origin)
+    $builder.Path = $path
+    $builder.Query = 'winghostty_deployment=' + [Uri]::EscapeDataString($Id)
+    return $builder.Uri
+}
+
+function Get-Sha256 {
+    param([Parameter(Mandatory)] [byte[]] $Bytes)
+
+    [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($Bytes)).
+        ToLowerInvariant()
+}
+
+$publicHandler = [Net.Http.HttpClientHandler]::new()
+$publicHandler.AllowAutoRedirect = $false
+$publicHandler.AutomaticDecompression = [Net.DecompressionMethods]::None
+$publicClient = [Net.Http.HttpClient]::new($publicHandler)
+$publicClient.Timeout = [TimeSpan]::FromSeconds(30)
+$publicClient.DefaultRequestHeaders.UserAgent.ParseAdd('winghostty-site-verifier/1')
+$publicClient.DefaultRequestHeaders.CacheControl =
+    [Net.Http.Headers.CacheControlHeaderValue]::new()
+$publicClient.DefaultRequestHeaders.CacheControl.NoCache = $true
+$publicClient.DefaultRequestHeaders.Pragma.ParseAdd('no-cache')
+
+function Test-PublicPayloadOnce {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [object[]] $Entries,
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+
+    foreach ($entry in $Entries) {
+        if ($entry.Path -ceq '_headers') {
+            # Pages consumes this control file; it is not a public static asset.
+            continue
+        }
+        $uri = New-PublicAssetUri `
+            -Origin $Origin `
+            -RelativePath $entry.Path `
+            -Id $Id `
+            -Commit $Commit
+        $request = [Net.Http.HttpRequestMessage]::new([Net.Http.HttpMethod]::Get, $uri)
+        $response = $null
+        try {
+            $response = $publicClient.SendAsync($request).GetAwaiter().GetResult()
+            $expectedStatus = if ($entry.Path -ceq '404.html') { 404 } else { 200 }
+            if ([int]$response.StatusCode -ne $expectedStatus) {
+                return 'failed'
+            }
+            $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+            if ((Get-Sha256 -Bytes $bytes) -cne $entry.Hash) { return 'failed' }
+        }
+        catch {
+            return 'failed'
+        }
+        finally {
+            if ($response) { $response.Dispose() }
+            $request.Dispose()
+        }
+    }
+    return 'verified'
+}
+
+function Assert-PublicPayload {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [object[]] $Entries,
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+
+    for ($attempt = 1; $attempt -le 6; $attempt++) {
+        $status = Test-PublicPayloadOnce `
+                -Origin $Origin `
+                -Entries $Entries `
+                -Id $Id `
+                -Commit $Commit
+        if ($status -cne 'failed') {
+            return $status
+        }
+        if ($attempt -lt 6) { Start-Sleep -Seconds 2 }
+    }
+    throw "Published site bytes did not match the manifest at $($Origin.DnsSafeHost)."
+}
+
+function Get-ResponseHeaderText {
+    param(
+        [Parameter(Mandatory)] [Net.Http.HttpResponseMessage] $Response,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    $values = $null
+    if ($Response.Headers.TryGetValues($Name, [ref]$values) -or
+        $Response.Content.Headers.TryGetValues($Name, [ref]$values)) {
+        return (@($values) -join ', ')
+    }
+    return ''
+}
+
+function Assert-PublicHeaderContract {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [string] $Id
+    )
+
+    $requiredCspTokens = [string[]] @(
+        "default-src 'self'"
+        "base-uri 'none'"
+        "object-src 'none'"
+        "frame-ancestors 'none'"
+        "script-src 'self' 'sha256-pISZ4uq8FeQ38HOwS22gAtqH+pfUgqkItu+zFe6qagg=' 'sha256-HgYMqcl1IJyO4BIHc3TA/IswS2cmPQtqqPBk9kLqGao='"
+        "script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
+        "font-src 'self' https://fonts.gstatic.com"
+        "connect-src 'self' https://api.github.com"
+    )
+    $probes = @(
+        [pscustomobject]@{
+            Path = '/'
+            CachePattern = '(?:^|,\s*)public,\s*max-age=0,\s*must-revalidate(?:,|$)'
+        }
+        [pscustomobject]@{
+            Path = '/bundle.js'
+            CachePattern = '(?:^|,\s*)public,\s*max-age=3600,\s*must-revalidate(?:,|$)'
+        }
+    )
+    foreach ($probe in $probes) {
+        $builder = [UriBuilder]::new($Origin)
+        $builder.Path = $probe.Path
+        $builder.Query = 'winghostty_deployment=' + [Uri]::EscapeDataString($Id)
+        $request =
+            [Net.Http.HttpRequestMessage]::new([Net.Http.HttpMethod]::Get, $builder.Uri)
+        $response = $null
+        try {
+            $response = $publicClient.SendAsync($request).GetAwaiter().GetResult()
+            if ([int]$response.StatusCode -ne 200) {
+                throw "Published header probe failed at $($Origin.DnsSafeHost)."
+            }
+            $cacheControl = Get-ResponseHeaderText `
+                -Response $response `
+                -Name 'Cache-Control'
+            if ($cacheControl -notmatch $probe.CachePattern) {
+                throw "Published cache policy mismatch at $($Origin.DnsSafeHost)."
+            }
+            if ((Get-ResponseHeaderText -Response $response -Name 'X-Content-Type-Options') -cne
+                    'nosniff' -or
+                (Get-ResponseHeaderText -Response $response -Name 'X-Frame-Options') -cne
+                    'DENY' -or
+                (Get-ResponseHeaderText -Response $response -Name 'Referrer-Policy') -cne
+                    'strict-origin-when-cross-origin') {
+                throw "Published browser security headers are incomplete at $($Origin.DnsSafeHost)."
+            }
+            $permissions =
+                Get-ResponseHeaderText -Response $response -Name 'Permissions-Policy'
+            foreach ($permission in @(
+                'camera=()',
+                'geolocation=()',
+                'microphone=()',
+                'payment=()',
+                'usb=()'
+            )) {
+                if (-not $permissions.Contains($permission, [StringComparison]::Ordinal)) {
+                    throw "Published permissions policy is incomplete at $($Origin.DnsSafeHost)."
+                }
+            }
+            $csp = Get-ResponseHeaderText `
+                -Response $response `
+                -Name 'Content-Security-Policy'
+            if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
+                throw "Published CSP allows broad inline scripts at $($Origin.DnsSafeHost)."
+            }
+            foreach ($token in $requiredCspTokens) {
+                if (-not $csp.Contains($token, [StringComparison]::Ordinal)) {
+                    throw "Published CSP is incomplete at $($Origin.DnsSafeHost)."
+                }
+            }
+        }
+        finally {
+            if ($response) { $response.Dispose() }
+            $request.Dispose()
+        }
+    }
+}
+
+function Assert-WwwRedirectContract {
+    param(
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+
+    $suffix = "/__winghostty_redirect_$($Commit.Substring(0, 12))" +
+        "?winghostty_deployment=$([Uri]::EscapeDataString($Id))"
+    $source = [Uri]::new("https://www.winghostty.com$suffix")
+    $expected = [Uri]::new("https://winghostty.com$suffix")
+    $request = [Net.Http.HttpRequestMessage]::new([Net.Http.HttpMethod]::Get, $source)
+    $response = $null
+    try {
+        $response = $publicClient.SendAsync($request).GetAwaiter().GetResult()
+        if ([int]$response.StatusCode -ne 301 -or
+            $null -eq $response.Headers.Location) {
+            throw 'www.winghostty.com is not configured with the required zone-level 301 redirect.'
+        }
+        $location = if ($response.Headers.Location.IsAbsoluteUri) {
+            $response.Headers.Location
+        } else {
+            [Uri]::new($source, $response.Headers.Location)
+        }
+        if ($location.AbsoluteUri -cne $expected.AbsoluteUri) {
+            throw 'www.winghostty.com redirect does not preserve the path and query at the apex.'
+        }
+    }
+    catch {
+        if ($_.Exception.Message -like 'www.winghostty.com*') { throw }
+        throw 'Unable to verify the www zone-level redirect.'
+    }
+    finally {
+        if ($response) { $response.Dispose() }
+        $request.Dispose()
+    }
+}
+
+try {
+    switch ($Mode) {
+        'Redirect' {
+            if ([string]::IsNullOrWhiteSpace($DeploymentId) -or
+                [string]::IsNullOrWhiteSpace($ExpectedCommit)) {
+                throw 'Redirect mode requires DeploymentId and ExpectedCommit.'
+            }
+            Assert-DeploymentId -Value $DeploymentId -Label 'Deployment ID'
+            if ($ExpectedCommit -cnotmatch '^[0-9a-f]{40}$') {
+                throw 'Expected commit must be a full lowercase Git SHA.'
+            }
+            Assert-WwwRedirectContract -Id $DeploymentId -Commit $ExpectedCommit
+            Write-Host 'Verified the zone-owned www redirect before production.'
+        }
+
+        'Deployment' {
+            foreach ($requiredValue in @(
+                $DeploymentId,
+                $ExpectedEnvironment,
+                $ExpectedBranch,
+                $ExpectedCommit,
+                $BaseUrl,
+                $PayloadDirectory,
+                $ManifestPath,
+                $ProvenancePath
+            )) {
+                if ([string]::IsNullOrWhiteSpace($requiredValue)) {
+                    throw 'Deployment mode is missing a required argument.'
+                }
+            }
+            if ($ExpectedEnvironment -cnotin @('preview', 'production')) {
+                throw 'ExpectedEnvironment must be preview or production.'
+            }
+            if ($ExpectedEnvironment -eq 'production' -and
+                $ExpectedBranch -cne $ProductionBranch) {
+                throw 'Production deployment branch must be main.'
+            }
+            if ($ExpectedEnvironment -eq 'preview' -and
+                $ExpectedBranch -ceq $ProductionBranch) {
+                throw 'Canary deployment cannot use the production branch.'
+            }
+            Assert-DeploymentId -Value $DeploymentId -Label 'Deployment ID'
+            $deployment = Get-Deployment -Id $DeploymentId
+            Assert-DeploymentContract `
+                -Deployment $deployment `
+                -Id $DeploymentId `
+                -Environment $ExpectedEnvironment `
+                -Branch $ExpectedBranch `
+                -Commit $ExpectedCommit
+
+            $project = Get-Project
+            Assert-ProjectContract -Project $project
+            if ($RequireCanonical) {
+                if ($ExpectedEnvironment -cne 'production') {
+                    throw 'Only a production deployment can be canonical.'
+                }
+                $project = Wait-CanonicalDeployment -ExpectedId $DeploymentId
+            }
+
+            $pagesOrigin = ConvertTo-PublicBaseUri -Value $BaseUrl -Kind pages
+            $apiOrigin = ConvertTo-PublicBaseUri -Value ([string]$deployment.url) -Kind pages
+            if ($pagesOrigin.AbsoluteUri.TrimEnd('/') -cne
+                $apiOrigin.AbsoluteUri.TrimEnd('/')) {
+                throw 'Wrangler deployment URL does not match Cloudflare API provenance.'
+            }
+            $entries = @(Get-ManifestEntries `
+                -Path $ManifestPath `
+                -PayloadRoot $PayloadDirectory)
+            [void](Assert-PublicPayload `
+                -Origin $pagesOrigin `
+                -Entries $entries `
+                -Id $DeploymentId `
+                -Commit $ExpectedCommit)
+            [void](Assert-PublicHeaderContract -Origin $pagesOrigin -Id $DeploymentId)
+
+            $verifiedHosts = [Collections.Generic.List[string]]::new()
+            [void]$verifiedHosts.Add($pagesOrigin.DnsSafeHost)
+            if (-not [string]::IsNullOrWhiteSpace($CanonicalBaseUrl)) {
+                if (-not $RequireCanonical -or $ExpectedEnvironment -cne 'production') {
+                    throw 'Canonical byte verification requires the canonical production deployment.'
+                }
+                $canonicalOrigin =
+                    ConvertTo-PublicBaseUri -Value $CanonicalBaseUrl -Kind canonical
+                if (@($project.domains) -cnotcontains $canonicalOrigin.DnsSafeHost) {
+                    throw 'The apex custom domain is not attached to the Pages project.'
+                }
+                [void](Assert-PublicPayload `
+                    -Origin $canonicalOrigin `
+                    -Entries $entries `
+                    -Id $DeploymentId `
+                    -Commit $ExpectedCommit)
+                [void](Assert-PublicHeaderContract `
+                    -Origin $canonicalOrigin `
+                    -Id $DeploymentId)
+                [void]$verifiedHosts.Add($canonicalOrigin.DnsSafeHost)
+            }
+            if ($VerifyWwwRedirect) {
+                if ([string]::IsNullOrWhiteSpace($CanonicalBaseUrl)) {
+                    throw 'www redirect verification requires CanonicalBaseUrl.'
+                }
+                Assert-WwwRedirectContract -Id $DeploymentId -Commit $ExpectedCommit
+                [void]$verifiedHosts.Add('www.winghostty.com')
+            }
+
+            $manifestHash = (Get-FileHash `
+                    -LiteralPath ([IO.Path]::GetFullPath($ManifestPath)) `
+                    -Algorithm SHA256).Hash.ToLowerInvariant()
+            Write-RedactedJson -Path $ProvenancePath -Value ([ordered]@{
+                schema_version = 'winghostty.cloudflare-pages-provenance.v1'
+                verified_at = [DateTimeOffset]::UtcNow.ToString('o')
+                project_name = $ProjectName
+                deployment_id = $DeploymentId
+                environment = $ExpectedEnvironment
+                branch = $ExpectedBranch
+                commit_hash = $ExpectedCommit
+                commit_dirty = $false
+                stage_status = 'success'
+                deployment_host = $pagesOrigin.DnsSafeHost
+                canonical = [bool]$RequireCanonical
+                manifest_sha256 = $manifestHash
+                file_count = $entries.Count
+                verified_hosts = [string[]]$verifiedHosts
+                canonical_html_verified =
+                    -not [string]::IsNullOrWhiteSpace($CanonicalBaseUrl)
+                github_repository = $env:GITHUB_REPOSITORY
+                github_run_id = $env:GITHUB_RUN_ID
+                github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+            })
+            Write-Host "Verified $ExpectedEnvironment deployment provenance and bytes."
+        }
+
+    }
+}
+finally {
+    $publicClient.Dispose()
+    $publicHandler.Dispose()
+    $apiClient.Dispose()
+    $apiHandler.Dispose()
+}

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -426,11 +426,19 @@ function Assert-PublicHeaderContract {
     $probes = @(
         [pscustomobject]@{
             Path = '/'
+            ExpectedStatus = 200
             ExpectedCache = [string]$Contract.root.cache_control
         }
         [pscustomobject]@{
             Path = '/bundle.js'
+            ExpectedStatus = 200
             ExpectedCache = [string]$Contract.bundle.cache_control
+        }
+        [pscustomobject]@{
+            Path = '/__winghostty_header_contract_' +
+                [Uri]::EscapeDataString($Id) + '/nested/page'
+            ExpectedStatus = 404
+            ExpectedCache = [string]$Contract.root.cache_control
         }
     )
     foreach ($probe in $probes) {
@@ -442,14 +450,16 @@ function Assert-PublicHeaderContract {
         $response = $null
         try {
             $response = $publicClient.SendAsync($request).GetAwaiter().GetResult()
-            if ([int]$response.StatusCode -ne 200) {
-                throw "Published header probe failed at $($Origin.DnsSafeHost)."
+            if ([int]$response.StatusCode -ne $probe.ExpectedStatus) {
+                throw "Published header probe failed for $($probe.Path) at " +
+                    "$($Origin.DnsSafeHost)."
             }
             $cacheControl = Get-ResponseHeaderText `
                 -Response $response `
                 -Name 'Cache-Control'
             if ($cacheControl -cne $probe.ExpectedCache) {
-                throw "Published cache policy mismatch at $($Origin.DnsSafeHost)."
+                throw "Published cache policy mismatch for $($probe.Path) at " +
+                    "$($Origin.DnsSafeHost)."
             }
             if ((Get-ResponseHeaderText -Response $response -Name 'X-Content-Type-Options') -cne
                     [string]$Contract.root.x_content_type_options -or

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -410,28 +410,18 @@ function Get-ResponseHeaderText {
 function Assert-PublicHeaderContract {
     param(
         [Parameter(Mandatory)] [Uri] $Origin,
-        [Parameter(Mandatory)] [string] $Id
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [object] $Contract
     )
 
-    $requiredCspTokens = [string[]] @(
-        "default-src 'self'"
-        "base-uri 'none'"
-        "object-src 'none'"
-        "frame-ancestors 'none'"
-        "script-src 'self' 'sha256-pISZ4uq8FeQ38HOwS22gAtqH+pfUgqkItu+zFe6qagg=' 'sha256-HgYMqcl1IJyO4BIHc3TA/IswS2cmPQtqqPBk9kLqGao='"
-        "script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
-        "font-src 'self' https://fonts.gstatic.com"
-        "connect-src 'self' https://api.github.com"
-    )
     $probes = @(
         [pscustomobject]@{
             Path = '/'
-            CachePattern = '(?:^|,\s*)public,\s*max-age=0,\s*must-revalidate(?:,|$)'
+            ExpectedCache = [string]$Contract.root.cache_control
         }
         [pscustomobject]@{
             Path = '/bundle.js'
-            CachePattern = '(?:^|,\s*)public,\s*max-age=3600,\s*must-revalidate(?:,|$)'
+            ExpectedCache = [string]$Contract.bundle.cache_control
         }
     )
     foreach ($probe in $probes) {
@@ -449,40 +439,20 @@ function Assert-PublicHeaderContract {
             $cacheControl = Get-ResponseHeaderText `
                 -Response $response `
                 -Name 'Cache-Control'
-            if ($cacheControl -notmatch $probe.CachePattern) {
+            if ($cacheControl -cne $probe.ExpectedCache) {
                 throw "Published cache policy mismatch at $($Origin.DnsSafeHost)."
             }
             if ((Get-ResponseHeaderText -Response $response -Name 'X-Content-Type-Options') -cne
-                    'nosniff' -or
+                    [string]$Contract.root.x_content_type_options -or
                 (Get-ResponseHeaderText -Response $response -Name 'X-Frame-Options') -cne
-                    'DENY' -or
+                    [string]$Contract.root.x_frame_options -or
                 (Get-ResponseHeaderText -Response $response -Name 'Referrer-Policy') -cne
-                    'strict-origin-when-cross-origin') {
+                    [string]$Contract.root.referrer_policy -or
+                (Get-ResponseHeaderText -Response $response -Name 'Permissions-Policy') -cne
+                    [string]$Contract.root.permissions_policy -or
+                (Get-ResponseHeaderText -Response $response -Name 'Content-Security-Policy') -cne
+                    [string]$Contract.root.content_security_policy) {
                 throw "Published browser security headers are incomplete at $($Origin.DnsSafeHost)."
-            }
-            $permissions =
-                Get-ResponseHeaderText -Response $response -Name 'Permissions-Policy'
-            foreach ($permission in @(
-                'camera=()',
-                'geolocation=()',
-                'microphone=()',
-                'payment=()',
-                'usb=()'
-            )) {
-                if (-not $permissions.Contains($permission, [StringComparison]::Ordinal)) {
-                    throw "Published permissions policy is incomplete at $($Origin.DnsSafeHost)."
-                }
-            }
-            $csp = Get-ResponseHeaderText `
-                -Response $response `
-                -Name 'Content-Security-Policy'
-            if ($csp.Contains("script-src 'self' 'unsafe-inline'", [StringComparison]::Ordinal)) {
-                throw "Published CSP allows broad inline scripts at $($Origin.DnsSafeHost)."
-            }
-            foreach ($token in $requiredCspTokens) {
-                if (-not $csp.Contains($token, [StringComparison]::Ordinal)) {
-                    throw "Published CSP is incomplete at $($Origin.DnsSafeHost)."
-                }
             }
         }
         finally {
@@ -597,12 +567,19 @@ try {
             $entries = @(Get-ManifestEntries `
                 -Path $ManifestPath `
                 -PayloadRoot $PayloadDirectory)
+            $headerContract = (
+                & (Join-Path $PSScriptRoot 'get-site-header-contract.ps1') `
+                    -SiteDirectory $PayloadDirectory
+            ) | ConvertFrom-Json -Depth 6
             [void](Assert-PublicPayload `
                 -Origin $pagesOrigin `
                 -Entries $entries `
                 -Id $DeploymentId `
                 -Commit $ExpectedCommit)
-            [void](Assert-PublicHeaderContract -Origin $pagesOrigin -Id $DeploymentId)
+            [void](Assert-PublicHeaderContract `
+                -Origin $pagesOrigin `
+                -Id $DeploymentId `
+                -Contract $headerContract)
 
             $verifiedHosts = [Collections.Generic.List[string]]::new()
             [void]$verifiedHosts.Add($pagesOrigin.DnsSafeHost)
@@ -622,7 +599,8 @@ try {
                     -Commit $ExpectedCommit)
                 [void](Assert-PublicHeaderContract `
                     -Origin $canonicalOrigin `
-                    -Id $DeploymentId)
+                    -Id $DeploymentId `
+                    -Contract $headerContract)
                 [void]$verifiedHosts.Add($canonicalOrigin.DnsSafeHost)
             }
             if ($VerifyWwwRedirect) {

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -188,7 +188,16 @@ function Wait-CanonicalDeployment {
     param([Parameter(Mandatory)] [string] $ExpectedId)
 
     for ($attempt = 1; $attempt -le 10; $attempt++) {
-        $project = Get-Project
+        try {
+            $project = Get-Project
+        }
+        catch {
+            if ($attempt -eq 10) {
+                throw 'Cloudflare canonical deployment polling failed after bounded retries.'
+            }
+            Start-Sleep -Seconds 2
+            continue
+        }
         Assert-ProjectContract -Project $project
         if ((Get-CanonicalDeploymentId -Project $project) -ceq $ExpectedId) {
             return $project
@@ -549,13 +558,14 @@ try {
                 -Branch $ExpectedBranch `
                 -Commit $ExpectedCommit
 
-            $project = Get-Project
-            Assert-ProjectContract -Project $project
             if ($RequireCanonical) {
                 if ($ExpectedEnvironment -cne 'production') {
                     throw 'Only a production deployment can be canonical.'
                 }
                 $project = Wait-CanonicalDeployment -ExpectedId $DeploymentId
+            } else {
+                $project = Get-Project
+                Assert-ProjectContract -Project $project
             }
 
             $pagesOrigin = ConvertTo-PublicBaseUri -Value $BaseUrl -Kind pages

--- a/site/README.md
+++ b/site/README.md
@@ -49,8 +49,8 @@ edits, run `node scripts/build-site-bundle.mjs` from the repo root.
 The existing `winghostty` project remains a Direct Upload Pages project. There
 is no `wrangler.toml`, `wrangler.json`, or Git-integrated Pages build.
 
-Production is owned by `.github/workflows/deploy-site.yml`. It runs only for
-relevant pushes to `main`, published releases, or an explicit manual dispatch;
+Production is owned by `.github/workflows/deploy-site.yml`. It runs for every
+push to `main`, published stable releases, or an explicit manual dispatch;
 pull requests do not deploy. The protected GitHub environment is
 `cloudflare-pages-production` and must provide:
 
@@ -109,3 +109,7 @@ pwsh -File scripts/build-site-payload.ps1 `
   -OutputDirectory (Join-Path $root payload) `
   -ManifestPath (Join-Path $root payload.sha256)
 ```
+
+The four deployment-only scripts require PowerShell 7.3 or newer and are
+intentionally outside the Windows PowerShell 5.1 harness compatibility scope.
+The workflow and this runbook invoke them with `pwsh`.

--- a/site/README.md
+++ b/site/README.md
@@ -91,9 +91,10 @@ The Pages custom domain is:
 
 - `winghostty.com`
 
-`site/_headers` keeps HTML and fallback responses revalidated and gives
-non-content-addressed assets bounded cache lifetimes without claiming they are
-immutable. Its CSP allowlists the two current inline theme bootstraps and the
+`site/_headers` keeps every response revalidated, including nested 404
+fallbacks. Cloudflare Pages still serves ETags and handles its edge cache,
+while browsers cannot retain stale routes or non-content-addressed assets
+without validation. Its CSP allowlists the two current inline theme bootstraps and the
 font stylesheet `onload` handler by exact SHA-256 hashes. `style-src` and
 `style-src-attr` retain `unsafe-inline` because the current React UI emits
 inline styles; removing that residual allowance requires a coordinated UI

--- a/site/README.md
+++ b/site/README.md
@@ -11,7 +11,7 @@ runtime shape:
 - `components/` - archive JSX references kept for design/source parity
 - `assets/` - SVG brand assets carried over from the archive
 - `404.html`, `styles.css`, `app.js` - standalone static extras already present in this repo
-- `_redirects` - canonical host redirect for `www` to apex
+- `_headers` - Cloudflare Pages cache and browser security policy
 
 ## Source of truth
 
@@ -46,14 +46,65 @@ edits, run `node scripts/build-site-bundle.mjs` from the repo root.
 
 ## Cloudflare Pages
 
-Project settings for v1:
+The existing `winghostty` project remains a Direct Upload Pages project. There
+is no `wrangler.toml`, `wrangler.json`, or Git-integrated Pages build.
 
-- Production branch: `main`
-- Build command: `exit 0`
-- Build output directory: `site`
-- Custom domains: `winghostty.com` and `www.winghostty.com`
+Production is owned by `.github/workflows/deploy-site.yml`. It runs only for
+relevant pushes to `main`, published releases, or an explicit manual dispatch;
+pull requests do not deploy. The protected GitHub environment is
+`cloudflare-pages-production` and must provide:
 
-Recommended follow-up in Pages:
+- `CLOUDFLARE_API_TOKEN` - a least-privilege token with Account / Cloudflare
+  Pages / Edit for this account
+- `CLOUDFLARE_ACCOUNT_ID` - the account identifier, stored as a secret so it is
+  not copied into logs or provenance
 
-- Keep preview deployments enabled for PRs.
-- Set build watch paths to `site/*` so app-only changes do not redeploy the marketing site.
+For a push, the workflow checks out the immutable event SHA. Published
+prereleases are ignored. For a published stable release, it checks out the
+current `main` head and requires its baked-in release copy to match the
+published tag and GitHub's public latest release. In both
+cases, the resolved SHA must remain the exact clean `origin/main` head before
+both deployment phases. Wrangler `4.114.0` installs in an isolated runner-temp
+directory. The workflow builds an exact static-file allowlist twice and
+requires identical, ordinally sorted SHA-256 manifests. That same payload is
+uploaded first to a non-production canary branch and then to `main`; Cloudflare
+API metadata, commit provenance, and every served byte are checked after each
+upload. The zone-owned `www` redirect is preflighted before production, so
+missing zone configuration cannot publish and then fail. Production
+verification also requires the exact HTML, fallback, static assets, cache
+policy, and security headers at `winghostty.com`; a Cloudflare challenge or any
+other substituted response fails verification.
+
+The workflow does not automatically roll back a failed production verification:
+the Pages API has no compare-and-swap rollback primitive, so an automated
+rollback could overwrite a newer dashboard/API deployment. The failed run
+retains redacted evidence for an operator to inspect before selecting a known
+production deployment in Cloudflare's rollback UI.
+
+`site/_redirects` is intentionally absent. Cloudflare Pages does not support a
+domain-level `www` redirect in that file. Configure the permanent
+`https://www.winghostty.com/*` to `https://winghostty.com/:splat` redirect at
+the Cloudflare zone level (Bulk Redirect or Redirect Rule), with path and query
+preservation. The deployment workflow verifies the zone-level 301.
+
+The Pages custom domain is:
+
+- `winghostty.com`
+
+`site/_headers` keeps HTML and fallback responses revalidated and gives
+non-content-addressed assets bounded cache lifetimes without claiming they are
+immutable. Its CSP allowlists the two current inline theme bootstraps and the
+font stylesheet `onload` handler by exact SHA-256 hashes. `style-src` and
+`style-src-attr` retain `unsafe-inline` because the current React UI emits
+inline styles; removing that residual allowance requires a coordinated UI
+refactor. Any inline-script or handler edit must update both the CSP hashes and
+the flagship contract test.
+
+To build the deploy payload locally:
+
+```powershell
+$root = Join-Path $env:TEMP winghostty-site-payload
+pwsh -File scripts/build-site-payload.ps1 `
+  -OutputDirectory (Join-Path $root payload) `
+  -ManifestPath (Join-Path $root payload.sha256)
+```

--- a/site/_headers
+++ b/site/_headers
@@ -1,10 +1,12 @@
 /*
-  Cache-Control: public, max-age=0, must-revalidate
   Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'sha256-yC0ipyWJhR/WFAUKuSwE4k/pKqXaK0lME+JKjiskz2E=' 'sha256-M1EKKzF1RYBeIVGhrvQ0VDz4v7KEea3QR0b7wayMT3M='; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; img-src 'self' data:; frame-src 'none'; worker-src 'none'; manifest-src 'self'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
+
+/
+  Cache-Control: public, max-age=0, must-revalidate
 
 /assets/*
   Cache-Control: public, max-age=86400, stale-while-revalidate=604800

--- a/site/_headers
+++ b/site/_headers
@@ -4,24 +4,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
-
-/
   Cache-Control: public, max-age=0, must-revalidate
-
-/assets/*
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
-
-/icons/*
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
-
-/vendor/*
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
-
-/app.js
-  Cache-Control: public, max-age=3600, must-revalidate
-
-/bundle.js
-  Cache-Control: public, max-age=3600, must-revalidate
-
-/styles.css
-  Cache-Control: public, max-age=3600, must-revalidate

--- a/site/_headers
+++ b/site/_headers
@@ -1,0 +1,25 @@
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'sha256-yC0ipyWJhR/WFAUKuSwE4k/pKqXaK0lME+JKjiskz2E=' 'sha256-M1EKKzF1RYBeIVGhrvQ0VDz4v7KEea3QR0b7wayMT3M='; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; img-src 'self' data:; frame-src 'none'; worker-src 'none'; manifest-src 'self'; upgrade-insecure-requests
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
+
+/assets/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/icons/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/vendor/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/app.js
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/bundle.js
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/styles.css
+  Cache-Control: public, max-age=3600, must-revalidate

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,1 +1,0 @@
-https://www.winghostty.com/* https://winghostty.com/:splat 301!

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8604,6 +8604,30 @@ try {
     if (-not $directiveSwapRejected) {
         throw 'Site CSP contract accepted hashes swapped between script directives.'
     }
+
+    $reusedHashHeaders = $fixtureHeadersText.Replace(
+        "style-src 'self'",
+        "script-src-elem '$attributeHash'; style-src 'self'"
+    )
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $reusedHashHeaders,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $unvalidatedDirectiveRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'cannot declare hashes in unvalidated directive script-src-elem') {
+            throw
+        }
+        $unvalidatedDirectiveRejected = $true
+    }
+    if (-not $unvalidatedDirectiveRejected) {
+        throw 'Site CSP contract accepted a reused hash in script-src-elem.'
+    }
 }
 finally {
     if ([IO.Directory]::Exists($siteCspFixtureRoot)) {

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8296,9 +8296,13 @@ foreach ($siteScript in @(
 
 Assert-TextContract `
     -Content $siteDeployWorkflowText `
-    -Pattern '(?ms)^on:\s+push:\s+branches:\s+- main\s+paths:.*?release:\s+types:\s+- published\s+workflow_dispatch:\s*$' `
-    -Description 'site deployment has only filtered main pushes, published releases, and manual dispatch triggers' `
+    -Pattern '(?ms)^on:\s+push:\s+branches:\s+- main\s+release:\s+types:\s+- published\s+workflow_dispatch:\s*$' `
+    -Description 'site deployment catches every main advance plus published releases and manual dispatch' `
     -Context $siteDeployWorkflow
+Assert-WorkflowContractAbsent `
+    -Path $siteDeployWorkflow `
+    -Pattern '(?m)^\s+paths(?:-ignore)?:' `
+    -Description 'site deployment cannot strand a site change behind a later path-filtered main advance'
 Assert-WorkflowContractAbsent `
     -Path $siteDeployWorkflow `
     -Pattern '(?m)^\s*(?:pull_request|pull_request_target):' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8450,6 +8450,11 @@ Assert-TextContract `
     -Pattern '(?ms)latest_stage\.status.*?commit_hash -cne \$Commit.*?commit_dirty -ne \$false.*?Get-ManifestEntries.*?Get-Sha256 -Bytes.*?get-site-header-contract\.ps1.*?Assert-PublicHeaderContract' `
     -Description 'Pages verification checks exact clean commit provenance, manifest bytes, and response controls' `
     -Context $cloudflarePagesVerifier
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Wait-CanonicalDeployment(?=\s|\{)') `
+    -Pattern '(?ms)for \(\$attempt = 1; \$attempt -le 10; \$attempt\+\+\).*?try \{\s*\$project = Get-Project.*?catch \{.*?\$attempt -eq 10.*?failed after bounded retries.*?Start-Sleep -Seconds 2.*?continue.*?Assert-ProjectContract.*?Get-CanonicalDeploymentId' `
+    -Description 'canonical promotion tolerates bounded transient project API failures but still validates project identity' `
+    -Context "$cloudflarePagesVerifier :: Wait-CanonicalDeployment"
 Assert-WorkflowContractAbsent `
     -Path $cloudflarePagesVerifier `
     -Pattern '(?i)cf-mitigated|AllowMitigatedHtml|mitigated-challenge|challenged_hosts|canonical_html_status' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8532,7 +8532,7 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?eventAttributeCount.*?eventHandlers.*?Get-CspSha256Source -Value \$eventHandlers.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
+    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?eventAttributeCount.*?eventHandlers.*?WebUtility\]::HtmlDecode.*?Get-CspSha256Source -Value \$decodedEventHandler.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
     -Description 'one catch-all contract binds exact complete source sets to both script directives and emits live expectations' `
     -Context $siteHeaderContract
 Assert-TextContract `
@@ -8709,6 +8709,29 @@ try {
     }
     if (-not $editedHandlerRejected) {
         throw 'Site CSP contract accepted an untracked event-handler edit.'
+    }
+
+    [IO.File]::WriteAllText(
+        $fixtureIndexPath,
+        $fixtureIndexText.Replace(
+            "onload=`"this.media='all'`"",
+            'onload="this.media=&quot;all&quot;"'
+        ),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $entityHandlerRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'script-src-attr sources do not exactly match') {
+            throw
+        }
+        $entityHandlerRejected = $true
+    }
+    if (-not $entityHandlerRejected) {
+        throw 'Site CSP contract hashed serialized rather than decoded handler text.'
     }
 
     [IO.File]::WriteAllText(

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8532,13 +8532,13 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?function Assert-ExactCspDirectiveHashes.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
-    -Description 'one catch-all contract binds unique CSP hashes to their exact script directives and emits live expectations' `
+    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
+    -Description 'one catch-all contract binds exact complete source sets to both script directives and emits live expectations' `
     -Context $siteHeaderContract
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern "(?ms)Assert-ExactCspDirectiveHashes.*?-DirectiveName 'script-src'.*?Assert-ExactCspDirectiveHashes.*?-DirectiveName 'script-src-attr'.*?expectedHashes\.UnionWith.*?declaredHashes\.Add.*?ConvertTo-Json" `
-    -Description 'script and event-handler hashes remain directive-specific before the global CSP allowlist check' `
+    -Pattern "(?ms)expectedScriptSources.*?'self'.*?expectedScriptAttributeSources.*?'unsafe-hashes'.*?expectedCspDirectives.*?default-src.*?script-src.*?script-src-attr.*?upgrade-insecure-requests.*?declaredDirectiveNames.*?exact expected directive set.*?Assert-ExactCspDirectiveSources.*?expectedHashes\.UnionWith.*?declaredHashes\.Add.*?ConvertTo-Json" `
+    -Description 'every CSP directive and source is exact before the global hash allowlist check' `
     -Context $siteHeaderContract
 
 $siteCspFixtureRoot = Join-Path (
@@ -8596,7 +8596,7 @@ try {
     }
     catch {
         if ($_.Exception.Message -notmatch
-            'script-src hashes do not exactly match') {
+            'script-src sources do not exactly match') {
             throw
         }
         $directiveSwapRejected = $true
@@ -8620,13 +8620,60 @@ try {
     }
     catch {
         if ($_.Exception.Message -notmatch
-            'cannot declare hashes in unvalidated directive script-src-elem') {
+            'exact expected directive set') {
             throw
         }
         $unvalidatedDirectiveRejected = $true
     }
     if (-not $unvalidatedDirectiveRejected) {
         throw 'Site CSP contract accepted a reused hash in script-src-elem.'
+    }
+
+    $unsafeOverrideHeaders = $fixtureHeadersText.Replace(
+        "style-src 'self'",
+        "script-src-elem 'unsafe-inline'; style-src 'self'"
+    )
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $unsafeOverrideHeaders,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $unsafeOverrideRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'exact expected directive set') {
+            throw
+        }
+        $unsafeOverrideRejected = $true
+    }
+    if (-not $unsafeOverrideRejected) {
+        throw 'Site CSP contract accepted an unsafe script-src-elem override.'
+    }
+
+    $sha384OverrideHeaders = $fixtureHeadersText.Replace(
+        "style-src 'self'",
+        "script-src-elem 'sha384-YWJjZA=='; style-src 'self'"
+    )
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $sha384OverrideHeaders,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $sha384OverrideRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch 'exact expected directive set') {
+            throw
+        }
+        $sha384OverrideRejected = $true
+    }
+    if (-not $sha384OverrideRejected) {
+        throw 'Site CSP contract accepted a SHA-384 script-src-elem override.'
     }
 }
 finally {

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8292,6 +8292,11 @@ foreach ($siteScript in @(
     if ($siteScriptErrors.Count -ne 0) {
         throw "Site deployment script does not parse: $siteScript ($($siteScriptErrors[0].Message))"
     }
+    Assert-TextContract `
+        -Content (Get-Content -LiteralPath $siteScript -Raw) `
+        -Pattern '(?m)^#requires -Version 7\.3\s*$' `
+        -Description 'workflow-owned site deployment scripts declare their PowerShell 7.3 floor' `
+        -Context $siteScript
 }
 
 Assert-TextContract `
@@ -8329,13 +8334,13 @@ Assert-TextContract `
     -Context "$siteDeployWorkflow :: checkout"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Resolve exact deployment commit' -Source $siteDeployWorkflow) `
-    -Pattern '(?ms)id: source.*?git rev-parse HEAD.*?\^\[0-9a-f\]\{40\}\$.*?"sha=\$sha" >> \$env:GITHUB_OUTPUT' `
-    -Description 'site deployment records the full resolved source SHA once after checkout' `
+    -Pattern '(?ms)id: source.*?\$sha = git rev-parse HEAD.*?\$LASTEXITCODE -ne 0.*?\$sha = \(\[string\]\(\$sha -join "`n"\)\)\.Trim\(\).*?\^\[0-9a-f\]\{40\}\$.*?"sha=\$sha" >> \$env:GITHUB_OUTPUT' `
+    -Description 'site deployment fails closed before recording the full resolved source SHA' `
     -Context "$siteDeployWorkflow :: source"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Validate committed site bundle and copy' -Source $siteDeployWorkflow) `
-    -Pattern '(?ms)GH_TOKEN:.*?github\.token.*?RELEASE_TAG:.*?github\.event\.release\.tag_name.*?get-site-header-contract\.ps1.*?GITHUB_EVENT_NAME -eq ''release''.*?RELEASE_TAG -cnotmatch ''\^v\(\?<version>\\d\+\\\.\\d\+\\\.\\d\+\)\$''.*?check-release-copy\.ps1.*?-ExpectedVersion \$Matches\.version.*?-CheckRemoteLatest.*?else \{.*?check-release-copy\.ps1 -CheckRemoteLatest.*?LASTEXITCODE' `
-    -Description 'release-triggered site deployments bind baked-in copy to the published semver tag' `
+    -Pattern '(?ms)GH_TOKEN:.*?github\.token.*?RELEASE_TAG:.*?github\.event\.release\.tag_name.*?check-site-copy\.ps1.*?npm ci --prefix site --ignore-scripts.*?check-site-bundle\.ps1.*?get-site-header-contract\.ps1.*?GITHUB_EVENT_NAME -eq ''release''.*?RELEASE_TAG -cnotmatch ''\^v\(\?<version>\\d\+\\\.\\d\+\\\.\\d\+\)\$''.*?check-release-copy\.ps1.*?-ExpectedVersion \$Matches\.version.*?-CheckRemoteLatest.*?else \{.*?check-release-copy\.ps1 -CheckRemoteLatest.*?LASTEXITCODE' `
+    -Description 'site copy is checked before dependencies and release copy binds to the published semver tag' `
     -Context "$siteDeployWorkflow :: site validation"
 $siteActionUses = [regex]::Matches(
     $siteDeployWorkflowText,
@@ -8382,6 +8387,11 @@ Assert-TextContract `
     -Pattern '(?ms)GITHUB_REPOSITORY -cne ''amanthanvi/winghostty''.*?git remote get-url origin.*?git fetch --force --no-tags origin.*?git rev-parse HEAD.*?refs/remotes/origin/\$DefaultBranch.*?\$head -cne \$ExpectedSha.*?git status --porcelain=v1 --untracked-files=all' `
     -Description 'the shared site gate binds both phases to a clean exact fork-local main head' `
     -Context $siteDeploymentHeadGate
+Assert-TextContract `
+    -Content (Get-Content -LiteralPath $siteDeploymentHeadGate -Raw) `
+    -Pattern '(?ms)\$originOutput = git remote get-url origin.*?\$LASTEXITCODE -ne 0.*?\$headOutput = git rev-parse HEAD.*?\$LASTEXITCODE -ne 0.*?\$originHeadOutput = git rev-parse.*?\$LASTEXITCODE -ne 0.*?\$status = @\(git status.*?\$LASTEXITCODE -ne 0.*?\$status\.Count -ne 0' `
+    -Description 'every deployment gate git query checks its own exit status before consuming output' `
+    -Context $siteDeploymentHeadGate
 $sitePayloadStep = Get-YamlStepBlock `
     -Content $siteDeployWorkflowText `
     -Name 'Build deterministic deploy payload twice' `
@@ -8398,19 +8408,28 @@ Assert-TextContract `
     -Context "$siteDeployWorkflow :: payload"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Verify canary provenance and bytes' -Source $siteDeployWorkflow) `
-    -Pattern '(?ms)-ExpectedEnvironment preview.*?-ExpectedBranch \$env:CANARY_BRANCH.*?-ExpectedCommit ''\$\{\{ steps\.source\.outputs\.sha \}\}''.*?-ManifestPath \$env:PAYLOAD_MANIFEST' `
+    -Pattern '(?ms)DEPLOY_SHA: \$\{\{ steps\.source\.outputs\.sha \}\}.*?-ExpectedEnvironment preview.*?-ExpectedBranch \$env:CANARY_BRANCH.*?-ExpectedCommit \$env:DEPLOY_SHA.*?-ManifestPath \$env:PAYLOAD_MANIFEST' `
     -Description 'canary verification binds API provenance and payload bytes to the exact commit' `
     -Context "$siteDeployWorkflow :: canary verification"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Require the zone-owned www redirect before production' -Source $siteDeployWorkflow) `
-    -Pattern '(?ms)-Mode Redirect.*?-DeploymentId \$env:DEPLOYMENT_ID.*?-ExpectedCommit ''\$\{\{ steps\.source\.outputs\.sha \}\}''' `
+    -Pattern '(?ms)DEPLOY_SHA: \$\{\{ steps\.source\.outputs\.sha \}\}.*?-Mode Redirect.*?-DeploymentId \$env:DEPLOYMENT_ID.*?-ExpectedCommit \$env:DEPLOY_SHA' `
     -Description 'the zone-owned www redirect is verified before the production write' `
     -Context "$siteDeployWorkflow :: redirect preflight"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Verify production provenance, domain, and bytes' -Source $siteDeployWorkflow) `
-    -Pattern "(?ms)-ExpectedEnvironment production.*?-ExpectedBranch main.*?-CanonicalBaseUrl 'https://winghostty\.com/'.*?-RequireCanonical.*?-VerifyWwwRedirect" `
+    -Pattern '(?ms)DEPLOY_SHA: \$\{\{ steps\.source\.outputs\.sha \}\}.*?-ExpectedEnvironment production.*?-ExpectedBranch main.*?-ExpectedCommit \$env:DEPLOY_SHA.*?-CanonicalBaseUrl ''https://winghostty\.com/''.*?-RequireCanonical.*?-VerifyWwwRedirect' `
     -Description 'production verification binds the canonical domain and zone redirect' `
     -Context "$siteDeployWorkflow :: production verification"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Resolve canary branch' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)DEPLOY_SHA: \$\{\{ steps\.source\.outputs\.sha \}\}.*?\$sha = \$env:DEPLOY_SHA' `
+    -Description 'canary metadata receives the validated SHA through the environment' `
+    -Context "$siteDeployWorkflow :: canary metadata"
+Assert-WorkflowContractAbsent `
+    -Path $siteDeployWorkflow `
+    -Pattern '(?m)^\s+(?:\$sha\s*=\s*''\$\{\{ steps\.source\.outputs\.sha \}\}''|-ExpectedCommit\s+''\$\{\{ steps\.source\.outputs\.sha \}\}'')' `
+    -Description 'validated action outputs are never interpolated directly into PowerShell source'
 Assert-WorkflowContractAbsent `
     -Path $siteDeployWorkflow `
     -Pattern '(?i)rollback|previous\.outputs\.deployment_id' `
@@ -8482,8 +8501,8 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'site\_redirects')) {
 }
 Assert-TextContract `
     -Content $siteReadmeText `
-    -Pattern '(?ms)Direct Upload.*?pull requests do not deploy.*?zone-owned `www` redirect\s+is preflighted.*?does not automatically roll back.*?zone level.*?workflow verifies the zone-level 301' `
-    -Description 'site operations document Direct Upload scope and the zone-owned www redirect' `
+    -Pattern '(?ms)Direct Upload.*?every\s+push to `main`.*?pull requests do not deploy.*?zone-owned `www` redirect\s+is preflighted.*?does not automatically roll back.*?zone level.*?workflow verifies the zone-level 301.*?deployment-only scripts require PowerShell 7\.3 or newer.*?outside the Windows PowerShell 5\.1 harness compatibility scope' `
+    -Description 'site operations document deployment triggers, Direct Upload scope, runtime floor, and the zone-owned redirect' `
     -Context $siteReadme
 Assert-TextContract `
     -Content $siteHeadersText `
@@ -8507,19 +8526,24 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
             [regex]::Match(
                 $siteHeadersText,
                 '(?m)^\s+Content-Security-Policy:\s*(?<value>.+)$'
-            ).Groups['value'].Value
+            ).Groups['value'].Value.Trim()
         )) {
     throw 'Central site header contract did not return the tracked CSP.'
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)one catch-all response policy.*?index\.html.*?404\.html.*?Get-CspSha256Source.*?declaredHashes.*?expectedHashes.*?ConvertTo-Json' `
-    -Description 'one catch-all contract derives CSP hashes from both HTML fallbacks and emits live expectations' `
+    -Pattern '(?ms)one catch-all response policy.*?index\.html.*?404\.html.*?Get-CspSha256Source.*?HashSet\[string\].*?declaredHashes\.Add.*?expectedHashes.*?ConvertTo-Json' `
+    -Description 'one catch-all contract compares unique CSP hash sets from both HTML fallbacks and emits live expectations' `
     -Context $siteHeaderContract
 Assert-TextContract `
-    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Assert-PublicHeaderContract(?=\s|\{)') `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicHeaderContractOnce(?=\s|\{)') `
     -Pattern "(?ms)Path = '/'.*?ExpectedStatus = 200.*?Path = '/bundle\.js'.*?ExpectedStatus = 200.*?__winghostty_header_contract_.*?nested/page'.*?ExpectedStatus = 404.*?Cache-Control" `
     -Description 'public header verification covers canonical HTML, an asset, and a nested 404 fallback' `
+    -Context "$cloudflarePagesVerifier :: Test-PublicHeaderContractOnce"
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Assert-PublicHeaderContract(?=\s|\{)') `
+    -Pattern '(?ms)for \(\$attempt = 1; \$attempt -le 6; \$attempt\+\+\).*?Test-PublicHeaderContractOnce.*?Start-Sleep -Seconds 2.*?did not converge' `
+    -Description 'public header verification tolerates bounded edge propagation before failing closed' `
     -Context "$cloudflarePagesVerifier :: Assert-PublicHeaderContract"
 
 $sitePayloadFixtureRoot = Join-Path (

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -2565,6 +2565,15 @@ Assert-JsonDocument `
 $releaseWorkflow = Join-Path $repoRoot '.github\workflows\release.yml'
 $readinessWorkflow = Join-Path $repoRoot '.github\workflows\release-readiness.yml'
 $testWorkflow = Join-Path $repoRoot '.github\workflows\test.yml'
+$siteDeployWorkflow = Join-Path $repoRoot '.github\workflows\deploy-site.yml'
+$siteBundleBuilder = Join-Path $repoRoot 'scripts\build-site-bundle.mjs'
+$sitePayloadBuilder = Join-Path $repoRoot 'scripts\build-site-payload.ps1'
+$cloudflarePagesVerifier = Join-Path $repoRoot 'scripts\verify-cloudflare-pages.ps1'
+$siteHeaders = Join-Path $repoRoot 'site\_headers'
+$siteReadme = Join-Path $repoRoot 'site\README.md'
+$site404 = Join-Path $repoRoot 'site\404.html'
+$siteIndex = Join-Path $repoRoot 'site\index.html'
+$siteGitattributes = Join-Path $repoRoot '.gitattributes'
 $accessibilityChecker = Join-Path $repoRoot 'scripts\check-accessibility-evidence.ps1'
 $runnerProvenanceChecker = Join-Path $repoRoot 'test\windows\assert-interactive-runner.ps1'
 $interactiveWin11Lib = Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1'
@@ -2598,6 +2607,15 @@ $signingTrustTest = Join-Path $repoRoot 'scripts\test-signing-trust.ps1'
 $releaseWorkflowText = Get-Content -LiteralPath $releaseWorkflow -Raw
 $readinessWorkflowText = Get-Content -LiteralPath $readinessWorkflow -Raw
 $testWorkflowText = Get-Content -LiteralPath $testWorkflow -Raw
+$siteDeployWorkflowText = Get-Content -LiteralPath $siteDeployWorkflow -Raw
+$siteBundleBuilderText = Get-Content -LiteralPath $siteBundleBuilder -Raw
+$sitePayloadBuilderText = Get-Content -LiteralPath $sitePayloadBuilder -Raw
+$cloudflarePagesVerifierText = Get-Content -LiteralPath $cloudflarePagesVerifier -Raw
+$siteHeadersText = Get-Content -LiteralPath $siteHeaders -Raw
+$siteReadmeText = Get-Content -LiteralPath $siteReadme -Raw
+$site404Text = Get-Content -LiteralPath $site404 -Raw
+$siteIndexText = Get-Content -LiteralPath $siteIndex -Raw
+$siteGitattributesText = Get-Content -LiteralPath $siteGitattributes -Raw
 $interactiveWin11LibText = Get-Content -LiteralPath $interactiveWin11Lib -Raw
 $cliShellHarnessText = Get-Content -LiteralPath $cliShellHarness -Raw
 $statefulWin11LibText = Get-Content -LiteralPath $statefulWin11Lib -Raw
@@ -8255,6 +8273,322 @@ Assert-TextContract `
     -Pattern '(?ms)Assert-WingetArchitectureCoverage\s+`\r?\n\s+-ManifestPath' `
     -Description 'package-manager preflight invokes the WinGet architecture gate' `
     -Context "$releasePreflight :: RequirePackageManagers"
+
+foreach ($siteScript in @($sitePayloadBuilder, $cloudflarePagesVerifier)) {
+    $siteScriptTokens = $null
+    $siteScriptErrors = $null
+    [void][Management.Automation.Language.Parser]::ParseFile(
+        $siteScript,
+        [ref]$siteScriptTokens,
+        [ref]$siteScriptErrors
+    )
+    if ($siteScriptErrors.Count -ne 0) {
+        throw "Site deployment script does not parse: $siteScript ($($siteScriptErrors[0].Message))"
+    }
+}
+
+Assert-TextContract `
+    -Content $siteDeployWorkflowText `
+    -Pattern '(?ms)^on:\s+push:\s+branches:\s+- main\s+paths:.*?release:\s+types:\s+- published\s+workflow_dispatch:\s*$' `
+    -Description 'site deployment has only filtered main pushes, published releases, and manual dispatch triggers' `
+    -Context $siteDeployWorkflow
+Assert-WorkflowContractAbsent `
+    -Path $siteDeployWorkflow `
+    -Pattern '(?m)^\s*(?:pull_request|pull_request_target):' `
+    -Description 'site deployment never runs for pull requests'
+Assert-TextContract `
+    -Content $siteDeployWorkflowText `
+    -Pattern '(?ms)^permissions:\s+contents: read\s+deployments: write\s+.*?^concurrency:\s+group: cloudflare-pages-production\s+cancel-in-progress: false\s*$' `
+    -Description 'site deployment uses minimum repository permissions and serialized non-canceling production concurrency' `
+    -Context $siteDeployWorkflow
+Assert-TextContract `
+    -Content (Get-YamlJobText -Content $siteDeployWorkflowText -Name 'deploy' -Source $siteDeployWorkflow) `
+    -Pattern '(?m)^\s+environment: cloudflare-pages-production\s*$' `
+    -Description 'site deployment is protected by the production environment' `
+    -Context "$siteDeployWorkflow :: deploy"
+Assert-TextContract `
+    -Content (Get-YamlJobText -Content $siteDeployWorkflowText -Name 'deploy' -Source $siteDeployWorkflow) `
+    -Pattern "(?m)^\s+if: github\.event_name != 'release' \|\| github\.event\.release\.prerelease == false\s*$" `
+    -Description 'stable site publication ignores prerelease events' `
+    -Context "$siteDeployWorkflow :: deploy"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Checkout exact event commit' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd.*?ref: \$\{\{ github\.event_name == ''release'' && github\.event\.repository\.default_branch \|\| github\.sha \}\}.*?persist-credentials: false' `
+    -Description 'site checkout uses exact event commits for pushes and current main for release publication' `
+    -Context "$siteDeployWorkflow :: checkout"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Resolve exact deployment commit' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)id: source.*?git rev-parse HEAD.*?\^\[0-9a-f\]\{40\}\$.*?"sha=\$sha" >> \$env:GITHUB_OUTPUT' `
+    -Description 'site deployment records the full resolved source SHA once after checkout' `
+    -Context "$siteDeployWorkflow :: source"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Validate committed site bundle and copy' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)GH_TOKEN:.*?github\.token.*?RELEASE_TAG:.*?github\.event\.release\.tag_name.*?GITHUB_EVENT_NAME -eq ''release''.*?RELEASE_TAG -cnotmatch ''\^v\(\?<version>\\d\+\\\.\\d\+\\\.\\d\+\)\$''.*?check-release-copy\.ps1.*?-ExpectedVersion \$Matches\.version.*?-CheckRemoteLatest.*?else \{.*?check-release-copy\.ps1 -CheckRemoteLatest.*?LASTEXITCODE' `
+    -Description 'release-triggered site deployments bind baked-in copy to the published semver tag' `
+    -Context "$siteDeployWorkflow :: site validation"
+$siteActionUses = [regex]::Matches(
+    $siteDeployWorkflowText,
+    '(?m)^\s*uses:\s+(?<action>[^\s@]+)@(?<ref>[^\s#]+)'
+)
+if ($siteActionUses.Count -ne 4 -or
+    @($siteActionUses | Where-Object {
+        $_.Groups['ref'].Value -cnotmatch '^[0-9a-f]{40}$'
+    }).Count -ne 0) {
+    throw 'Every site deployment action must use a full immutable commit SHA.'
+}
+$wranglerUses = @($siteActionUses | Where-Object {
+    $_.Groups['action'].Value -ceq 'cloudflare/wrangler-action'
+})
+if ($wranglerUses.Count -ne 2 -or
+    @($wranglerUses | Where-Object {
+        $_.Groups['ref'].Value -cne 'ebbaa1584979971c8614a24965b4405ff95890e0'
+    }).Count -ne 0) {
+    throw 'Canary and production must use the pinned official Wrangler action v4 commit.'
+}
+foreach ($deployStepName in @(
+    'Deploy exact payload to canary',
+    'Deploy identical payload to production'
+)) {
+    $deployStep = Get-YamlStepBlock `
+        -Content $siteDeployWorkflowText `
+        -Name $deployStepName `
+        -Source $siteDeployWorkflow
+    Assert-TextContract `
+        -Content $deployStep `
+        -Pattern '(?ms)wranglerVersion: 4\.114\.0.*?workingDirectory: \$\{\{ steps\.payload\.outputs\.wrangler_directory \}\}.*?quiet: true.*?pages deploy "\$\{\{ steps\.payload\.outputs\.directory \}\}".*?--project-name=winghostty.*?--commit-hash="\$\{\{ steps\.source\.outputs\.sha \}\}".*?--commit-dirty=false' `
+        -Description 'isolated Wrangler deploys the same clean exact-commit payload with the required version' `
+        -Context "$siteDeployWorkflow :: $deployStepName"
+}
+if ([regex]::Matches(
+        $siteDeployWorkflowText,
+        '(?m)^      - name: Require exact origin main before (?:canary|production)$'
+    ).Count -ne 2 -or
+    [regex]::Matches(
+        $siteDeployWorkflowText,
+        "git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'"
+    ).Count -ne 2 -or
+    [regex]::Matches(
+        $siteDeployWorkflowText,
+        '\$head -cne \$env:DEPLOY_SHA -or \$head -cne \$originMain'
+    ).Count -ne 2) {
+    throw 'Site deployment must reassert the exact clean origin/main head before both uploads.'
+}
+$sitePayloadStep = Get-YamlStepBlock `
+    -Content $siteDeployWorkflowText `
+    -Name 'Build deterministic deploy payload twice' `
+    -Source $siteDeployWorkflow
+Assert-TextContract `
+    -Content $sitePayloadStep `
+    -Pattern '(?ms)build-site-payload\.ps1.*?build-site-payload\.ps1.*?SequenceEqual\[byte\].*?different sorted SHA-256 manifests' `
+    -Description 'site payload is built twice and compared by its sorted SHA-256 manifest' `
+    -Context "$siteDeployWorkflow :: payload"
+Assert-TextContract `
+    -Content $sitePayloadStep `
+    -Pattern '(?ms)winghostty-wrangler-.*?New-Item -ItemType Directory -Path \$wrangler.*?wrangler_directory=' `
+    -Description 'Wrangler installs in a runner-temporary directory outside the checkout' `
+    -Context "$siteDeployWorkflow :: payload"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Verify canary provenance and bytes' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)-ExpectedEnvironment preview.*?-ExpectedBranch \$env:CANARY_BRANCH.*?-ExpectedCommit ''\$\{\{ steps\.source\.outputs\.sha \}\}''.*?-ManifestPath \$env:PAYLOAD_MANIFEST' `
+    -Description 'canary verification binds API provenance and payload bytes to the exact commit' `
+    -Context "$siteDeployWorkflow :: canary verification"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Require the zone-owned www redirect before production' -Source $siteDeployWorkflow) `
+    -Pattern '(?ms)-Mode Redirect.*?-DeploymentId \$env:DEPLOYMENT_ID.*?-ExpectedCommit ''\$\{\{ steps\.source\.outputs\.sha \}\}''' `
+    -Description 'the zone-owned www redirect is verified before the production write' `
+    -Context "$siteDeployWorkflow :: redirect preflight"
+Assert-TextContract `
+    -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Verify production provenance, domain, and bytes' -Source $siteDeployWorkflow) `
+    -Pattern "(?ms)-ExpectedEnvironment production.*?-ExpectedBranch main.*?-CanonicalBaseUrl 'https://winghostty\.com/'.*?-RequireCanonical.*?-VerifyWwwRedirect" `
+    -Description 'production verification binds the canonical domain and zone redirect' `
+    -Context "$siteDeployWorkflow :: production verification"
+Assert-WorkflowContractAbsent `
+    -Path $siteDeployWorkflow `
+    -Pattern '(?i)rollback|previous\.outputs\.deployment_id' `
+    -Description 'production verification cannot race an automatic Pages rollback'
+Assert-WorkflowContractAbsent `
+    -Path $cloudflarePagesVerifier `
+    -Pattern '(?i)/rollback|Mode Rollback|RollbackDeploymentId' `
+    -Description 'the verifier exposes no non-atomic automatic rollback path'
+Assert-TextContract `
+    -Content $site404Text `
+    -Pattern '(?ms)href="/assets/favicon\.svg".*?href="/styles\.css\?v=[0-9a-f]{64}".*?src="/app\.js\?v=[0-9a-f]{64}"' `
+    -Description 'the nested 404 fallback resolves all local assets from the site root' `
+    -Context $site404
+Assert-TextContract `
+    -Content $cloudflarePagesVerifierText `
+    -Pattern '"/__winghostty_missing_\$\(\$Commit\.Substring\(0, 12\)\)/nested/page"' `
+    -Description 'deployment verification exercises the 404 fallback below a multi-segment path' `
+    -Context $cloudflarePagesVerifier
+Assert-TextContract `
+    -Content $siteIndexText `
+    -Pattern '(?ms)property="og:image" content="https://winghostty\.com/assets/winghostty-social\.png".*?property="og:image:type" content="image/png".*?property="og:image:width" content="1200".*?property="og:image:height" content="630".*?name="twitter:card" content="summary_large_image".*?name="twitter:image" content="https://winghostty\.com/assets/winghostty-social\.png"' `
+    -Description 'social previews use a current raster large-image card with explicit dimensions' `
+    -Context $siteIndex
+Assert-TextContract `
+    -Content $sitePayloadBuilderText `
+    -Pattern "'assets/winghostty-social\.png'" `
+    -Description 'the deterministic Cloudflare payload includes the social preview image' `
+    -Context $sitePayloadBuilder
+Assert-TextContract `
+    -Content $siteGitattributesText `
+    -Pattern '(?ms)^site/\*\.html text eol=lf\r?$.*?^site/\*\.css text eol=lf\r?$.*?^site/\*\.js text eol=lf\r?$.*?^site/_headers text eol=lf\r?$.*?^site/assets/\*\.svg text eol=lf\r?$.*?^site/components/\*\*/\*\.jsx text eol=lf\r?$.*?^site/vendor/\*\.js text eol=lf\r?$.*?^scripts/build-site-bundle\.mjs text eol=lf\r?$' `
+    -Description 'every text file in the site payload and its source graph has a deterministic LF checkout rule' `
+    -Context $siteGitattributes
+Assert-TextContract `
+    -Content $siteBundleBuilderText `
+    -Pattern '(?ms)const normalizeLf = .*?styles\.css.*?normalizeLf\(fs\.readFileSync.*?app\.js.*?normalizeLf\(fs\.readFileSync' `
+    -Description 'cache keys hash the canonical LF representation used by clean CI checkouts' `
+    -Context $siteBundleBuilder
+Assert-TextContract `
+    -Content $cloudflarePagesVerifierText `
+    -Pattern '(?ms)latest_stage\.status.*?commit_hash -cne \$Commit.*?commit_dirty -ne \$false.*?Get-ManifestEntries.*?Get-Sha256 -Bytes.*?Assert-PublicHeaderContract' `
+    -Description 'Pages verification checks exact clean commit provenance, manifest bytes, and response controls' `
+    -Context $cloudflarePagesVerifier
+Assert-WorkflowContractAbsent `
+    -Path $cloudflarePagesVerifier `
+    -Pattern '(?i)cf-mitigated|AllowMitigatedHtml|mitigated-challenge|challenged_hosts|canonical_html_status' `
+    -Description 'custom-domain verification cannot accept substituted challenge HTML'
+Assert-TextContract `
+    -Content $cloudflarePagesVerifierText `
+    -Pattern '(?ms)\$canonicalOrigin.*?Assert-PublicPayload.*?-Origin \$canonicalOrigin.*?Assert-PublicHeaderContract.*?-Origin \$canonicalOrigin.*?\$verifiedHosts\.Add\(\$canonicalOrigin\.DnsSafeHost\).*?canonical_html_verified' `
+    -Description 'canonical production HTML, fallback bytes, and response controls must verify before provenance succeeds' `
+    -Context $cloudflarePagesVerifier
+Assert-TextContract `
+    -Content $cloudflarePagesVerifierText `
+    -Pattern '(?ms)\$json\.Contains\(\$ApiToken.*?\$json\.Contains\(\$AccountId.*?Refusing to write provenance containing Cloudflare credentials' `
+    -Description 'deployment provenance fails closed if credentials or account identifiers enter the artifact' `
+    -Context $cloudflarePagesVerifier
+Assert-WorkflowContractAbsent `
+    -Path $siteDeployWorkflow `
+    -Pattern '(?i)wrangler\.(?:toml|json|jsonc)' `
+    -Description 'Direct Upload does not introduce Wrangler configuration'
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'site\_redirects')) {
+    throw 'Unsupported domain-level Pages _redirects file must remain absent.'
+}
+Assert-TextContract `
+    -Content $siteReadmeText `
+    -Pattern '(?ms)Direct Upload.*?pull requests do not deploy.*?zone-owned `www` redirect\s+is preflighted.*?does not automatically roll back.*?zone level.*?workflow verifies the zone-level 301' `
+    -Description 'site operations document Direct Upload scope and the zone-owned www redirect' `
+    -Context $siteReadme
+Assert-TextContract `
+    -Content $siteHeadersText `
+    -Pattern '(?ms)Cache-Control: public, max-age=0, must-revalidate.*?Content-Security-Policy:.*?X-Content-Type-Options: nosniff.*?X-Frame-Options: DENY.*?Referrer-Policy: strict-origin-when-cross-origin.*?Permissions-Policy:' `
+    -Description 'Pages responses use revalidation and baseline browser security headers' `
+    -Context $siteHeaders
+Assert-TextContract `
+    -Content $siteHeadersText `
+    -Pattern "(?ms)script-src 'self' 'sha256-[^']+' 'sha256-[^']+'; script-src-attr 'unsafe-hashes' 'sha256-[^']+';" `
+    -Description 'inline scripts and the font load handler use narrow CSP hashes' `
+    -Context $siteHeaders
+if ($siteHeadersText -match "script-src 'self'[^;]*'unsafe-inline'") {
+    throw 'Pages CSP cannot broadly allow inline scripts.'
+}
+
+function Get-CspSha256Source {
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Value)
+
+    $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Value)
+    return 'sha256-' + [Convert]::ToBase64String(
+        [Security.Cryptography.SHA256]::HashData($bytes)
+    )
+}
+
+$expectedCspHashes = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::Ordinal
+)
+foreach ($htmlName in @('index.html', '404.html')) {
+    $html = [IO.File]::ReadAllText(
+        (Join-Path $repoRoot "site\$htmlName"),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $inlineScripts = @(
+        [regex]::Matches($html, '(?is)<script(?<attrs>[^>]*)>(?<body>.*?)</script>') |
+            Where-Object { $_.Groups['attrs'].Value -notmatch '\bsrc\s*=' }
+    )
+    if ($inlineScripts.Count -ne 1) {
+        throw "Expected exactly one CSP-hashed inline theme script in site/$htmlName."
+    }
+    [void]$expectedCspHashes.Add(
+        (Get-CspSha256Source -Value $inlineScripts[0].Groups['body'].Value)
+    )
+}
+[void]$expectedCspHashes.Add(
+    (Get-CspSha256Source -Value "this.media='all'")
+)
+$declaredCspHashes = @(
+    [regex]::Matches($siteHeadersText, "'(?<hash>sha256-[A-Za-z0-9+/]+=*)'") |
+        ForEach-Object { $_.Groups['hash'].Value }
+)
+if ($declaredCspHashes.Count -ne $expectedCspHashes.Count -or
+    @($declaredCspHashes | Where-Object {
+        -not $expectedCspHashes.Contains($_)
+    }).Count -ne 0) {
+    throw 'Pages CSP hashes do not exactly match the inline HTML scripts and handlers.'
+}
+
+$sitePayloadFixtureRoot = Join-Path (
+    [IO.Path]::GetTempPath()
+) "winghostty-site-payload-contract-$PID-$([Guid]::NewGuid().ToString('N'))"
+$sitePayloadFixtureRoot = [IO.Path]::GetFullPath($sitePayloadFixtureRoot)
+$tempPrefix = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\', '/') +
+    [IO.Path]::DirectorySeparatorChar
+if (-not $sitePayloadFixtureRoot.StartsWith(
+        $tempPrefix,
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+    throw 'Site payload contract fixture escaped the system temp directory.'
+}
+try {
+    $firstPayload = Join-Path $sitePayloadFixtureRoot 'first'
+    $secondPayload = Join-Path $sitePayloadFixtureRoot 'second'
+    $firstManifest = Join-Path $sitePayloadFixtureRoot 'first.sha256'
+    $secondManifest = Join-Path $sitePayloadFixtureRoot 'second.sha256'
+    & $sitePayloadBuilder `
+        -OutputDirectory $firstPayload `
+        -ManifestPath $firstManifest
+    & $sitePayloadBuilder `
+        -OutputDirectory $secondPayload `
+        -ManifestPath $secondManifest
+    $firstManifestBytes = [IO.File]::ReadAllBytes($firstManifest)
+    $secondManifestBytes = [IO.File]::ReadAllBytes($secondManifest)
+    if (-not [Linq.Enumerable]::SequenceEqual[byte](
+            $firstManifestBytes,
+            $secondManifestBytes
+        )) {
+        throw 'Site payload builder is not byte-for-byte deterministic.'
+    }
+    $manifestPaths = @(
+        [IO.File]::ReadAllLines($firstManifest) |
+            ForEach-Object {
+                $match = [regex]::Match(
+                    $_,
+                    '^[0-9a-f]{64}  (?<path>_headers|[A-Za-z0-9][A-Za-z0-9._/-]*)$'
+                )
+                if (-not $match.Success) {
+                    throw 'Site payload manifest line does not use the strict SHA-256 format.'
+                }
+                $match.Groups['path'].Value
+            }
+    )
+    $sortedManifestPaths = [string[]]$manifestPaths.Clone()
+    [Array]::Sort($sortedManifestPaths, [StringComparer]::Ordinal)
+    if (-not [Linq.Enumerable]::SequenceEqual[string](
+            [string[]]$manifestPaths,
+            $sortedManifestPaths
+        ) -or
+        $manifestPaths -notcontains '_headers' -or
+        $manifestPaths -contains '_redirects' -or
+        $manifestPaths -contains 'main.jsx' -or
+        @($manifestPaths | Where-Object { $_ -like 'components/*' }).Count -ne 0) {
+        throw 'Site deploy manifest escaped the clean sorted static allowlist.'
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $sitePayloadFixtureRoot) {
+        Remove-Item -LiteralPath $sitePayloadFixtureRoot -Recurse -Force
+    }
+}
 
 & (Join-Path $root 'Test-WindowsX64Baseline.ps1')
 

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8532,9 +8532,84 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)one catch-all response policy.*?index\.html.*?404\.html.*?Get-CspSha256Source.*?HashSet\[string\].*?declaredHashes\.Add.*?expectedHashes.*?ConvertTo-Json' `
-    -Description 'one catch-all contract compares unique CSP hash sets from both HTML fallbacks and emits live expectations' `
+    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?function Assert-ExactCspDirectiveHashes.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
+    -Description 'one catch-all contract binds unique CSP hashes to their exact script directives and emits live expectations' `
     -Context $siteHeaderContract
+Assert-TextContract `
+    -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
+    -Pattern "(?ms)Assert-ExactCspDirectiveHashes.*?-DirectiveName 'script-src'.*?Assert-ExactCspDirectiveHashes.*?-DirectiveName 'script-src-attr'.*?expectedHashes\.UnionWith.*?declaredHashes\.Add.*?ConvertTo-Json" `
+    -Description 'script and event-handler hashes remain directive-specific before the global CSP allowlist check' `
+    -Context $siteHeaderContract
+
+$siteCspFixtureRoot = Join-Path (
+    [IO.Path]::GetTempPath()
+) "winghostty-site-csp-contract-$PID-$([Guid]::NewGuid().ToString('N'))"
+$siteCspFixtureRoot = [IO.Path]::GetFullPath($siteCspFixtureRoot)
+$siteCspTempPrefix = [IO.Path]::GetFullPath(
+    [IO.Path]::GetTempPath()
+).TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+if (-not $siteCspFixtureRoot.StartsWith(
+        $siteCspTempPrefix,
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+    throw "Refusing unsafe CSP fixture path: $siteCspFixtureRoot"
+}
+[IO.Directory]::CreateDirectory($siteCspFixtureRoot) | Out-Null
+try {
+    Get-ChildItem -LiteralPath (Join-Path $repoRoot 'site') |
+        Copy-Item `
+            -Destination $siteCspFixtureRoot `
+            -Recurse `
+            -Force
+    $fixtureHeadersPath = Join-Path $siteCspFixtureRoot '_headers'
+    $fixtureHeadersText = [IO.File]::ReadAllText($fixtureHeadersPath)
+    $scriptHash = [regex]::Match(
+        $fixtureHeadersText,
+        "script-src 'self' '(?<hash>sha256-[^']+)'"
+    ).Groups['hash'].Value
+    $attributeHash = [regex]::Match(
+        $fixtureHeadersText,
+        "script-src-attr 'unsafe-hashes' '(?<hash>sha256-[^']+)'"
+    ).Groups['hash'].Value
+    if ([string]::IsNullOrWhiteSpace($scriptHash) -or
+        [string]::IsNullOrWhiteSpace($attributeHash)) {
+        throw 'Could not identify CSP hashes for the directive-swap regression.'
+    }
+    $swappedHeaders = $fixtureHeadersText.Replace(
+        "'$scriptHash'",
+        "'__WINGHOSTTY_SCRIPT_HASH__'"
+    ).Replace(
+        "'$attributeHash'",
+        "'$scriptHash'"
+    ).Replace(
+        "'__WINGHOSTTY_SCRIPT_HASH__'",
+        "'$attributeHash'"
+    )
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $swappedHeaders,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $directiveSwapRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'script-src hashes do not exactly match') {
+            throw
+        }
+        $directiveSwapRejected = $true
+    }
+    if (-not $directiveSwapRejected) {
+        throw 'Site CSP contract accepted hashes swapped between script directives.'
+    }
+}
+finally {
+    if ([IO.Directory]::Exists($siteCspFixtureRoot)) {
+        [IO.Directory]::Delete($siteCspFixtureRoot, $true)
+    }
+}
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicHeaderContractOnce(?=\s|\{)') `
     -Pattern "(?ms)Path = '/'.*?ExpectedStatus = 200.*?Path = '/bundle\.js'.*?ExpectedStatus = 200.*?__winghostty_header_contract_.*?nested/page'.*?ExpectedStatus = 404.*?Cache-Control" `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8483,8 +8483,8 @@ Assert-TextContract `
     -Context $siteReadme
 Assert-TextContract `
     -Content $siteHeadersText `
-    -Pattern '(?ms)Cache-Control: public, max-age=0, must-revalidate.*?Content-Security-Policy:.*?X-Content-Type-Options: nosniff.*?X-Frame-Options: DENY.*?Referrer-Policy: strict-origin-when-cross-origin.*?Permissions-Policy:' `
-    -Description 'Pages responses use revalidation and baseline browser security headers' `
+    -Pattern '(?ms)^/\*\s+Content-Security-Policy:.*?X-Content-Type-Options: nosniff.*?X-Frame-Options: DENY.*?Referrer-Policy: strict-origin-when-cross-origin.*?Permissions-Policy:.*?^/\s+Cache-Control: public, max-age=0, must-revalidate.*?^/bundle\.js\s+Cache-Control: public, max-age=3600, must-revalidate' `
+    -Description 'Pages uses catch-all browser security headers and non-overlapping root and bundle cache rules' `
     -Context $siteHeaders
 Assert-TextContract `
     -Content $siteHeadersText `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8532,8 +8532,13 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
+    -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?eventAttributeCount.*?eventHandlers.*?Get-CspSha256Source -Value \$eventHandlers.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
     -Description 'one catch-all contract binds exact complete source sets to both script directives and emits live expectations' `
+    -Context $siteHeaderContract
+Assert-TextContract `
+    -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
+    -Pattern '(?ms)expectedPermissions.*?accelerometer=\(\).*?autoplay=\(\).*?gyroscope=\(\).*?magnetometer=\(\).*?declaredPermissionTokens.*?declaredPermissions.*?expectedPermissions\.Count.*?denylist contract' `
+    -Description 'permissions policy uses an exact duplicate-free directive denylist' `
     -Context $siteHeaderContract
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
@@ -8674,6 +8679,61 @@ try {
     }
     if (-not $sha384OverrideRejected) {
         throw 'Site CSP contract accepted a SHA-384 script-src-elem override.'
+    }
+
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $fixtureHeadersText,
+        [Text.UTF8Encoding]::new($false)
+    )
+    $fixtureIndexPath = Join-Path $siteCspFixtureRoot 'index.html'
+    $fixtureIndexText = [IO.File]::ReadAllText($fixtureIndexPath)
+    [IO.File]::WriteAllText(
+        $fixtureIndexPath,
+        $fixtureIndexText.Replace(
+            "onload=`"this.media='all'`"",
+            "onload=`"this.media='screen'`""
+        ),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $editedHandlerRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'script-src-attr sources do not exactly match') {
+            throw
+        }
+        $editedHandlerRejected = $true
+    }
+    if (-not $editedHandlerRejected) {
+        throw 'Site CSP contract accepted an untracked event-handler edit.'
+    }
+
+    [IO.File]::WriteAllText(
+        $fixtureIndexPath,
+        $fixtureIndexText,
+        [Text.UTF8Encoding]::new($false)
+    )
+    [IO.File]::WriteAllText(
+        $fixtureHeadersPath,
+        $fixtureHeadersText.Replace('accelerometer=()', 'accelerometer=(self)'),
+        [Text.UTF8Encoding]::new($false)
+    )
+    $weakenedPermissionRejected = $false
+    try {
+        & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
+    }
+    catch {
+        if ($_.Exception.Message -notmatch
+            'permissions policy does not exactly match') {
+            throw
+        }
+        $weakenedPermissionRejected = $true
+    }
+    if (-not $weakenedPermissionRejected) {
+        throw 'Site header contract accepted a weakened permissions policy.'
     }
 }
 finally {

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8715,23 +8715,15 @@ try {
         $fixtureIndexPath,
         $fixtureIndexText.Replace(
             "onload=`"this.media='all'`"",
-            'onload="this.media=&quot;all&quot;"'
+            'onload="this.media=&#39;all&#39;"'
         ),
         [Text.UTF8Encoding]::new($false)
     )
-    $entityHandlerRejected = $false
     try {
         & $siteHeaderContract -SiteDirectory $siteCspFixtureRoot | Out-Null
     }
     catch {
-        if ($_.Exception.Message -notmatch
-            'script-src-attr sources do not exactly match') {
-            throw
-        }
-        $entityHandlerRejected = $true
-    }
-    if (-not $entityHandlerRejected) {
-        throw 'Site CSP contract hashed serialized rather than decoded handler text.'
+        throw 'Site CSP contract did not hash the browser-decoded handler text.'
     }
 
     [IO.File]::WriteAllText(

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8487,9 +8487,13 @@ Assert-TextContract `
     -Context $siteReadme
 Assert-TextContract `
     -Content $siteHeadersText `
-    -Pattern '(?ms)^/\*\s+Content-Security-Policy:.*?X-Content-Type-Options: nosniff.*?X-Frame-Options: DENY.*?Referrer-Policy: strict-origin-when-cross-origin.*?Permissions-Policy:.*?^/\s+Cache-Control: public, max-age=0, must-revalidate.*?^/bundle\.js\s+Cache-Control: public, max-age=3600, must-revalidate' `
-    -Description 'Pages uses catch-all browser security headers and non-overlapping root and bundle cache rules' `
+    -Pattern '(?ms)^/\*\s+Content-Security-Policy:.*?X-Content-Type-Options: nosniff.*?X-Frame-Options: DENY.*?Referrer-Policy: strict-origin-when-cross-origin.*?Permissions-Policy:.*?Cache-Control: public, max-age=0, must-revalidate\s*$' `
+    -Description 'Pages uses one catch-all browser security and revalidation policy' `
     -Context $siteHeaders
+Assert-WorkflowContractAbsent `
+    -Path $siteHeaders `
+    -Pattern '(?m)^/(?!\*)' `
+    -Description 'path-specific cache rules cannot overlap the catch-all response policy'
 Assert-TextContract `
     -Content $siteHeadersText `
     -Pattern "(?ms)script-src 'self' 'sha256-[^']+' 'sha256-[^']+'; script-src-attr 'unsafe-hashes' 'sha256-[^']+';" `
@@ -8509,9 +8513,14 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
-    -Pattern '(?ms)index\.html.*?404\.html.*?Get-CspSha256Source.*?declaredHashes.*?expectedHashes.*?ConvertTo-Json' `
-    -Description 'one reusable contract derives CSP hashes from both HTML fallbacks and emits live expectations' `
+    -Pattern '(?ms)one catch-all response policy.*?index\.html.*?404\.html.*?Get-CspSha256Source.*?declaredHashes.*?expectedHashes.*?ConvertTo-Json' `
+    -Description 'one catch-all contract derives CSP hashes from both HTML fallbacks and emits live expectations' `
     -Context $siteHeaderContract
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Assert-PublicHeaderContract(?=\s|\{)') `
+    -Pattern "(?ms)Path = '/'.*?ExpectedStatus = 200.*?Path = '/bundle\.js'.*?ExpectedStatus = 200.*?__winghostty_header_contract_.*?nested/page'.*?ExpectedStatus = 404.*?Cache-Control" `
+    -Description 'public header verification covers canonical HTML, an asset, and a nested 404 fallback' `
+    -Context "$cloudflarePagesVerifier :: Assert-PublicHeaderContract"
 
 $sitePayloadFixtureRoot = Join-Path (
     [IO.Path]::GetTempPath()

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -2568,6 +2568,8 @@ $testWorkflow = Join-Path $repoRoot '.github\workflows\test.yml'
 $siteDeployWorkflow = Join-Path $repoRoot '.github\workflows\deploy-site.yml'
 $siteBundleBuilder = Join-Path $repoRoot 'scripts\build-site-bundle.mjs'
 $sitePayloadBuilder = Join-Path $repoRoot 'scripts\build-site-payload.ps1'
+$siteHeaderContract = Join-Path $repoRoot 'scripts\get-site-header-contract.ps1'
+$siteDeploymentHeadGate = Join-Path $repoRoot 'scripts\require-site-deployment-head.ps1'
 $cloudflarePagesVerifier = Join-Path $repoRoot 'scripts\verify-cloudflare-pages.ps1'
 $siteHeaders = Join-Path $repoRoot 'site\_headers'
 $siteReadme = Join-Path $repoRoot 'site\README.md'
@@ -8274,7 +8276,12 @@ Assert-TextContract `
     -Description 'package-manager preflight invokes the WinGet architecture gate' `
     -Context "$releasePreflight :: RequirePackageManagers"
 
-foreach ($siteScript in @($sitePayloadBuilder, $cloudflarePagesVerifier)) {
+foreach ($siteScript in @(
+    $sitePayloadBuilder,
+    $siteHeaderContract,
+    $siteDeploymentHeadGate,
+    $cloudflarePagesVerifier
+)) {
     $siteScriptTokens = $null
     $siteScriptErrors = $null
     [void][Management.Automation.Language.Parser]::ParseFile(
@@ -8323,7 +8330,7 @@ Assert-TextContract `
     -Context "$siteDeployWorkflow :: source"
 Assert-TextContract `
     -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name 'Validate committed site bundle and copy' -Source $siteDeployWorkflow) `
-    -Pattern '(?ms)GH_TOKEN:.*?github\.token.*?RELEASE_TAG:.*?github\.event\.release\.tag_name.*?GITHUB_EVENT_NAME -eq ''release''.*?RELEASE_TAG -cnotmatch ''\^v\(\?<version>\\d\+\\\.\\d\+\\\.\\d\+\)\$''.*?check-release-copy\.ps1.*?-ExpectedVersion \$Matches\.version.*?-CheckRemoteLatest.*?else \{.*?check-release-copy\.ps1 -CheckRemoteLatest.*?LASTEXITCODE' `
+    -Pattern '(?ms)GH_TOKEN:.*?github\.token.*?RELEASE_TAG:.*?github\.event\.release\.tag_name.*?get-site-header-contract\.ps1.*?GITHUB_EVENT_NAME -eq ''release''.*?RELEASE_TAG -cnotmatch ''\^v\(\?<version>\\d\+\\\.\\d\+\\\.\\d\+\)\$''.*?check-release-copy\.ps1.*?-ExpectedVersion \$Matches\.version.*?-CheckRemoteLatest.*?else \{.*?check-release-copy\.ps1 -CheckRemoteLatest.*?LASTEXITCODE' `
     -Description 'release-triggered site deployments bind baked-in copy to the published semver tag' `
     -Context "$siteDeployWorkflow :: site validation"
 $siteActionUses = [regex]::Matches(
@@ -8359,20 +8366,18 @@ foreach ($deployStepName in @(
         -Description 'isolated Wrangler deploys the same clean exact-commit payload with the required version' `
         -Context "$siteDeployWorkflow :: $deployStepName"
 }
-if ([regex]::Matches(
-        $siteDeployWorkflowText,
-        '(?m)^      - name: Require exact origin main before (?:canary|production)$'
-    ).Count -ne 2 -or
-    [regex]::Matches(
-        $siteDeployWorkflowText,
-        "git fetch --force --no-tags origin 'refs/heads/main:refs/remotes/origin/main'"
-    ).Count -ne 2 -or
-    [regex]::Matches(
-        $siteDeployWorkflowText,
-        '\$head -cne \$env:DEPLOY_SHA -or \$head -cne \$originMain'
-    ).Count -ne 2) {
-    throw 'Site deployment must reassert the exact clean origin/main head before both uploads.'
+foreach ($phase in @('canary', 'production')) {
+    Assert-TextContract `
+        -Content (Get-YamlStepBlock -Content $siteDeployWorkflowText -Name "Require exact origin main before $phase" -Source $siteDeployWorkflow) `
+        -Pattern "(?ms)require-site-deployment-head\.ps1.*?-ExpectedSha \`$env:DEPLOY_SHA.*?-DefaultBranch \`$env:DEFAULT_BRANCH.*?-Phase $phase" `
+        -Description "site deployment invokes the shared exact-main gate before $phase" `
+        -Context "$siteDeployWorkflow :: $phase head gate"
 }
+Assert-TextContract `
+    -Content (Get-Content -LiteralPath $siteDeploymentHeadGate -Raw) `
+    -Pattern '(?ms)GITHUB_REPOSITORY -cne ''amanthanvi/winghostty''.*?git remote get-url origin.*?git fetch --force --no-tags origin.*?git rev-parse HEAD.*?refs/remotes/origin/\$DefaultBranch.*?\$head -cne \$ExpectedSha.*?git status --porcelain=v1 --untracked-files=all' `
+    -Description 'the shared site gate binds both phases to a clean exact fork-local main head' `
+    -Context $siteDeploymentHeadGate
 $sitePayloadStep = Get-YamlStepBlock `
     -Content $siteDeployWorkflowText `
     -Name 'Build deterministic deploy payload twice' `
@@ -8442,7 +8447,7 @@ Assert-TextContract `
     -Context $siteBundleBuilder
 Assert-TextContract `
     -Content $cloudflarePagesVerifierText `
-    -Pattern '(?ms)latest_stage\.status.*?commit_hash -cne \$Commit.*?commit_dirty -ne \$false.*?Get-ManifestEntries.*?Get-Sha256 -Bytes.*?Assert-PublicHeaderContract' `
+    -Pattern '(?ms)latest_stage\.status.*?commit_hash -cne \$Commit.*?commit_dirty -ne \$false.*?Get-ManifestEntries.*?Get-Sha256 -Bytes.*?get-site-header-contract\.ps1.*?Assert-PublicHeaderContract' `
     -Description 'Pages verification checks exact clean commit provenance, manifest bytes, and response controls' `
     -Context $cloudflarePagesVerifier
 Assert-WorkflowContractAbsent `
@@ -8481,51 +8486,23 @@ Assert-TextContract `
     -Pattern "(?ms)script-src 'self' 'sha256-[^']+' 'sha256-[^']+'; script-src-attr 'unsafe-hashes' 'sha256-[^']+';" `
     -Description 'inline scripts and the font load handler use narrow CSP hashes' `
     -Context $siteHeaders
-if ($siteHeadersText -match "script-src 'self'[^;]*'unsafe-inline'") {
-    throw 'Pages CSP cannot broadly allow inline scripts.'
+$siteHeaderContractJson = & $siteHeaderContract `
+    -SiteDirectory (Join-Path $repoRoot 'site')
+$siteHeaderContractObject = $siteHeaderContractJson | ConvertFrom-Json -Depth 6
+if ([string]$siteHeaderContractObject.root.content_security_policy -cne
+        [string](
+            [regex]::Match(
+                $siteHeadersText,
+                '(?m)^\s+Content-Security-Policy:\s*(?<value>.+)$'
+            ).Groups['value'].Value
+        )) {
+    throw 'Central site header contract did not return the tracked CSP.'
 }
-
-function Get-CspSha256Source {
-    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Value)
-
-    $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Value)
-    return 'sha256-' + [Convert]::ToBase64String(
-        [Security.Cryptography.SHA256]::HashData($bytes)
-    )
-}
-
-$expectedCspHashes = [Collections.Generic.HashSet[string]]::new(
-    [StringComparer]::Ordinal
-)
-foreach ($htmlName in @('index.html', '404.html')) {
-    $html = [IO.File]::ReadAllText(
-        (Join-Path $repoRoot "site\$htmlName"),
-        [Text.UTF8Encoding]::new($false)
-    )
-    $inlineScripts = @(
-        [regex]::Matches($html, '(?is)<script(?<attrs>[^>]*)>(?<body>.*?)</script>') |
-            Where-Object { $_.Groups['attrs'].Value -notmatch '\bsrc\s*=' }
-    )
-    if ($inlineScripts.Count -ne 1) {
-        throw "Expected exactly one CSP-hashed inline theme script in site/$htmlName."
-    }
-    [void]$expectedCspHashes.Add(
-        (Get-CspSha256Source -Value $inlineScripts[0].Groups['body'].Value)
-    )
-}
-[void]$expectedCspHashes.Add(
-    (Get-CspSha256Source -Value "this.media='all'")
-)
-$declaredCspHashes = @(
-    [regex]::Matches($siteHeadersText, "'(?<hash>sha256-[A-Za-z0-9+/]+=*)'") |
-        ForEach-Object { $_.Groups['hash'].Value }
-)
-if ($declaredCspHashes.Count -ne $expectedCspHashes.Count -or
-    @($declaredCspHashes | Where-Object {
-        -not $expectedCspHashes.Contains($_)
-    }).Count -ne 0) {
-    throw 'Pages CSP hashes do not exactly match the inline HTML scripts and handlers.'
-}
+Assert-TextContract `
+    -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
+    -Pattern '(?ms)index\.html.*?404\.html.*?Get-CspSha256Source.*?declaredHashes.*?expectedHashes.*?ConvertTo-Json' `
+    -Description 'one reusable contract derives CSP hashes from both HTML fallbacks and emits live expectations' `
+    -Context $siteHeaderContract
 
 $sitePayloadFixtureRoot = Join-Path (
     [IO.Path]::GetTempPath()


### PR DESCRIPTION
## Outcome

Adds a no-manual-upload Cloudflare Pages deployment pipeline directly on current `main`.

- every `main` advance runs the gate, preventing path-filter races from stranding site changes
- deterministic 16-file allowlisted payload with repeat-build SHA-256 proof
- pinned checkout, Wrangler, and evidence-upload actions
- exact-current-main source binding for push, stable release, and manual events
- prerelease events ignored by design
- non-production canary before the production write
- Cloudflare API provenance, commit, environment, byte, CSP, and security-header verification
- one non-overlapping revalidation policy verified for root HTML, bundle, and nested 404 fallback
- canonical apex verification and mandatory zone-owned `www` redirect preflight
- protected `cloudflare-pages-production` GitHub environment runbook
- unsupported Pages `_redirects` removed; zone-level redirect is explicit

## Validation

- PowerShell parser and YAML checks
- two independent payload builds — identical 16-file manifests
- `test/windows/flagship/Test-VerificationContracts.ps1` — PASS (2 scenarios)
- exact LF CSP hashes regenerated and contract-verified in a clean worktree
- independent GPT-5.6 Sol deployment audits
- Greptile 5/5 exact-head review
- substantive CodeRabbit exact-head review: no remaining actionable findings
- all Codex findings addressed: CSP derivation, cache-rule overlap, main-head catch-up, and nested fallback caching

## Deployment setup

The repository runbook in `site/README.md` documents the one-time, least-privilege Cloudflare token, GitHub environment secrets, and zone-level `www` redirect. After setup, merging to `main` deploys and verifies canary then production without manual upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Cloudflare Pages deployments for main-branch updates, stable releases, and manual runs.
  * Added canary validation before production publishing, including asset, security-header, provenance, and redirect checks.
  * Added deterministic deployment payload verification to ensure published files match the expected site content.
  * Added strict browser security and caching headers for the site.

* **Documentation**
  * Updated deployment procedures, validation requirements, custom-domain behavior, and local build instructions.

* **Tests**
  * Expanded deployment and site-content checks, including negative security-policy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->