### PR TITLE
fix(site): verify challenged custom domains safely

### DIFF
--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -290,13 +290,27 @@ function ConvertTo-PublicBaseUri {
         throw 'Deployment verification URL must be an HTTPS origin.'
     }
     if ($Kind -eq 'pages' -and
-        $uri.DnsSafeHost -cnotmatch '^[a-z0-9-]+\.winghostty\.pages\.dev$') {
+        $uri.DnsSafeHost -cnotmatch '^[0-9a-f]{8}\.winghostty\.pages\.dev$') {
         throw 'Deployment URL is not an immutable winghostty Pages origin.'
     }
     if ($Kind -eq 'canonical' -and $uri.DnsSafeHost -cne 'winghostty.com') {
         throw 'Canonical URL must be https://winghostty.com/.'
     }
     return $uri
+}
+
+function Assert-ImmutablePagesDeploymentOrigin {
+    param(
+        [Parameter(Mandatory)] [Uri] $Origin,
+        [Parameter(Mandatory)] [string] $DeploymentId
+    )
+
+    $idMatch = [regex]::Match($DeploymentId, '^(?<label>[0-9a-f]{8})-')
+    if (-not $idMatch.Success -or
+        $Origin.DnsSafeHost -cne
+            "$($idMatch.Groups['label'].Value).winghostty.pages.dev") {
+        throw 'Immutable Pages origin does not match the deployment ID.'
+    }
 }
 
 function New-PublicAssetUri {
@@ -645,6 +659,9 @@ try {
                 $apiOrigin.AbsoluteUri.TrimEnd('/')) {
                 throw 'Wrangler deployment URL does not match Cloudflare API provenance.'
             }
+            Assert-ImmutablePagesDeploymentOrigin `
+                -Origin $pagesOrigin `
+                -DeploymentId $DeploymentId
             $entries = @(Get-ManifestEntries `
                 -Path $ManifestPath `
                 -PayloadRoot $PayloadDirectory)

--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -290,8 +290,8 @@ function ConvertTo-PublicBaseUri {
         throw 'Deployment verification URL must be an HTTPS origin.'
     }
     if ($Kind -eq 'pages' -and
-        $uri.DnsSafeHost -cnotmatch '^(?:[a-z0-9-]+\.)?winghostty\.pages\.dev$') {
-        throw 'Deployment URL is not a winghostty Pages origin.'
+        $uri.DnsSafeHost -cnotmatch '^[a-z0-9-]+\.winghostty\.pages\.dev$') {
+        throw 'Deployment URL is not an immutable winghostty Pages origin.'
     }
     if ($Kind -eq 'canonical' -and $uri.DnsSafeHost -cne 'winghostty.com') {
         throw 'Canonical URL must be https://winghostty.com/.'
@@ -345,12 +345,18 @@ function Test-PublicPayloadOnce {
         [Parameter(Mandatory)] [Uri] $Origin,
         [Parameter(Mandatory)] [object[]] $Entries,
         [Parameter(Mandatory)] [string] $Id,
-        [Parameter(Mandatory)] [string] $Commit
+        [Parameter(Mandatory)] [string] $Commit,
+        [switch] $StaticOnly
     )
 
     foreach ($entry in $Entries) {
         if ($entry.Path -ceq '_headers') {
             # Pages consumes this control file; it is not a public static asset.
+            continue
+        }
+        if ($StaticOnly -and $entry.Path -cin @('index.html', '404.html')) {
+            # A custom-domain challenge can replace HTML. The immutable Pages
+            # deployment remains the authoritative full-payload verification.
             continue
         }
         $uri = New-PublicAssetUri `
@@ -385,7 +391,8 @@ function Assert-PublicPayload {
         [Parameter(Mandatory)] [Uri] $Origin,
         [Parameter(Mandatory)] [object[]] $Entries,
         [Parameter(Mandatory)] [string] $Id,
-        [Parameter(Mandatory)] [string] $Commit
+        [Parameter(Mandatory)] [string] $Commit,
+        [switch] $StaticOnly
     )
 
     for ($attempt = 1; $attempt -le 6; $attempt++) {
@@ -393,7 +400,8 @@ function Assert-PublicPayload {
                 -Origin $Origin `
                 -Entries $Entries `
                 -Id $Id `
-                -Commit $Commit
+                -Commit $Commit `
+                -StaticOnly:$StaticOnly
         if ($status -cne 'failed') {
             return $status
         }
@@ -444,27 +452,31 @@ function Test-PublicHeaderContractOnce {
     param(
         [Parameter(Mandatory)] [Uri] $Origin,
         [Parameter(Mandatory)] [string] $Id,
-        [Parameter(Mandatory)] [object] $Contract
+        [Parameter(Mandatory)] [object] $Contract,
+        [switch] $StaticOnly
     )
 
-    $probes = @(
-        [pscustomobject]@{
+    $probes = @()
+    if (-not $StaticOnly) {
+        $probes += [pscustomobject]@{
             Path = '/'
             ExpectedStatus = 200
             ExpectedCache = [string]$Contract.root.cache_control
         }
-        [pscustomobject]@{
-            Path = '/bundle.js'
-            ExpectedStatus = 200
-            ExpectedCache = [string]$Contract.bundle.cache_control
-        }
-        [pscustomobject]@{
+    }
+    $probes += [pscustomobject]@{
+        Path = '/bundle.js'
+        ExpectedStatus = 200
+        ExpectedCache = [string]$Contract.bundle.cache_control
+    }
+    if (-not $StaticOnly) {
+        $probes += [pscustomobject]@{
             Path = '/__winghostty_header_contract_' +
                 [Uri]::EscapeDataString($Id) + '/nested/page'
             ExpectedStatus = 404
             ExpectedCache = [string]$Contract.not_found.cache_control
         }
-    )
+    }
     foreach ($probe in $probes) {
         $builder = [UriBuilder]::new($Origin)
         $builder.Path = $probe.Path
@@ -513,14 +525,16 @@ function Assert-PublicHeaderContract {
     param(
         [Parameter(Mandatory)] [Uri] $Origin,
         [Parameter(Mandatory)] [string] $Id,
-        [Parameter(Mandatory)] [object] $Contract
+        [Parameter(Mandatory)] [object] $Contract,
+        [switch] $StaticOnly
     )
 
     for ($attempt = 1; $attempt -le 6; $attempt++) {
         if (Test-PublicHeaderContractOnce `
                 -Origin $Origin `
                 -Id $Id `
-                -Contract $Contract) {
+                -Contract $Contract `
+                -StaticOnly:$StaticOnly) {
             return
         }
         if ($attempt -lt 6) { Start-Sleep -Seconds 2 }
@@ -663,11 +677,13 @@ try {
                     -Origin $canonicalOrigin `
                     -Entries $entries `
                     -Id $DeploymentId `
-                    -Commit $ExpectedCommit)
+                    -Commit $ExpectedCommit `
+                    -StaticOnly)
                 [void](Assert-PublicHeaderContract `
                     -Origin $canonicalOrigin `
                     -Id $DeploymentId `
-                    -Contract $headerContract)
+                    -Contract $headerContract `
+                    -StaticOnly)
                 [void]$verifiedHosts.Add($canonicalOrigin.DnsSafeHost)
             }
             if ($VerifyWwwRedirect) {
@@ -682,7 +698,7 @@ try {
                     -LiteralPath ([IO.Path]::GetFullPath($ManifestPath)) `
                     -Algorithm SHA256).Hash.ToLowerInvariant()
             Write-RedactedJson -Path $ProvenancePath -Value ([ordered]@{
-                schema_version = 'winghostty.cloudflare-pages-provenance.v1'
+                schema_version = 'winghostty.cloudflare-pages-provenance.v2'
                 verified_at = [DateTimeOffset]::UtcNow.ToString('o')
                 project_name = $ProjectName
                 deployment_id = $DeploymentId
@@ -696,8 +712,10 @@ try {
                 manifest_sha256 = $manifestHash
                 file_count = $entries.Count
                 verified_hosts = [string[]]$verifiedHosts
-                canonical_html_verified =
+                immutable_html_verified = $true
+                canonical_static_assets_verified =
                     -not [string]::IsNullOrWhiteSpace($CanonicalBaseUrl)
+                canonical_html_verified = $false
                 github_repository = $env:GITHUB_REPOSITORY
                 github_run_id = $env:GITHUB_RUN_ID
                 github_run_attempt = $env:GITHUB_RUN_ATTEMPT

--- a/site/README.md
+++ b/site/README.md
@@ -71,9 +71,13 @@ uploaded first to a non-production canary branch and then to `main`; Cloudflare
 API metadata, commit provenance, and every served byte are checked after each
 upload. The zone-owned `www` redirect is preflighted before production, so
 missing zone configuration cannot publish and then fail. Production
-verification also requires the exact HTML, fallback, static assets, cache
-policy, and security headers at `winghostty.com`; a Cloudflare challenge or any
-other substituted response fails verification.
+verification requires the exact HTML, fallback, static assets, cache policy,
+and security headers at the immutable Pages deployment URL. At
+`winghostty.com`, it separately verifies Pages API domain attachment, every
+non-HTML static asset byte, and the static response cache and security headers.
+Cloudflare can replace custom-domain HTML with a managed challenge, so the
+provenance records canonical HTML as unverified. Challenge HTML is never
+accepted as published site content.
 
 The workflow does not automatically roll back a failed production verification:
 the Pages API has no compare-and-swap rollback primitive, so an automated

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8609,6 +8609,42 @@ $cloudflareVerifierAst = [System.Management.Automation.Language.Parser]::ParseIn
 if ($cloudflareVerifierErrors.Count -ne 0) {
     throw 'Cloudflare verifier must parse for public-verification call checks.'
 }
+$immutableOriginBindingCalls = @($cloudflareVerifierAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -ceq 'Assert-ImmutablePagesDeploymentOrigin'
+}, $true))
+$urlIdentityChecks = @($cloudflareVerifierAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.IfStatementAst] -and
+        $node.Extent.Text.Contains(
+            'Wrangler deployment URL does not match Cloudflare API provenance.'
+        )
+}, $true))
+if ($immutableOriginBindingCalls.Count -ne 1 -or
+    $urlIdentityChecks.Count -ne 1) {
+    throw 'Deployment flow must contain one URL identity check and origin binding.'
+}
+$originBindingElements = @(
+    $immutableOriginBindingCalls[0].CommandElements
+)
+if ($originBindingElements.Count -ne 5 -or
+    $originBindingElements[1] -isnot
+        [System.Management.Automation.Language.CommandParameterAst] -or
+    $originBindingElements[1].ParameterName -cne 'Origin' -or
+    $originBindingElements[2] -isnot
+        [System.Management.Automation.Language.VariableExpressionAst] -or
+    $originBindingElements[2].VariablePath.UserPath -cne 'pagesOrigin' -or
+    $originBindingElements[3] -isnot
+        [System.Management.Automation.Language.CommandParameterAst] -or
+    $originBindingElements[3].ParameterName -cne 'DeploymentId' -or
+    $originBindingElements[4] -isnot
+        [System.Management.Automation.Language.VariableExpressionAst] -or
+    $originBindingElements[4].VariablePath.UserPath -cne 'DeploymentId' -or
+    $immutableOriginBindingCalls[0].Extent.StartOffset -le
+        $urlIdentityChecks[0].Extent.EndOffset) {
+    throw 'Deployment flow must bind pagesOrigin to DeploymentId after URL identity.'
+}
 $publicVerificationCalls = @($cloudflareVerifierAst.FindAll({
     param($node)
     $node -is [System.Management.Automation.Language.CommandAst] -and

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8565,16 +8565,39 @@ if ($immutablePagesOrigin.DnsSafeHost -cne
     '69cd5628.winghostty.pages.dev') {
     throw 'Immutable Pages deployment origin was not preserved.'
 }
-$mutablePagesOriginRejected = $false
-try {
-    [void](ConvertTo-PublicBaseUri `
-        -Value 'https://winghostty.pages.dev/' `
-        -Kind pages)
-} catch {
-    $mutablePagesOriginRejected = $true
+foreach ($mutablePagesUrl in @(
+    'https://winghostty.pages.dev/',
+    'https://main.winghostty.pages.dev/'
+)) {
+    $mutablePagesOriginRejected = $false
+    try {
+        [void](ConvertTo-PublicBaseUri `
+            -Value $mutablePagesUrl `
+            -Kind pages)
+    } catch {
+        $mutablePagesOriginRejected = $true
+    }
+    if (-not $mutablePagesOriginRejected) {
+        throw "Mutable Pages origin passed immutable validation: $mutablePagesUrl"
+    }
 }
-if (-not $mutablePagesOriginRejected) {
-    throw 'Mutable Pages project origin passed immutable deployment validation.'
+$immutableOriginBindingFunctionText = Get-PowerShellBlockText `
+    -Content $cloudflarePagesVerifierText `
+    -HeaderPattern '^function\s+Assert-ImmutablePagesDeploymentOrigin(?=\s|\{)'
+. ([scriptblock]::Create($immutableOriginBindingFunctionText))
+Assert-ImmutablePagesDeploymentOrigin `
+    -Origin $immutablePagesOrigin `
+    -DeploymentId '69cd5628-1d01-4095-9774-6f8cfe7d7d1e'
+$mismatchedDeploymentIdRejected = $false
+try {
+    Assert-ImmutablePagesDeploymentOrigin `
+        -Origin $immutablePagesOrigin `
+        -DeploymentId 'deadbeef-1d01-4095-9774-6f8cfe7d7d1e'
+} catch {
+    $mismatchedDeploymentIdRejected = $true
+}
+if (-not $mismatchedDeploymentIdRejected) {
+    throw 'Immutable Pages origin was not bound to its deployment ID.'
 }
 $cloudflareVerifierTokens = $null
 $cloudflareVerifierErrors = $null

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -8554,10 +8554,159 @@ Assert-WorkflowContractAbsent `
     -Path $cloudflarePagesVerifier `
     -Pattern '(?i)cf-mitigated|AllowMitigatedHtml|mitigated-challenge|challenged_hosts|canonical_html_status' `
     -Description 'custom-domain verification cannot accept substituted challenge HTML'
+$publicBaseUriFunctionText = Get-PowerShellBlockText `
+    -Content $cloudflarePagesVerifierText `
+    -HeaderPattern '^function\s+ConvertTo-PublicBaseUri(?=\s|\{)'
+. ([scriptblock]::Create($publicBaseUriFunctionText))
+$immutablePagesOrigin = ConvertTo-PublicBaseUri `
+    -Value 'https://69cd5628.winghostty.pages.dev/' `
+    -Kind pages
+if ($immutablePagesOrigin.DnsSafeHost -cne
+    '69cd5628.winghostty.pages.dev') {
+    throw 'Immutable Pages deployment origin was not preserved.'
+}
+$mutablePagesOriginRejected = $false
+try {
+    [void](ConvertTo-PublicBaseUri `
+        -Value 'https://winghostty.pages.dev/' `
+        -Kind pages)
+} catch {
+    $mutablePagesOriginRejected = $true
+}
+if (-not $mutablePagesOriginRejected) {
+    throw 'Mutable Pages project origin passed immutable deployment validation.'
+}
+$cloudflareVerifierTokens = $null
+$cloudflareVerifierErrors = $null
+$cloudflareVerifierAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $cloudflarePagesVerifierText,
+    [ref]$cloudflareVerifierTokens,
+    [ref]$cloudflareVerifierErrors
+)
+if ($cloudflareVerifierErrors.Count -ne 0) {
+    throw 'Cloudflare verifier must parse for public-verification call checks.'
+}
+$publicVerificationCalls = @($cloudflareVerifierAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -cin @(
+            'Assert-PublicPayload',
+            'Assert-PublicHeaderContract'
+        )
+}, $true))
+$expectedPublicVerificationCalls = @(
+    [pscustomobject]@{
+        Command = 'Assert-PublicPayload'
+        Origin = 'pagesOrigin'
+        StaticOnly = $false
+    }
+    [pscustomobject]@{
+        Command = 'Assert-PublicHeaderContract'
+        Origin = 'pagesOrigin'
+        StaticOnly = $false
+    }
+    [pscustomobject]@{
+        Command = 'Assert-PublicPayload'
+        Origin = 'canonicalOrigin'
+        StaticOnly = $true
+    }
+    [pscustomobject]@{
+        Command = 'Assert-PublicHeaderContract'
+        Origin = 'canonicalOrigin'
+        StaticOnly = $true
+    }
+)
+foreach ($expectedCall in $expectedPublicVerificationCalls) {
+    $matchingCalls = @($publicVerificationCalls | Where-Object {
+        $elements = @($_.CommandElements)
+        $originIndex = [Array]::FindIndex(
+            [object[]]$elements,
+            [Predicate[object]] { param($element) $element.Extent.Text -ceq '-Origin' }
+        )
+        $originIndex -ge 0 -and
+            $originIndex + 1 -lt $elements.Count -and
+            $elements[$originIndex + 1] -is
+                [System.Management.Automation.Language.VariableExpressionAst] -and
+            $elements[$originIndex + 1].VariablePath.UserPath -ceq
+                $expectedCall.Origin -and
+            $_.GetCommandName() -ceq $expectedCall.Command -and
+            (@($elements | Where-Object {
+                $_.Extent.Text -ceq '-StaticOnly'
+            }).Count -eq 1) -eq $expectedCall.StaticOnly
+    })
+    if ($matchingCalls.Count -ne 1) {
+        throw "Expected exactly one $($expectedCall.Command) call for " +
+            "$($expectedCall.Origin) with StaticOnly=$($expectedCall.StaticOnly)."
+    }
+}
+if ($publicVerificationCalls.Count -ne $expectedPublicVerificationCalls.Count) {
+    throw 'Unexpected public-verification call bypasses the immutable/canonical policy.'
+}
+$expectedPublicVerificationWrappers = @(
+    [pscustomobject]@{
+        Wrapper = 'Assert-PublicPayload'
+        Inner = 'Test-PublicPayloadOnce'
+    }
+    [pscustomobject]@{
+        Wrapper = 'Assert-PublicHeaderContract'
+        Inner = 'Test-PublicHeaderContractOnce'
+    }
+)
+foreach ($expectedWrapper in $expectedPublicVerificationWrappers) {
+    $wrapperDefinitions = @(
+        Get-NamedFunctionDefinitions `
+            -Ast $cloudflareVerifierAst `
+            -Name $expectedWrapper.Wrapper
+    )
+    if ($wrapperDefinitions.Count -ne 1) {
+        throw "Expected exactly one $($expectedWrapper.Wrapper) function."
+    }
+    $staticOnlyParameters = @(
+        $wrapperDefinitions[0].Body.ParamBlock.Parameters |
+            Where-Object {
+                $_.Name.VariablePath.UserPath -ceq 'StaticOnly'
+            }
+    )
+    $innerCalls = @($wrapperDefinitions[0].FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -ceq $expectedWrapper.Inner
+    }, $true))
+    $forwardedSwitches = @(
+        if ($innerCalls.Count -eq 1) {
+            $innerCalls[0].CommandElements |
+                Where-Object {
+                    $_ -is
+                        [System.Management.Automation.Language.CommandParameterAst] -and
+                    $_.ParameterName -ceq 'StaticOnly' -and
+                    $_.Argument -is
+                        [System.Management.Automation.Language.VariableExpressionAst] -and
+                    $_.Argument.VariablePath.UserPath -ceq 'StaticOnly'
+                }
+        }
+    )
+    if ($staticOnlyParameters.Count -ne 1 -or
+        $staticOnlyParameters[0].StaticType -ne [switch] -or
+        $innerCalls.Count -ne 1 -or
+        $forwardedSwitches.Count -ne 1) {
+        throw "$($expectedWrapper.Wrapper) must forward exactly " +
+            "-StaticOnly:`$StaticOnly to $($expectedWrapper.Inner)."
+    }
+}
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicPayloadOnce(?=\s|\{)') `
+    -Pattern '(?ms)\[switch\]\s+\$StaticOnly.*?\$entry\.Path -ceq ''_headers''.*?\$StaticOnly -and \$entry\.Path -cin @\(''index\.html'', ''404\.html''\).*?continue.*?New-PublicAssetUri' `
+    -Description 'static-only payload verification excludes only Pages control and HTML documents before hashing remaining assets' `
+    -Context "$cloudflarePagesVerifier :: Test-PublicPayloadOnce"
+Assert-TextContract `
+    -Content (Get-PowerShellBlockText -Content $cloudflarePagesVerifierText -HeaderPattern '^function\s+Test-PublicHeaderContractOnce(?=\s|\{)') `
+    -Pattern '(?ms)\[switch\]\s+\$StaticOnly.*?if \(-not \$StaticOnly\) \{.*?Path = ''/''.*?\}.*?Path = ''/bundle\.js''.*?if \(-not \$StaticOnly\) \{.*?Path = ''/__winghostty_header_contract_''' `
+    -Description 'static-only response verification always checks bundle controls and excludes HTML route probes' `
+    -Context "$cloudflarePagesVerifier :: Test-PublicHeaderContractOnce"
 Assert-TextContract `
     -Content $cloudflarePagesVerifierText `
-    -Pattern '(?ms)\$canonicalOrigin.*?Assert-PublicPayload.*?-Origin \$canonicalOrigin.*?Assert-PublicHeaderContract.*?-Origin \$canonicalOrigin.*?\$verifiedHosts\.Add\(\$canonicalOrigin\.DnsSafeHost\).*?canonical_html_verified' `
-    -Description 'canonical production HTML, fallback bytes, and response controls must verify before provenance succeeds' `
+    -Pattern '(?ms)schema_version\s*=\s*''winghostty\.cloudflare-pages-provenance\.v2''.*?immutable_html_verified\s*=\s*\$true.*?canonical_static_assets_verified\s*=\s*-not \[string\]::IsNullOrWhiteSpace\(\$CanonicalBaseUrl\).*?canonical_html_verified\s*=\s*\$false' `
+    -Description 'deployment provenance distinguishes immutable HTML, canonical static assets, and unverified canonical HTML' `
     -Context $cloudflarePagesVerifier
 Assert-TextContract `
     -Content $cloudflarePagesVerifierText `


### PR DESCRIPTION
## Summary

- keep full byte, HTML, fallback, cache, and security-header verification on immutable Pages deployment URLs
- verify the apex custom domain using exact non-HTML asset bytes, Pages domain attachment, and static response controls without accepting managed challenge HTML
- emit truthful v2 provenance that distinguishes immutable HTML, canonical static assets, and unverified canonical HTML
- reject the mutable `winghostty.pages.dev` project root as an immutable deployment origin
- add executable and AST contracts for URL rejection, call-site policy, switch propagation, skipped documents, and provenance

## Validation

- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`
- `pwsh -NoProfile -File scripts/check-release-copy.ps1`
- `pwsh -NoProfile -File scripts/check-site-bundle.ps1`
- deterministic 16-file payload build
- PowerShell parse checks
- `git diff --check`
- two independent deployment/security re-audits: clean after findings addressed

## Deployment rationale

Cloudflare currently substitutes managed challenge HTML at the apex for automated clients while serving the complete deployment at the immutable Pages URL and exact static assets at the apex. This change never treats challenge HTML as site content and records canonical HTML as unverified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cloudflare Pages origin validation to accept only the expected immutable hostname format.
  - Refined deployment verification to focus canonical checks on immutable static assets, including content and security headers.
  - Added clearer verification coverage reporting, distinguishing immutable HTML checks from canonical static-asset checks.

- **Documentation**
  - Updated Cloudflare Pages production verification guidance with separate details for the canonical domain and deployment URL.

- **Tests**
  - Expanded verification contract coverage for origins, static assets, headers, and provenance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->