### PR TITLE
ci: retain Cloudflare deployment diagnostics

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -136,7 +136,6 @@ jobs:
           wranglerVersion: 4.114.0
           packageManager: npm
           workingDirectory: ${{ steps.payload.outputs.wrangler_directory }}
-          quiet: true
           command: >-
             pages deploy "${{ steps.payload.outputs.directory }}"
             --project-name=winghostty
@@ -203,7 +202,6 @@ jobs:
           wranglerVersion: 4.114.0
           packageManager: npm
           workingDirectory: ${{ steps.payload.outputs.wrangler_directory }}
-          quiet: true
           command: >-
             pages deploy "${{ steps.payload.outputs.directory }}"
             --project-name=winghostty

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8371,9 +8371,12 @@ foreach ($deployStepName in @(
         -Source $siteDeployWorkflow
     Assert-TextContract `
         -Content $deployStep `
-        -Pattern '(?ms)wranglerVersion: 4\.114\.0.*?workingDirectory: \$\{\{ steps\.payload\.outputs\.wrangler_directory \}\}.*?quiet: true.*?pages deploy "\$\{\{ steps\.payload\.outputs\.directory \}\}".*?--project-name=winghostty.*?--commit-hash="\$\{\{ steps\.source\.outputs\.sha \}\}".*?--commit-dirty=false' `
-        -Description 'isolated Wrangler deploys the same clean exact-commit payload with the required version' `
+        -Pattern '(?ms)wranglerVersion: 4\.114\.0.*?workingDirectory: \$\{\{ steps\.payload\.outputs\.wrangler_directory \}\}.*?pages deploy "\$\{\{ steps\.payload\.outputs\.directory \}\}".*?--project-name=winghostty.*?--commit-hash="\$\{\{ steps\.source\.outputs\.sha \}\}".*?--commit-dirty=false' `
+        -Description 'isolated Wrangler deploys the same clean exact-commit payload with the required version and visible diagnostics' `
         -Context "$siteDeployWorkflow :: $deployStepName"
+    if ($deployStep -match '(?m)^\s*quiet:') {
+        throw "Cloudflare deployment diagnostics must remain visible ($siteDeployWorkflow :: $deployStepName)"
+    }
 }
 foreach ($phase in @('canary', 'production')) {
     Assert-TextContract `


### PR DESCRIPTION
## Summary
- keep Wrangler output visible for canary and production Pages deploys
- preserve credential redaction while exposing actionable Cloudflare errors

## Why
The first production workflow run after #99 failed inside the canary upload, but \quiet: true\ suppressed Wrangler's error and left only \Action failed\. This restores evidence needed to diagnose and complete deployment.

## Validation
- \git diff --check\`n- workflow structure unchanged apart from removing the optional quiet inputs

## Summary by Sourcery

CI:
- Remove the quiet option from Wrangler deploy steps so workflow logs retain Cloudflare error details while keeping credentials redacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment output is now more visible during canary and production releases.
  * Existing deployment targets and commit handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->