### PR TITLE
fix(site): verify Cloudflare cache semantics

### DIFF
--- a/scripts/get-site-header-contract.ps1
+++ b/scripts/get-site-header-contract.ps1
@@ -298,4 +298,7 @@ if ($declaredHashes.Count -ne $expectedHashes.Count -or
     bundle = [ordered]@{
         cache_control = $security['Cache-Control']
     }
+    not_found = [ordered]@{
+        cache_control = 'no-store'
+    }
 } | ConvertTo-Json -Depth 4 -Compress

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -416,6 +416,30 @@ function Get-ResponseHeaderText {
     return ''
 }
 
+function Test-EquivalentCacheControl {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string] $Actual,
+        [Parameter(Mandatory)] [string] $Expected
+    )
+
+    $actualTokens = @($Actual.Split(',') | ForEach-Object { $_.Trim() })
+    $expectedTokens = @($Expected.Split(',') | ForEach-Object { $_.Trim() })
+    $actualSet = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    $expectedSet = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($token in $actualTokens) {
+        if (-not $token -or -not $actualSet.Add($token)) { return $false }
+    }
+    foreach ($token in $expectedTokens) {
+        if (-not $token -or -not $expectedSet.Add($token)) { return $false }
+    }
+    return $actualSet.Count -eq $expectedSet.Count -and
+        @($expectedSet | Where-Object { -not $actualSet.Contains($_) }).Count -eq 0
+}
+
 function Test-PublicHeaderContractOnce {
     param(
         [Parameter(Mandatory)] [Uri] $Origin,
@@ -438,7 +462,7 @@ function Test-PublicHeaderContractOnce {
             Path = '/__winghostty_header_contract_' +
                 [Uri]::EscapeDataString($Id) + '/nested/page'
             ExpectedStatus = 404
-            ExpectedCache = [string]$Contract.root.cache_control
+            ExpectedCache = [string]$Contract.not_found.cache_control
         }
     )
     foreach ($probe in $probes) {
@@ -456,7 +480,9 @@ function Test-PublicHeaderContractOnce {
             $cacheControl = Get-ResponseHeaderText `
                 -Response $response `
                 -Name 'Cache-Control'
-            if ($cacheControl -cne $probe.ExpectedCache) {
+            if (-not (Test-EquivalentCacheControl `
+                    -Actual $cacheControl `
+                    -Expected $probe.ExpectedCache)) {
                 return $false
             }
             if ((Get-ResponseHeaderText -Response $response -Name 'X-Content-Type-Options') -cne

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8602,6 +8602,9 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
         )) {
     throw 'Central site header contract did not return the tracked CSP.'
 }
+if ([string]$siteHeaderContractObject.not_found.cache_control -cne 'no-store') {
+    throw 'Central site header contract must require generated 404 responses not to be cached.'
+}
 Assert-TextContract `
     -Content (Get-Content -LiteralPath $siteHeaderContract -Raw) `
     -Pattern '(?ms)expectedScriptHashes.*?expectedScriptAttributeHashes.*?eventAttributeCount.*?eventHandlers.*?WebUtility\]::HtmlDecode.*?Get-CspSha256Source -Value \$decodedEventHandler.*?function Assert-ExactCspDirectiveSources.*?declaredTokens.*?declared\.Add.*?Expected\.Count' `
@@ -8832,6 +8835,33 @@ Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicHeaderContractOnce(?=\s|\{)') `
     -Pattern "(?ms)Path = '/'.*?ExpectedStatus = 200.*?Path = '/bundle\.js'.*?ExpectedStatus = 200.*?__winghostty_header_contract_.*?nested/page'.*?ExpectedStatus = 404.*?Cache-Control" `
     -Description 'public header verification covers canonical HTML, an asset, and a nested 404 fallback' `
+    -Context "$cloudflarePagesVerifier :: Test-PublicHeaderContractOnce"
+$cacheControlContract = Get-PowerShellBlockText `
+    -Content $cloudflarePagesVerifierText `
+    -HeaderPattern '^function\s+Test-EquivalentCacheControl(?=\s|\{)'
+. ([scriptblock]::Create($cacheControlContract))
+if (-not (Test-EquivalentCacheControl `
+        -Actual 'PUBLIC, must-revalidate, max-age=0' `
+        -Expected 'public, max-age=0, must-revalidate') -or
+    -not (Test-EquivalentCacheControl -Actual 'no-store' -Expected 'no-store') -or
+    (Test-EquivalentCacheControl `
+        -Actual 'public, max-age=0' `
+        -Expected 'public, max-age=0, must-revalidate') -or
+    (Test-EquivalentCacheControl `
+        -Actual 'public, max-age=0, must-revalidate, immutable' `
+        -Expected 'public, max-age=0, must-revalidate') -or
+    (Test-EquivalentCacheControl `
+        -Actual 'public, public, max-age=0, must-revalidate' `
+        -Expected 'public, max-age=0, must-revalidate') -or
+    (Test-EquivalentCacheControl `
+        -Actual '' `
+        -Expected 'public, max-age=0, must-revalidate')) {
+    throw 'Published cache-control verification must ignore order and case but reject missing, extra, or duplicate directives.'
+}
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicHeaderContractOnce(?=\s|\{)') `
+    -Pattern '(?ms)ExpectedStatus = 404.*?ExpectedCache = \[string\]\$Contract\.not_found\.cache_control.*?Test-EquivalentCacheControl.*?-Actual \$cacheControl.*?-Expected \$probe\.ExpectedCache' `
+    -Description 'published headers compare exact cache directive sets and require no-store for generated 404 responses' `
     -Context "$cloudflarePagesVerifier :: Test-PublicHeaderContractOnce"
 Assert-TextContract `
     -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Assert-PublicHeaderContract(?=\s|\{)') `


### PR DESCRIPTION
## Summary

- compare Cache-Control as an exact case-insensitive directive set instead of a byte-ordered string
- reject missing, extra, duplicate, or empty directives
- require Cloudflare's generated nested 404 response to remain `no-store`
- add executable regression cases for reordered/cased, missing, extra, duplicate, empty, and 404 policies

## Failure fixed

Deploy Site run 30187909366 deployed canary `95065e88-8c61-41a7-9c52-65c3df4e329b`, then failed header convergence. The immutable edge response reordered the equivalent 200 directives to `public, must-revalidate, max-age=0`, while generated 404s correctly override the catch-all public policy with `no-store`.

Run: https://github.com/amanthanvi/winghostty/actions/runs/30187909366

## Validation

- changed PowerShell files parse cleanly
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- deterministic payload built twice: 16 files each
- actual immutable canary header contract: PASS across `/`, `/bundle.js`, and nested 404
- `git diff --check`

## Summary by Sourcery

Strengthen Cloudflare Pages header verification to compare Cache-Control directives as case-insensitive sets and enforce no-store for generated 404 responses.

New Features:
- Introduce a Cache-Control comparison helper that validates headers as case-insensitive directive sets instead of ordered strings.

Bug Fixes:
- Fix public header contract verification to require the specific 404 cache policy from the not_found contract instead of reusing the root policy.

Enhancements:
- Extend flagship verification tests to cover Cache-Control directive reordering, casing, missing, extra, duplicate, empty, and 404-specific policies.
- Augment the site header contract JSON to include a dedicated not_found cache_control entry set to no-store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public header validation to accept equivalent `Cache-Control` directives regardless of order or capitalization.
  * Added explicit `no-store` caching for generated 404 responses.
  * Strengthened verification to detect missing, extra, or duplicate cache directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->