### PR TITLE
apprt/win32: audit Ghostty 1.3 surfaces and fix two input-path gaps (#135)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -38,6 +38,8 @@ noctty is based on post-`v1.3.1` upstream main (`1.3.2-dev`, `ba398dfff`,
   OSC 52 selectors target the single native Windows clipboard).
 - Bidi, combining marks, grapheme cluster rendering.
 - Kitty graphics protocol and inline image display.
+- Kitty keyboard protocol with press, repeat, and release events, Caps Lock
+  and Num Lock state, and left/right modifier identity.
 - Shell integration for bash, zsh, fish, elvish, nushell, and PowerShell
   (PowerShell through `shell-integration = detect`). `cmd.exe` is a plain
   fallback without prompt/cwd/command-finish integration.
@@ -90,7 +92,9 @@ Win32-validated VT protocol coverage is tracked in
   scrolling.
 - Clipboard paste confirmation for risky content, including dropped
   payloads, gated by `clipboard-paste-protection`. HTML copy writes both
-  CF_HTML and a plain-text fallback.
+  CF_HTML and a plain-text fallback. `clipboard-codepoint-map` applies to
+  plain, VT, and HTML selection copies; clipboard reads, URL copies, OSC 52
+  writes, and `write_screen_file` exports are not mapped.
 - A configurable quick terminal on an edge or the center of the selected
   monitor. It has no default binding; `global:` keybinds use
   `RegisterHotKey`. `exclusive` keyboard interactivity falls back to focused
@@ -99,7 +103,8 @@ Win32-validated VT protocol coverage is tracked in
   gated by `desktop-notifications`. Command-finish toasts also need
   `notify-on-command-finish` and a `notify` action, and are the only toasts
   that focus the originating pane when clicked; OSC 9 / OSC 777 toasts are
-  display-only.
+  display-only. Command-finish toasts depend on OSC 133 command marks, which
+  `cmd.exe` does not supply.
 - Taskbar progress for the active pane in each host window, driven by
   terminal progress reports when `progress-style` is enabled.
 - Session restore via `window-save-state`: windows, tabs, splits, profiles,
@@ -112,6 +117,8 @@ Win32-validated VT protocol coverage is tracked in
 - Ctrl-based default keybindings, mostly shared with Ghostty's non-macOS
   defaults. Windows-specific exceptions include `Alt+Arrow` pane focus and
   `Alt+F4` to close the window.
