### PR TITLE
windows: stabilize High Contrast preview validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
   <a href="SECURITY.md">Security</a>
 </p>
 
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
+
 ---
 
 ## What is winghostty?

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -5744,9 +5744,11 @@ $paletteThemeFunctions = @($paletteThemeAst.FindAll({
 $openThemeQueryFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Open-ThemeQuery')
 $themePaletteDismissedFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Test-ThemePaletteDismissed')
 $postHighContrastFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Invoke-PostHighContrastPresentationCanary')
-if ($paletteThemeFunctions.Count -ne 3 -or $openThemeQueryFunctions.Count -ne 1 -or
-    $themePaletteDismissedFunctions.Count -ne 1 -or $postHighContrastFunctions.Count -ne 1) {
-    throw 'Palette theme harness must define only its exact query, dismissal, and post-High-Contrast presentation functions.'
+$suppressedPreviewDiagnosticFunctions = @($paletteThemeFunctions | Where-Object Name -eq 'Write-SuppressedPreviewDiagnostic')
+if ($paletteThemeFunctions.Count -ne 4 -or $openThemeQueryFunctions.Count -ne 1 -or
+    $themePaletteDismissedFunctions.Count -ne 1 -or $postHighContrastFunctions.Count -ne 1 -or
+    $suppressedPreviewDiagnosticFunctions.Count -ne 1) {
+    throw 'Palette theme harness must define only its exact query, dismissal, diagnostic, and post-High-Contrast presentation functions.'
 }
 $openThemeQueryParameters = @($openThemeQueryFunctions[0].Parameters)
 if ($openThemeQueryParameters.Count -ne 4 -or
@@ -6091,8 +6093,10 @@ if ($highContrastStabilityWaits.Count -ne 2 -or
     }).Count -ne 1 -or
     $paletteThemeHarnessText -notmatch [regex]::Escape('SystemParametersInfo(0x42, $activeHc.cbSize, [ref]$activeHc, 0)') -or
     $paletteThemeHarnessText -notmatch [regex]::Escape('($activeHc.dwFlags -band 1) -eq 0') -or
-    $paletteThemeHarnessText -notmatch [regex]::Escape('High Contrast preview framebuffer stable: baseline={0:x6}, settled={1:x6}, transitions={2}')) {
-    throw 'High Contrast theme preview must reject Dracula, prove a stable settled framebuffer, verify active High Contrast, and report transitions.'
+    $paletteThemeHarnessText -notmatch [regex]::Escape('High Contrast preview framebuffer: baseline={0:x6}, settled-or-last={1:x6}, transitions={2}') -or
+    ([regex]::Matches($paletteThemeHarnessText, '(?m)^\s*Write-SuppressedPreviewDiagnostic \$hcPixel \$suppressedPreview\s*$')).Count -ne 4 -or
+    $paletteThemeHarnessText -notmatch '(?s)catch\s*\{\s*Write-SuppressedPreviewDiagnostic \$hcPixel \$suppressedPreview\s+throw\s*\}') {
+    throw 'High Contrast theme preview must reject Dracula, prove a stable settled framebuffer, verify active High Contrast, and report transitions before success or failure.'
 }
 $highContrastCloseCalls = @($paletteThemeAst.FindAll({
     param($node)

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -3944,6 +3944,12 @@ $highContrastCalls = @(
 if ($highContrastFunctions.Count -ne 1 -or $highContrastCalls.Count -ne 2) {
     throw 'Targeted and full accessibility evidence must share one High Contrast proof helper.'
 }
+$highContrastFunctionText = $highContrastFunctions[0].Extent.Text
+if ($highContrastFunctionText -notmatch [regex]::Escape('$compoundRestoreBudgetSeconds = 20') -or
+    $highContrastFunctionText -notmatch [regex]::Escape('[DateTime]::UtcNow.AddSeconds($compoundRestoreBudgetSeconds)') -or
+    $highContrastFunctionText -notmatch [regex]::Escape('budget_seconds = $compoundRestoreBudgetSeconds')) {
+    throw 'Compound High Contrast restoration must reserve a diagnostic-consistent 20-second convergence budget.'
+}
 Assert-NoUnreachableStatements `
     -Ast $highContrastFunctions[0].Body `
     -Context 'Invoke-AccessibilityHighContrastProof'

--- a/test/windows/flagship/Test-VerificationContracts.ps1
+++ b/test/windows/flagship/Test-VerificationContracts.ps1
@@ -6085,11 +6085,14 @@ if ($highContrastStabilityWaits.Count -ne 2 -or
         $_.Extent.Text -match [regex]::Escape('$hcPresentation.Stable.Restart()')
     }).Count -ne 1 -or
     @($highContrastStabilityWaits | Where-Object {
-        $_.Extent.Text -match [regex]::Escape("throw 'Theme preview changed terminal colors while High Contrast was active.'") -and
-            $_.Extent.Text -match [regex]::Escape('$suppressedPreviewStable.Reset()') -and
-            $_.Extent.Text -match [regex]::Escape('$previewPixel -band 0xFFFFFF) -eq $draculaRgb')
-    }).Count -ne 1) {
-    throw 'High Contrast theme preview must reject Dracula immediately and prove the original framebuffer stable for two seconds.'
+        $_.Extent.Text -match [regex]::Escape('$previewRgb -eq $draculaRgb') -and
+            $_.Extent.Text -match [regex]::Escape('$suppressedPreview.Stable.Restart()') -and
+            $_.Extent.Text -match [regex]::Escape('$suppressedPreview.TransitionCount++')
+    }).Count -ne 1 -or
+    $paletteThemeHarnessText -notmatch [regex]::Escape('SystemParametersInfo(0x42, $activeHc.cbSize, [ref]$activeHc, 0)') -or
+    $paletteThemeHarnessText -notmatch [regex]::Escape('($activeHc.dwFlags -band 1) -eq 0') -or
+    $paletteThemeHarnessText -notmatch [regex]::Escape('High Contrast preview framebuffer stable: baseline={0:x6}, settled={1:x6}, transitions={2}')) {
+    throw 'High Contrast theme preview must reject Dracula, prove a stable settled framebuffer, verify active High Contrast, and report transitions.'
 }
 $highContrastCloseCalls = @($paletteThemeAst.FindAll({
     param($node)

--- a/test/windows/interactive-win11-accessibility.ps1
+++ b/test/windows/interactive-win11-accessibility.ps1
@@ -2675,7 +2675,8 @@ function Invoke-AccessibilityHighContrastProof(
                 throw "Targeted High Contrast state was not restored exactly. diagnostic=$restoreDiagnosticPath recovery=$recoveryPath"
             }
             if ($toggleAttempted -and $null -ne $semanticPixel) {
-                $compoundRestoreDeadline = [DateTime]::UtcNow.AddSeconds(10)
+                $compoundRestoreBudgetSeconds = 20
+                $compoundRestoreDeadline = [DateTime]::UtcNow.AddSeconds($compoundRestoreBudgetSeconds)
                 $script:hcRestorePollCount = 0
                 $script:hcRestoreDiagnostic = $null
                 try {
@@ -2763,7 +2764,7 @@ function Invoke-AccessibilityHighContrastProof(
                             poll = $script:hcRestorePollCount
                             timed_out = $false
                             deadline_utc = $compoundRestoreDeadline.ToString('o')
-                            budget_seconds = 10
+                            budget_seconds = $compoundRestoreBudgetSeconds
                             recovery_path = $recoveryPath
                             diagnostic_path = $restoreDiagnosticPath
                             process_alive = -not $Process.HasExited

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -197,19 +197,36 @@ try {
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         $hcEdit = Open-ThemeQuery $hcHost 'Dracula' $deadline $hcRun.Process
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-        $suppressedPreviewStable = [Diagnostics.Stopwatch]::new()
+        $suppressedPreview = [pscustomobject]@{
+            Pixel = $hcPixel
+            Stable = [Diagnostics.Stopwatch]::new()
+            TransitionCount = 0
+        }
         Wait-InteractiveWin11Until -Deadline $deadline -Description 'suppressed High Contrast theme preview' -Process $hcRun.Process -Condition {
             $previewPixel = Get-StatefulPixel $hcSurface.Hwnd
-            if (($previewPixel -band 0xFFFFFF) -eq $draculaRgb) {
-                throw 'Theme preview changed terminal colors while High Contrast was active.'
+            $previewRgb = $previewPixel -band 0xFFFFFF
+            if ($previewRgb -eq $draculaRgb) {
+                throw ('Theme preview changed terminal colors while High Contrast was active: rgb={0:x6}.' -f $previewRgb)
             }
-            if ($previewPixel -ne $hcPixel) {
-                $suppressedPreviewStable.Reset()
+            if ($previewPixel -ne $suppressedPreview.Pixel) {
+                $suppressedPreview.Pixel = $previewPixel
+                $suppressedPreview.TransitionCount++
+                $suppressedPreview.Stable.Restart()
                 return $false
             }
-            if (-not $suppressedPreviewStable.IsRunning) { $suppressedPreviewStable.Start() }
-            return $suppressedPreviewStable.Elapsed -ge [TimeSpan]::FromSeconds(2)
+            if (-not $suppressedPreview.Stable.IsRunning) { $suppressedPreview.Stable.Start() }
+            return $suppressedPreview.Stable.Elapsed -ge [TimeSpan]::FromSeconds(2)
         }
+        $activeHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new()
+        $activeHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($activeHc)
+        if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $activeHc.cbSize, [ref]$activeHc, 0)) {
+            throw 'SPI_GETHIGHCONTRAST verification failed after suppressed theme preview.'
+        }
+        if (($activeHc.dwFlags -band 1) -eq 0) {
+            throw 'High Contrast became inactive during the suppressed theme preview.'
+        }
+        Write-Host ('High Contrast preview framebuffer stable: baseline={0:x6}, settled={1:x6}, transitions={2}' -f `
+            ($hcPixel -band 0xFFFFFF), ($suppressedPreview.Pixel -band 0xFFFFFF), $suppressedPreview.TransitionCount)
         if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         Invoke-StatefulButton $hcHost 2004 $deadline $hcRun.Process

--- a/test/windows/interactive-win11-palette-theme.ps1
+++ b/test/windows/interactive-win11-palette-theme.ps1
@@ -34,6 +34,11 @@ function Open-ThemeQuery([IntPtr]$HostHwnd, [string]$Query, [DateTime]$Deadline,
     return $edit.Hwnd
 }
 
+function Write-SuppressedPreviewDiagnostic([int]$BaselinePixel, $Preview) {
+    Write-Host ('High Contrast preview framebuffer: baseline={0:x6}, settled-or-last={1:x6}, transitions={2}' -f `
+        ($BaselinePixel -band 0xFFFFFF), ($Preview.Pixel -band 0xFFFFFF), $Preview.TransitionCount)
+}
+
 function Test-ThemePaletteDismissed([IntPtr]$HostHwnd) {
     return @(Get-StatefulChildren $HostHwnd | Where-Object {
         $_.Id -ge 2001 -and $_.Id -le 2006
@@ -202,31 +207,39 @@ try {
             Stable = [Diagnostics.Stopwatch]::new()
             TransitionCount = 0
         }
-        Wait-InteractiveWin11Until -Deadline $deadline -Description 'suppressed High Contrast theme preview' -Process $hcRun.Process -Condition {
-            $previewPixel = Get-StatefulPixel $hcSurface.Hwnd
-            $previewRgb = $previewPixel -band 0xFFFFFF
-            if ($previewRgb -eq $draculaRgb) {
-                throw ('Theme preview changed terminal colors while High Contrast was active: rgb={0:x6}.' -f $previewRgb)
+        try {
+            Wait-InteractiveWin11Until -Deadline $deadline -Description 'suppressed High Contrast theme preview' -Process $hcRun.Process -Condition {
+                $previewPixel = Get-StatefulPixel $hcSurface.Hwnd
+                $previewTransitioned = $previewPixel -ne $suppressedPreview.Pixel
+                if ($previewTransitioned) {
+                    $suppressedPreview.Pixel = $previewPixel
+                    $suppressedPreview.TransitionCount++
+                    $suppressedPreview.Stable.Restart()
+                }
+                $previewRgb = $previewPixel -band 0xFFFFFF
+                if ($previewRgb -eq $draculaRgb) {
+                    throw ('Theme preview changed terminal colors while High Contrast was active: rgb={0:x6}.' -f $previewRgb)
+                }
+                if ($previewTransitioned) { return $false }
+                if (-not $suppressedPreview.Stable.IsRunning) { $suppressedPreview.Stable.Start() }
+                return $suppressedPreview.Stable.Elapsed -ge [TimeSpan]::FromSeconds(2)
             }
-            if ($previewPixel -ne $suppressedPreview.Pixel) {
-                $suppressedPreview.Pixel = $previewPixel
-                $suppressedPreview.TransitionCount++
-                $suppressedPreview.Stable.Restart()
-                return $false
-            }
-            if (-not $suppressedPreview.Stable.IsRunning) { $suppressedPreview.Stable.Start() }
-            return $suppressedPreview.Stable.Elapsed -ge [TimeSpan]::FromSeconds(2)
+        }
+        catch {
+            Write-SuppressedPreviewDiagnostic $hcPixel $suppressedPreview
+            throw
         }
         $activeHc = [WinghosttyStatefulNative+HIGHCONTRAST]::new()
         $activeHc.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($activeHc)
         if (-not [WinghosttyStatefulNative]::SystemParametersInfo(0x42, $activeHc.cbSize, [ref]$activeHc, 0)) {
+            Write-SuppressedPreviewDiagnostic $hcPixel $suppressedPreview
             throw 'SPI_GETHIGHCONTRAST verification failed after suppressed theme preview.'
         }
         if (($activeHc.dwFlags -band 1) -eq 0) {
+            Write-SuppressedPreviewDiagnostic $hcPixel $suppressedPreview
             throw 'High Contrast became inactive during the suppressed theme preview.'
         }
-        Write-Host ('High Contrast preview framebuffer stable: baseline={0:x6}, settled={1:x6}, transitions={2}' -f `
-            ($hcPixel -band 0xFFFFFF), ($suppressedPreview.Pixel -band 0xFFFFFF), $suppressedPreview.TransitionCount)
+        Write-SuppressedPreviewDiagnostic $hcPixel $suppressedPreview
         if ((Get-Content $configPath -Raw) -notmatch 'theme\s*=\s*0x96f') { throw 'High Contrast preview mutated persisted theme.' }
         $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
         Invoke-StatefulButton $hcHost 2004 $deadline $hcRun.Process


### PR DESCRIPTION
## Summary

- let the High Contrast framebuffer settle after a rapid system-theme transition
- keep rejecting an applied Dracula preview while verifying High Contrast remains active
- log baseline, settled color, and transition count for future diagnostics

Follow-up hardening for #110 after the exact-main interactive composite exposed a repeatable late-settling pixel transition.

## Validation

- PowerShell AST parse
- `git diff --check`
- `interactive-win11-palette-theme.ps1 -ResetState -ExerciseHighContrast -TimeoutSeconds 60`
- full `interactive-win11-accessibility.ps1 -ResetState -TimeoutSeconds 120 -IdleSoakSeconds 0`, immediately followed by the palette/theme High Contrast harness

## Additional hardening

- give the compound High Contrast host/settings reversal twenty seconds to converge because each UIA/DWM diagnostic poll can consume several seconds
- enforce one shared restore-budget value for both the deadline and emitted diagnostics

## Risks / Follow-ups

- harness-only change; no Winghostty runtime behavior changes
- interactive validation requires an uncontested Windows desktop because real foreground input invalidates focus assertions
## Summary by Sourcery

Harden Windows High Contrast preview validation in the interactive palette/theme test harness to ensure the framebuffer settles and High Contrast remains active during theme transitions.

Enhancements:
- Track High Contrast preview framebuffer pixel changes, including baseline, settled color, and transition count, to wait for a stable state before proceeding.
- Verify via SystemParametersInfo that High Contrast remains active after a suppressed theme preview and fail if it becomes inactive.

Tests:
- Strengthen the interactive-win11-palette-theme.ps1 High Contrast preview checks to reject any Dracula theme application while High Contrast is active and to log diagnostic information for late-settling transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved High Contrast theme preview validation by waiting for the display to stabilize before checking results.
  * Added verification that High Contrast remains enabled after the preview settles.
  * Enhanced diagnostics with baseline and final colors, transition counts, and clearer failure details.
  * Improved detection of unexpected preview colors and incomplete display transitions.
  * Increased the High Contrast restoration timeout to 20 seconds for more reliable recovery.

* **Documentation**
  * Added a Greptile “War on Bugs” badge to the project README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->