### PR TITLE
release: block Defender-detected installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,7 @@ jobs:
             }
           }
 
-      - name: Scan setup artifacts with Microsoft Defender
+      - name: Scan Windows release artifacts with Microsoft Defender
         shell: pwsh
         timeout-minutes: 10
         run: |
@@ -385,7 +385,12 @@ jobs:
           }
 
           $version = "${{ steps.meta.outputs.version }}"
-          $setupPaths = @(
+          $portablePayloads = @(
+            "winghostty/winghostty.com",
+            "winghostty/winghostty.exe",
+            "winghostty/ghostty-vt.dll"
+          )
+          $scanPaths = @(
             foreach ($arch in (Get-WindowsPackageArchitectures)) {
               $artifactDir = Join-Path $PWD "dist/artifacts/winghostty-$version-windows-$arch"
               $setupName = New-WindowsPackageArtifactName -Version $version -Architecture $arch -Kind setup
@@ -394,16 +399,25 @@ jobs:
                 throw "Missing Defender scan input: $setupPath"
               }
               $setupPath
+
+              $extractDir = Join-Path $env:RUNNER_TEMP "winghostty-release-verify-$arch"
+              foreach ($relative in $portablePayloads) {
+                $payloadPath = Join-Path $extractDir $relative
+                if (-not (Test-Path -LiteralPath $payloadPath)) {
+                  throw "Missing Defender scan input: $payloadPath"
+                }
+                $payloadPath
+              }
             }
           )
