### PR TITLE
build: harden release validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
         shell: pwsh
         run: ./scripts/check-release-copy.ps1
 
+      - name: Release copy UTC date tests
+        shell: pwsh
+        run: ./scripts/test-release-copy-date.ps1
+
       - name: Remote release copy checks
         if: github.event_name == 'schedule'
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,12 @@ jobs:
         shell: pwsh
         run: ./scripts/check-release-copy.ps1
 
-      - name: Release copy UTC date tests
+      - name: Release copy UTC date tests (PowerShell 7)
         shell: pwsh
+        run: ./scripts/test-release-copy-date.ps1
+
+      - name: Release copy UTC date tests (Windows PowerShell 5.1)
+        shell: powershell
         run: ./scripts/test-release-copy-date.ps1
 
       - name: Remote release copy checks

--- a/scripts/check-release-copy.ps1
+++ b/scripts/check-release-copy.ps1
@@ -10,6 +10,7 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
 . (Join-Path $PSScriptRoot "windows-architecture.ps1")
+. (Join-Path $PSScriptRoot "release-copy-date.ps1")
 
 $copyPaths = @(
     "README.md",
@@ -232,15 +233,7 @@ if ($CheckRemoteLatest) {
             if ($release) {
                 $publishedDate = $null
                 try {
-                    $publishedAtUtc = if ($release.publishedAt -is [DateTime]) {
-                        $release.publishedAt.ToUniversalTime()
-                    } else {
-                        [DateTimeOffset]::Parse([string]$release.publishedAt).UtcDateTime
-                    }
-                    $publishedDate = $publishedAtUtc.ToString(
-                        "yyyy-MM-dd",
-                        [System.Globalization.CultureInfo]::InvariantCulture
-                    )
+                    $publishedDate = ConvertTo-UtcReleaseDate -PublishedAt $release.publishedAt
                 } catch {
                     Add-Failure "Could not parse GitHub latest-release publishedAt date: $($release.publishedAt)"
                 }

--- a/scripts/check-release-copy.ps1
+++ b/scripts/check-release-copy.ps1
@@ -232,7 +232,12 @@ if ($CheckRemoteLatest) {
             if ($release) {
                 $publishedDate = $null
                 try {
-                    $publishedDate = [DateTimeOffset]::Parse([string]$release.publishedAt).UtcDateTime.ToString(
+                    $publishedAtUtc = if ($release.publishedAt -is [DateTime]) {
+                        $release.publishedAt.ToUniversalTime()
+                    } else {
+                        [DateTimeOffset]::Parse([string]$release.publishedAt).UtcDateTime
+                    }
+                    $publishedDate = $publishedAtUtc.ToString(
                         "yyyy-MM-dd",
                         [System.Globalization.CultureInfo]::InvariantCulture
                     )

--- a/scripts/release-copy-date.ps1
+++ b/scripts/release-copy-date.ps1
@@ -1,0 +1,30 @@
+function ConvertTo-UtcReleaseDate {
+    param(
+        [Parameter(Mandatory)]
+        [object] $PublishedAt
+    )
+
+    $publishedAtUtc = if ($PublishedAt -is [DateTimeOffset]) {
+        $PublishedAt.UtcDateTime
+    } elseif ($PublishedAt -is [DateTime]) {
+        if ($PublishedAt.Kind -eq [DateTimeKind]::Unspecified) {
+            [DateTime]::SpecifyKind($PublishedAt, [DateTimeKind]::Utc)
+        } else {
+            $PublishedAt.ToUniversalTime()
+        }
+    } else {
+        $styles = [System.Globalization.DateTimeStyles]::AllowWhiteSpaces -bor
+            [System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+            [System.Globalization.DateTimeStyles]::AdjustToUniversal
+        [DateTimeOffset]::Parse(
+            [string] $PublishedAt,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            $styles
+        ).UtcDateTime
+    }
+
+    return $publishedAtUtc.ToString(
+        "yyyy-MM-dd",
+        [System.Globalization.CultureInfo]::InvariantCulture
+    )
+}

--- a/scripts/test-release-copy-date.ps1
+++ b/scripts/test-release-copy-date.ps1
@@ -1,40 +1,57 @@
 $ErrorActionPreference = "Stop"
-. (Join-Path $PSScriptRoot "release-copy-date.ps1")
 
-$cases = @(
-    @{
-        Name = "UTC DateTime"
-        Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T22:01:54"), [DateTimeKind]::Utc)
-        Expected = "2026-08-06"
-    },
-    @{
-        Name = "ISO-8601 UTC string"
-        Value = "2026-08-06T22:01:54Z"
-        Expected = "2026-08-06"
-    },
-    @{
-        Name = "ISO-8601 offset crosses UTC date"
-        Value = "2026-08-07T01:30:00+03:00"
-        Expected = "2026-08-06"
-    },
-    @{
-        Name = "DateTimeOffset crosses UTC date"
-        Value = [DateTimeOffset]::new(2026, 8, 7, 1, 30, 0, [TimeSpan]::FromHours(3))
-        Expected = "2026-08-06"
-    },
-    @{
-        Name = "Unspecified DateTime is GitHub UTC"
-        Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T23:30:00"), [DateTimeKind]::Unspecified)
-        Expected = "2026-08-06"
-    }
-)
+$tempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$fixtureRoot = Join-Path $tempRoot "winghostty-release-copy-date-$PID-$([Guid]::NewGuid().ToString('N'))"
 
-foreach ($case in $cases) {
-    $actual = ConvertTo-UtcReleaseDate -PublishedAt $case.Value
-    if ($actual -ne $case.Expected) {
-        throw "$($case.Name): expected $($case.Expected), got $actual."
+try {
+    [System.IO.Directory]::CreateDirectory($fixtureRoot) | Out-Null
+    $helperPath = Join-Path $fixtureRoot "release-copy-date.ps1"
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot "release-copy-date.ps1") -Destination $helperPath
+    . $helperPath
+
+    $cases = @(
+        @{
+            Name = "UTC DateTime"
+            Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T22:01:54"), [DateTimeKind]::Utc)
+            Expected = "2026-08-06"
+        },
+        @{
+            Name = "ISO-8601 UTC string"
+            Value = "2026-08-06T22:01:54Z"
+            Expected = "2026-08-06"
+        },
+        @{
+            Name = "ISO-8601 offset crosses UTC date"
+            Value = "2026-08-07T01:30:00+03:00"
+            Expected = "2026-08-06"
+        },
+        @{
+            Name = "DateTimeOffset crosses UTC date"
+            Value = [DateTimeOffset]::new(2026, 8, 7, 1, 30, 0, [TimeSpan]::FromHours(3))
+            Expected = "2026-08-06"
+        },
+        @{
+            Name = "Unspecified DateTime is GitHub UTC"
+            Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T23:30:00"), [DateTimeKind]::Unspecified)
+            Expected = "2026-08-06"
+        }
+    )
+
+    foreach ($case in $cases) {
+        $actual = ConvertTo-UtcReleaseDate -PublishedAt $case.Value
+        if ($actual -ne $case.Expected) {
+            throw "$($case.Name): expected $($case.Expected), got $actual."
+        }
+        Write-Host "PASS: $($case.Name) -> $actual"
     }
-    Write-Host "PASS: $($case.Name) -> $actual"
+
+    Write-Host "Release copy UTC date tests passed ($($cases.Count) cases)." -ForegroundColor Green
+} finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        $resolvedFixtureRoot = [System.IO.Path]::GetFullPath($fixtureRoot)
+        if (-not $resolvedFixtureRoot.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove release-copy test directory outside the temp root: $resolvedFixtureRoot"
+        }
+        Remove-Item -LiteralPath $resolvedFixtureRoot -Recurse -Force
+    }
 }
-
-Write-Host "Release copy UTC date tests passed ($($cases.Count) cases)." -ForegroundColor Green

--- a/scripts/test-release-copy-date.ps1
+++ b/scripts/test-release-copy-date.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "release-copy-date.ps1")
+
+$cases = @(
+    @{
+        Name = "UTC DateTime"
+        Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T22:01:54"), [DateTimeKind]::Utc)
+        Expected = "2026-08-06"
+    },
+    @{
+        Name = "ISO-8601 UTC string"
+        Value = "2026-08-06T22:01:54Z"
+        Expected = "2026-08-06"
+    },
+    @{
+        Name = "ISO-8601 offset crosses UTC date"
+        Value = "2026-08-07T01:30:00+03:00"
+        Expected = "2026-08-06"
+    },
+    @{
+        Name = "DateTimeOffset crosses UTC date"
+        Value = [DateTimeOffset]::new(2026, 8, 7, 1, 30, 0, [TimeSpan]::FromHours(3))
+        Expected = "2026-08-06"
+    },
+    @{
+        Name = "Unspecified DateTime is GitHub UTC"
+        Value = [DateTime]::SpecifyKind([DateTime]::Parse("2026-08-06T23:30:00"), [DateTimeKind]::Unspecified)
+        Expected = "2026-08-06"
+    }
+)
+
+foreach ($case in $cases) {
+    $actual = ConvertTo-UtcReleaseDate -PublishedAt $case.Value
+    if ($actual -ne $case.Expected) {
+        throw "$($case.Name): expected $($case.Expected), got $actual."
+    }
+    Write-Host "PASS: $($case.Name) -> $actual"
+}
+
+Write-Host "Release copy UTC date tests passed ($($cases.Count) cases)." -ForegroundColor Green

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2892,9 +2892,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- preserve GitHub release timestamps as UTC when PowerShell `ConvertFrom-Json` returns a `DateTime`
- update vulnerable transitive `brace-expansion` and `fast-uri` lock entries to patched versions
- add no direct dependency, override, or runtime package

## Validation
- `pwsh -NoProfile -File scripts/check-release-copy.ps1 -ExpectedVersion 1.3.123 -CheckRemoteLatest`
- `npm ci --prefix site --ignore-scripts`
- `npm audit --prefix site` (0 vulnerabilities)
- `npm test --prefix site`
- `npm run build --prefix site`
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`
- `pwsh -NoProfile -File scripts/check-site-bundle.ps1`
- `pwsh -NoProfile -File scripts/check-source-format.ps1`
- `git diff --check`

## Context
This closes the actionable residual validation risks found while releasing the fix for #110. The three outage-created zero-job Actions records remain undeletable by GitHub (`cancel`/`force-cancel` return 409; `DELETE` returns 403), but each is superseded by a successful exact-SHA run.

## Summary by Sourcery

Harden release validation and update vulnerable site dependencies.

Bug Fixes:
- Ensure GitHub release timestamps are consistently treated as UTC during release validation to avoid date misinterpretation.

Build:
- Update vulnerable transitive site dependencies, including brace-expansion and fast-uri, to patched versions in the package lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release date handling for values provided as date objects or date-like text.
  * Ensured release dates are consistently converted to UTC and displayed in the expected format.
  * Corrected date handling for time zone offsets that cross calendar days.
  * Added validation coverage for common release date formats to help prevent future inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->