+- `key-remap` applies to focused and in-app keybinds and to terminal
+  encoding, but not to `global:` hotkeys, which register the literal chord.
 - Native settings window (Appearance, Terminal, Shell, Privacy, Updates,
   Keybindings, Advanced) that stages edits until Save and patches your
   config without rewriting unrelated text.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -24,9 +24,12 @@ Last reviewed: 2026-09-02.
 | [Custom keybindings](https://ghostty.org/docs/config/keybind)                                                      | Same `keybind = trigger=action` grammar and `+list-keybinds` flow; defaults are the shared non-macOS set with Windows-specific exceptions.                                                                                  |
 | [Color Theme](https://ghostty.org/docs/features/theme)                                                             | Built-in themes, separate light/dark themes, custom themes, and `+list-themes` ship on Windows.                                                                                                                             |
 | [Configuration: `background-opacity`](https://ghostty.org/docs/config/reference)                                   | Transparent terminal backgrounds work on Windows and can be toggled live.                                                                                                                                                   |
-| [Terminal API (VT)](https://ghostty.org/docs/vt) and [VT reference](https://ghostty.org/docs/vt/reference)         | The shared Ghostty terminal core carries the documented VT/OSC surface; child-to-terminal delivery also depends on the selected ConPTY. See [ConPTY transport](#conpty-transport).                                          |
+| [Terminal API (VT)](https://ghostty.org/docs/vt) and [VT reference](https://ghostty.org/docs/vt/reference)         | The shared Ghostty terminal core carries the documented VT/OSC/Kitty surface. Win32-validated coverage: [windows-vt-conformance.md](windows-vt-conformance.md).                                                             |
+| [Kitty keyboard protocol](https://ghostty.org/docs/vt)                                                             | Win32 supplies press, repeat, release, lock, and sided modifier state to the shared encoder. See [keyboard input](#keyboard-input).                                                                                         |
 | [Features overview: windows, tabs, and splits](https://ghostty.org/docs/features)                                  | Native Win32 windows, tabs, and splits ship today in noctty.                                                                                                                                                                |
 | [Configuration: `scrollbar`](https://ghostty.org/docs/config/reference)                                            | Per-pane graphical scrollbars honor `system` (Windows dynamic-scrollbar preference) or `never`; search matches appear as markers. See [search and scrollbars](#search-and-scrollbars).                                      |
+| [Configuration: `notify-on-command-finish`](https://ghostty.org/docs/config/reference)                             | Focus policy, duration threshold, and bell/`notify` actions are applied; `notify` also needs `desktop-notifications`. See [notifications and progress](#notifications-and-progress).                                        |
+| [Configuration: `clipboard-codepoint-map`](https://ghostty.org/docs/config/reference)                              | Selection copies apply the map before the clipboard write. See [clipboard and drag-drop](#clipboard-and-drag-drop).                                                                                                         |
 | [Configuration: `clipboard-paste-protection`](https://ghostty.org/docs/config/reference)                           | Risky clipboard and dropped-content pastes use a native confirmation. See [clipboard and drag-drop](#clipboard-and-drag-drop).                                                                                              |
 | [Action reference: `copy_to_clipboard:html`](https://ghostty.org/docs/config/keybind/reference)                    | HTML copy writes CF_HTML and a plain-text fallback in one clipboard transaction.                                                                                                                                            |
 | Kitty graphics protocol                                                                                            | Parser and renderer support ship, but child APC delivery depends on ConPTY. The bundled source passed the measured payload byte-exactly; the tested in-box fallback stripped it. See [ConPTY transport](#conpty-transport). |
@@ -44,6 +47,7 @@ Last reviewed: 2026-09-02.
 | [Features overview](https://ghostty.org/docs/features)                                       | Accessibility is partial: UI Automation covers the daily chrome and terminal text, but caption buttons, overlay rows, and menus are uncovered. Only NVDA has been measured, with mixed results. See [accessibility notes](#accessibility) and the [screen-reader matrix](accessibility-matrix.md). |
 | OSC 52 primary/selection clipboard selectors                                                 | Windows has one native clipboard: writes with selectors `c`, `s`, and `p` all target it; read replies still echo the requested selector.                                                                                                                                                           |
 | [Configuration: `link-previews`](https://ghostty.org/docs/config/reference)                  | Link matching, highlighting, and opening work, but the Win32 runtime does not render the preview tooltip.                                                                                                                                                                                          |
+| [Configuration: `key-remap`](https://ghostty.org/docs/config/reference)                      | Focused and in-app keybinds plus terminal encoding honor remaps; `global:` hotkeys keep the literal configured chord. See [keyboard input](#keyboard-input).                                                                                                                                       |
 
 ## Windows-Specific
 
@@ -98,6 +102,23 @@ that:
   does not auto-install remote terminfo; uncached hosts use
   `xterm-256color`.
 - `cmd.exe` remains a plain fallback shell without automatic integration.
+
+### Keyboard input
+
+The Win32 path supplies press, repeat, and release events to the shared Kitty
+encoder, with Caps Lock, Num Lock, and left/right modifier state on every
+physical event. While a client has Kitty `report_all` enabled, ordinary keys
+carry their text on the physical event instead of the `WM_CHAR` commit, so
+press and release keep one identity; AltGr chords ride the same path with the
+synthetic Ctrl+Alt collapsed, a dead key stays composing until its composed
+character arrives, and a dead key that cannot combine delivers both
+characters. IME commits remain text without a physical key. These paths have
+unit coverage but have not been exercised on a real non-US keyboard.
+
+`key-remap` changes modifier state before focused or in-app keybind matching
+and terminal encoding; it does not change physical key identity. `global:`
+bindings register the literal configured chord through `RegisterHotKey`, so
+remaps do not retarget system-wide hotkeys.
 
 ### Accessibility
 
@@ -171,6 +192,9 @@ a `notify-on-command-finish-action` that includes `notify`; they are the only
 toasts that carry a launch argument, so only they focus the originating pane
 when clicked. OSC 9 / OSC 777 toasts are display-only. Reliable cold-start
 activation depends on the installed Start menu shortcut.
+`notify-on-command-finish-after` and the focus policy are applied before the
+bell or toast; command marks come from shell integration or OSC 133, which
+`cmd.exe` does not supply.
 
 With `progress-style = true`, terminal progress reports map to normal, paused,
 error, or indeterminate taskbar states for the active pane in each host. If
@@ -180,8 +204,8 @@ the taskbar COM interface fails, noctty disables the native indicator.
 
 `Ctrl+Shift+F` opens search for the focused pane. Search state and controls
 are per pane; results can mark the graphical scrollbar. `scrollbar = system`
-respects Windows' dynamic-scrollbar preference; `never` removes only the
-visual widget.
+respects Windows' dynamic-scrollbar preference and stays visible in High
+Contrast; `never` removes only the visual widget.
 
 ### Clipboard and drag-drop
 
@@ -190,6 +214,10 @@ pastes and the stricter dropped-payload classifier. CF_HTML copies also place
 a plain-text fallback on the clipboard. Dropped files, text, URLs, and HTML
 are converted to terminal input. Shift changes file/text handling, Ctrl
 suppresses file-path quoting, and Alt is reserved.
+
+`clipboard-codepoint-map` is applied by the shared selection formatter before
+plain, VT, or HTML bytes reach the clipboard. Clipboard reads, URL copies,
+OSC 52 writes, and `write_screen_file` exports are not mapped.
 
 ### Child-process limits
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -380,6 +380,13 @@ AltGr, the modifier state noctty reads cannot tell the two apart, so left
 Ctrl plus right Alt is always read as AltGr there; use left Alt or right
 Ctrl for a deliberate Ctrl+Alt chord.
 
+While a program has the Kitty keyboard protocol's `report_all` flag enabled,
+typed text travels on the physical key event rather than a separate character
+commit, so the press and release a program pairs share one key identity. This
+includes AltGr characters and dead-key sequences. `key-remap` affects
+keybinds and terminal encoding but not `global:` hotkeys, which register the
+literal chord you configured.
+
 Console applications reached through ConPTY see these sequences through
 conhost's own decoder, which does not translate every form back into a
 console key record. `[Console]::ReadKey()` therefore reports less than the

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2761,8 +2761,8 @@ fn copySelectionToClipboards(
             formatter.content = .{ .selection = sel };
             try formatter.format(&aw.writer);
 
-            // Note: We don't apply codepoint mappings to VT format since it contains
-            // escape sequences that should be preserved as-is
+            // Codepoint mappings affect terminal cell text; formatter-generated
+            // VT escape sequences are preserved as-is.
             try contents.append(alloc, .{
                 .mime = "text/plain",
                 .data = try aw.toOwnedSliceSentinel(0),
@@ -2778,8 +2778,7 @@ fn copySelectionToClipboards(
             formatter.content = .{ .selection = sel };
             try formatter.format(&aw.writer);
 
-            // Note: We don't apply codepoint mappings to HTML format since HTML
-            // has its own character encoding and entity system
+            // Codepoint mappings are applied before HTML encoding.
             try contents.append(alloc, .{
                 .mime = "text/html",
                 .data = try aw.toOwnedSliceSentinel(0),
@@ -2797,7 +2796,7 @@ fn copySelectionToClipboards(
             });
 
             assert(aw.written().len == 0);
-            // Second, generate HTML without codepoint mappings
+            // Second, generate HTML with the same codepoint mappings.
             formatter = .init(self.io.terminal.screens.active, opts: {
                 var copy = opts;
                 copy.emit = .html;
@@ -2813,7 +2812,6 @@ fn copySelectionToClipboards(
             formatter.content = .{ .selection = sel };
             try formatter.format(&aw.writer);
 
-            // Note: We don't apply codepoint mappings to HTML format
             try contents.append(alloc, .{
                 .mime = "text/html",
                 .data = try aw.toOwnedSliceSentinel(0),

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -13095,8 +13095,12 @@ const Host = struct {
         lParam: LPARAM,
     ) bool {
         if (self.activeSurface() != null) return false;
-        const message = keyEventFromWin32Message(msg, wParam, lParam) orelse return false;
-        return self.app.core_app.keyEvent(self.app, message.event);
+        var message = keyEventFromWin32Message(msg, wParam, lParam, true) orelse return false;
+        message.bindText();
+        // `App.keyEvent` does not apply `key-remap` itself; only
+        // `Surface.keyCallback` does, and there is no surface here.
+        const event = remapWin32KeyEvent(message.event, &self.app.config.@"key-remap");
+        return self.app.core_app.keyEvent(self.app, event);
     }
 
     fn prepareActiveTabVisibility(self: *Host, active_index: usize) void {
@@ -13519,13 +13523,13 @@ const Host = struct {
         lParam: LPARAM,
     ) bool {
         if (self.overlay_mode != .command_palette) return false;
-        const event = (keyEventFromWin32Message(msg, wParam, lParam) orelse return false).event;
-        const entry = self.app.config.keybind.set.getEvent(event) orelse return false;
-        const actions: []const input.Binding.Action = switch (entry.value_ptr.*) {
-            .leader => return false,
-            inline .leaf, .leaf_chained => |leaf| leaf.generic().actionsSlice(),
-        };
-        return bindingActionsToggleCommandPalette(actions);
+        var message = keyEventFromWin32Message(msg, wParam, lParam, true) orelse return false;
+        message.bindText();
+        return keyEventTogglesCommandPalette(
+            message.event,
+            &self.app.config.keybind.set,
+            &self.app.config.@"key-remap",
+        );
     }
 
     fn reloadProfiles(self: *Host) !bool {
@@ -21999,6 +22003,8 @@ const windowTitleSyncChanged = labels.windowTitleSyncChanged;
 const scrollStatusTextChanged = labels.scrollStatusTextChanged;
 
 const bindingActionsToggleCommandPalette = labels.bindingActionsToggleCommandPalette;
+const remapWin32KeyEvent = labels.remapWin32KeyEvent;
+const keyEventTogglesCommandPalette = labels.keyEventTogglesCommandPalette;
 
 const profileShortcutIndexFromKey = labels.profileShortcutIndexFromKey;
 
@@ -29348,7 +29354,24 @@ pub const Surface = struct {
     fn handleKeyMessage(self: *Surface, msg: UINT, wParam: WPARAM, lParam: LPARAM) void {
         if (!self.core_initialized) return;
 
-        const message = keyEventFromWin32Message(msg, wParam, lParam) orelse return;
+        // Under Kitty `report_all` the text must ride on the physical key
+        // event so press and release keep one identity; see
+        // `win32_input.deferPlainTextToCharMessage`.
+        const kitty_report_all = kitty_report_all: {
+            self.core_surface.renderer_state.mutex.lock();
+            defer self.core_surface.renderer_state.mutex.unlock();
+            break :kitty_report_all self.core_surface.renderer_state.terminal.screens.active.kitty_keyboard.current().report_all;
+        };
+        var message = keyEventFromWin32Message(
+            msg,
+            wParam,
+            lParam,
+            win32_input.deferPlainTextToCharMessage(kitty_report_all, self.ime_composing),
+        ) orelse return;
+        // `message` lives for the rest of this function, which covers every
+        // read of `event.utf8` below including the post-`keyCallback`
+        // accessibility notification.
+        message.bindText();
         const event = message.event;
 
         const effect = self.core_surface.keyCallback(event) catch |err| {

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -47,12 +47,23 @@ pub const RegisteredGlobalHotkey = struct {
     binding: *const input.Binding.Set.Value,
 };
 
+/// `ToUnicode` is given a four-unit buffer, so the most text one key can
+/// produce is four BMP characters (12 bytes of UTF-8) or two supplementary
+/// ones (8 bytes). 16 bytes covers either.
+const text_capacity = 16;
+
 const KeyText = struct {
-    utf8: [8]u8 = [_]u8{0} ** 8,
+    /// UTF-8 for every code unit the layout produced for this key, not just
+    /// the first one: an accent that cannot combine with the key that
+    /// follows it yields both characters in one translation.
+    utf8: [text_capacity]u8 = [_]u8{0} ** text_capacity,
     len: usize = 0,
     consumed_mods: input.Mods = .{},
     unshifted_codepoint: u21 = 0,
     deferred_utf16_units: usize = 0,
+    /// The layout reported a dead key. There is no text yet; the composed
+    /// character arrives with the next key.
+    dead_key: bool = false,
 };
 
 pub const DeferredCharState = struct {
@@ -115,9 +126,25 @@ pub const DeferredCharState = struct {
     }
 };
 
-const Win32KeyMessage = struct {
+pub const Win32KeyMessage = struct {
     event: input.KeyEvent,
     deferred_utf16_units: usize = 0,
+
+    /// Translated key text travels inline, not as a slice. `event.utf8` is a
+    /// borrowed slice and `keyEventFromWin32Message` returns its message by
+    /// value, so a slice into the `KeyText` local it translated from dangles
+    /// the instant it returns. The bytes are carried here instead and the
+    /// slice is rebased by `bindText` once the value has landed in the frame
+    /// that actually uses it.
+    text: [text_capacity]u8 = [_]u8{0} ** text_capacity,
+    text_len: usize = 0,
+
+    /// Point `event.utf8` at this value's own storage. Must be called on the
+    /// caller's copy, after the message has been returned, and that copy must
+    /// outlive every use of `event.utf8`.
+    pub fn bindText(self: *Win32KeyMessage) void {
+        self.event.utf8 = self.text[0..self.text_len];
+    }
 };
 
 pub fn lParamBits(lParam: LPARAM) usize {
@@ -673,13 +700,26 @@ fn utf16CodeUnitCount(codepoint: u21) usize {
     return if (codepoint <= std.math.maxInt(u16)) 1 else 2;
 }
 
+/// Whether plain typed text should be committed by the following `WM_CHAR`
+/// instead of travelling on the physical key event.
+///
+/// `allow_defer` is false while a Kitty `report_all` client is active. The
+/// synthetic `WM_CHAR` commit event carries no physical key and no modifiers,
+/// so deferring would split one keystroke into a press with identity but no
+/// text and a commit with text but no identity, and the release would never
+/// pair with either. AltGr needs no exception here: the synthetic Ctrl+Alt pair
+/// has already been collapsed by `normalizeAltGrMods` on layouts that have an
+/// AltGr, so the physical event carries the layout text (`@` for German
+/// `AltGr+Q`) with empty modifiers and the same key identity as its release.
 fn shouldDeferTextToCharMessage(
     action: input.Action,
     key: input.Key,
     mods: input.Mods,
     translated: KeyText,
+    allow_defer: bool,
 ) bool {
     if (action == .release) return false;
+    if (!allow_defer) return false;
     // AltGr has already been normalized for layouts that use it. Any
     // modifiers still present here describe a terminal chord.
     if (mods.super or mods.ctrl or mods.alt) return false;
@@ -696,14 +736,40 @@ fn shouldDeferTextToCharMessage(
     return !isControlCodepoint(translated.unshifted_codepoint);
 }
 
-fn deferTextToCharMessage(
+/// Plain text is committed by `WM_CHAR` unless a Kitty `report_all` client is
+/// active. IME composition keeps deferring either way: its commit is text
+/// without a physical key by design.
+pub fn deferPlainTextToCharMessage(kitty_report_all: bool, ime_composing: bool) bool {
+    return !kitty_report_all or ime_composing;
+}
+
+fn applyTranslatedKeyText(
     result: *Win32KeyMessage,
     translated: KeyText,
+    defer_text: bool,
 ) void {
+    // Copy the bytes rather than slicing `translated`: it is a by-value
+    // parameter whose storage does not outlive this call, and `result` is
+    // about to be returned by value anyway. `event.utf8` is left empty here
+    // and bound to the caller's own copy via `bindText`.
+    @memcpy(result.text[0..translated.len], translated.utf8[0..translated.len]);
+    result.text_len = translated.len;
     result.event.utf8 = "";
-    result.event.consumed_mods = .{};
-    result.event.composing = true;
-    result.deferred_utf16_units = translated.deferred_utf16_units;
+    result.event.consumed_mods = translated.consumed_mods;
+    if (defer_text) {
+        // Keep the physical-key event visible to bindings/modifier state
+        // but defer text emission to WM_CHAR so plain typing doesn't rely
+        // on ToUnicode/GetKeyboardState timing.
+        result.text_len = 0;
+        result.event.consumed_mods = .{};
+    }
+    // A dead key is composing whether or not text is deferred: without the
+    // flag the encoder would emit a bare `CSI <unshifted> u` for the accent
+    // press before the composed character arrives.
+    if (defer_text or translated.dead_key) {
+        result.event.composing = true;
+        result.deferred_utf16_units = translated.deferred_utf16_units;
+    }
 }
 
 pub fn shouldAuthorizeDeferredCharMessage(effect: CoreSurface.InputEffect) bool {
@@ -793,6 +859,35 @@ fn printableCodepoint(units: []const u16) ?u21 {
     return codepoint;
 }
 
+/// Decode every UTF-16 unit the layout produced into `buf` and return the
+/// UTF-8 length. The whole result is rejected (0) when any codepoint is a
+/// control character, because the core encoder derives C0 bytes itself from
+/// the key and modifiers, or when a surrogate is unpaired.
+fn printableText(units: []const u16, buf: *[text_capacity]u8) usize {
+    var len: usize = 0;
+    var i: usize = 0;
+    while (i < units.len) {
+        const codepoint: u21 = cp: {
+            if (i + 1 < units.len and
+                std.unicode.utf16IsHighSurrogate(units[i]) and
+                std.unicode.utf16IsLowSurrogate(units[i + 1]))
+            {
+                const pair = std.unicode.utf16DecodeSurrogatePair(
+                    &.{ units[i], units[i + 1] },
+                ) catch return 0;
+                i += 2;
+                break :cp pair;
+            }
+            const unit = units[i];
+            i += 1;
+            break :cp unit;
+        };
+        if (isControlCodepoint(codepoint)) return 0;
+        len += std.unicode.utf8Encode(codepoint, buf[len..]) catch return 0;
+    }
+    return len;
+}
+
 /// Translate `vk` against a masked copy of the keyboard state and return the
 /// printable codepoint it produces, if any.
 fn translatePrintableCodepoint(
@@ -855,6 +950,7 @@ fn translateKeyText(
     if (count < 0) {
         // Dead key. The composed text arrives later as WM_CHAR.
         result.deferred_utf16_units = 1;
+        result.dead_key = true;
         return result;
     }
     if (count > 0) result.deferred_utf16_units = @intCast(count);
@@ -869,22 +965,27 @@ fn translateKeyText(
     // Caps Lock is masked with Ctrl but Shift is not: in a Ctrl chord Shift is
     // part of the chord the user typed, while Caps Lock is ambient state that
     // must not change which key the chord reports.
-    const codepoint: ?u21 = if (mods.ctrl)
-        translatePrintableCodepoint(vk, scan_code, state, .{
+    if (mods.ctrl) {
+        if (translatePrintableCodepoint(vk, scan_code, state, .{
             .control = true,
             .caps_lock = true,
-        })
-    else
-        printableCodepoint(utf16[0..@min(@as(usize, @intCast(count)), utf16.len)]);
-
-    if (codepoint) |cp| {
-        result.len = std.unicode.utf8Encode(cp, &result.utf8) catch 0;
-        // Shift is only consumed when the layout used it to produce the text.
-        // In a Ctrl chord shift is part of the chord, so it stays live.
-        if (result.len > 0 and !mods.ctrl) {
-            result.consumed_mods = .{ .shift = mods.shift };
+        })) |cp| {
+            result.len = std.unicode.utf8Encode(cp, &result.utf8) catch 0;
         }
+        return result;
     }
+
+    // Keep every unit the layout produced. A dead key that cannot combine with
+    // this key yields the accent and the key together (`´x`); when the text
+    // rides on the physical event instead of `WM_CHAR`, dropping the second
+    // character would lose the key that was actually pressed.
+    result.len = printableText(
+        utf16[0..@min(@as(usize, @intCast(count)), utf16.len)],
+        &result.utf8,
+    );
+    // Shift is only consumed when the layout used it to produce the text.
+    // In a Ctrl chord shift is part of the chord, so it stays live.
+    if (result.len > 0) result.consumed_mods = .{ .shift = mods.shift };
 
     return result;
 }
@@ -905,10 +1006,15 @@ fn packetKeyMessage(action: input.Action) Win32KeyMessage {
     };
 }
 
+/// Build the key event for a `WM_(SYS)KEYDOWN` / `WM_(SYS)KEYUP` message.
+/// The returned value owns its text; call `bindText` on the copy that will
+/// outlive every read of `event.utf8`. `defer_plain_text` comes from
+/// `deferPlainTextToCharMessage`.
 pub fn keyEventFromWin32Message(
     msg: UINT,
     wParam: WPARAM,
     lParam: LPARAM,
+    defer_plain_text: bool,
 ) ?Win32KeyMessage {
     const action: input.Action = switch (msg) {
         c.WM_KEYUP, c.WM_SYSKEYUP => .release,
@@ -950,14 +1056,11 @@ pub fn keyEventFromWin32Message(
 
     if (action != .release) {
         const translated = translateKeyText(vk, lParam, mods, keyboard_state);
-        result.event.utf8 = translated.utf8[0..translated.len];
-        result.event.consumed_mods = translated.consumed_mods;
-        if (shouldDeferTextToCharMessage(action, key, mods, translated)) {
-            // Keep the physical-key event visible to bindings/modifier state
-            // but defer text emission to WM_CHAR so plain typing doesn't rely
-            // on ToUnicode/GetKeyboardState timing.
-            deferTextToCharMessage(&result, translated);
-        }
+        applyTranslatedKeyText(
+            &result,
+            translated,
+            shouldDeferTextToCharMessage(action, key, mods, translated, defer_plain_text),
+        );
     }
 
     return result;
@@ -1039,8 +1142,8 @@ test "win32 unshifted codepoint agrees across press and release" {
     const keys = [_]UINT{ c.VK_DIVIDE, c.VK_MULTIPLY, c.VK_ADD, c.VK_A, c.VK_OEM_COMMA };
     for (keys) |vk| {
         const lParam = testingScanCode(vk);
-        const press = keyEventFromWin32Message(c.WM_KEYDOWN, vk, lParam).?;
-        const release = keyEventFromWin32Message(c.WM_KEYUP, vk, lParam).?;
+        const press = keyEventFromWin32Message(c.WM_KEYDOWN, vk, lParam, true).?;
+        const release = keyEventFromWin32Message(c.WM_KEYUP, vk, lParam, true).?;
         try std.testing.expectEqual(
             press.event.unshifted_codepoint,
             release.event.unshifted_codepoint,
@@ -1053,6 +1156,7 @@ test "win32 unshifted codepoint agrees across press and release" {
         c.WM_KEYUP,
         c.VK_DIVIDE,
         testingScanCode(c.VK_DIVIDE),
+        true,
     ).?;
     try std.testing.expectEqual(@as(u21, '/'), divide.event.unshifted_codepoint);
     try std.testing.expectEqual(@as(u21, 0), unshiftedCodepointForVirtualKey(c.VK_DIVIDE));
@@ -1266,24 +1370,28 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .key_a,
         .{},
         .{ .len = 1, .unshifted_codepoint = 'a', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .repeat,
         .space,
         .{},
         .{ .len = 1, .unshifted_codepoint = ' ', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .quote,
         .{},
         .{ .unshifted_codepoint = '\'', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
         .digit_2,
         .{ .ctrl = true, .alt = true },
         .{ .unshifted_codepoint = '2', .deferred_utf16_units = 1 },
+        true,
     ));
     const raw_alt_gr: input.Mods = .{
         .ctrl = true,
@@ -1295,18 +1403,21 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .equal,
         raw_alt_gr,
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .equal,
         withoutSyntheticAltGr(raw_alt_gr),
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
         .equal,
         .{ .alt = true, .sides = .{ .alt = .right } },
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
@@ -1317,13 +1428,194 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
             .sides = .{ .ctrl = .right, .alt = .right },
         },
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+        true,
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(
         .press,
         .enter,
         .{},
         .{ .unshifted_codepoint = 0x0D },
+        true,
     ));
+}
+
+test "win32 kitty-report-all skips WM_CHAR deferral" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expect(deferPlainTextToCharMessage(false, false));
+    try std.testing.expect(!deferPlainTextToCharMessage(true, false));
+    try std.testing.expect(deferPlainTextToCharMessage(true, true));
+    try std.testing.expect(!shouldDeferTextToCharMessage(
+        .press,
+        .key_a,
+        .{ .shift = true, .caps_lock = true },
+        .{ .len = 1, .unshifted_codepoint = 'a', .deferred_utf16_units = 1 },
+        false,
+    ));
+}
+
+// A dead key produces no text yet, so its press must stay `composing` even
+// when plain text is no longer deferred: otherwise the encoder emits a bare
+// `CSI <unshifted> u` for the accent before the composed character arrives.
+test "win32 kitty-report-all dead key remains composing" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var message: Win32KeyMessage = .{ .event = .{
+        .action = .press,
+        .key = .quote,
+        .unshifted_codepoint = '\'',
+    } };
+    applyTranslatedKeyText(
+        &message,
+        .{ .unshifted_codepoint = '\'', .deferred_utf16_units = 1, .dead_key = true },
+        false,
+    );
+    message.bindText();
+
+    try std.testing.expect(message.event.composing);
+    try std.testing.expectEqualStrings("", message.event.utf8);
+    try std.testing.expectEqual(@as(usize, 1), message.deferred_utf16_units);
+}
+
+// Under kitty `report_all` the translated text is no longer suppressed, so it
+// is read on the ordinary typing path. `event.utf8` is a borrowed slice and
+// `keyEventFromWin32Message` returns its message by value, so the bytes must
+// live in the message itself: a slice into the `KeyText` local would dangle
+// before `keyCallback` ever saw it.
+test "win32 translated key text is owned by the message it travels in" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var translated: KeyText = .{
+        .len = 1,
+        .unshifted_codepoint = 'a',
+        .deferred_utf16_units = 1,
+    };
+    translated.utf8[0] = 'a';
+
+    var message: Win32KeyMessage = .{ .event = .{
+        .action = .press,
+        .key = .key_a,
+    } };
+    applyTranslatedKeyText(&message, translated, false);
+
+    // Nothing points at `translated`; the bytes were copied out.
+    try std.testing.expectEqualStrings("", message.event.utf8);
+    try std.testing.expectEqual(@as(usize, 1), message.text_len);
+
+    message.bindText();
+    try std.testing.expectEqualStrings("a", message.event.utf8);
+    try std.testing.expectEqual(
+        @intFromPtr(&message.text),
+        @intFromPtr(message.event.utf8.ptr),
+    );
+
+    // A copy, which is what every caller of `keyEventFromWin32Message` gets,
+    // must rebase onto its own storage, not keep pointing at the original.
+    var copy = message;
+    copy.bindText();
+    try std.testing.expectEqualStrings("a", copy.event.utf8);
+    try std.testing.expectEqual(
+        @intFromPtr(&copy.text),
+        @intFromPtr(copy.event.utf8.ptr),
+    );
+
+    // Deferral to WM_CHAR still suppresses the text after binding.
+    var deferred: Win32KeyMessage = .{ .event = .{
+        .action = .press,
+        .key = .key_a,
+    } };
+    applyTranslatedKeyText(&deferred, translated, true);
+    deferred.bindText();
+    try std.testing.expectEqualStrings("", deferred.event.utf8);
+    try std.testing.expect(deferred.event.composing);
+}
+
+// ToUnicode returns more than one unit when a dead key cannot combine with the
+// key that follows it (acute accent then `x` on US-International yields both).
+// When the text rides on the physical event, every unit has to survive,
+// because the WM_CHARs that would otherwise have carried them are no longer
+// authorized.
+test "win32 translated key text keeps every unit ToUnicode returned" {
+    var buf: [text_capacity]u8 = undefined;
+
+    const accent_then_x = [_]u16{ 0x00B4, 'x' };
+    try std.testing.expectEqualStrings("\u{B4}x", buf[0..printableText(&accent_then_x, &buf)]);
+
+    const pair = [_]u16{ 0xD83D, 0xDE42 };
+    try std.testing.expectEqualStrings("\u{1F642}", buf[0..printableText(&pair, &buf)]);
+
+    const four = [_]u16{ 'a', 'b', 'c', 'd' };
+    try std.testing.expectEqualStrings("abcd", buf[0..printableText(&four, &buf)]);
+
+    // Control characters and unpaired surrogates reject the whole result; the
+    // encoder derives C0 bytes from the key and modifiers itself.
+    const control = [_]u16{ 'a', 0x01 };
+    try std.testing.expectEqual(@as(usize, 0), printableText(&control, &buf));
+    const lone_high = [_]u16{0xD83D};
+    try std.testing.expectEqual(@as(usize, 0), printableText(&lone_high, &buf));
+    try std.testing.expectEqual(@as(usize, 0), printableText(&.{}, &buf));
+}
+
+// German AltGr+Q under `report_all`: the physical press carries "@" with the
+// synthetic Ctrl+Alt collapsed, and the release hashes to the same binding
+// identity, so a client pairing press and release sees one key.
+test "win32 kitty-report-all AltGr press carries text on the physical event" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const raw_alt_gr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    const mods = withoutSyntheticAltGr(raw_alt_gr);
+    var translated: KeyText = .{
+        .len = 1,
+        .unshifted_codepoint = 'q',
+        .deferred_utf16_units = 1,
+    };
+    translated.utf8[0] = '@';
+
+    try std.testing.expect(!shouldDeferTextToCharMessage(.press, .key_q, mods, translated, false));
+
+    var press: Win32KeyMessage = .{ .event = .{
+        .action = .press,
+        .key = .key_q,
+        .mods = mods,
+        .binding_mods = bindingModsOverride(raw_alt_gr, mods),
+        .unshifted_codepoint = 'q',
+    } };
+    applyTranslatedKeyText(&press, translated, false);
+    press.bindText();
+    const release: input.KeyEvent = .{
+        .action = .release,
+        .key = .key_q,
+        .mods = mods,
+        .binding_mods = bindingModsOverride(raw_alt_gr, mods),
+        .unshifted_codepoint = 'q',
+    };
+
+    try std.testing.expect(!press.event.composing);
+    try std.testing.expectEqualStrings("@", press.event.utf8);
+    try std.testing.expectEqual(@as(usize, 0), press.deferred_utf16_units);
+    try std.testing.expectEqual(press.event.bindingHash(), release.bindingHash());
+
+    const flags: @import("../../terminal/kitty/key.zig").Flags = .{
+        .disambiguate = true,
+        .report_events = true,
+        .report_alternates = true,
+        .report_all = true,
+        .report_associated = true,
+    };
+    var press_buf: [64]u8 = undefined;
+    var press_writer: std.Io.Writer = .fixed(&press_buf);
+    try input.key_encode.encode(&press_writer, press.event, .{ .kitty_flags = flags });
+    // Key code is the unshifted `q`; no modifiers; associated text is `@`.
+    try std.testing.expectEqualStrings("\x1b[113;;64u", press_writer.buffered());
+
+    var release_buf: [64]u8 = undefined;
+    var release_writer: std.Io.Writer = .fixed(&release_buf);
+    try input.key_encode.encode(&release_writer, release, .{ .kitty_flags = flags });
+    try std.testing.expectEqualStrings("\x1b[113;1:3u", release_writer.buffered());
 }
 
 test "win32 deferred char authorization respects key handling effect" {
@@ -1354,7 +1646,7 @@ test "win32 AltGr binding identity agrees across deferred press and release" {
         .unshifted_codepoint = 'a',
     };
 
-    deferTextToCharMessage(&press, .{ .deferred_utf16_units = 1 });
+    applyTranslatedKeyText(&press, .{ .deferred_utf16_units = 1 }, true);
 
     try std.testing.expect(std.meta.eql(normalized, press.event.mods));
     try std.testing.expect(std.meta.eql(raw_alt_gr, press.event.bindingMods()));
@@ -1385,7 +1677,7 @@ test "win32 AltGr binding identity agrees across deferred press and release" {
 }
 
 test "win32 VK_PACKET key down authorizes one unit without direct text or modifiers" {
-    const message = keyEventFromWin32Message(c.WM_KEYDOWN, c.VK_PACKET, 0).?;
+    const message = keyEventFromWin32Message(c.WM_KEYDOWN, c.VK_PACKET, 0, true).?;
     try std.testing.expectEqual(input.Action.press, message.event.action);
     try std.testing.expectEqual(input.Key.unidentified, message.event.key);
     try std.testing.expectEqualStrings("", message.event.utf8);
@@ -1397,7 +1689,7 @@ test "win32 VK_PACKET key down authorizes one unit without direct text or modifi
 }
 
 test "win32 VK_PACKET key up authorizes no units or text" {
-    const message = keyEventFromWin32Message(c.WM_KEYUP, c.VK_PACKET, 0).?;
+    const message = keyEventFromWin32Message(c.WM_KEYUP, c.VK_PACKET, 0, true).?;
     try std.testing.expectEqual(input.Action.release, message.event.action);
     try std.testing.expectEqual(input.Key.unidentified, message.event.key);
     try std.testing.expectEqualStrings("", message.event.utf8);

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -484,6 +484,36 @@ pub fn bindingActionsToggleCommandPalette(actions: []const input.Binding.Action)
     return false;
 }
 
+/// Apply `key-remap` to a key event the same way `Surface.keyCallback` does.
+/// Two Win32 paths hand events to the core without going through a surface:
+/// the empty-host app-input path and the command-palette toggle lookup. Both
+/// must see remapped modifiers or a remapped chord silently misses there.
+pub fn remapWin32KeyEvent(
+    event_orig: input.KeyEvent,
+    remaps: *const input.KeyRemapSet,
+) input.KeyEvent {
+    var event = event_orig;
+    event.mods = remaps.apply(event_orig.mods);
+    if (event_orig.binding_mods) |binding_mods| {
+        event.binding_mods = remaps.apply(binding_mods);
+    }
+    return event;
+}
+
+pub fn keyEventTogglesCommandPalette(
+    event_orig: input.KeyEvent,
+    keybinds: *const input.Binding.Set,
+    remaps: *const input.KeyRemapSet,
+) bool {
+    const event = remapWin32KeyEvent(event_orig, remaps);
+    const entry = keybinds.getEvent(event) orelse return false;
+    const actions: []const input.Binding.Action = switch (entry.value_ptr.*) {
+        .leader => return false,
+        inline .leaf, .leaf_chained => |leaf| leaf.generic().actionsSlice(),
+    };
+    return bindingActionsToggleCommandPalette(actions);
+}
+
 fn commandPaletteDirectionFromWheelDelta(delta: i16) bool {
     return delta > 0;
 }
@@ -3617,6 +3647,31 @@ test "win32 command palette toggle binding is recognized inside action chains" {
     const present = [_]input.Binding.Action{ .{ .copy_to_clipboard = .mixed }, .toggle_command_palette };
     try std.testing.expect(!bindingActionsToggleCommandPalette(&absent));
     try std.testing.expect(bindingActionsToggleCommandPalette(&present));
+}
+
+// Differential, not tautological: the same event misses the default
+// ctrl+shift+p binding with an empty remap set and matches it with alt=ctrl.
+test "win32 key-remap applies to command palette toggle lookup" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const configpkg = @import("../../config.zig");
+    var cfg = try configpkg.Config.default(std.testing.allocator);
+    defer cfg.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var remaps: input.KeyRemapSet = .empty;
+    try remaps.parseCLI(arena.allocator(), "alt=ctrl");
+    remaps.finalize();
+
+    const event: input.KeyEvent = .{
+        .key = .key_p,
+        .mods = .{ .shift = true, .alt = true },
+        .unshifted_codepoint = 'p',
+    };
+    const no_remaps: input.KeyRemapSet = .empty;
+    try std.testing.expect(!keyEventTogglesCommandPalette(event, &cfg.keybind.set, &no_remaps));
+    try std.testing.expect(keyEventTogglesCommandPalette(event, &cfg.keybind.set, &remaps));
 }
 
 test "win32 buildInspectorBannerText reflects host inspector context" {


### PR DESCRIPTION
One-time audit that five Ghostty 1.3 core features actually behave on the Win32 app runtime rather than silently no-opping, tracing each one config -> apprt -> effect. Three were already wired end to end and are now documented as such. Two had real gaps on the Win32 input path; both fixes were bounded and are covered by tests.

Fixes #135

## State of this branch

- Base branch: `issues/120-docs-accuracy` (PR #155). Retarget to `main` after #155 merges.
- Head `2c04c5e3f`, one commit on top of `d84d2243e` (#155), which sits on `main` at `13e07ba35`.
- #162 (`issues/122-gpu-floor`) is stacked on this branch and merges after it.
- Re-authored on top of main's `src/apprt/win32/input.zig` extraction (#177) and the docs debloat (#206), so the key-translation code this PR changes now lives in `src/apprt/win32/input.zig` rather than inline in `src/apprt/win32.zig`.

## Changes

**Verdicts**

| Surface | Verdict |
| --- | --- |
| Kitty keyboard protocol | Wired after a bounded fix |
| `scrollbar` | Wired |
| notify-on-command-finish trio | Wired |
| `key-remap` | Partial after a bounded fix (`global:` still literal) |
| `clipboard-codepoint-map` | Wired for selection copies |

**Fix 1 — Kitty keyboard `report_all`.** Ordinary printable input was deferred to `WM_CHAR`, whose synthetic commit event carries no physical key and no modifiers. Under kitty `report_all` this split one keypress into a press with identity but no text, plus a commit with text but no identity, and the release paired with neither. `Surface.handleKeyMessage` now reads the active kitty mode and passes it into `keyEventFromWin32Message`; `deferPlainTextToCharMessage` (`src/apprt/win32/input.zig:742`) skips `WM_CHAR` deferral for non-IME `report_all`. IME composition still defers, so composed input is unaffected.

**Fix 2 — `key-remap` on direct Win32 paths.** The remap was applied only inside `Surface.keyCallback`, so two Win32 paths bypassed it: the empty-host app-input path (`Host.hostKeyEvent`, which by construction runs when there is no active surface) and the command-palette toggle lookup. Both now go through `remapWin32KeyEvent` / `keyEventTogglesCommandPalette` (`src/apprt/win32/labels.zig:486-509`). Verified that `App.keyEvent` does not itself remap, so there is no double-application.

**Documented, not fixed:**

- `global:` hotkeys register the literal configured chord through `RegisterHotKey` and do not honor remaps. Fixing that needs one-way remaps expanded into every physical source plus multi-hotkey registration and dedup — beyond a bounded fix, so it is recorded as `Partial` with the reason.
- Clipboard reads, URL copies, OSC 52 writes, and `write_screen_file` exports are not codepoint-mapped. The `write_screen_file` case is a shared export-path inconsistency, not a Win32 wiring gap, and was explicitly left alone.
- Command-finish notifications need OSC 133 command marks; `cmd.exe` does not supply them automatically.

**Comment correction.** `Surface.copySelectionToClipboards` carried three comments claiming VT and HTML copies skip codepoint mappings. The shared `opts` apply them to every branch, and `formatter.zig` tests prove it. Comments corrected; no behavior change.

## Review rounds folded into this commit

Earlier rounds of this PR carried these as separate follow-up commits. The branch has since been re-authored, so all of them are in `2c04c5e3f`; the shas quoted in older review replies no longer exist.

1. **Translated text must not dangle.** `event.utf8` used to slice `KeyText.utf8`, a by-value parameter, and `Win32KeyMessage` is returned by value, so the storage was gone before `keyCallback` read it. The bytes now travel inline in `Win32KeyMessage.text` and each caller rebases the slice onto its own copy with `bindText()`. Test `win32 translated key text is owned by the message it travels in` asserts `event.utf8.ptr == &message.text`.
2. **AltGr press/release identity.** The first fix kept an AltGr exemption inside `shouldDeferTextToCharMessage`, which meant the physical keydown was still deferred and marked `composing`, then dropped by `src/input/key_encode.zig:146`; the client saw an unidentified `@` press and a physical `Q` release. That exemption is gone. `keyEventFromWin32Message` now collapses Windows' synthetic left-Ctrl + right-Alt pair up front (`normalizeAltGrMods`, `src/apprt/win32/input.zig:369`, applied at `:1035`), so under `report_all` the German `AltGr+Q` press carries `@` with empty mods, `.key = .key_q`, `unshifted_codepoint = 'q'`, and `binding_mods` still holding the raw pair for keybind identity; the release carries the same key and the same binding hash. Test `win32 kitty-report-all AltGr press carries text on the physical event` (`:1562`) encodes both: press `CSI 113;;64u`, release `CSI 113;1:3u`.
3. **Every unit `ToUnicode` returns is kept.** `translateKeyText` used to encode only `utf16[0]` on a positive count, and with deferral off the later `WM_CHAR`s are unauthorized and discarded, so an incompatible dead-key sequence such as acute-accent-then-`x` lost the `x`. `printableText` (`:866`) now decodes every returned unit, pairs surrogates, and rejects the whole result if any codepoint is a control character or a surrogate is unpaired. `KeyText.utf8` and `Win32KeyMessage.text` grew from 8 to `text_capacity = 16` bytes (`:53`), which covers the four-unit `ToUnicode` buffer for four BMP characters or two supplementary ones. Test `win32 translated key text keeps every unit ToUnicode returned` (`:1538`).
4. **Dead keys no longer emit a spurious keypress.** A negative `ToUnicode` count means a dead key; without deferral `composing` stayed false and the encoder emitted a bare `CSI <unshifted> u` before the composed character. `KeyText` carries a `dead_key` flag and `applyTranslatedKeyText` (`:746`) marks the event `composing` whether or not text is deferred, with `deferred_utf16_units` bookkeeping unchanged so the following `WM_CHAR` still commits exactly one unit.
5. **Command-palette regression caught in review.** An early pass rewrote `commandPaletteToggleKeyMessage` to require `self.activeSurface()` and read the surface's config, which would have broken closing an open palette in a host with no active surface. It keeps the host-scoped config source with the remap layered on.

## Validation

Run on `2c04c5e3f`, Windows 11, clean worktree:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4177 passed; 71 skipped; 0 failed |
| `scripts/check-zig-format.ps1` | passed (696 tracked sources) |
| `scripts/check-source-format.ps1` | passed |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| `npx prettier@3 --check docs/status.md docs/windows-capability-matrix.md docs/windows.md` | all clean |

Targeted filters, all PASS: `kitty-report-all`, `key-remap`, `shouldDeferTextToCharMessage`, `translated key text`, `AltGr`, `commandFinishPlan`, plus the broader `win32`, `key_encode` and `kitty` filters.

The `key-remap` palette test is differential, not tautological: the same event is asserted to miss the binding with an empty remap set and to match it with `alt=ctrl`.

## Residuals / user steps

- Static audit plus unit and build validation. Real keyboard layouts, AltGr and dead-key sequences, IME composition, live kitty negotiation in a TUI, scrollbar animation, WinRT/Focus Assist behavior, and toast activation were **not** exercised interactively. The capability matrix says so in the keyboard-input note rather than implying non-US layouts were validated.
- Highest-value runtime follow-up: the non-IME `report_all` path relies on `ToUnicode` for text, so multilingual and dead-key behavior under a TUI that enables `report_all` is the thing most likely to falsify this change. Worth a manual pass on a German or US-International layout.
- `normalizeAltGrMods` probes the active layout for AltGr mappings, but only while left Ctrl and right Alt are both held, so the probe is off the hot path.
- `handleKeyMessage` takes `renderer_state.mutex` once per key message to read the kitty mode. This matches the existing locking pattern in the file, but it is new per-keystroke lock traffic under heavy key repeat.
- `global:` hotkeys still ignore `key-remap`. Not in scope here.

## Summary by Sourcery

Audit Win32 support for selected Ghostty 1.3 surfaces, fix Kitty keyboard and key-remapping input gaps, and document the resulting behavior and limitations.

Bug Fixes:
- Preserve physical key identity, text, modifier state, and press/release pairing for ordinary Win32 input when Kitty keyboard `report_all` is enabled, including AltGr and dead-key sequences.
- Apply `key-remap` consistently to Win32 host input and command-palette shortcut matching.

Enhancements:
- Audit and clarify Win32 support and limitations for Kitty keyboard input, scrollbars, command-finish notifications, key remapping, and clipboard codepoint mapping.
- Correct clipboard mapping comments to reflect that selection mappings apply across plain-text, VT, and HTML output.

Documentation:
- Expand Windows capability documentation with validated behavior, partial support, known limitations, and untested runtime follow-ups.

Tests:
- Add coverage for Kitty `report_all` deferral, AltGr and dead-key handling, multi-unit translated text, owned key text, and remapped command-palette bindings.

Bug Fixes:

- Preserve Kitty keyboard press and release metadata for ordinary non-IME input when `report_all` is enabled, including correct AltGr and dead-key behavior.
- Apply `key-remap` consistently to Win32 host input and command-palette shortcut matching.

Enhancements:

- Audit and document Win32 support for Kitty keyboard input, scrollbars, command-finish notifications, key remapping, and clipboard codepoint mapping, including known limitations.
- Correct clipboard mapping comments and clarify that selection copies apply mappings across plain-text, VT, and HTML formats.

Documentation:

- Expand the Windows capability documentation with validated support, partial support, limitations, and runtime follow-up notes for the audited surfaces.

Tests:

- Add coverage for modifier state, Kitty `report_all` deferral, AltGr and dead-key handling, multi-unit `ToUnicode` results, owned translated key text, and remapped command-palette bindings.

---

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows keyboard handling with Kitty keyboard protocol support, including modifier, dead-key, AltGr, and composed-text behavior.
  * Applied `key-remap` consistently to focused keybindings and terminal input.
  * Expanded clipboard codepoint mapping across plain text, VT, and HTML copies.
  * Added Windows capability documentation for command-finish notifications and keyboard behavior.

* **Documentation**
  * Updated Windows capability references, configuration guidance, and keyboard input notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->