-          if ($setupPaths.Count -ne 2) {
-            throw "Expected exactly two setup artifacts for Defender scanning; found $($setupPaths.Count)."
+          if ($scanPaths.Count -ne 8) {
+            throw "Expected exactly eight release artifacts for Defender scanning; found $($scanPaths.Count)."
           }
 
-          foreach ($setupPath in $setupPaths) {
-            & $scanner -Scan -ScanType 3 -File $setupPath -DisableRemediation -ReturnHR
+          foreach ($scanPath in $scanPaths) {
+            & $scanner -Scan -ScanType 3 -File $scanPath -DisableRemediation -ReturnHR
             if ($LASTEXITCODE -ne 0) {
-              throw "Microsoft Defender rejected $setupPath with exit code $LASTEXITCODE."
+              throw "Microsoft Defender rejected $scanPath with exit code $LASTEXITCODE."
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,8 +346,10 @@ jobs:
         run: |
           . (Join-Path $PWD "scripts/windows-architecture.ps1")
           $status = Get-MpComputerStatus -ErrorAction Stop
-          if (-not $status.AMServiceEnabled -or -not $status.AntivirusEnabled) {
-            throw "Microsoft Defender Antivirus must be active before release publication."
+          if (-not $status.AMServiceEnabled -or
+              -not $status.AntivirusEnabled -or
+              $status.AMRunningMode -ne "Normal") {
+            throw "Microsoft Defender Antivirus must be active in Normal mode before release publication."
           }
 
           $scannerCandidates = @(
@@ -357,8 +359,17 @@ jobs:
           if (Test-Path -LiteralPath $platformRoot) {
             $scannerCandidates = @(
               Get-ChildItem -LiteralPath $platformRoot -Directory |
-                Sort-Object Name -Descending |
-                ForEach-Object { Join-Path $_.FullName "MpCmdRun.exe" }
+                ForEach-Object {
+                  $platformVersion = ($_.Name -replace '-\d+$', '') -as [version]
+                  if ($null -ne $platformVersion) {
+                    [pscustomobject]@{
+                      Version = $platformVersion
+                      Path = Join-Path $_.FullName "MpCmdRun.exe"
+                    }
+                  }
+                } |
+                Sort-Object Version -Descending |
+                ForEach-Object { $_.Path }
             ) + $scannerCandidates
           }
           $scanner = $scannerCandidates |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,62 @@ jobs:
             }
           }
 
+      - name: Scan setup artifacts with Microsoft Defender
+        shell: pwsh
+        timeout-minutes: 10
+        run: |
+          . (Join-Path $PWD "scripts/windows-architecture.ps1")
+          $status = Get-MpComputerStatus -ErrorAction Stop
+          if (-not $status.AMServiceEnabled -or -not $status.AntivirusEnabled) {
+            throw "Microsoft Defender Antivirus must be active before release publication."
+          }
+
+          $scannerCandidates = @(
+            (Join-Path $env:ProgramFiles "Windows Defender/MpCmdRun.exe")
+          )
+          $platformRoot = Join-Path $env:ProgramData "Microsoft/Windows Defender/Platform"
+          if (Test-Path -LiteralPath $platformRoot) {
+            $scannerCandidates = @(
+              Get-ChildItem -LiteralPath $platformRoot -Directory |
+                Sort-Object Name -Descending |
+                ForEach-Object { Join-Path $_.FullName "MpCmdRun.exe" }
+            ) + $scannerCandidates
+          }
+          $scanner = $scannerCandidates |
+            Where-Object { Test-Path -LiteralPath $_ } |
+            Select-Object -First 1
+          if (-not $scanner) {
+            throw "MpCmdRun.exe was not found."
+          }
+
+          & $scanner -SignatureUpdate
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Defender signature update failed with exit code $LASTEXITCODE."
+          }
+
+          $version = "${{ steps.meta.outputs.version }}"
+          $setupPaths = @(
+            foreach ($arch in (Get-WindowsPackageArchitectures)) {
+              $artifactDir = Join-Path $PWD "dist/artifacts/winghostty-$version-windows-$arch"
+              $setupName = New-WindowsPackageArtifactName -Version $version -Architecture $arch -Kind setup
+              $setupPath = Join-Path $artifactDir $setupName
+              if (-not (Test-Path -LiteralPath $setupPath)) {
+                throw "Missing Defender scan input: $setupPath"
+              }
+              $setupPath
+            }
+          )
+          if ($setupPaths.Count -ne 2) {
+            throw "Expected exactly two setup artifacts for Defender scanning; found $($setupPaths.Count)."
+          }
+
+          foreach ($setupPath in $setupPaths) {
+            & $scanner -Scan -ScanType 3 -File $setupPath -DisableRemediation -ReturnHR
+            if ($LASTEXITCODE -ne 0) {
+              throw "Microsoft Defender rejected $setupPath with exit code $LASTEXITCODE."
+            }
+          }
+
       - name: Generate package manager metadata
         shell: pwsh
         run: >

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -46,10 +46,10 @@ Authenticode-signed.
 
 Before publication, the Release workflow updates Microsoft Defender
 signatures and scans both setup artifacts with remediation disabled. A missing
-or inactive scanner, update failure, or detection fails the release. This is a
-current-engine regression gate for the published installer bytes; it does not
-replace a publicly trusted signing identity or reproduce every enterprise
-security policy.
+or inactive scanner, update or scan error, or detection fails the release.
+This is a current-engine regression gate for the published installer bytes; it
+does not replace a publicly trusted signing identity or reproduce every
+enterprise security policy.
 
 ## Local Packaging
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -45,11 +45,12 @@ Authenticode-signed; the ZIP container itself is checksummed, not
 Authenticode-signed.
 
 Before publication, the Release workflow updates Microsoft Defender
-signatures and scans both setup artifacts with remediation disabled. A missing
-or inactive scanner, update or scan error, or detection fails the release.
-This is a current-engine regression gate for the published installer bytes; it
-does not replace a publicly trusted signing identity or reproduce every
-enterprise security policy.
+signatures and scans both setup artifacts plus the six PE files extracted from
+the portable ZIPs, with remediation disabled. A missing or inactive scanner,
+update or scan error, or detection fails the release. This is a current-engine
+regression gate for the published Windows executable bytes; it does not replace
+a publicly trusted signing identity or reproduce every enterprise security
+policy.
 
 ## Local Packaging
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -44,6 +44,13 @@ The release installer and Windows PE files inside the portable ZIP are
 Authenticode-signed; the ZIP container itself is checksummed, not
 Authenticode-signed.
 
+Before publication, the Release workflow updates Microsoft Defender
+signatures and scans both setup artifacts with remediation disabled. A missing
+or inactive scanner, update failure, or detection fails the release. This is a
+current-engine regression gate for the published installer bytes; it does not
+replace a publicly trusted signing identity or reproduce every enterprise
+security policy.
+
 ## Local Packaging
 
 Build the app first:

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -7835,6 +7835,23 @@ Assert-TextContract `
     -Pattern '(?ms)GH_REPO: \$\{\{ github\.repository \}\}.*?gh release view \$tag --repo \$env:GH_REPO.*?gh release create \$tag --repo \$env:GH_REPO.*?if \(\$LASTEXITCODE -ne 0\).*?gh release edit \$tag --repo \$env:GH_REPO.*?if \(\$LASTEXITCODE -ne 0\).*?gh release upload \$tag --repo \$env:GH_REPO.*?if \(\$LASTEXITCODE -ne 0\)' `
     -Description 'GitHub release commands pin the fork and mutations fail closed' `
     -Context "$releaseWorkflow :: Publish GitHub Release"
+$defenderScanStep = Get-YamlStepBlock `
+    -Content $releaseWorkflowText `
+    -Name 'Scan setup artifacts with Microsoft Defender' `
+    -Source $releaseWorkflow
+Assert-TextContract `
+    -Content $defenderScanStep `
+    -Pattern '(?ms)Get-MpComputerStatus -ErrorAction Stop.*?AMServiceEnabled.*?AntivirusEnabled.*?MpCmdRun\.exe.*?-SignatureUpdate.*?if \(\$LASTEXITCODE -ne 0\).*?Get-WindowsPackageArchitectures.*?-Kind setup.*?setupPaths\.Count -ne 2.*?-Scan -ScanType 3 -File \$setupPath -DisableRemediation -ReturnHR.*?if \(\$LASTEXITCODE -ne 0\)' `
+    -Description 'release scans both setup artifacts with active current Microsoft Defender and fails closed' `
+    -Context "$releaseWorkflow :: Scan setup artifacts with Microsoft Defender"
+$signedArtifactStepIndex = $releaseWorkflowText.IndexOf('      - name: Verify signed release artifacts')
+$defenderScanStepIndex = $releaseWorkflowText.IndexOf('      - name: Scan setup artifacts with Microsoft Defender')
+$publishReleaseStepIndex = $releaseWorkflowText.IndexOf('      - name: Publish GitHub Release')
+if ($signedArtifactStepIndex -lt 0 -or
+    $defenderScanStepIndex -le $signedArtifactStepIndex -or
+    $publishReleaseStepIndex -le $defenderScanStepIndex) {
+    throw 'Microsoft Defender scanning must run after artifact verification and before release publication.'
+}
 $signedArtifactStep = Get-YamlStepBlock `
     -Content $releaseWorkflowText `
     -Name 'Verify signed release artifacts' `

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -6697,7 +6697,7 @@ $releasePreflightStepSha256 =
 $readinessPreflightStepSha256 =
     '021214f70c1b21adcc770f9e96f66daf1ada2f9eae4180daf3958236941b05c9'
 $releaseWorkflowSha256 =
-    '86f805975d1883fca7e65b279c08e5d6cc5f65ee876d3af20e450a0d49660662'
+    'e2ebc484f30d233ecade23ca6226f710af2705f2e8ef934bc8d111a41782f352'
 $readinessWorkflowSha256 =
     '2659a58baeffaa9861c33bd4cdcd7adc8838dd6f9e91d51dcffc338af906f303'
 # Full-file pins deliberately make every workflow edit a semantic-review event,
@@ -7841,7 +7841,7 @@ $defenderScanStep = Get-YamlStepBlock `
     -Source $releaseWorkflow
 Assert-TextContract `
     -Content $defenderScanStep `
-    -Pattern '(?ms)Get-MpComputerStatus -ErrorAction Stop.*?AMServiceEnabled.*?AntivirusEnabled.*?MpCmdRun\.exe.*?-SignatureUpdate.*?if \(\$LASTEXITCODE -ne 0\).*?Get-WindowsPackageArchitectures.*?-Kind setup.*?setupPaths\.Count -ne 2.*?-Scan -ScanType 3 -File \$setupPath -DisableRemediation -ReturnHR.*?if \(\$LASTEXITCODE -ne 0\)' `
+    -Pattern '(?ms)Get-MpComputerStatus -ErrorAction Stop.*?AMServiceEnabled.*?AntivirusEnabled.*?AMRunningMode -ne "Normal".*?-replace ''-\\d\+\$'', ''''.*?-as \[version\].*?Sort-Object Version -Descending.*?MpCmdRun\.exe.*?-SignatureUpdate.*?if \(\$LASTEXITCODE -ne 0\).*?Get-WindowsPackageArchitectures.*?-Kind setup.*?setupPaths\.Count -ne 2.*?-Scan -ScanType 3 -File \$setupPath -DisableRemediation -ReturnHR.*?if \(\$LASTEXITCODE -ne 0\)' `
     -Description 'release scans both setup artifacts with active current Microsoft Defender and fails closed' `
     -Context "$releaseWorkflow :: Scan setup artifacts with Microsoft Defender"
 $signedArtifactStepIndex = $releaseWorkflowText.IndexOf('      - name: Verify signed release artifacts')

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -6697,7 +6697,7 @@ $releasePreflightStepSha256 =
 $readinessPreflightStepSha256 =
     '021214f70c1b21adcc770f9e96f66daf1ada2f9eae4180daf3958236941b05c9'
 $releaseWorkflowSha256 =
-    'e2ebc484f30d233ecade23ca6226f710af2705f2e8ef934bc8d111a41782f352'
+    '2aba54c3128eae8ab191751f2c746785347ae8a7dd166e12f69db2bd5ed36b4f'
 $readinessWorkflowSha256 =
     '2659a58baeffaa9861c33bd4cdcd7adc8838dd6f9e91d51dcffc338af906f303'
 # Full-file pins deliberately make every workflow edit a semantic-review event,
@@ -7837,15 +7837,15 @@ Assert-TextContract `
     -Context "$releaseWorkflow :: Publish GitHub Release"
 $defenderScanStep = Get-YamlStepBlock `
     -Content $releaseWorkflowText `
-    -Name 'Scan setup artifacts with Microsoft Defender' `
+    -Name 'Scan Windows release artifacts with Microsoft Defender' `
     -Source $releaseWorkflow
 Assert-TextContract `
     -Content $defenderScanStep `
-    -Pattern '(?ms)Get-MpComputerStatus -ErrorAction Stop.*?AMServiceEnabled.*?AntivirusEnabled.*?AMRunningMode -ne "Normal".*?-replace ''-\\d\+\$'', ''''.*?-as \[version\].*?Sort-Object Version -Descending.*?MpCmdRun\.exe.*?-SignatureUpdate.*?if \(\$LASTEXITCODE -ne 0\).*?Get-WindowsPackageArchitectures.*?-Kind setup.*?setupPaths\.Count -ne 2.*?-Scan -ScanType 3 -File \$setupPath -DisableRemediation -ReturnHR.*?if \(\$LASTEXITCODE -ne 0\)' `
-    -Description 'release scans both setup artifacts with active current Microsoft Defender and fails closed' `
-    -Context "$releaseWorkflow :: Scan setup artifacts with Microsoft Defender"
+    -Pattern '(?ms)Get-MpComputerStatus -ErrorAction Stop.*?AMServiceEnabled.*?AntivirusEnabled.*?AMRunningMode -ne "Normal".*?-replace ''-\\d\+\$'', ''''.*?-as \[version\].*?Sort-Object Version -Descending.*?MpCmdRun\.exe.*?-SignatureUpdate.*?if \(\$LASTEXITCODE -ne 0\).*?winghostty/winghostty\.com.*?winghostty/winghostty\.exe.*?winghostty/ghostty-vt\.dll.*?Get-WindowsPackageArchitectures.*?-Kind setup.*?winghostty-release-verify-\$arch.*?scanPaths\.Count -ne 8.*?-Scan -ScanType 3 -File \$scanPath -DisableRemediation -ReturnHR.*?if \(\$LASTEXITCODE -ne 0\)' `
+    -Description 'release scans installers and portable PE payloads with active current Microsoft Defender and fails closed' `
+    -Context "$releaseWorkflow :: Scan Windows release artifacts with Microsoft Defender"
 $signedArtifactStepIndex = $releaseWorkflowText.IndexOf('      - name: Verify signed release artifacts')
-$defenderScanStepIndex = $releaseWorkflowText.IndexOf('      - name: Scan setup artifacts with Microsoft Defender')
+$defenderScanStepIndex = $releaseWorkflowText.IndexOf('      - name: Scan Windows release artifacts with Microsoft Defender')
 $publishReleaseStepIndex = $releaseWorkflowText.IndexOf('      - name: Publish GitHub Release')
 if ($signedArtifactStepIndex -lt 0 -or
     $defenderScanStepIndex -le $signedArtifactStepIndex -or

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -6697,7 +6697,7 @@ $releasePreflightStepSha256 =
 $readinessPreflightStepSha256 =
     '021214f70c1b21adcc770f9e96f66daf1ada2f9eae4180daf3958236941b05c9'
 $releaseWorkflowSha256 =
-    '4cb17b2e84359fdbd199c5e0b65a7035a1409fe28ddb8cf199c1c9157d48dd76'
+    '86f805975d1883fca7e65b279c08e5d6cc5f65ee876d3af20e450a0d49660662'
 $readinessWorkflowSha256 =
     '2659a58baeffaa9861c33bd4cdcd7adc8838dd6f9e91d51dcffc338af906f303'
 # Full-file pins deliberately make every workflow edit a semantic-review event,


### PR DESCRIPTION
## Summary

- require active Microsoft Defender before release publication
- update Defender signatures and scan both setup artifacts plus all six signed PE payloads extracted from the portable ZIPs, with remediation disabled
- fail closed when the scanner is missing/inactive, signatures cannot update, an artifact is missing, or Defender returns a detection/error
- pin scanner behavior and release-step ordering in flagship verification contracts
- document what this gate does and does not establish

## Root cause

The v1.3.119 Inno setup wrapper was quarantined as `Trojan:Win32/Wacatac.C!ml`. Existing release gates proved hashes, Authenticode signatures, and the updater SPKI pin, but never submitted the final setup bytes to the Windows Defender engine before publication.

The current v1.3.120 x64 and ARM64 setup assets both scan clean locally with Defender signature `1.455.406.0`. This change turns that artifact-level check into a mandatory pre-publication gate so the same class of detected installer cannot be published unnoticed.

## Impact

Release publication stops before GitHub Release, Scoop, or WinGet updates if either setup artifact or any portable PE payload is detected by current Microsoft Defender definitions. Scanning uses `-DisableRemediation` so CI reports the result without deleting evidence.

## Validation

- `pwsh -NoProfile -File test\windows\flagship\Test-VerificationContracts.ps1`
- `MpCmdRun.exe -SignatureUpdate` (exit 0)
- `MpCmdRun.exe -Scan -ScanType 3 -File <v1.3.120 x64 setup> -DisableRemediation -ReturnHR` (no threats, exit 0)
- `MpCmdRun.exe -Scan -ScanType 3 -File <v1.3.120 ARM64 setup> -DisableRemediation -ReturnHR` (no threats, exit 0)
- `git diff --check`

`prettier` and `actionlint` were unavailable locally; no new tooling was installed.

## Risks / follow-ups

- The release workflow now depends on an active Defender engine and successful definition update; failures intentionally block publication.
- This gate reflects the current Microsoft Defender engine. It cannot reproduce every enterprise policy, cloud verdict, Smart App Control rule, or future definition.
- The current self-signed certificate still does not create public publisher trust or transferable SmartScreen reputation; migration to a CA-backed signing identity remains separate work under ADR-0005.

Closes #96

## Summary by Sourcery

Gate Windows release publication on successful Microsoft Defender scans of the final setup installers.

New Features:
- Add a release workflow step that updates Microsoft Defender signatures and scans both x64 and ARM64 setup artifacts before publication, failing on missing/disabled Defender, update failure, or any detection.

Enhancements:
- Extend flagship verification contracts to pin the presence, behavior, and ordering of the Defender scanning step relative to artifact verification and release publication.

Documentation:
- Document the new Microsoft Defender-based pre-publication scan gate and its guarantees and limitations in PACKAGING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Windows release installers are now scanned with Microsoft Defender as part of the release process.
  * The release will fail if Defender isn’t available/in active mode, signature updates or scanning fail, required artifacts aren’t found, or any threats are detected.
* **Documentation**
  * Updated the packaging guidance to describe the Defender scan as a release gate for published installer bytes.
* **Quality Assurance**
  * Added workflow verification to ensure the scan runs after signed artifact verification and before release publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
