### PR TITLE
fix: synchronize initial Win32 surface focus

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -24246,9 +24246,11 @@ pub const Surface = struct {
         if (GetFocus() == hwnd) {
             self.window_focused = true;
         }
-        if (self.window_focused) {
-            self.focusChanged(true);
-        }
+
+        // Both the core and renderer default to focused, so always send the
+        // actual state. Otherwise the first focus event may be ignored as
+        // unchanged for a surface that started unfocused.
+        self.focusChanged(self.window_focused);
         if (activate_during_init) {
             try host.refreshChrome();
             try host.layout();

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -60,6 +60,8 @@ const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 const RENDER_FOLLOWUP_BURST_MS = 128;
 
+const UNFOCUSED_HEARTBEAT_MS = 250;
+
 /// Whether calls to `drawFrame` must be done from the app thread.
 ///
 /// If this is `true` then we send a `redraw_surface` message to the apprt
@@ -117,6 +119,12 @@ cursor_c: xev.Completion = .{},
 /// completed timer remains `.active` until its callback is popped, so reusing
 /// it from another callback can corrupt libxev's intrusive completion queue.
 cursor_blink_reset_at: ?std.time.Instant = null,
+
+/// Focused surfaces already render for cursor blinking. On Win32, repeated
+/// renderer wakeups may be combined, so this timer keeps unfocused surfaces
+/// updating and their renderer mailboxes draining.
+heartbeat_h: xev.Timer,
+heartbeat_c: xev.Completion = .{},
 
 /// The surface we're rendering to.
 surface: *apprt.Surface,
@@ -209,6 +217,9 @@ pub fn init(
     var cursor_timer = try xev.Timer.init();
     errdefer cursor_timer.deinit();
 
+    var heartbeat_h = try xev.Timer.init();
+    errdefer heartbeat_h.deinit();
+
     // The mailbox for messaging this thread
     var mailbox = try Mailbox.create(alloc);
     errdefer mailbox.destroy(alloc);
@@ -223,6 +234,7 @@ pub fn init(
         .draw_h = draw_h,
         .draw_now = draw_now,
         .cursor_h = cursor_timer,
+        .heartbeat_h = heartbeat_h,
         .surface = surface,
         .search_generation = search_generation,
         .renderer = renderer_impl,
@@ -241,6 +253,7 @@ pub fn deinit(self: *Thread) void {
     self.draw_h.deinit();
     self.draw_now.deinit();
     self.cursor_h.deinit();
+    self.heartbeat_h.deinit();
     self.loop.deinit();
 
     // Nothing can possibly access the mailbox anymore, destroy it.
@@ -307,6 +320,8 @@ fn threadMain_(self: *Thread) !void {
 
     // Start the draw timer
     self.syncDrawTimer();
+
+    self.syncUnfocusedHeartbeat();
 
     // Run
     log.debug("starting renderer thread", .{});
@@ -425,6 +440,8 @@ fn drainMailbox(self: *Thread) !bool {
 
                 // Visibility changes can suppress or restart animation draws.
                 self.syncDrawTimer();
+
+                self.syncUnfocusedHeartbeat();
             },
 
             .focus => |v| focus: {
@@ -442,6 +459,9 @@ fn drainMailbox(self: *Thread) !bool {
 
                 // We always resync our draw timer (may disable it)
                 self.syncDrawTimer();
+
+                // Replace periodic cursor renders while unfocused.
+                self.syncUnfocusedHeartbeat();
 
                 if (!v) {
                     // Let an already-queued one-shot timer expire and disarm
@@ -587,6 +607,100 @@ fn scheduleRenderFollowup(self: *Thread) void {
         self,
         renderCallback,
     );
+}
+
+fn shouldRunUnfocusedHeartbeat(visible: bool, focused: bool) bool {
+    return visible and !focused;
+}
+
+const HeartbeatArmDecision = enum { arm, skip };
+
+/// Only reuse a dead completion. On IOCP, an active completion may have fired
+/// but still be queued, so submitting it again would corrupt libxev state.
+fn heartbeatArmDecision(
+    eligible: bool,
+    completion_dead: bool,
+) HeartbeatArmDecision {
+    if (!eligible) return .skip;
+    return if (completion_dead) .arm else .skip;
+}
+
+const HeartbeatTickDecision = enum { retire, render_and_rearm };
+
+fn heartbeatTickDecision(eligible: bool) HeartbeatTickDecision {
+    return if (eligible) .render_and_rearm else .retire;
+}
+
+fn syncUnfocusedHeartbeat(self: *Thread) void {
+    switch (heartbeatArmDecision(
+        shouldRunUnfocusedHeartbeat(self.flags.visible, self.flags.focused),
+        self.heartbeat_c.state() == .dead,
+    )) {
+        .skip => return,
+        .arm => self.heartbeat_h.run(
+            &self.loop,
+            &self.heartbeat_c,
+            UNFOCUSED_HEARTBEAT_MS,
+            Thread,
+            self,
+            heartbeatCallback,
+        ),
+    }
+}
+
+fn heartbeatCallback(
+    self_: ?*Thread,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    r: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    _ = r catch |err| switch (err) {
+        // Sent when the timer is canceled, which is fine.
+        error.Canceled => return .disarm,
+        else => {
+            log.warn("error in unfocused heartbeat callback err={}", .{err});
+            return .disarm;
+        },
+    };
+
+    const t: *Thread = self_ orelse {
+        log.warn("heartbeat callback fired without data set", .{});
+        return .disarm;
+    };
+
+    switch (heartbeatTickDecision(shouldRunUnfocusedHeartbeat(
+        t.flags.visible,
+        t.flags.focused,
+    ))) {
+        .retire => return .disarm,
+        .render_and_rearm => {},
+    }
+
+    // renderOnce updates terminal state and drains the renderer mailbox;
+    // drawFrame would only present the current frame.
+    _ = t.renderOnce(false);
+
+    // renderOnce may process a focus or visibility change. Check again before
+    // scheduling the next tick.
+    switch (heartbeatTickDecision(shouldRunUnfocusedHeartbeat(
+        t.flags.visible,
+        t.flags.focused,
+    ))) {
+        .retire => return .disarm,
+        .render_and_rearm => {},
+    }
+
+    // libxev has removed the completion from its queue, so it is safe to reuse.
+    t.heartbeat_h.run(
+        &t.loop,
+        &t.heartbeat_c,
+        UNFOCUSED_HEARTBEAT_MS,
+        Thread,
+        t,
+        heartbeatCallback,
+    );
+
+    return .disarm;
 }
 
 /// Arm the cursor's one-shot timer only when libxev no longer owns the
@@ -920,4 +1034,55 @@ test "renderer follow-up check tracks visible terminal dirtiness" {
 
     try term.printString("x");
     try testing.expect(terminal_render_dirty.needsRendererWake(&term));
+}
+
+test "unfocused heartbeat runs only while visible and unfocused" {
+    const testing = std.testing;
+
+    try testing.expect(!shouldRunUnfocusedHeartbeat(true, true));
+    try testing.expect(shouldRunUnfocusedHeartbeat(true, false));
+    try testing.expect(!shouldRunUnfocusedHeartbeat(false, false));
+    try testing.expect(!shouldRunUnfocusedHeartbeat(false, true));
+}
+
+test "unfocused heartbeat arms only an eligible, dead completion" {
+    const testing = std.testing;
+
+    try testing.expectEqual(HeartbeatArmDecision.arm, heartbeatArmDecision(true, true));
+    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(true, false));
+    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(false, true));
+    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(false, false));
+}
+
+test "unfocused heartbeat tick renders while eligible and retires otherwise" {
+    const testing = std.testing;
+
+    try testing.expectEqual(
+        HeartbeatTickDecision.render_and_rearm,
+        heartbeatTickDecision(true),
+    );
+    try testing.expectEqual(
+        HeartbeatTickDecision.retire,
+        heartbeatTickDecision(false),
+    );
+}
+
+test "unfocused heartbeat submits the timer when eligible" {
+    const testing = std.testing;
+
+    // syncUnfocusedHeartbeat only reads the fields initialized below.
+    var thr: Thread = undefined;
+    thr.loop = try xev.Loop.init(.{});
+    defer thr.loop.deinit();
+    thr.heartbeat_h = try xev.Timer.init();
+    defer thr.heartbeat_h.deinit();
+    thr.heartbeat_c = .{};
+    thr.flags = .{};
+
+    thr.syncUnfocusedHeartbeat();
+    try testing.expect(thr.heartbeat_c.state() == .dead);
+
+    thr.flags.focused = false;
+    thr.syncUnfocusedHeartbeat();
+    try testing.expect(thr.heartbeat_c.state() != .dead);
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -60,8 +60,6 @@ const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 const RENDER_FOLLOWUP_BURST_MS = 128;
 
-const UNFOCUSED_HEARTBEAT_MS = 250;
-
 /// Whether calls to `drawFrame` must be done from the app thread.
 ///
 /// If this is `true` then we send a `redraw_surface` message to the apprt
@@ -119,12 +117,6 @@ cursor_c: xev.Completion = .{},
 /// completed timer remains `.active` until its callback is popped, so reusing
 /// it from another callback can corrupt libxev's intrusive completion queue.
 cursor_blink_reset_at: ?std.time.Instant = null,
-
-/// Focused surfaces already render for cursor blinking. On Win32, repeated
-/// renderer wakeups may be combined, so this timer keeps unfocused surfaces
-/// updating and their renderer mailboxes draining.
-heartbeat_h: xev.Timer,
-heartbeat_c: xev.Completion = .{},
 
 /// The surface we're rendering to.
 surface: *apprt.Surface,
@@ -217,9 +209,6 @@ pub fn init(
     var cursor_timer = try xev.Timer.init();
     errdefer cursor_timer.deinit();
 
-    var heartbeat_h = try xev.Timer.init();
-    errdefer heartbeat_h.deinit();
-
     // The mailbox for messaging this thread
     var mailbox = try Mailbox.create(alloc);
     errdefer mailbox.destroy(alloc);
@@ -234,7 +223,6 @@ pub fn init(
         .draw_h = draw_h,
         .draw_now = draw_now,
         .cursor_h = cursor_timer,
-        .heartbeat_h = heartbeat_h,
         .surface = surface,
         .search_generation = search_generation,
         .renderer = renderer_impl,
@@ -253,7 +241,6 @@ pub fn deinit(self: *Thread) void {
     self.draw_h.deinit();
     self.draw_now.deinit();
     self.cursor_h.deinit();
-    self.heartbeat_h.deinit();
     self.loop.deinit();
 
     // Nothing can possibly access the mailbox anymore, destroy it.
@@ -320,8 +307,6 @@ fn threadMain_(self: *Thread) !void {
 
     // Start the draw timer
     self.syncDrawTimer();
-
-    self.syncUnfocusedHeartbeat();
 
     // Run
     log.debug("starting renderer thread", .{});
@@ -440,8 +425,6 @@ fn drainMailbox(self: *Thread) !bool {
 
                 // Visibility changes can suppress or restart animation draws.
                 self.syncDrawTimer();
-
-                self.syncUnfocusedHeartbeat();
             },
 
             .focus => |v| focus: {
@@ -459,9 +442,6 @@ fn drainMailbox(self: *Thread) !bool {
 
                 // We always resync our draw timer (may disable it)
                 self.syncDrawTimer();
-
-                // Replace periodic cursor renders while unfocused.
-                self.syncUnfocusedHeartbeat();
 
                 if (!v) {
                     // Let an already-queued one-shot timer expire and disarm
@@ -607,100 +587,6 @@ fn scheduleRenderFollowup(self: *Thread) void {
         self,
         renderCallback,
     );
-}
-
-fn shouldRunUnfocusedHeartbeat(visible: bool, focused: bool) bool {
-    return visible and !focused;
-}
-
-const HeartbeatArmDecision = enum { arm, skip };
-
-/// Only reuse a dead completion. On IOCP, an active completion may have fired
-/// but still be queued, so submitting it again would corrupt libxev state.
-fn heartbeatArmDecision(
-    eligible: bool,
-    completion_dead: bool,
-) HeartbeatArmDecision {
-    if (!eligible) return .skip;
-    return if (completion_dead) .arm else .skip;
-}
-
-const HeartbeatTickDecision = enum { retire, render_and_rearm };
-
-fn heartbeatTickDecision(eligible: bool) HeartbeatTickDecision {
-    return if (eligible) .render_and_rearm else .retire;
-}
-
-fn syncUnfocusedHeartbeat(self: *Thread) void {
-    switch (heartbeatArmDecision(
-        shouldRunUnfocusedHeartbeat(self.flags.visible, self.flags.focused),
-        self.heartbeat_c.state() == .dead,
-    )) {
-        .skip => return,
-        .arm => self.heartbeat_h.run(
-            &self.loop,
-            &self.heartbeat_c,
-            UNFOCUSED_HEARTBEAT_MS,
-            Thread,
-            self,
-            heartbeatCallback,
-        ),
-    }
-}
-
-fn heartbeatCallback(
-    self_: ?*Thread,
-    _: *xev.Loop,
-    _: *xev.Completion,
-    r: xev.Timer.RunError!void,
-) xev.CallbackAction {
-    _ = r catch |err| switch (err) {
-        // Sent when the timer is canceled, which is fine.
-        error.Canceled => return .disarm,
-        else => {
-            log.warn("error in unfocused heartbeat callback err={}", .{err});
-            return .disarm;
-        },
-    };
-
-    const t: *Thread = self_ orelse {
-        log.warn("heartbeat callback fired without data set", .{});
-        return .disarm;
-    };
-
-    switch (heartbeatTickDecision(shouldRunUnfocusedHeartbeat(
-        t.flags.visible,
-        t.flags.focused,
-    ))) {
-        .retire => return .disarm,
-        .render_and_rearm => {},
-    }
-
-    // renderOnce updates terminal state and drains the renderer mailbox;
-    // drawFrame would only present the current frame.
-    _ = t.renderOnce(false);
-
-    // renderOnce may process a focus or visibility change. Check again before
-    // scheduling the next tick.
-    switch (heartbeatTickDecision(shouldRunUnfocusedHeartbeat(
-        t.flags.visible,
-        t.flags.focused,
-    ))) {
-        .retire => return .disarm,
-        .render_and_rearm => {},
-    }
-
-    // libxev has removed the completion from its queue, so it is safe to reuse.
-    t.heartbeat_h.run(
-        &t.loop,
-        &t.heartbeat_c,
-        UNFOCUSED_HEARTBEAT_MS,
-        Thread,
-        t,
-        heartbeatCallback,
-    );
-
-    return .disarm;
 }
 
 /// Arm the cursor's one-shot timer only when libxev no longer owns the
@@ -1034,55 +920,4 @@ test "renderer follow-up check tracks visible terminal dirtiness" {
 
     try term.printString("x");
     try testing.expect(terminal_render_dirty.needsRendererWake(&term));
-}
-
-test "unfocused heartbeat runs only while visible and unfocused" {
-    const testing = std.testing;
-
-    try testing.expect(!shouldRunUnfocusedHeartbeat(true, true));
-    try testing.expect(shouldRunUnfocusedHeartbeat(true, false));
-    try testing.expect(!shouldRunUnfocusedHeartbeat(false, false));
-    try testing.expect(!shouldRunUnfocusedHeartbeat(false, true));
-}
-
-test "unfocused heartbeat arms only an eligible, dead completion" {
-    const testing = std.testing;
-
-    try testing.expectEqual(HeartbeatArmDecision.arm, heartbeatArmDecision(true, true));
-    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(true, false));
-    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(false, true));
-    try testing.expectEqual(HeartbeatArmDecision.skip, heartbeatArmDecision(false, false));
-}
-
-test "unfocused heartbeat tick renders while eligible and retires otherwise" {
-    const testing = std.testing;
-
-    try testing.expectEqual(
-        HeartbeatTickDecision.render_and_rearm,
-        heartbeatTickDecision(true),
-    );
-    try testing.expectEqual(
-        HeartbeatTickDecision.retire,
-        heartbeatTickDecision(false),
-    );
-}
-
-test "unfocused heartbeat submits the timer when eligible" {
-    const testing = std.testing;
-
-    // syncUnfocusedHeartbeat only reads the fields initialized below.
-    var thr: Thread = undefined;
-    thr.loop = try xev.Loop.init(.{});
-    defer thr.loop.deinit();
-    thr.heartbeat_h = try xev.Timer.init();
-    defer thr.heartbeat_h.deinit();
-    thr.heartbeat_c = .{};
-    thr.flags = .{};
-
-    thr.syncUnfocusedHeartbeat();
-    try testing.expect(thr.heartbeat_c.state() == .dead);
-
-    thr.flags.focused = false;
-    thr.syncUnfocusedHeartbeat();
-    try testing.expect(thr.heartbeat_c.state() != .dead);
 }


### PR DESCRIPTION
Follow-up fix to https://github.com/amanthanvi/winghostty/pull/108. This specifically tries to fix terminal windows not updating contents when visible on a monitor, but not actively focused (e.g. `tail -f` would freeze on focus lost). This fix seemed more of a hack to me. I suspect there is a more elegant solution, but this got the job done and I haven't noticed any negative performance impacts while trying it out in my build.

The following is in AI-generated summary of the changes:

## Summary

A visible but unfocused surface can stop showing new terminal output until it receives focus again.

The cursor blink timer is disarmed on focus loss (`cursorBlinkTimerDecision` returns `.disarm` when `!focused`), and it was the only thing forcing a periodic `renderOnce`. An unfocused surface is then left depending entirely on wakeups from the IO thread, and those coalesce heavily on Win32 — a problem this codebase already works around elsewhere with the Win32-only render follow-up timer.

When those wakeups coalesce away, the renderer thread simply sleeps. Two things stop at once: no repaints, and — because `drainMailbox` only runs inside `renderOnce` — no mailbox draining either.

## Fix

Add a 250ms heartbeat timer, armed only while a surface is visible and unfocused. It calls `renderOnce` rather than `drawFrame`, which matters: `drawFrame` only re-presents existing frame data, while `renderOnce` runs `updateFrame` to pull in new terminal content and drains the mailbox.

It follows the same IOCP constraint as the cursor timer, which this repo has been bitten by before: a completion can read `.active` while it is merely "completed but not yet popped", and reusing it corrupts libxev's queue. So the heartbeat is never cancelled externally — it retires from inside its own callback once focus returns or the surface goes invisible, and is only ever armed on a `.dead` completion.

Eligibility is re-decided *after* `renderOnce`, not just before it. `renderOnce` drains the mailbox first, so it can deliver the very `.focus`/`.visible` change that retires the timer — precisely the case the heartbeat exists to catch, since it means the wake accompanying that message was coalesced away. Rearming on the pre-render decision would leave one dormant tick scheduled.

**Also seeds the initial focus state.** Win32 dispatched `focusChanged` only when the surface already owned focus, while both `Surface.focused` and the renderer thread default to focused. A surface created in the background therefore claimed focus it did not have — and because `focusCallback` has a same-value fast path, its first focus *gain* was swallowed, so the renderer kept believing it was focused until the surface had gained and then lost focus. The heartbeat could not arm before that. It now dispatches the real state either way, which is a correctness fix in its own right beyond the heartbeat.

Focused behavior is otherwise untouched; the arming gate is strictly `visible and !focused`.

## Tradeoffs

The heartbeat is deliberately unconditional rather than gated on `terminal_render_dirty.needsRendererWake`. A wrong dirty-predicate would silently reintroduce the exact bug being fixed, so correctness first; the optimization is easy to add once the behavior is confirmed.

## Caveat

This treats the symptom. The established evidence is that Win32 async notifications coalesce and rendering then stops; whether notifications are literally lost is a diagnosis, not something instrumentation has proven. The heartbeat bounds the resulting stall to 250ms instead of indefinitely. Wakeup reliability on Win32 deserves a separate look.

## Testing

Both scheduling decisions are factored into pure functions so they can be tested, matching `shouldRunRefreshTimer` in the search thread and the existing cursor blink decision.

- `unfocused heartbeat runs only while visible and unfocused` — all four visible/focused combinations of the eligibility predicate.
- `unfocused heartbeat arms only an eligible, dead completion` — eligibility crossed with completion liveness. This is the guard that matters: resubmitting a completion libxev still owns corrupts its intrusive queue on IOCP. Removing the guard fails this test.
- `unfocused heartbeat tick renders while eligible and retires otherwise` — retire versus render-and-rearm.
- `unfocused heartbeat submits the timer when eligible` — the scheduling entry point: no submit while focused, submit on focus loss.

Each was verified by mutation, not just by passing: inverting the eligibility predicate fails two tests, and deleting the dead-completion guard fails one.

**What is not covered.** The callback is never executed, because `renderOnce` needs a real renderer, surface, and state. Its disposition is tested through `heartbeatTickDecision` rather than by running it. The Win32 initial focus dispatch is also untested: `Surface.init` creates a real HWND via `CreateWindowExW` against a host window, registers an OLE drop target, and builds a GL context, so there is no harness that reaches it without substantial mocking.

## Validation

- [x] `zig build test -Dtest-filter=win32`
- [x] `zig build test -Dtest-filter=scroll`
- [x] `zig build test -Dtest-filter=keybind`
- [x] `zig build -Demit-exe=true`

## Summary by Sourcery

Ensure visible but unfocused terminal surfaces continue rendering and draining renderer mailboxes, particularly on Win32.

Enhancements:
- Introduce an unfocused heartbeat timer in the renderer thread to periodically invoke rendering for visible, unfocused surfaces.
- Gate heartbeat scheduling on visibility, focus state, and safe completion reuse to avoid IOCP/libxev corruption.
- Adjust Win32 surface initialization to dispatch the correct initial focus state to the core and renderer.
- Add unit tests covering heartbeat eligibility, arming, tick behavior, and timer submission logic for the renderer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Focus state notifications now correctly report both focused and unfocused states.
  * Visible, unfocused surfaces continue processing rendering work through a periodic heartbeat.
  * Improved synchronization when surfaces change visibility or focus state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->