### PR TITLE
docs: re-baseline status.md and the Windows capability matrix (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ compares it feature by feature with upstream Ghostty.
 
 ## Install
 
-You need Windows 10 or 11, x64 or ARM64, and a GPU driver with OpenGL 4.3 or
-newer. Latest release:
+You need Windows 10 version 1809 (build 17763) or newer, or Windows 11, on
+x64 or ARM64, and a GPU driver with OpenGL 4.3 or newer. Latest release:
 [noctty 1.3.124](https://github.com/amanthanvi/noctty/releases/tag/v1.3.124),
 published 2026-09-02.
 
@@ -110,7 +110,9 @@ defaults. Details are in [docs/windows.md](docs/windows.md).
 ## Build from source
 
 You need Zig 0.15.x (patch 2 or later), Visual Studio 2022 with the MSVC
-toolchain on PATH, and Git for Windows.
+toolchain on PATH, and Git for Windows. Compiling has no build-number
+requirement of its own; running what you build still needs Windows 10 1809
+(build 17763) or newer.
 
 ```powershell
 zig build -Demit-exe=true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
-noctty runs on Windows 10 and 11, x64 and ARM64, and needs a GPU driver with
-OpenGL 4.3 or newer.
+noctty runs on Windows 10 version 1809 (build 17763) or newer and Windows 11,
+x64 and ARM64, and needs a GPU driver with OpenGL 4.3 or newer.
 
 ## Install with Scoop
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -3,7 +3,7 @@
 What works in noctty, what is experimental, and what is out of scope. When
 this page disagrees with a commit message, trust this page.
 
-Last updated: 2026-09-01, against current fork HEAD.
+Last updated: 2026-09-02, against current fork HEAD.
 
 For a row-by-row mapping against official Ghostty docs, including the
 implementation detail this page leaves out, see
@@ -19,7 +19,9 @@ noctty is based on post-`v1.3.1` upstream main (`1.3.2-dev`, `ba398dfff`,
 
 ## Supported platform
 
-- Windows 10 and Windows 11, on x64 and ARM64.
+- Windows 10 version 1809 (build 17763) or newer, and Windows 11, on
+  x64 and ARM64. ConPTY is a static import, so earlier builds fail to load
+  rather than degrade.
 - No macOS, Linux, or cross-platform app runtime ships from this repo.
   `libghostty-vt` stays buildable for non-Windows targets as a library.
 - WSL sessions work from the profile picker. Making WSL the default shell
@@ -51,7 +53,8 @@ Win32-validated VT protocol coverage is tracked in
   falling back to the in-box conhost, which strips Kitty APC and Sixel DCS
   payloads. See
   [windows-vt-conformance.md](windows-vt-conformance.md#conpty-transport-generations-and-mangling-catalog).
-- Native Win32 windows, tab bar with overflow, same-window tab reorder, and
+- Native Win32 windows, tab bar with overflow, a numeric tab overview
+  (`toggle_tab_overview`, no default keybind), same-window tab reorder, and
   exact-pane drag-to-split.
 - Horizontal and vertical splits.
 - Structural undo/redo for new splits, single-tab close (restoring the
@@ -68,13 +71,37 @@ Win32-validated VT protocol coverage is tracked in
   and drives, registered by the installer or explicitly per-user for
   portable builds.
 - Per-monitor DPI scaling.
-- DWM dark title bar that follows the app theme.
+- DWM dark caption that follows the app theme on all supported builds, plus
+  an integrated title bar with native caption actions and Snap Layout hover
+  on Windows 11 while the tab bar and decorations are visible
+  (`window-show-tab-bar = never` and older builds keep the stock caption).
 - High-contrast mode detection and palette switching.
 - IME for CJK and other composed input.
 - A local sensitive-input indicator for no-echo input. `toggle_secure_input`
   is a visual affordance only; it does not block system-wide keyboard hooks
   the way macOS Secure Keyboard Entry does.
-- Drag-and-drop of files into the terminal.
+- Drag-and-drop of files, plain text, URLs, and HTML into a pane. Shift
+  changes file/text handling, Ctrl suppresses file-path quoting, and Alt has
+  no assigned behavior.
+- Per-pane docked scrollback search (`Ctrl+Shift+F`) with regex, case, and
+  whole-word modes, result navigation, and match markers on the scrollbar.
+- Per-pane graphical scrollbars. `scrollbar = system` follows Windows'
+  dynamic-scrollbar preference; `never` hides the widget without disabling
+  scrolling.
+- Clipboard paste confirmation for risky content, including dropped
+  payloads, gated by `clipboard-paste-protection`. HTML copy writes both
+  CF_HTML and a plain-text fallback.
+- A configurable quick terminal on an edge or the center of the selected
+  monitor. It has no default binding; `global:` keybinds use
+  `RegisterHotKey`. `exclusive` keyboard interactivity falls back to focused
+  input, and `quick-terminal-space-behavior` has no Windows effect.
+- WinRT Action Center notifications with an in-app banner/log fallback,
+  gated by `desktop-notifications`. Command-finish toasts also need
+  `notify-on-command-finish` and a `notify` action, and are the only toasts
+  that focus the originating pane when clicked; OSC 9 / OSC 777 toasts are
+  display-only.
+- Taskbar progress for the active pane in each host window, driven by
+  terminal progress reports when `progress-style` is enabled.
 - Session restore via `window-save-state`: windows, tabs, splits, profiles,
   working directories, and explicit titles come back; child processes do
   not. The opt-in `window-save-state-scrollback` line count also restores
@@ -99,6 +126,9 @@ Win32-validated VT protocol coverage is tracked in
   open, or protected paste.
 - Copy mode (`Ctrl+Shift+X`): modal vi-style selection and scrollback
   navigation, with keyboard copy/cancel and no PTY input leakage.
+- Opt-in Job Object limits for Windows-local child processes through the
+  retained `linux-cgroup*` keys and `windows-job-object-kill-on-close`. Off
+  by default; WSL process trees are not covered.
 
 ### Performance measurement
 
@@ -189,6 +219,17 @@ flag toggles, and the docked search query edit do not announce their role,
 state, or name. Per-widget expectations, what the automated UIA harness
 proves, and per-reader results are in
 [accessibility-matrix.md](accessibility-matrix.md).
+
+### Link previews
+
+`link-previews` is parsed and the shared core emits link-hover preview
+actions, but the Win32 runtime does not render the preview tooltip. Link
+matching, hover highlighting, and opening work.
+
+### Status bar
+
+Not shipping. `Host.statusBarHeight()` returns 0, so no terminal rows are
+reserved; host banners and overlays carry transient status instead.
 
 ### Win32 runtime extraction
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -5,7 +5,7 @@ Windows. Cells stay short; rows with real nuance point into the
 [Notes](#notes) section below. Update rows when Windows behavior changes or
 when upstream docs add or remove a surface that this fork cares about.
 
-Last reviewed: 2026-08-21.
+Last reviewed: 2026-09-02.
 
 ## Status legend
 
@@ -25,8 +25,11 @@ Last reviewed: 2026-08-21.
 | [Color Theme](https://ghostty.org/docs/features/theme)                                                             | Built-in themes, separate light/dark themes, custom themes, and `+list-themes` ship on Windows.                                                                                                                             |
 | [Configuration: `background-opacity`](https://ghostty.org/docs/config/reference)                                   | Transparent terminal backgrounds work on Windows and can be toggled live.                                                                                                                                                   |
 | [Terminal API (VT)](https://ghostty.org/docs/vt) and [VT reference](https://ghostty.org/docs/vt/reference)         | The shared Ghostty terminal core carries the documented VT/OSC surface; child-to-terminal delivery also depends on the selected ConPTY. See [ConPTY transport](#conpty-transport).                                          |
-| Kitty graphics protocol                                                                                            | Parser and renderer support ship, but child APC delivery depends on ConPTY. The bundled source passed the measured payload byte-exactly; the tested in-box fallback stripped it. See [ConPTY transport](#conpty-transport). |
 | [Features overview: windows, tabs, and splits](https://ghostty.org/docs/features)                                  | Native Win32 windows, tabs, and splits ship today in noctty.                                                                                                                                                                |
+| [Configuration: `scrollbar`](https://ghostty.org/docs/config/reference)                                            | Per-pane graphical scrollbars honor `system` (Windows dynamic-scrollbar preference) or `never`; search matches appear as markers. See [search and scrollbars](#search-and-scrollbars).                                      |
+| [Configuration: `clipboard-paste-protection`](https://ghostty.org/docs/config/reference)                           | Risky clipboard and dropped-content pastes use a native confirmation. See [clipboard and drag-drop](#clipboard-and-drag-drop).                                                                                              |
+| [Action reference: `copy_to_clipboard:html`](https://ghostty.org/docs/config/keybind/reference)                    | HTML copy writes CF_HTML and a plain-text fallback in one clipboard transaction.                                                                                                                                            |
+| Kitty graphics protocol                                                                                            | Parser and renderer support ship, but child APC delivery depends on ConPTY. The bundled source passed the measured payload byte-exactly; the tested in-box fallback stripped it. See [ConPTY transport](#conpty-transport). |
 
 ## Partial
 
@@ -40,16 +43,18 @@ Last reviewed: 2026-08-21.
 | [Configuration: `background-blur`](https://ghostty.org/docs/config/reference)                | Windows 11 22H2+ with `background-opacity < 1` requests the DWM tabbed backdrop; accepted but inert on Windows 10 and 11 21H2. Radii are treated as on/off.                                                                                                                                        |
 | [Features overview](https://ghostty.org/docs/features)                                       | Accessibility is partial: UI Automation covers the daily chrome and terminal text, but caption buttons, overlay rows, and menus are uncovered. Only NVDA has been measured, with mixed results. See [accessibility notes](#accessibility) and the [screen-reader matrix](accessibility-matrix.md). |
 | OSC 52 primary/selection clipboard selectors                                                 | Windows has one native clipboard: writes with selectors `c`, `s`, and `p` all target it; read replies still echo the requested selector.                                                                                                                                                           |
+| [Configuration: `link-previews`](https://ghostty.org/docs/config/reference)                  | Link matching, highlighting, and opening work, but the Win32 runtime does not render the preview tooltip.                                                                                                                                                                                          |
 
 ## Windows-Specific
 
 | Ghostty docs surface                                                              | noctty note                                                                                                                                                                                                          |
 | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Features overview](https://ghostty.org/docs/features)                            | Upstream docs still say Windows support is planned. noctty ships a native Win32 app on Windows 10/11 x64 and ARM64.                                                                                                  |
+| [Features overview](https://ghostty.org/docs/features)                            | Upstream docs still say Windows support is planned. noctty ships a native Win32 app on Windows 10 1809 (build 17763) or newer and Windows 11, x64 and ARM64.                                                         |
 | [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Terminal content renders with OpenGL 4.3+ via WGL. See [renderer notes](#renderer).                                                                                                                                  |
 | [Configuration](https://ghostty.org/docs/config)                                  | Windows state/config paths live under `%LOCALAPPDATA%\noctty\...`, not the macOS/Linux paths documented upstream.                                                                                                    |
 | Local automation                                                                  | Versioned JSON state and stable local verbs for windows, tabs, splits, focus, policy-allowed actions, and control-free text. See [automation.md](automation.md).                                                     |
-| [Features overview](https://ghostty.org/docs/features)                            | Win32-specific UX: DWM dark title bar, high-contrast palette switching, IME, drag-and-drop, and native context menus.                                                                                                |
+| [Features overview](https://ghostty.org/docs/features)                            | Win32-specific UX: DWM dark caption, high-contrast palette switching, IME, and native context menus.                                                                                                                 |
+| Integrated title bar                                                              | Windows 11 uses app-owned caption chrome with native caption actions and Snap Layout hover while the tab bar and decorations are visible; `window-show-tab-bar = never` and older builds use the stock caption.      |
 | Universal palette                                                                 | One blended, fuzzy-ranked command surface. See [universal palette notes](#universal-palette).                                                                                                                        |
 | Named layouts                                                                     | Saves one window's tab/split/profile/cwd/title shape and materializes it in a new window from keybind, palette, or CLI.                                                                                              |
 | Quick select and copy mode                                                        | Visible regex targets plus modal keyboard selection and scrollback navigation. See [windows.md](windows.md#quick-select--copy-mode).                                                                                 |
@@ -59,6 +64,13 @@ Last reviewed: 2026-08-21.
 | SSH host discovery                                                                | Concrete aliases from `%USERPROFILE%\.ssh\config` appear as system `ssh.exe` launch entries in the picker and palette.                                                                                               |
 | Windows default terminal                                                          | `+register-default-terminal` selects noctty per user through the Windows Terminal 1.24-or-newer OpenConsole handoff; see [windows.md](windows.md#default-terminal).                                                  |
 | Taskbar jump lists                                                                | Recent working directories and detected shell profiles launch from the pinned or running taskbar button. See [taskbar jump list](windows.md#taskbar-jump-list).                                                      |
+| Quick terminal and global hotkeys                                                 | Configurable edge/center terminal toggled by a bindable action; `global:` bindings use `RegisterHotKey`. See [quick terminal](#quick-terminal).                                                                      |
+| Desktop notifications                                                             | WinRT Action Center toasts with a local fallback; only command-finish toasts have a click action. See [notifications and progress](#notifications-and-progress).                                                     |
+| Taskbar progress                                                                  | Terminal progress reports drive the active pane's taskbar indicator when `progress-style` is enabled. See [notifications and progress](#notifications-and-progress).                                                 |
+| Docked search                                                                     | Each pane has a docked scrollback search with regex, case, whole-word, navigation, and scrollbar markers. See [search and scrollbars](#search-and-scrollbars).                                                       |
+| Tab overview                                                                      | The bindable `toggle_tab_overview` action opens a numeric tab switcher; it has no default keybind.                                                                                                                   |
+| Drag and drop                                                                     | Each pane accepts files, plain text, URLs, and HTML. See [clipboard and drag-drop](#clipboard-and-drag-drop).                                                                                                        |
+| Opt-in child-process limits                                                       | Retained `linux-cgroup*` keys map to Job Objects for Windows-local children only. See [child-process limits](#child-process-limits).                                                                                 |
 
 ## Notes
 
@@ -142,12 +154,66 @@ redo restore exact tab, pane, split-tree, ratio, and focus identity. The
 universal palette provides the equivalent keyboard workflow. Cross-window
 OLE transfer is not shipped.
 
+### Quick terminal
+
+No default keybind. Bind `toggle_quick_terminal`; add the `global:` prefix
+for a system-wide hotkey while noctty is running. Windows can reject a
+reserved or conflicting trigger. Position, size, monitor, animation,
+autohide, and focus behavior are configurable. `exclusive` maps to focused
+input, and `quick-terminal-space-behavior` has no Windows effect.
+
+### Notifications and progress
+
+WinRT toasts use noctty's AppUserModelID and fall back to a host banner, then
+the log, when native delivery fails. `desktop-notifications` gates every
+toast. Command-finish toasts additionally need `notify-on-command-finish` and
+a `notify-on-command-finish-action` that includes `notify`; they are the only
+toasts that carry a launch argument, so only they focus the originating pane
+when clicked. OSC 9 / OSC 777 toasts are display-only. Reliable cold-start
+activation depends on the installed Start menu shortcut.
+
+With `progress-style = true`, terminal progress reports map to normal, paused,
+error, or indeterminate taskbar states for the active pane in each host. If
+the taskbar COM interface fails, noctty disables the native indicator.
+
+### Search and scrollbars
+
+`Ctrl+Shift+F` opens search for the focused pane. Search state and controls
+are per pane; results can mark the graphical scrollbar. `scrollbar = system`
+respects Windows' dynamic-scrollbar preference; `never` removes only the
+visual widget.
+
+### Clipboard and drag-drop
+
+`clipboard-paste-protection` controls confirmation for unsafe clipboard
+pastes and the stricter dropped-payload classifier. CF_HTML copies also place
+a plain-text fallback on the clipboard. Dropped files, text, URLs, and HTML
+are converted to terminal input. Shift changes file/text handling, Ctrl
+suppresses file-path quoting, and Alt is reserved.
+
+### Child-process limits
+
+The retained `linux-cgroup`, `linux-cgroup-memory-limit`,
+`linux-cgroup-processes-limit`, and `linux-cgroup-hard-fail` keys opt
+Windows-local launches into Job Object enforcement. Off by default;
+best-effort failures continue without limits unless hard-fail is set.
+`windows-job-object-kill-on-close` is also opt-in. WSL launches are excluded.
+
 ## Maintenance Anchors
 
-- `src/config/Config.zig` — config docs, keybinds, `auto-update` docstrings.
+- `src/config/Config.zig` — config docs, keybinds, feature gates, and limits.
 - `src/termio/shell_integration.zig` and `src/config/windows_shell.zig` —
   shell integration and Windows shell detection.
-- `src/apprt/win32.zig`, `src/apprt/win32_theme.zig`, and
-  `src/apprt/win32_uia/` — Win32 runtime, chrome/input, accessibility.
+- `src/apprt/win32.zig`, `src/apprt/win32_quick_terminal.zig`,
+  `src/apprt/win32_search_bar.zig`, and
+  `src/apprt/win32_scrollbar_geometry.zig` — Win32 runtime and interactive UI.
+- `src/apprt/win32_toast_winrt.zig`, `src/apprt/win32_toast_activation.zig`,
+  `src/apprt/win32_aumid.zig`, and `src/apprt/win32_taskbar_progress.zig` —
+  notifications and shell progress.
+- `src/apprt/win32_clipboard_html.zig`, `src/apprt/win32_paste_protection.zig`,
+  `src/apprt/win32_surface_drop_target.zig`, and
+  `src/apprt/win32_job_object.zig` — clipboard, drop, and process limits.
+- `src/apprt/win32_theme.zig` and `src/apprt/win32_uia/` — theme policy and
+  accessibility providers.
 - `docs/status.md` and `docs/getting-started.md` — user-facing summaries that
   should stay aligned with this matrix.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -8,7 +8,10 @@ protocol coverage validated on the Win32 runtime, see
 
 ## Supported systems
 
-- Windows 10 and Windows 11 on x64 and ARM64.
+- Windows 10 version 1809 (build 17763) or newer, and Windows 11, on x64
+  and ARM64. 1809 is a hard floor: `CreatePseudoConsole` is a static
+  `kernel32` import, so an earlier build refuses to start the process rather
+  than degrading.
 - Native Win32 application runtime.
 - OpenGL 4.3 or newer through WGL.
 - `libghostty-vt` stays portable as a library. This repository does not
@@ -271,10 +274,17 @@ package.
 
 Desktop notifications use WinRT toasts when available and fall back to
 in-app banners when Windows notification policy, Focus Assist, app identity,
-or runtime availability prevents a toast. Terminal progress reports map to
-Windows taskbar progress for the active surface in each host window.
-Terminal apps can also set in-terminal progress state through Ghostty's
-shared VT/OSC support.
+or runtime availability prevents a toast. `desktop-notifications` gates every
+toast, including command-finish toasts, which additionally need
+`notify-on-command-finish` and a `notify-on-command-finish-action` that
+includes `notify`. Only command-finish toasts focus the originating pane when
+clicked; OSC 9 and OSC 777 toasts are display-only.
+
+Terminal progress reports map to Windows taskbar progress for the active
+surface in each host window when `progress-style` is enabled; with
+`progress-style = false` the sequences are silently ignored. Terminal apps
+can also set in-terminal progress state through Ghostty's shared VT/OSC
+support.
 
 ## Power and battery
 
@@ -368,9 +378,17 @@ everything.
 The native Win32 host window provides a tab bar with overflow handling,
 same-window drag reorder, and exact-pane drag-to-split with reversible
 subtree transfer; horizontal and vertical splits; per-monitor DPI handling;
-DWM dark title bar integration; high-contrast palette switching; IME
-support; drag-and-drop of files into the terminal; and native right-click
-context menus.
+a DWM dark caption; high-contrast palette switching; IME support;
+drag-and-drop of files, plain text, URLs, and HTML into a pane; and native
+right-click context menus.
+
+The dark caption is chosen at runtime, not by build number:
+`DWMWA_USE_IMMERSIVE_DARK_MODE` (20) is tried first and the legacy attribute
+(19) is used when DWM rejects it. Windows 11 additionally gets an integrated
+title bar (app-owned caption with native caption actions and Snap Layout
+hover) while the tab bar and window decorations are visible;
+`window-show-tab-bar = never` or hidden decorations fall back to the stock
+caption, as do older builds.
 
 The universal palette puts actions, live tabs, panes, Windows profiles,
 named layouts, and native settings in one fuzzy-ranked, keyboard-driven


### PR DESCRIPTION
Re-baselines `docs/status.md` and `docs/windows-capability-matrix.md` against a module-by-module audit of `src/apprt/` (68 files). Every added or corrected row was verified against live wiring in `src/apprt/win32.zig` plus its config surface in `src/config/Config.zig` — no rows were written from memory or from the issue text.

The docs materially undersold the product in some places and oversold it in two others; both directions are corrected.

Fixes #120

## State of this branch

- Base branch: `main`. Rebased onto `13e07ba35` (`release: RFC3161 timestamping and a preflight timestamp gate (#137) (#208)`).
- Two commits: `bb2c779ea` (reflow `docs/windows-capability-matrix.md` for Prettier) and `d84d2243e` (the re-baseline itself).
- Re-authored on top of the docs debloat (#206, `e3a38268e`), so the prose is shorter than earlier rounds of this PR. Every factual correction below survived the re-authoring; none of the paragraphs #206 deleted were restored.
- #156 (`issues/135-ghostty-13-win32-audit`) and then #162 (`issues/122-gpu-floor`) are stacked on this branch and must merge after it.

## Changes

Newly documented, each verified as actually shipping and wired:

- Quick terminal, including `global:` bindings registered through `RegisterHotKey`, with the real limits stated (`exclusive` maps to focused input; `quick-terminal-space-behavior` is stored but never read, so virtual-desktop following does not work).
- WinRT Action Center toasts with click-to-focus activation and in-app banner/log fallback.
- Windows taskbar progress for the active pane, gated by `progress-style`.
- Per-pane docked scrollback search (regex / case / whole-word, navigation, scrollbar match markers).
- Per-pane graphical scrollbars and what `scrollbar = system` vs `never` actually do.
- Clipboard paste protection and CF_HTML copy.
- Full drag-and-drop surface: files, plain text, URLs, HTML, plus the Shift/Ctrl/Alt modifier semantics.
- The `toggle_tab_overview` action (no default keybind).
- Opt-in Job Object child-process limits behind the retained `linux-cgroup*` keys.

Corrected in the other direction — the issue assumed these ship, the code says otherwise:

- **Link previews** are documented as not shipped. `win32_link_preview.HoverTracker` is constructed (`win32.zig:3639`, `:30159`) but never driven or rendered.
- **The status bar** is deliberately not documented as shipping. `Host.statusBarHeight()` returns `0` unconditionally (`win32.zig:16362`) and every paint path early-returns on it.

Also corrected: accessibility wording states the real bounded-history limits (500 rows / 40,000 cells, `win32_uia/text.zig:117-118`); the title-bar rows distinguish the Windows 11 integrated caption from the stock caption; `Maintenance Anchors` updated; `Last updated` / `Last reviewed` refreshed.

Gate conditions added in review rounds, all now stated on every page that mentions the feature:

- **Integrated title bar.** `shouldUseIntegratedTitlebar` (`win32.zig:411-416`) returns `os_build >= OS_BUILD_WIN11_21H2 and show_tab_bar != .never`, and `usesIntegratedTitlebar` (`:600`) additionally requires the tab bar and decorations to be visible. The OS version alone never enables the integrated caption.
- **Command-finish toasts.** `App.commandFinishPlan` (`win32.zig:9528-9549`) computes `.notify = notify_on_command_finish_action.notify and desktop_notifications`, so `desktop-notifications = false` suppresses them regardless of the command-finish settings.
- **Dark caption is not Windows 11 only.** `win32_theme.applyWindow` sets `DWMWA_USE_IMMERSIVE_DARK_MODE` unconditionally with a `_V1` fallback, so the stock caption on older builds is still dark-themed.

Also changed, outside the two reference pages:

- `README.md:51` and `docs/getting-started.md:3` now state the Windows 10 version 1809 (build 17763) floor instead of "Windows 10 and 11"; `README.md:113-115` records that compiling from source has no build-number requirement of its own.
- `docs/windows.md` carries the floor and its cause (`CreatePseudoConsole` is a static `kernel32` import, so an earlier build refuses to start the process rather than degrading), the notification and progress gates, the runtime dark-caption selection, the integrated-title-bar condition, and the full drag-and-drop payload list.

## Validation

Run on `d84d2243e` (rebased onto `13e07ba35`), Windows 11, clean worktree:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4171 passed; 71 skipped; 0 failed |
| `scripts/check-zig-format.ps1` | passed (696 tracked sources) |
| `scripts/check-source-format.ps1` | passed |
| `scripts/check-release-copy.ps1` | "Release copy checks passed." |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| `npx prettier@3 --check` on all five changed files | all clean |
| `git diff --name-only origin/main...HEAD -- src` | empty (docs-only change) |

`npx prettier@3 --check "docs/*.md"` still reports `docs/accessibility-inventory.md`, `docs/accessibility-matrix.md`, `docs/windows-benchmark-methodology.md` and `docs/wt-chrome-reference.md`. None of those four are touched by this PR and all four are already dirty at `origin/main`. `README.md` and `docs/getting-started.md` were in that list in earlier rounds; #206 reformatted them, so they are clean at `origin/main` and this PR keeps them clean.

Spot-checks against source, independent of the implementing agent — all reconfirmed on the rebased tree: `statusBarHeight` returns 0 (`win32.zig:16362`); `toggleTabOverview` exists (`win32.zig:26511`); `linux-cgroup` is a Job Object input (`Config.zig:3149`); `progress-style` gates progress (`Config.zig:3238`); no default `toggle_quick_terminal` binding; `Ctrl+Shift+F` is the real default for `start_search` (`Config.zig:6504`); UIA limits are 500 / 40_000 (`win32_uia/text.zig:117-118`); drop modifier semantics match `win32_surface_drop.zig:8-12`; `space_behavior` is set at `win32.zig:8761` and read nowhere (`win32_quick_terminal.zig:67` stores it and no consumer exists); the universal palette label is literally "Recent commands" (`win32_universal_palette.zig:71`).

## Residuals / user steps

- Static wiring audit only. WinRT cold-start activation, OS hotkey reservation, taskbar COM behavior, Snap Layout hover, and Narrator/NVDA behavior were not exercised interactively.
- The repository-wide `npx prettier --check "docs/*.md"` cannot go green until the four pre-existing files above are reformatted. Deliberately out of scope here.
- Link previews and the status bar are documented as not-shipping. If either is meant to ship, that is a separate feature issue.

## Summary by Sourcery

Align Windows documentation with the implemented runtime and configuration behavior.

Bug Fixes:
- Correct the documented Windows support floor to Windows 10 version 1809 (build 17763) or newer.
- Correct capability claims for unsupported link previews, the non-shipping status bar, notification activation, title-bar behavior, accessibility limits, and taskbar progress gating.

Enhancements:
- Re-baseline Windows status and capability documentation against the implemented Win32 runtime, covering shipped quick terminal, notifications, taskbar progress, search, scrollbars, clipboard and drag-and-drop, tab overview, and opt-in child-process limits.
- Refresh Windows-specific capability notes, maintenance anchors, and review dates.

Documentation:
- Update installation and Windows documentation with the Windows 10 version floor and clarify that source compilation has no separate build-number requirement.

Tests:
- Validate formatting for the changed documentation and audit documented Windows capabilities against the source and configuration surfaces.

Bug Fixes:

- Correct documented Windows support to require Windows 10 version 1809 (build 17763) or newer.
- Correct capability claims for unsupported link previews, the non-shipping status bar, notification activation scope, title-bar behavior, accessibility limits, and taskbar progress gating.

Enhancements:

- Re-baseline the Windows status and capability documentation against the Win32 runtime and configuration surfaces, documenting shipped quick terminal, notifications, taskbar progress, search, scrollbars, clipboard and drag-and-drop support, tab overview, and opt-in child-process limits.
- Refresh Windows-specific capability notes, maintenance anchors, and review dates across the status, capability matrix, and Windows documentation.

Documentation:

- Update installation and build requirements with the Windows 10 version floor and clarify that source compilation has no separate build-number requirement.

Tests:

- Validate formatting for the changed documentation and perform a source-based module audit of the documented Windows capabilities.

---

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.