### PR TITLE
fix: never block the app thread on a full renderer mailbox

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -744,7 +744,7 @@ pub fn init(
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
-            .renderer_wakeup = render_thread.wakeup,
+            .renderer_wakeup = &self.renderer_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
             .terminal_output_transport = &self.terminal_output_transport,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -847,6 +847,13 @@ pub fn deinit(self: *Surface) void {
     // Stop search thread
     if (self.search) |*s| s.deinit();
 
+    // Stop the IO producer while the renderer can still drain its mailbox.
+    {
+        self.io_thread.stop.notify() catch |err|
+            log.err("error notifying io thread to stop, may stall err={}", .{err});
+        self.io_thr.join();
+    }
+
     // Stop rendering thread
     {
         self.renderer_thread.stop.notify() catch |err|
@@ -855,13 +862,6 @@ pub fn deinit(self: *Surface) void {
 
         // We need to become the active rendering thread again
         self.renderer.threadEnter(self.rt_surface) catch unreachable;
-    }
-
-    // Stop our IO thread
-    {
-        self.io_thread.stop.notify() catch |err|
-            log.err("error notifying io thread to stop, may stall err={}", .{err});
-        self.io_thr.join();
     }
 
     // We need to deinit AFTER everything is stopped, since there are

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1936,22 +1936,24 @@ pub fn updateConfig(
         break :font_size size;
     });
 
-    // We need to store our configs in a heap-allocated pointer so that
-    // our messages aren't huge.
-    var renderer_message = try rendererpkg.Message.initChangeConfig(self.alloc, config);
-    errdefer renderer_message.deinit();
-    var termio_config_ptr = try self.alloc.create(termio.Termio.DerivedConfig);
-    errdefer self.alloc.destroy(termio_config_ptr);
-    termio_config_ptr.* = try termio.Termio.DerivedConfig.init(self.alloc, config);
-    errdefer termio_config_ptr.deinit();
+    {
+        // We need to store our configs in a heap-allocated pointer so that
+        // our messages aren't huge.
+        var renderer_message = try rendererpkg.Message.initChangeConfig(self.alloc, config);
+        errdefer renderer_message.deinit();
+        var termio_config_ptr = try self.alloc.create(termio.Termio.DerivedConfig);
+        errdefer self.alloc.destroy(termio_config_ptr);
+        termio_config_ptr.* = try termio.Termio.DerivedConfig.init(self.alloc, config);
+        errdefer termio_config_ptr.deinit();
 
-    self.renderer_thread.send(renderer_message);
-    self.queueIo(.{
-        .change_config = .{
-            .alloc = self.alloc,
-            .ptr = termio_config_ptr,
-        },
-    }, .unlocked);
+        self.renderer_thread.send(renderer_message);
+        self.queueIo(.{
+            .change_config = .{
+                .alloc = self.alloc,
+                .ptr = termio_config_ptr,
+            },
+        }, .unlocked);
+    }
 
     // With mailbox messages sent, we have to wake them up so they process it.
     self.queueRender() catch |err| {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -974,7 +974,7 @@ pub fn activateInspector(self: *Surface) !void {
     }
 
     // Notify our components we have an inspector active
-    _ = self.renderer_thread.mailbox.push(.{ .inspector = true }, .{ .forever = {} });
+    self.renderer_thread.send(.{ .inspector = true });
     self.queueIo(.{ .inspector = true }, .unlocked);
 }
 
@@ -991,7 +991,7 @@ pub fn deactivateInspector(self: *Surface) void {
     }
 
     // Notify our components we have deactivated inspector
-    _ = self.renderer_thread.mailbox.push(.{ .inspector = false }, .{ .forever = {} });
+    self.renderer_thread.send(.{ .inspector = false });
     self.queueIo(.{ .inspector = false }, .unlocked);
 
     // Deinit the inspector
@@ -1225,11 +1225,9 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 return;
             }
 
-            _ = self.renderer_thread.mailbox.push(
+            self.renderer_thread.send(
                 .{ .search_viewport_matches = payload },
-                .forever,
             );
-            try self.renderer_thread.wakeup.notify();
         },
 
         .search_selected_match => |v| {
@@ -1239,11 +1237,9 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
                 return;
             }
 
-            _ = self.renderer_thread.mailbox.push(
+            self.renderer_thread.send(
                 .{ .search_selected_match = payload },
-                .forever,
             );
-            try self.renderer_thread.wakeup.notify();
         },
 
         .search_total => |v| {
@@ -1949,7 +1945,7 @@ pub fn updateConfig(
     termio_config_ptr.* = try termio.Termio.DerivedConfig.init(self.alloc, config);
     errdefer termio_config_ptr.deinit();
 
-    _ = self.renderer_thread.mailbox.push(renderer_message, .{ .forever = {} });
+    self.renderer_thread.send(renderer_message);
     self.queueIo(.{
         .change_config = .{
             .alloc = self.alloc,
@@ -2638,14 +2634,14 @@ pub fn setFontSize(self: *Surface, size: font.face.DesiredSize) !void {
 
     // Notify our render thread of the new font stack. The renderer
     // MUST accept the new font grid and deref the old.
-    _ = self.renderer_thread.mailbox.push(.{
+    self.renderer_thread.send(.{
         .font_grid = .{
             .grid = font_grid,
             .set = &self.app.font_grid_set,
             .old_key = self.font_grid_key,
             .new_key = font_grid_key,
         },
-    }, .{ .forever = {} });
+    });
 
     // Once we've sent the key we can replace our key
     self.font_grid_key = font_grid_key;
@@ -3496,13 +3492,12 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
     if (self.visible == visible) return;
     self.visible = visible;
 
-    _ = self.renderer_thread.mailbox.push(.{
+    self.renderer_thread.send(.{
         .visible = visible,
-    }, .{ .forever = {} });
+    });
 
     if (self.search) |*s| {
-        _ = s.state.mailbox.push(.{ .visible = visible }, .forever);
-        s.state.wakeup.notify() catch {};
+        s.state.send(.{ .visible = visible });
     }
 
     try self.queueRender();
@@ -3522,13 +3517,12 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
     self.focused = focused;
 
     // Notify our render thread of the new state
-    _ = self.renderer_thread.mailbox.push(.{
+    self.renderer_thread.send(.{
         .focus = focused,
-    }, .{ .forever = {} });
+    });
 
     if (self.search) |*s| {
-        _ = s.state.mailbox.push(.{ .focus = focused }, .forever);
-        s.state.wakeup.notify() catch {};
+        s.state.send(.{ .focus = focused });
     }
 
     if (!focused) unfocused: {
@@ -5399,14 +5393,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
 
         .navigate_search => |nav| {
             const s: *Search = if (self.search) |*s| s else return false;
-            _ = s.state.mailbox.push(
+            s.state.send(
                 .{ .select = switch (nav) {
                     .next => .next,
                     .previous => .prev,
                 } },
-                .forever,
             );
-            s.state.wakeup.notify() catch {};
         },
 
         .copy_to_clipboard => |format| {
@@ -5987,7 +5979,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             .main => @panic("crash binding action, crashing intentionally"),
 
             .render => {
-                _ = self.renderer_thread.mailbox.push(.{ .crash = {} }, .{ .forever = {} });
+                self.renderer_thread.send(.{ .crash = {} });
                 self.queueRender() catch |err| {
                     // Not a big deal if this fails.
                     log.warn("failed to notify renderer of crash message err={}", .{err});
@@ -6080,21 +6072,18 @@ pub fn invalidateSearchResults(self: *Surface) !bool {
 
     var req = try terminal.search.Thread.Message.WriteReq.init(self.alloc, "");
     errdefer req.deinit();
-    _ = s.state.mailbox.push(
+    s.state.send(
         .{ .change_query = .{
             .generation = generation,
             .options = self.search_query_options,
             .req = req,
         } },
-        .forever,
     );
-    s.state.wakeup.notify() catch {};
     return true;
 }
 
 fn syncClearSearchState(self: *Surface, generation: u64) !void {
-    _ = self.renderer_thread.mailbox.push(.{ .search_clear = generation }, .forever);
-    try self.renderer_thread.wakeup.notify();
+    self.renderer_thread.send(.{ .search_clear = generation });
 
     _ = try self.rt_app.performAction(
         .{ .surface = self },
@@ -6176,15 +6165,13 @@ pub fn setSearchQuery(
     errdefer req.deinit();
     const generation = self.nextSearchGeneration();
 
-    _ = s.state.mailbox.push(
+    s.state.send(
         .{ .change_query = .{
             .generation = generation,
             .options = query_options,
             .req = req,
         } },
-        .forever,
     );
-    s.state.wakeup.notify() catch {};
     return true;
 }
 

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -20,11 +20,14 @@ const Allocator = std.mem.Allocator;
 ///     the full queue so we can get rid of the overhead of a ton of
 ///     locks and bounds checking and do a one-time drain.
 ///
-/// One key usage pattern is that our blocking queues are single producer
-/// single consumer (SPSC). This should let us do some interesting optimizations
-/// in the future. At the time of writing this, the blocking queue implementation
-/// is purposely naive to build something quickly, but we should benchmark
-/// and make this more optimized as necessary.
+/// These queues were originally written for single producer, single consumer
+/// (SPSC) use, but that is no longer accurate: the renderer mailbox in
+/// particular is written by both the app thread and the IO thread. Blocking
+/// operations must therefore assume another producer can take a freed slot
+/// before a woken waiter reacquires the mutex. At the time of writing this,
+/// the blocking queue implementation is purposely naive to build something
+/// quickly, but we should benchmark and make this more optimized as
+/// necessary.
 pub fn BlockingQueue(
     comptime T: type,
     comptime capacity: usize,
@@ -111,7 +114,16 @@ pub fn BlockingQueue(
                     .forever => {
                         self.not_full_waiters += 1;
                         defer self.not_full_waiters -= 1;
-                        self.cond_not_full.wait(&self.mutex);
+
+                        // Wait in a loop, as condition variables require.
+                        // A single wait is not enough: the wake can be
+                        // spurious, and this queue is multi-producer, so
+                        // another producer can claim the freed slot before
+                        // we reacquire the mutex. Falling through in either
+                        // case would report a failed push to callers who
+                        // asked to wait indefinitely, silently dropping
+                        // messages that carry ownership or state.
+                        while (self.full()) self.cond_not_full.wait(&self.mutex);
                     },
 
                     .ns => |ns| {
@@ -121,8 +133,8 @@ pub fn BlockingQueue(
                     },
                 }
 
-                // If we're still full, then we failed to write. This can
-                // happen in situations where we are interrupted.
+                // A timed wait can expire, or be interrupted, with the
+                // queue still full. `.forever` cannot reach here full.
                 if (self.full()) return 0;
             }
 
@@ -245,4 +257,61 @@ test "timed push" {
 
     // Timed push should fail
     try testing.expectEqual(@as(Q.Size, 0), q.push(2, .{ .ns = 1000 }));
+}
+
+test "forever push waits again when a wake leaves the queue full" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    try testing.expectEqual(@as(Q.Size, 1), q.push(1, .{ .instant = {} }));
+    try testing.expectEqual(@as(Q.Size, 0), q.push(2, .{ .instant = {} }));
+
+    const Pusher = struct {
+        q: *Q,
+        result: Q.Size = 0,
+
+        fn run(self: *@This()) void {
+            self.result = self.q.push(99, .{ .forever = {} });
+        }
+    };
+
+    var pusher: Pusher = .{ .q = q };
+    const thread = try std.Thread.spawn(.{}, Pusher.run, .{&pusher});
+
+    // Wait until the pusher is parked on the condition variable.
+    while (true) {
+        q.mutex.lock();
+        const waiting = q.not_full_waiters;
+        q.mutex.unlock();
+        if (waiting == 1) break;
+        std.Thread.yield() catch {};
+    }
+
+    // The interleaving that loses messages: a consumer frees the slot and
+    // signals, but another producer refills it before the waiter can
+    // reacquire the mutex. Doing both under the lock makes that
+    // deterministic -- the waiter cannot observe the opening. A single-wait
+    // `.forever` gives up here and returns 0.
+    q.mutex.lock();
+    q.len -= 1;
+    q.cond_not_full.signal();
+    q.len += 1;
+    q.mutex.unlock();
+
+    // Let the woken pusher reacquire the mutex and observe the still-full
+    // queue before we free a slot for real. Without this the pusher races
+    // the pop below and a single-wait `.forever` can pass by luck.
+    std.Thread.sleep(50 * std.time.ns_per_ms);
+
+    // Now genuinely make room for it.
+    try testing.expectEqual(@as(u64, 1), q.pop().?);
+    thread.join();
+
+    // The push waited rather than reporting failure, and the value landed.
+    try testing.expect(pusher.result != 0);
+    try testing.expectEqual(@as(u64, 99), q.pop().?);
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -389,6 +389,26 @@ fn syncDrawTimer(self: *Thread) void {
     );
 }
 
+/// Enqueue a message and wake the renderer to process it.
+///
+/// The first notification lets the renderer make room if the mailbox is
+/// full. The second covers the case where that notification is processed
+/// before the message is enqueued.
+pub fn send(self: *Thread, msg: rendererpkg.Message) void {
+    self.notify();
+
+    // Renderer messages may transfer ownership or required state.
+    _ = self.mailbox.push(msg, .{ .forever = {} });
+
+    self.notify();
+}
+
+fn notify(self: *Thread) void {
+    self.wakeup.notify() catch |err| {
+        log.warn("error notifying renderer thread err={}", .{err});
+    };
+}
+
 /// Drain the mailbox.
 fn drainMailbox(self: *Thread) !bool {
     // There's probably a more elegant way to do this...
@@ -920,4 +940,115 @@ test "renderer follow-up check tracks visible terminal dirtiness" {
 
     try term.printString("x");
     try testing.expect(terminal_render_dirty.needsRendererWake(&term));
+}
+
+test "send wakes the renderer before waiting on a full mailbox" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // This is the deadlock from the original bug, in miniature: a full
+    // mailbox whose consumer is asleep and only drains once woken. If
+    // `send` pushes before notifying, nothing ever wakes the consumer and
+    // the push waits forever.
+    var mailbox = try Mailbox.create(alloc);
+    defer mailbox.destroy(alloc);
+
+    var filled: usize = 0;
+    while (mailbox.push(.{ .reset_cursor_blink = {} }, .{ .instant = {} }) != 0) {
+        filled += 1;
+    }
+    try testing.expect(filled > 0);
+
+    // Confirm the mailbox really is full before we test the blocking path.
+    try testing.expectEqual(
+        @as(Mailbox.Size, 0),
+        mailbox.push(.{ .focus = true }, .{ .instant = {} }),
+    );
+
+    const Consumer = struct {
+        loop: xev.Loop,
+        wakeup: *xev.Async,
+        wakeup_c: xev.Completion = .{},
+        guard: xev.Timer,
+        guard_c: xev.Completion = .{},
+        mailbox: *Mailbox,
+        to_drain: usize,
+        woken: bool = false,
+        ready: std.atomic.Value(bool) = .init(false),
+
+        const Consumer = @This();
+
+        /// Pop exactly the messages we pre-filled, leaving whatever the
+        /// sender adds. Draining until empty would race the sender's push.
+        fn drain(self: *Consumer) void {
+            for (0..self.to_drain) |_| _ = self.mailbox.pop();
+            self.loop.stop();
+        }
+
+        fn onWake(
+            self_: ?*Consumer,
+            _: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Async.WaitError!void,
+        ) xev.CallbackAction {
+            _ = r catch {};
+            const self = self_.?;
+            self.woken = true;
+            self.drain();
+            return .disarm;
+        }
+
+        fn onGuard(
+            self_: ?*Consumer,
+            _: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Timer.RunError!void,
+        ) xev.CallbackAction {
+            _ = r catch {};
+            // Safety valve. On a regression the wakeup never arrives, so we
+            // drain anyway and let the `woken` assertion fail rather than
+            // hanging the test suite forever.
+            self_.?.drain();
+            return .disarm;
+        }
+
+        fn run(self: *Consumer) void {
+            self.wakeup.wait(&self.loop, &self.wakeup_c, Consumer, self, onWake);
+            self.guard.run(&self.loop, &self.guard_c, 5000, Consumer, self, onGuard);
+            self.ready.store(true, .release);
+            self.loop.run(.until_done) catch {};
+        }
+    };
+
+    // `send` only touches `wakeup` and `mailbox`, so the rest of the thread
+    // state is never read here.
+    var thr: Thread = undefined;
+    thr.wakeup = try xev.Async.init();
+    defer thr.wakeup.deinit();
+    thr.mailbox = mailbox;
+
+    var consumer: Consumer = .{
+        .loop = try xev.Loop.init(.{}),
+        .wakeup = &thr.wakeup,
+        .guard = try xev.Timer.init(),
+        .mailbox = mailbox,
+        .to_drain = filled,
+    };
+    defer consumer.loop.deinit();
+    defer consumer.guard.deinit();
+
+    const consumer_thread = try std.Thread.spawn(.{}, Consumer.run, .{&consumer});
+    while (!consumer.ready.load(.acquire)) std.Thread.yield() catch {};
+
+    thr.send(.{ .focus = true });
+    consumer_thread.join();
+
+    // The consumer was woken by `send`, not by the safety valve.
+    try testing.expect(consumer.woken);
+
+    // And the message was delivered rather than dropped.
+    const delivered = mailbox.pop();
+    try testing.expect(delivered != null);
+    try testing.expect(std.meta.activeTag(delivered.?) == .focus);
+    try testing.expect(mailbox.pop() == null);
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -395,16 +395,25 @@ fn syncDrawTimer(self: *Thread) void {
 /// full. The second covers the case where that notification is processed
 /// before the message is enqueued.
 pub fn send(self: *Thread, msg: rendererpkg.Message) void {
-    self.notify();
-
-    // Renderer messages may transfer ownership or required state.
-    _ = self.mailbox.push(msg, .{ .forever = {} });
-
-    self.notify();
+    sendMessage(&self.wakeup, self.mailbox, msg);
 }
 
-fn notify(self: *Thread) void {
-    self.wakeup.notify() catch |err| {
+/// Enqueue a message through a shared renderer wake handle.
+pub fn sendMessage(
+    wakeup: *xev.Async,
+    mailbox: *Mailbox,
+    msg: rendererpkg.Message,
+) void {
+    notify(wakeup);
+
+    // Renderer messages may transfer ownership or required state.
+    _ = mailbox.push(msg, .{ .forever = {} });
+
+    notify(wakeup);
+}
+
+fn notify(wakeup: *xev.Async) void {
+    wakeup.notify() catch |err| {
         log.warn("error notifying renderer thread err={}", .{err});
     };
 }
@@ -1020,16 +1029,12 @@ test "send wakes the renderer before waiting on a full mailbox" {
         }
     };
 
-    // `send` only touches `wakeup` and `mailbox`, so the rest of the thread
-    // state is never read here.
-    var thr: Thread = undefined;
-    thr.wakeup = try xev.Async.init();
-    defer thr.wakeup.deinit();
-    thr.mailbox = mailbox;
+    var wakeup = try xev.Async.init();
+    defer wakeup.deinit();
 
     var consumer: Consumer = .{
         .loop = try xev.Loop.init(.{}),
-        .wakeup = &thr.wakeup,
+        .wakeup = &wakeup,
         .guard = try xev.Timer.init(),
         .mailbox = mailbox,
         .to_drain = filled,
@@ -1040,7 +1045,7 @@ test "send wakes the renderer before waiting on a full mailbox" {
     const consumer_thread = try std.Thread.spawn(.{}, Consumer.run, .{&consumer});
     while (!consumer.ready.load(.acquire)) std.Thread.yield() catch {};
 
-    thr.send(.{ .focus = true });
+    sendMessage(&wakeup, mailbox, .{ .focus = true });
     consumer_thread.join();
 
     // The consumer was woken by `send`, not by the safety valve.

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -269,6 +269,26 @@ fn threadMain_(self: *Thread) !void {
     }
 }
 
+/// Enqueue a message and wake the search thread to process it.
+///
+/// The first notification lets the search thread make room if the mailbox
+/// is full. The second covers the case where that notification is processed
+/// before the message is enqueued.
+pub fn send(self: *Thread, msg: Message) void {
+    self.notify();
+
+    // Search messages may transfer ownership or required state.
+    _ = self.mailbox.push(msg, .{ .forever = {} });
+
+    self.notify();
+}
+
+fn notify(self: *Thread) void {
+    self.wakeup.notify() catch |err| {
+        log.warn("error notifying search thread err={}", .{err});
+    };
+}
+
 /// Drain the mailbox.
 fn drainMailbox(self: *Thread) !void {
     while (self.mailbox.pop()) |message| {

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -36,7 +36,7 @@ renderer_state: *RendererState,
 
 /// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
-renderer_wakeup: xev.Async,
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for renderer messages.
 renderer_mailbox: *RendererThread.Mailbox,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -206,7 +206,7 @@ renderer_state: *renderer.State,
 
 /// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
-renderer_wakeup: xev.Async,
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for notifying the renderer of things.
 renderer_mailbox: *renderer.Thread.Mailbox,
@@ -684,8 +684,11 @@ pub fn resize(
     }
 
     // Mail the renderer so that it can update the GPU and re-render
-    _ = self.renderer_mailbox.push(.{ .resize = size }, .{ .forever = {} });
-    self.renderer_wakeup.notify() catch {};
+    renderer.Thread.sendMessage(
+        self.renderer_wakeup,
+        self.renderer_mailbox,
+        .{ .resize = size },
+    );
 }
 
 /// Resize terminal/backend state before the IO thread starts.
@@ -717,7 +720,11 @@ pub fn resizeBeforeThreadStart(
         self.terminal.modes.set(.synchronized_output, false);
     }
 
-    _ = self.renderer_mailbox.push(.{ .resize = size }, .{ .forever = {} });
+    renderer.Thread.sendMessage(
+        self.renderer_wakeup,
+        self.renderer_mailbox,
+        .{ .resize = size },
+    );
 }
 
 /// Make a size report.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -39,7 +39,7 @@ pub const StreamHandler = struct {
 
     /// A handle to wake up the renderer. This hints to the renderer that
     /// a repaint should happen.
-    renderer_wakeup: xev.Async,
+    renderer_wakeup: *xev.Async,
 
     /// The default cursor state. This is used with CSI q. This is
     /// set to true when we're currently in the default cursor state.
@@ -169,16 +169,11 @@ pub const StreamHandler = struct {
         self.renderer_state.mutex.unlock();
         defer self.renderer_state.mutex.lock();
         self.renderer_state.noteRenderWakeupNotify();
-        self.renderer_wakeup.notify() catch |err| {
-            // This is an EXTREMELY unlikely case. We still don't return
-            // and attempt to send the message because its most likely
-            // that everything is fine, but log in case a freeze happens.
-            log.warn(
-                "failed to notify renderer, may deadlock err={}",
-                .{err},
-            );
-        };
-        _ = self.renderer_mailbox.push(msg, .{ .forever = {} });
+        renderer.Thread.sendMessage(
+            self.renderer_wakeup,
+            self.renderer_mailbox,
+            msg,
+        );
     }
 
     pub fn vt(


### PR DESCRIPTION
First off, thank you so much for sharing this repo. I am so very happy to finally use ghostty on windows.

I ran into a pretty annoying issue while trying it out for the first time though: whenever I would leave a winghostty window in the background for long enough, when I alt+tabbed back it would often freeze up and become unresponsive and I would have to force quit the program and restart.

I used Claude Code and Codex to investigate the issue with a procdump taken when the hang was happening. It eventually found a fix and after running it on a build myself long enough to feel confident about it I felt it was worth contributing back.

Not sure how you feel about AI-coded contributions, but I did spend some effort to do a few code review phases with different agents and try to catch any possible issues with this upfront. And, I did try to de-slopify the comments as much as I could. Hopefully this is at least helpful in pointing out the issue even if the solution itself is not what you'd like.

The following is an AI generated summary of the changes:

## Summary

The app thread could block forever pushing to a full renderer mailbox, freezing every window in the process.

`Surface`'s app-thread callbacks pushed to the renderer and search mailboxes with `.forever`, but the wakeup that drains those mailboxes was only issued *after* the push. A full queue therefore parked the caller on `cond_not_full` before it could reach the code that wakes the thread responsible for draining it — a permanent deadlock, not a slow path.

On Win32 the app thread runs the window procedure for every window in the process, so this froze the entire application until Windows killed it. No exception is raised for a deadlock, so the local crash handler wrote nothing and `%LOCALAPPDATA%\winghostty\crash` stayed empty.

## Fix

**Notify before the push.** This is the fix for the deadlock: the ordering was the problem, not blocking itself. The consumer has already been told to drain before the producer waits, so the cycle cannot form. `send` notifies again after the push, because the first wakeup can be consumed by a drain that runs before the push lands.

**Make `.forever` actually wait forever.** Despite the name, the `.forever` branch of `BlockingQueue.push` waited once and then reported a failed push if the queue was still full. That is not a correct condition variable wait — wakes can be spurious — and the renderer mailbox is genuinely multi-producer: the app thread and the IO thread both push to it, so another producer can claim the freed slot before a woken waiter reacquires the mutex. Every caller already discarded the result and assumed delivery, so that fallthrough silently dropped messages under contention. It now waits in a `while (self.full())` loop. The module comment claiming these queues are SPSC is corrected at the same time, since it is no longer true and the blocking path depends on it not being true.

Note this changes `.forever` for all its callers, including the termio paths, which previously could drop a `.resize` in the same interleaving.

**Delivery is therefore guaranteed rather than best-effort.** These messages are not disposable notifications — they carry ownership (`.font_grid`, `.change_config`, search payloads) or state the receiver must observe exactly once (`.focus`, `.visible`, whose senders have same-value fast paths and so would never resend a lost update). `send` returns `void`; there is no delivery result for callers to overlook.

A caller can still block if the renderer thread is genuinely wedged rather than merely idle. That is pre-existing behaviour and is not the failure this addresses; the dump below shows an idle renderer, not a stuck one.

`searchCallback_`'s `.forever` pushes are deliberately left alone. They run on the search thread and push to the surface mailbox — the opposite direction, and not part of this failure.

## Evidence

From a hang dump taken while frozen:

- UI thread blocked in `SleepConditionVariableSRW` with an `INFINITE` timeout, called from `Surface.focusCallback`
- the renderer mailbox at 64/64, every slot holding an undrained `.reset_cursor_blink`
- `not_full_waiters = 1`
- all 67 threads parked in wait syscalls — nothing running, nothing holding a lock

## Testing

Two new regression tests:

- `send wakes the renderer before waiting on a full mailbox` (`src/renderer/Thread.zig`) reproduces the deadlock in miniature: a full mailbox whose consumer only drains once woken. It asserts the wakeup arrives before `send` blocks and that the message is delivered. A guard timer drains after 5s so a regression fails the assertion instead of hanging CI.
- `forever push waits again when a wake leaves the queue full` (`src/datastruct/blocking_queue.zig`) covers the contended handoff: a slot is freed and signalled but refilled under the same lock, so the waiter observes a still-full queue and must keep waiting rather than report failure.

Both were verified to fail when their respective fix is reverted, not just to pass as written.

Manually verified on Windows 11: the hang no longer reproduces on the case that previously triggered it (long-lived window, output in the background, alt-tab back).

## Validation

- [x] `zig build test -Dtest-filter=win32`
- [x] `zig build test -Dtest-filter=scroll`
- [x] `zig build test -Dtest-filter=keybind`
- [x] `zig build -Demit-exe=true`

## Summary by Sourcery

Prevent deadlocks and message loss in renderer and search threads by guaranteeing mailbox delivery and waking consumers before blocking.

Bug Fixes:
- Ensure pushes with `.forever` on blocking queues wait correctly in a loop, avoiding dropped messages when wakes occur with the queue still full.
- Avoid application thread hangs by notifying renderer and search threads before enqueueing into potentially full mailboxes, breaking the deadlock condition.

Enhancements:
- Introduce `send` helpers on renderer and search threads to encapsulate reliable enqueue-and-wakeup semantics for messages carrying ownership or critical state.
- Update blocking queue documentation to reflect multi-producer usage and clarify behavior of blocking operations.

Tests:
- Add regression tests validating that `send` wakes the renderer before blocking on a full mailbox and that `.forever` pushes do not report failure when a wake leaves the queue full.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing inspector updates, search results, configuration and font changes, navigation, visibility, and focus changes.
  * Prevented messages from being lost when rendering or search processing is busy or temporarily waking.
  * Improved crash handling, search query delivery, and terminal resize updates.
  * Ensured queued operations continue waiting safely when processing capacity is temporarily full.

* **Tests**
  * Added concurrency coverage to verify reliable message delivery during wakeups, high activity, and queue contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->