### PR TITLE
win32: commit AltGr layout text

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23203,6 +23203,10 @@ fn shouldDeferTextToCharMessage(
     return !isControlCodepoint(translated.unshifted_codepoint);
 }
 
+fn shouldAuthorizeDeferredCharMessage(effect: CoreSurface.InputEffect) bool {
+    return effect == .ignored;
+}
+
 const DeferredCharState = struct {
     pending_units: usize = 0,
     high_surrogate: ?u16 = null,
@@ -26981,9 +26985,8 @@ pub const Surface = struct {
 
         const message = keyEventFromWin32Message(msg, wParam, lParam) orelse return;
         const event = message.event;
-        self.deferred_char.authorize(message.deferred_utf16_units);
 
-        _ = self.core_surface.keyCallback(event) catch |err| {
+        const effect = self.core_surface.keyCallback(event) catch |err| {
             log.err("win32 key callback failed err={} vk={} action={} key={} mods={}", .{
                 err,
                 @as(UINT, @intCast(wParam & 0xFFFF)),
@@ -26993,6 +26996,10 @@ pub const Surface = struct {
             });
             return;
         };
+        if (effect == .closed) return;
+        if (shouldAuthorizeDeferredCharMessage(effect)) {
+            self.deferred_char.authorize(message.deferred_utf16_units);
+        }
         if (event.utf8.len != 0) {
             if (self.terminal_accessibility) |session| session.noteInput(event.utf8);
         }
@@ -31548,6 +31555,12 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .{},
         .{ .unshifted_codepoint = 0x0D },
     ));
+}
+
+test "win32 deferred char authorization respects key handling effect" {
+    try std.testing.expect(shouldAuthorizeDeferredCharMessage(.ignored));
+    try std.testing.expect(!shouldAuthorizeDeferredCharMessage(.consumed));
+    try std.testing.expect(!shouldAuthorizeDeferredCharMessage(.closed));
 }
 
 test "win32 VK_PACKET key down authorizes one unit without direct text or modifiers" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23185,7 +23185,10 @@ fn shouldDeferTextToCharMessage(
     translated: KeyText,
 ) bool {
     if (action == .release) return false;
-    if (mods.ctrl or mods.alt or mods.super) return false;
+    // Windows reports AltGr as synthetic left Ctrl plus right Alt. The
+    // resulting WM_CHAR is layout text, not a Ctrl+Alt terminal chord.
+    const alt_gr = mods.ctrl and mods.alt and mods.sides.alt == .right;
+    if (mods.super or ((mods.ctrl or mods.alt) and !alt_gr)) return false;
     if (key.modifier()) return false;
 
     switch (key) {
@@ -31515,6 +31518,18 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .digit_2,
         .{ .ctrl = true, .alt = true },
         .{ .unshifted_codepoint = '2', .deferred_utf16_units = 1 },
+    ));
+    try std.testing.expect(shouldDeferTextToCharMessage(
+        .press,
+        .equal,
+        .{ .ctrl = true, .alt = true, .sides = .{ .alt = .right } },
+        .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+    ));
+    try std.testing.expect(!shouldDeferTextToCharMessage(
+        .press,
+        .equal,
+        .{ .alt = true, .sides = .{ .alt = .right } },
+        .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -23187,7 +23187,8 @@ fn shouldDeferTextToCharMessage(
     if (action == .release) return false;
     // Windows reports AltGr as synthetic left Ctrl plus right Alt. The
     // resulting WM_CHAR is layout text, not a Ctrl+Alt terminal chord.
-    const alt_gr = mods.ctrl and mods.alt and mods.sides.alt == .right;
+    const alt_gr = mods.ctrl and mods.alt and
+        mods.sides.ctrl == .left and mods.sides.alt == .right;
     if (mods.super or ((mods.ctrl or mods.alt) and !alt_gr)) return false;
     if (key.modifier()) return false;
 
@@ -31529,6 +31530,16 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .press,
         .equal,
         .{ .alt = true, .sides = .{ .alt = .right } },
+        .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+    ));
+    try std.testing.expect(!shouldDeferTextToCharMessage(
+        .press,
+        .equal,
+        .{
+            .ctrl = true,
+            .alt = true,
+            .sides = .{ .ctrl = .right, .alt = .right },
+        },
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(


### PR DESCRIPTION
## Summary

- recognize Windows AltGr (`Ctrl` + right `Alt`) as a layout-text chord
- defer AltGr output to the existing authorized `WM_CHAR` commit path
- preserve ordinary Ctrl/Alt shortcut behavior and cover both cases with regression tests

## Root cause

Windows exposes AltGr as synthetic left Ctrl plus right Alt. The Win32 input gate rejected every Ctrl/Alt-modified key from the layout-text commit path, so the Swedish `AltGr` + `+` translation (`U+005C`, backslash) stayed a modified key event and produced no terminal text.

## User impact

Nordic and other AltGr-based layouts can now type backslash and other layout-produced characters without changing shortcut semantics for regular Ctrl/Alt chords.

## Validation

- `scripts/dev-windows.cmd zig build test -Dtest-filter=shouldDeferTextToCharMessage`
- `scripts/dev-windows.cmd zig build test -Dtest-filter=win32`
- `scripts/dev-windows.cmd zig build`
- process-local Win32 `ToUnicodeEx` probe: `sv-SE` + `VK_OEM_PLUS` + AltGr => `U+005C` (`\`)

Closes #110

## Summary by Sourcery

Handle Windows AltGr layout-text input correctly while preserving existing modifier shortcut behavior.

Bug Fixes:
- Treat AltGr (Ctrl + right Alt) as layout text so AltGr-based keyboard layouts correctly commit characters like backslash instead of being dropped as modified key events.

Tests:
- Extend win32 shouldDeferTextToCharMessage tests to cover AltGr combinations and ensure plain Ctrl/Alt shortcuts remain unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows keyboard input handling for AltGr (Left Ctrl + Right Alt) combinations.
  * Continued filtering unsupported modifier combinations, including standalone Right Alt, Right Ctrl + Right Alt, and Super.
* **Tests**
  * Added coverage verifying that valid AltGr input is accepted while unsupported modifier combinations remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->