### PR TITLE
ci: make interactive composite dispatch-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,11 +157,11 @@ jobs:
 
   windows-interactive:
     name: Windows 11 Interactive Composite
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      github.event_name == 'schedule' ||
-      github.ref == 'refs/heads/main' ||
-      (github.event_name == 'workflow_dispatch' && inputs.run_interactive_win11)
+    # Dispatch-only: the interactive runner is registered ephemerally for
+    # release validation, so no standing runner exists to serve queued jobs.
+    # Dispatch Test with run_interactive_win11=true and arm the runner to
+    # produce release evidence.
+    if: github.event_name == 'workflow_dispatch' && inputs.run_interactive_win11
     runs-on: [self-hosted, Windows, X64, winghostty-interactive]
     timeout-minutes: 60
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -194,16 +194,21 @@ Recommended order:
 2. Configure or rotate the `release` environment signing secrets.
 3. Run the **Release Readiness** workflow with the target plain semver
    version, for example `1.3.107`.
-4. After readiness passes, either:
+4. Produce interactive evidence for the release SHA: register the
+   self-hosted interactive runner ephemerally, then dispatch the **Test**
+   workflow with `run_interactive_win11=true`. The interactive job runs
+   only on this opted-in dispatch, and the **Release** workflow refuses
+   to publish without its hash-bound evidence at the exact release SHA.
+5. After readiness passes, either:
    - push tag `v<version>`, or
    - manually dispatch the **Release** workflow with `version=<version>`.
-5. Confirm the workflow published artifacts for both x64 and ARM64:
+6. Confirm the workflow published artifacts for both x64 and ARM64:
    - installer
    - portable ZIP
    - `SHA256SUMS-windows-<arch>.txt`
    - legacy x64 `SHA256SUMS.txt`
    - GitHub Release notes/assets
-6. Confirm follow-on publishes:
+7. Confirm follow-on publishes:
    - Scoop manifest update
    - WinGet submission
 

--- a/test/windows/flagship/README.md
+++ b/test/windows/flagship/README.md
@@ -16,10 +16,11 @@ pwsh -File test/windows/flagship/Test-VerificationContracts.ps1
 ```
 
 Hosted Windows CI runs the x64 portable smoke through
-`Invoke-PortableSmoke.ps1`. Same-repository pull requests run the stable GUI
-smoke subset; pushes to `main`, the nightly schedule, and opted-in manual
-dispatches run the full composite on the unlocked self-hosted runner labeled
-`winghostty-interactive`. Fork pull requests never execute on that runner.
+`Invoke-PortableSmoke.ps1`. The full composite runs only on opted-in
+manual dispatches (`run_interactive_win11=true`) on the unlocked
+self-hosted runner labeled `winghostty-interactive`; no standing runner
+exists, so the machine is registered ephemerally when release evidence
+is needed. Fork pull requests never execute on that runner.
 The job fails unless the runner is Windows 11 x64, non-system, attached to the
 active console session with an Explorer shell, on the `Default` input desktop,
 and checked out at the exact workflow SHA. Its name, user, session, exact


### PR DESCRIPTION
## Summary

- The `Windows 11 Interactive Composite` job needs a self-hosted runner that is registered ephemerally (one job, then self-deregistration, per the flagship trust-boundary design). Its PR/main-push/nightly triggers therefore queued jobs that could never start whenever the runner wasn't manually re-armed \u2014 which is how this lane sat dark for days.
- The job is now `workflow_dispatch`-only, gated on `run_interactive_win11=true`. This matches how the release gate already consumes it: `release.yml` requires hash-bound interactive evidence at the exact release SHA, and its failure message already says to dispatch Test with the flag.
- Docs aligned: flagship README describes the dispatch-plus-ephemeral-runner flow, and the PACKAGING release runbook gains an explicit step to produce interactive evidence before tagging.
- Hosted coverage is unchanged: Windows Build And Tests, ARM64, and the x64 Portable Package Smoke still run on every push, PR, and nightly schedule.

## Validation

- [x] `js-yaml` parse of `.github/workflows/test.yml` \u2014 clean
- [x] `pwsh scripts/check-release-copy.ps1` \u2014 passed
- [x] `prettier --check` on changed markdown \u2014 clean
- N/A: zig test suites (workflow + docs change only)

## Risks / Follow-ups

- Interactive evidence is now produced on demand at release time (runner re-arm script lives on the maintainer machine). If a future contributor expects nightly interactive coverage, the flagship README and runbook now say why it's dispatch-only.

## Summary by Sourcery

Restrict the Windows 11 Interactive Composite CI job to manual dispatch with an explicit flag and document its ephemeral self-hosted runner and release-evidence role.

CI:
- Change the Windows 11 Interactive Composite job in test.yml to run only on workflow_dispatch events gated by run_interactive_win11, reflecting its ephemeral runner setup.

Documentation:
- Update the Windows flagship README to describe dispatch-only execution on an ephemeral self-hosted Windows 11 runner for interactive tests.
- Extend the PACKAGING release runbook to require producing interactive evidence via a flagged Test workflow dispatch before tagging and publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows interactive testing to run only through explicitly requested manual workflows.
  * Removed automatic Windows GUI smoke runs from pull requests, scheduled jobs, and main-branch pushes.

* **Documentation**
  * Updated release procedures to require verified Windows interactive test evidence before publishing.
  * Clarified ephemeral runner requirements and manual execution steps for flagship Windows testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->