### PR TITLE
update: make the release feed re-pointable and HTTPS-strict (#140)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -122,8 +122,9 @@ Win32-validated VT protocol coverage is tracked in
 
 ### Updater
 
-- Checks `api.github.com/repos/amanthanvi/noctty/releases/latest` at most
-  once every 24 hours and never replaces binaries silently.
+- Checks the stable release feed (GitHub Releases by default, overridable
+  with `auto-update-feed-url`) at most once every 24 hours and never replaces
+  binaries silently.
 - `auto-update = download` stages only releases that pass checksum metadata
   plus Authenticode verification. Applying a staged update is always
   user-initiated. Details in [windows.md](windows.md#updates).

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -477,11 +477,17 @@ integration; noctty does not currently add jump-list layout entries.
 auto-update = check
 ```
 
-The updater calls `api.github.com/repos/amanthanvi/noctty/releases/latest`
-at most once every 24 hours and never replaces binaries silently. In `check`
-mode it opens the release page when a newer stable version exists. It is the
-only outbound network call the app makes; there is no telemetry and no
-analytics.
+The updater checks the configured release feed at most once every 24 hours
+and never replaces binaries silently. The feed defaults to noctty's GitHub
+Releases API and can be changed with `auto-update-feed-url`; checksum,
+Authenticode, and pinned-publisher-key verification stay mandatory whatever
+the feed host. In `check` mode it opens the release page when a newer stable
+version exists. It is the only outbound network call the app makes; there is
+no telemetry and no analytics.
+
+Upstream Ghostty is leaving GitHub, so the maintainer periodically checks
+that the `upstream` remote and the release-feed host are still live and
+re-points them if either moves.
 
 `auto-update = download` downloads only stable Windows installer releases
 that ship architecture-specific SHA256 metadata, verifies the installer's

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -481,9 +481,12 @@ The updater checks the configured release feed at most once every 24 hours
 and never replaces binaries silently. The feed defaults to noctty's GitHub
 Releases API and can be changed with `auto-update-feed-url`; checksum,
 Authenticode, and pinned-publisher-key verification stay mandatory whatever
-the feed host. In `check` mode it opens the release page when a newer stable
-version exists. It is the only outbound network call the app makes; there is
-no telemetry and no analytics.
+the feed host. For tests and diagnostics, `NOCTTY_UPDATE_FEED_URL` overrides
+the compiled-in default when no explicit `auto-update-feed-url` is set. The
+precedence is explicit config, then the environment variable, then the
+compiled-in default. In `check` mode it opens the release page when a newer
+stable version exists. It is the only outbound network call the app makes;
+there is no telemetry and no analytics.
 
 Upstream Ghostty is leaving GitHub, so the maintainer periodically checks
 that the `upstream` remote and the release-feed host are still live and

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -484,9 +484,12 @@ Authenticode, and pinned-publisher-key verification stay mandatory whatever
 the feed host. For tests and diagnostics, `NOCTTY_UPDATE_FEED_URL` overrides
 the compiled-in default when no explicit `auto-update-feed-url` is set. The
 precedence is explicit config, then the environment variable, then the
-compiled-in default. In `check` mode it opens the release page when a newer
-stable version exists. It is the only outbound network call the app makes;
-there is no telemetry and no analytics.
+compiled-in default; a blank or whitespace-only value at either level falls
+through to the next, and a value that is not a valid HTTPS URL is ignored
+with a warning. Changing the effective feed discards the previous feed's
+cached release, dismissal, and staged installer. In `check` mode it opens the
+release page when a newer stable version exists. It is the only outbound
+network call the app makes; there is no telemetry and no analytics.
 
 Upstream Ghostty is leaving GitHub, so the maintainer periodically checks
 that the `upstream` remote and the release-feed host are still live and

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2572,6 +2572,7 @@ const UpdateCheckRequest = struct {
     state_path: []u8,
     current_version: std.SemanticVersion,
     current_version_string: []u8,
+    release_feed_url: []u8,
     force: bool,
     manual: bool,
     respect_dismissal: bool,
@@ -2580,6 +2581,7 @@ const UpdateCheckRequest = struct {
     fn deinit(self: *UpdateCheckRequest) void {
         self.alloc.free(self.state_path);
         self.alloc.free(self.current_version_string);
+        self.alloc.free(self.release_feed_url);
         self.* = undefined;
     }
 };
@@ -5457,12 +5459,19 @@ pub const App = struct {
         const request = try self.core_app.alloc.create(UpdateCheckRequest);
         errdefer self.core_app.alloc.destroy(request);
 
+        const release_feed_url = try updatepkg.resolveReleaseFeedUrl(
+            self.core_app.alloc,
+            self.config.@"auto-update-feed-url",
+        );
+        errdefer self.core_app.alloc.free(release_feed_url);
+
         request.* = .{
             .alloc = self.core_app.alloc,
             .ui_thread_id = self.ui_thread_id,
             .state_path = try updatepkg.defaultStatePath(self.core_app.alloc),
             .current_version = build_config.version,
             .current_version_string = try self.core_app.alloc.dupe(u8, build_config.version_string),
+            .release_feed_url = release_feed_url,
             .force = opts.force,
             .manual = opts.manual,
             .respect_dismissal = opts.respect_dismissal,
@@ -9656,6 +9665,7 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
 
     const result = updatepkg.checkLatestStableRelease(alloc, request.state_path, .{
         .current_version = request.current_version,
+        .release_feed_url = request.release_feed_url,
         .force = request.force,
         .respect_dismissal = request.respect_dismissal,
     }) catch |err| {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2575,6 +2575,7 @@ const UpdateCheckRequest = struct {
     release_feed_url: []u8,
     force: bool,
     manual: bool,
+    configured_feed_ignored_non_https: bool,
     respect_dismissal: bool,
     download: bool,
 
@@ -5464,6 +5465,9 @@ pub const App = struct {
             self.config.@"auto-update-feed-url",
         );
         errdefer self.core_app.alloc.free(release_feed_url);
+        const configured_feed_ignored_non_https = configuredFeedIsNonHttps(
+            self.config.@"auto-update-feed-url",
+        );
 
         request.* = .{
             .alloc = self.core_app.alloc,
@@ -5474,6 +5478,7 @@ pub const App = struct {
             .release_feed_url = release_feed_url,
             .force = opts.force,
             .manual = opts.manual,
+            .configured_feed_ignored_non_https = configured_feed_ignored_non_https,
             .respect_dismissal = opts.respect_dismissal,
             .download = self.config.@"auto-update" == .download,
         };
@@ -9676,6 +9681,7 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
                 .{@errorName(err)},
             ) catch null;
         }
+        appendConfiguredFeedIgnoredNote(request, completion);
         postUpdateCheckCompletion(request.ui_thread_id, completion);
         return;
     };
@@ -9738,11 +9744,35 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
         },
     }
 
+    appendConfiguredFeedIgnoredNote(request, completion);
     postUpdateCheckCompletion(request.ui_thread_id, completion);
 }
 
 fn tryOrNull(alloc: Allocator, text: []const u8) ?[]u8 {
     return alloc.dupe(u8, text) catch null;
+}
+
+fn configuredFeedIsNonHttps(configured: ?[]const u8) bool {
+    const value = configured orelse return false;
+    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (trimmed.len == 0) return false;
+    const uri = std.Uri.parse(trimmed) catch return false;
+    return !std.ascii.eqlIgnoreCase(uri.scheme, "https");
+}
+
+fn appendConfiguredFeedIgnoredNote(
+    request: *const UpdateCheckRequest,
+    completion: *UpdateCheckCompletion,
+) void {
+    if (!request.manual or !request.configured_feed_ignored_non_https) return;
+
+    const note = "Configured update feed ignored because its URL is not HTTPS.";
+    const message = if (completion.manual_message) |existing|
+        std.fmt.allocPrint(request.alloc, "{s} {s}", .{ existing, note }) catch return
+    else
+        request.alloc.dupe(u8, note) catch return;
+    if (completion.manual_message) |existing| request.alloc.free(existing);
+    completion.manual_message = message;
 }
 
 fn updateStageFailureMessage(alloc: Allocator, err: anyerror) ![]u8 {
@@ -9752,6 +9782,8 @@ fn updateStageFailureMessage(alloc: Allocator, err: anyerror) ![]u8 {
         error.InvalidChecksum => "SHA256SUMS.txt contains an invalid checksum",
         error.InstallerChecksumMismatch => "the downloaded installer did not match SHA256SUMS.txt",
         error.InvalidAuthenticodeSignature => "the installer Authenticode signature could not be trusted",
+        error.InstallerVersionInfoUnavailable => "the installer VersionInfo block was missing or unreadable",
+        error.InstallerVersionOlderThanRelease => "the installer version was older than the release feed version",
         error.AuthenticodeRequiresWindows => "Authenticode verification is only available on Windows",
         error.SignatureVerifierUnavailable => "Windows signature verification is unavailable",
         error.InvalidStatePath => "the updater state directory could not be resolved",

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2575,7 +2575,9 @@ const UpdateCheckRequest = struct {
     release_feed_url: []u8,
     force: bool,
     manual: bool,
-    configured_feed_ignored_non_https: bool,
+    /// Set when a configured or environment feed URL was dropped because it
+    /// is not a valid HTTPS URL, naming which one was dropped.
+    ignored_feed_source: ?updatepkg.FeedSource,
     respect_dismissal: bool,
     download: bool,
 
@@ -2592,6 +2594,9 @@ const UpdateCheckCompletion = struct {
     release: ?updatepkg.Release = null,
     manual_message: ?[]u8 = null,
     staged: bool = false,
+    /// The check discarded state that belonged to a previously configured
+    /// feed, so a notice raised from that feed must not stay actionable.
+    clear_stale_notice: bool = false,
 
     fn deinit(self: *UpdateCheckCompletion) void {
         if (self.release) |*value| value.deinit(self.alloc);
@@ -5460,14 +5465,15 @@ pub const App = struct {
         const request = try self.core_app.alloc.create(UpdateCheckRequest);
         errdefer self.core_app.alloc.destroy(request);
 
-        const release_feed_url = try updatepkg.resolveReleaseFeedUrl(
+        // The ignored-feed note has to come from the resolver, not from the
+        // config value alone: NOCTTY_UPDATE_FEED_URL is also a feed source
+        // and it is also dropped when it is not HTTPS.
+        const resolved_feed = try updatepkg.resolveReleaseFeed(
             self.core_app.alloc,
             self.config.@"auto-update-feed-url",
         );
+        const release_feed_url = resolved_feed.url;
         errdefer self.core_app.alloc.free(release_feed_url);
-        const configured_feed_ignored_non_https = configuredFeedIsNonHttps(
-            self.config.@"auto-update-feed-url",
-        );
 
         request.* = .{
             .alloc = self.core_app.alloc,
@@ -5478,7 +5484,7 @@ pub const App = struct {
             .release_feed_url = release_feed_url,
             .force = opts.force,
             .manual = opts.manual,
-            .configured_feed_ignored_non_https = configured_feed_ignored_non_https,
+            .ignored_feed_source = resolved_feed.ignored_non_https,
             .respect_dismissal = opts.respect_dismissal,
             .download = self.config.@"auto-update" == .download,
         };
@@ -5489,6 +5495,12 @@ pub const App = struct {
 
     fn handleUpdateCheckCompletion(self: *App, completion: *UpdateCheckCompletion) void {
         self.update_check_running.store(false, .release);
+
+        // The old notice offers Install (staged installer from the old feed)
+        // or Open Release (release URL from the old feed). Once the check
+        // discarded that feed's state, neither action is still valid, so drop
+        // the notice before anything below can raise a replacement.
+        if (completion.clear_stale_notice) self.clearUpdateNotice();
 
         if (completion.release) |release| {
             self.setUpdateNotice(release.version_text, release.release_url, completion.staged) catch |err| {
@@ -5577,7 +5589,20 @@ pub const App = struct {
         const state_path = try updatepkg.defaultStatePath(self.core_app.alloc);
         defer self.core_app.alloc.free(state_path);
 
-        var staged = updatepkg.verifyStagedWindowsInstall(self.core_app.alloc, state_path) catch |err| {
+        // Re-resolve the feed rather than trusting the staged metadata: a
+        // staged installer only stays applicable while the feed that
+        // produced it is still the effective one.
+        const release_feed_url = try updatepkg.resolveReleaseFeedUrl(
+            self.core_app.alloc,
+            self.config.@"auto-update-feed-url",
+        );
+        defer self.core_app.alloc.free(release_feed_url);
+
+        var staged = updatepkg.verifyStagedWindowsInstall(
+            self.core_app.alloc,
+            state_path,
+            release_feed_url,
+        ) catch |err| {
             self.showUpdateInfo(updateApplyFailureMessage(err)) catch |banner_err| {
                 log.warn("failed to show updater apply failure err={}", .{banner_err});
             };
@@ -9668,7 +9693,7 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
         alloc.destroy(completion);
     }
 
-    const result = updatepkg.checkLatestStableRelease(alloc, request.state_path, .{
+    const outcome = updatepkg.checkLatestStableRelease(alloc, request.state_path, .{
         .current_version = request.current_version,
         .release_feed_url = request.release_feed_url,
         .force = request.force,
@@ -9686,15 +9711,21 @@ fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
         return;
     };
     defer {
-        var owned = result;
+        var owned = outcome;
         owned.deinit(alloc);
     }
+    completion.clear_stale_notice = outcome.feed_state_invalidated;
 
-    switch (result) {
+    switch (outcome.result) {
         .update_available => |release| {
             stage_download: {
                 if (request.download) {
-                    var staged = updatepkg.stageWindowsInstall(alloc, request.state_path, &release) catch |err| {
+                    var staged = updatepkg.stageWindowsInstall(
+                        alloc,
+                        request.state_path,
+                        request.release_feed_url,
+                        &release,
+                    ) catch |err| {
                         log.warn("failed to stage verified updater download err={}", .{err});
                         if (request.manual) {
                             completion.manual_message = updateStageFailureMessage(alloc, err) catch null;
@@ -9752,21 +9783,18 @@ fn tryOrNull(alloc: Allocator, text: []const u8) ?[]u8 {
     return alloc.dupe(u8, text) catch null;
 }
 
-fn configuredFeedIsNonHttps(configured: ?[]const u8) bool {
-    const value = configured orelse return false;
-    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
-    if (trimmed.len == 0) return false;
-    const uri = std.Uri.parse(trimmed) catch return false;
-    return !std.ascii.eqlIgnoreCase(uri.scheme, "https");
-}
-
 fn appendConfiguredFeedIgnoredNote(
     request: *const UpdateCheckRequest,
     completion: *UpdateCheckCompletion,
 ) void {
-    if (!request.manual or !request.configured_feed_ignored_non_https) return;
+    if (!request.manual) return;
+    const ignored = request.ignored_feed_source orelse return;
 
-    const note = "Configured update feed ignored because its URL is not HTTPS.";
+    const note = switch (ignored) {
+        .configured => "Configured update feed ignored because its URL is not a valid HTTPS URL.",
+        .environment => "NOCTTY_UPDATE_FEED_URL ignored because its URL is not a valid HTTPS URL.",
+        .default => return,
+    };
     const message = if (completion.manual_message) |existing|
         std.fmt.allocPrint(request.alloc, "{s} {s}", .{ existing, note }) catch return
     else
@@ -9814,6 +9842,7 @@ fn updateStageFailureMessage(alloc: Allocator, err: anyerror) ![]u8 {
 fn updateApplyFailureMessage(err: anyerror) []const u8 {
     return switch (err) {
         error.NoStagedWindowsInstall => "No verified staged update is available. Run Check for Updates again.",
+        error.StagedInstallFeedMismatch => "The staged update came from a different update feed. Run Check for Updates again.",
         error.InvalidStagedInstallerPath => "The staged update path is invalid. Run Check for Updates again.",
         error.InvalidInstallPath => "The current install path is invalid. The staged update was not launched.",
         error.InstallerChecksumMismatch => "The staged update no longer matches its verified checksum. Run Check for Updates again.",

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -21210,6 +21210,11 @@ fn patchOrAppendEdits(
     user_edited: std.StaticBitSet(std.enums.values(@import("../config/key.zig").Key).len),
     out: *std.ArrayListUnmanaged(u8),
 ) !void {
+    // Three `inline for`s over every Config field run here. Adding
+    // `auto-update-feed-url` pushes that past the default 1000-branch quota,
+    // which surfaces as a compile error in this file rather than at the new
+    // option. State the budget so the next option added does not do it again.
+    @setEvalBranchQuota(10_000);
     const ConfigKey = @import("../config/key.zig").Key;
     const ConfigFormatter = @import("../config/formatter.zig");
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3323,6 +3323,13 @@ term: []const u8 = "xterm-ghostty",
 ///    the verified staged installer after a user click.
 @"auto-update": ?AutoUpdate = null,
 
+/// The HTTPS release-feed URL used for stable auto-update checks.
+///
+/// The default is noctty's latest GitHub Release API endpoint. Changing the
+/// feed does not weaken checksum, Authenticode, or pinned-publisher-key
+/// verification of downloaded installers.
+@"auto-update-feed-url": ?[:0]const u8 = null,
+
 /// The release channel to use for auto-updates.
 ///
 /// The default value of this matches the release channel of the currently

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3327,7 +3327,10 @@ term: []const u8 = "xterm-ghostty",
 ///
 /// The default is noctty's latest GitHub Release API endpoint. Changing the
 /// feed does not weaken checksum, Authenticode, or pinned-publisher-key
-/// verification of downloaded installers.
+/// verification of downloaded installers. For tests and diagnostics,
+/// `NOCTTY_UPDATE_FEED_URL` can override the default when this option is not
+/// set. Precedence is explicit config, then the environment variable, then the
+/// compiled-in default.
 @"auto-update-feed-url": ?[:0]const u8 = null,
 
 /// The release channel to use for auto-updates.

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -41,6 +41,8 @@ const pinned_publisher_spki_sha256 = [_][Sha256.digest_length]u8{
 pub const State = struct {
     last_checked_at: i64 = 0,
     last_seen_version: ?[]u8 = null,
+    release_feed_url: ?[]u8 = null,
+    release_url: ?[]u8 = null,
     dismissed_version: ?[]u8 = null,
     staged_version: ?[]u8 = null,
     staged_installer_path: ?[]u8 = null,
@@ -50,6 +52,8 @@ pub const State = struct {
 
     pub fn deinit(self: *State, alloc: Allocator) void {
         if (self.last_seen_version) |value| alloc.free(value);
+        if (self.release_feed_url) |value| alloc.free(value);
+        if (self.release_url) |value| alloc.free(value);
         if (self.dismissed_version) |value| alloc.free(value);
         if (self.staged_version) |value| alloc.free(value);
         if (self.staged_installer_path) |value| alloc.free(value);
@@ -117,10 +121,31 @@ pub const CheckResult = union(enum) {
 
 pub const CheckOptions = struct {
     current_version: std.SemanticVersion,
+    release_feed_url: []const u8,
     force: bool = false,
     respect_dismissal: bool = true,
     now: i64 = 0,
 };
+
+pub fn resolveReleaseFeedUrl(alloc: Allocator, configured: ?[]const u8) ![]u8 {
+    const env_value = try internal_os.getEnvVarOwnedTrimmedNotEmpty(
+        alloc,
+        "NOCTTY_UPDATE_FEED_URL",
+    );
+    defer if (env_value) |value| alloc.free(value);
+
+    const candidate = env_value orelse if (configured) |value|
+        std.mem.trim(u8, value, &std.ascii.whitespace)
+    else
+        "";
+    if (candidate.len == 0) return alloc.dupe(u8, latest_stable_api_url);
+    _ = validateHttpsUrl(candidate) catch {
+        log.warn("ignoring non-HTTPS update feed URL; using the default release feed", .{});
+        return alloc.dupe(u8, latest_stable_api_url);
+    };
+
+    return alloc.dupe(u8, candidate);
+}
 
 pub fn defaultStatePath(alloc: Allocator) ![]u8 {
     return internal_os.xdg.state(alloc, .{
@@ -150,6 +175,7 @@ pub fn loadState(alloc: Allocator, path: []const u8) !State {
     };
 
     var state: State = .{};
+    errdefer state.deinit(alloc);
     if (root.get("last_checked_at")) |value| {
         switch (value) {
             .integer => |integer| state.last_checked_at = @intCast(integer),
@@ -159,6 +185,18 @@ pub fn loadState(alloc: Allocator, path: []const u8) !State {
     if (root.get("last_seen_version")) |value| {
         switch (value) {
             .string => |text| state.last_seen_version = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
+    if (root.get("release_feed_url")) |value| {
+        switch (value) {
+            .string => |text| state.release_feed_url = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
+    if (root.get("release_url")) |value| {
+        switch (value) {
+            .string => |text| state.release_url = try alloc.dupe(u8, text),
             else => {},
         }
     }
@@ -218,6 +256,10 @@ pub fn saveState(path: []const u8, state: *const State) !void {
     try writer.print("{d}", .{state.last_checked_at});
     try writer.writeAll(",\"last_seen_version\":");
     try writeOptionalJsonString(writer, state.last_seen_version);
+    try writer.writeAll(",\"release_feed_url\":");
+    try writeOptionalJsonString(writer, state.release_feed_url);
+    try writer.writeAll(",\"release_url\":");
+    try writeOptionalJsonString(writer, state.release_url);
     try writer.writeAll(",\"dismissed_version\":");
     try writeOptionalJsonString(writer, state.dismissed_version);
     try writer.writeAll(",\"staged_version\":");
@@ -261,19 +303,20 @@ pub fn checkLatestStableRelease(
     defer state.deinit(alloc);
     const now = if (options.now > 0) options.now else std.time.timestamp();
 
-    if (!options.force and !shouldCheckNetwork(state.last_checked_at, now)) {
+    if (!options.force and !shouldCheckNetwork(&state, options.release_feed_url, now)) {
         if (try cachedAvailableRelease(alloc, &state, options.current_version, options.respect_dismissal)) |release| {
             return .{ .update_available = release };
         }
         return .throttled;
     }
 
-    var release = try fetchLatestStableRelease(alloc);
+    var release = try fetchLatestStableRelease(alloc, options.release_feed_url);
     errdefer release.deinit(alloc);
 
     state.last_checked_at = now;
-    if (state.last_seen_version) |value| alloc.free(value);
-    state.last_seen_version = try alloc.dupe(u8, release.version_text);
+    replaceOptionalOwned(alloc, &state.last_seen_version, try alloc.dupe(u8, release.version_text));
+    replaceOptionalOwned(alloc, &state.release_feed_url, try alloc.dupe(u8, options.release_feed_url));
+    replaceOptionalOwned(alloc, &state.release_url, try alloc.dupe(u8, release.release_url));
     try saveState(state_path, &state);
 
     const latest_version = try parseVersionText(release.version_text);
@@ -444,6 +487,102 @@ fn replaceOptionalOwned(alloc: Allocator, slot: *?[]u8, value: []u8) void {
     slot.* = value;
 }
 
+fn fetchHttps(
+    alloc: Allocator,
+    context: []const u8,
+    initial_url: []const u8,
+    extra_headers: []const std.http.Header,
+    response_writer: *std.Io.Writer,
+) !void {
+    _ = try validateHttpsUrl(initial_url);
+
+    var client: std.http.Client = .{ .allocator = alloc };
+    defer client.deinit();
+
+    var current_url = try alloc.dupe(u8, initial_url);
+    defer alloc.free(current_url);
+
+    var redirect_count: u8 = 0;
+    while (true) {
+        var next_url: ?[]u8 = null;
+        {
+            const uri = try validateHttpsUrl(current_url);
+            var request = try client.request(.GET, uri, .{
+                .redirect_behavior = .unhandled,
+                .extra_headers = extra_headers,
+            });
+            defer request.deinit();
+
+            try request.sendBodiless();
+            var response = try request.receiveHead(&.{});
+
+            if (response.head.status.class() == .redirect) {
+                if (redirect_count >= 3) return error.TooManyHttpRedirects;
+                const location = response.head.location orelse return error.HttpRedirectLocationMissing;
+
+                const combined_len = std.math.add(
+                    usize,
+                    current_url.len,
+                    location.len,
+                ) catch return error.OutOfMemory;
+                const resolution_len = std.math.mul(
+                    usize,
+                    3,
+                    std.math.add(usize, combined_len, 1) catch return error.OutOfMemory,
+                ) catch return error.OutOfMemory;
+                const resolution_buf = try alloc.alloc(u8, resolution_len);
+                defer alloc.free(resolution_buf);
+                @memcpy(resolution_buf[0..location.len], location);
+                var aux_buf = resolution_buf;
+                const resolved = uri.resolveInPlace(location.len, &aux_buf) catch
+                    return error.InvalidUpdateUrl;
+
+                const resolved_url = try std.fmt.allocPrint(
+                    alloc,
+                    "{f}",
+                    .{resolved.fmt(.all)},
+                );
+                errdefer alloc.free(resolved_url);
+                _ = try validateHttpsUrl(resolved_url);
+                next_url = resolved_url;
+
+                const redirect_reader = response.reader(&.{});
+                _ = redirect_reader.discardRemaining() catch |err| switch (err) {
+                    error.ReadFailed => return response.bodyErr().?,
+                };
+                redirect_count += 1;
+            } else {
+                try requireOkHttpStatus(context, current_url, response.head.status);
+
+                const decompress_buffer: []u8 = switch (response.head.content_encoding) {
+                    .identity => &.{},
+                    .zstd => try alloc.alloc(u8, std.compress.zstd.default_window_len),
+                    .deflate, .gzip => try alloc.alloc(u8, std.compress.flate.max_window_len),
+                    .compress => return error.UnsupportedCompressionMethod,
+                };
+                defer if (decompress_buffer.len > 0) alloc.free(decompress_buffer);
+
+                var transfer_buffer: [64]u8 = undefined;
+                var decompress: std.http.Decompress = undefined;
+                const body_reader = response.readerDecompressing(
+                    &transfer_buffer,
+                    &decompress,
+                    decompress_buffer,
+                );
+                _ = body_reader.streamRemaining(response_writer) catch |err| switch (err) {
+                    error.ReadFailed => return response.bodyErr().?,
+                    else => |write_err| return write_err,
+                };
+                return;
+            }
+        }
+
+        const replacement = next_url orelse unreachable;
+        alloc.free(current_url);
+        current_url = replacement;
+    }
+}
+
 fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !void {
     if (!std.fs.path.isAbsolute(dest_path)) return error.InvalidDownloadPath;
 
@@ -466,24 +605,21 @@ fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !
     var file_open = true;
     errdefer if (file_open) file.close();
 
-    var client: std.http.Client = .{ .allocator = alloc };
-    defer client.deinit();
-
     var file_buf: [64 * 1024]u8 = undefined;
     var file_writer = file.writer(&file_buf);
-    const result = try client.fetch(.{
-        .location = .{ .url = url },
-        .extra_headers = &.{
+    try fetchHttps(
+        alloc,
+        "download",
+        url,
+        &.{
             .{ .name = "accept", .value = "application/octet-stream" },
             .{ .name = "user-agent", .value = "noctty-updater" },
         },
-        .response_writer = &file_writer.interface,
-    });
+        &file_writer.interface,
+    );
     try file_writer.interface.flush();
     file.close();
     file_open = false;
-
-    try requireOkHttpStatus("download", url, result.status);
 
     std.fs.deleteFileAbsolute(dest_path) catch |err| switch (err) {
         error.FileNotFound => {},
@@ -885,10 +1021,13 @@ const CryptProviderCert = extern struct {
     pChainElement: ?*const anyopaque,
 };
 
-fn shouldCheckNetwork(last_checked_at: i64, now: i64) bool {
-    if (last_checked_at <= 0) return true;
-    if (now <= last_checked_at) return true;
-    return now - last_checked_at >= throttle_seconds;
+fn shouldCheckNetwork(state: *const State, release_feed_url: []const u8, now: i64) bool {
+    const cached_feed_url = state.release_feed_url orelse return true;
+    if (state.release_url == null) return true;
+    if (!std.mem.eql(u8, cached_feed_url, release_feed_url)) return true;
+    if (state.last_checked_at <= 0) return true;
+    if (now <= state.last_checked_at) return true;
+    return now - state.last_checked_at >= throttle_seconds;
 }
 
 fn cachedAvailableRelease(
@@ -898,6 +1037,8 @@ fn cachedAvailableRelease(
     respect_dismissal: bool,
 ) !?Release {
     const last_seen = state.last_seen_version orelse return null;
+    const cached_release_url = state.release_url orelse return null;
+    _ = validateHttpsUrl(cached_release_url) catch return null;
     const latest_version = parseVersionText(last_seen) catch return null;
     if (current_version.order(latest_version) != .lt) return null;
     if (respect_dismissal) {
@@ -906,32 +1047,32 @@ fn cachedAvailableRelease(
         }
     }
 
-    // Cached state only persists the version string, so throttled responses
-    // cannot reconstruct asset-scoped installer metadata.
+    const version_text = try alloc.dupe(u8, last_seen);
+    errdefer alloc.free(version_text);
+    const release_url = try alloc.dupe(u8, cached_release_url);
+
+    // Cached state does not persist asset-scoped installer metadata.
     return .{
-        .version_text = try alloc.dupe(u8, last_seen),
-        .release_url = try releaseUrlForVersion(alloc, last_seen),
+        .version_text = version_text,
+        .release_url = release_url,
     };
 }
 
-fn fetchLatestStableRelease(alloc: Allocator) !Release {
-    var client: std.http.Client = .{ .allocator = alloc };
-    defer client.deinit();
-
+fn fetchLatestStableRelease(alloc: Allocator, release_feed_url: []const u8) !Release {
     var response_buf: std.Io.Writer.Allocating = .init(alloc);
     defer response_buf.deinit();
 
-    const result = try client.fetch(.{
-        .location = .{ .url = latest_stable_api_url },
-        .extra_headers = &.{
+    try fetchHttps(
+        alloc,
+        "release metadata",
+        release_feed_url,
+        &.{
             .{ .name = "accept", .value = "application/vnd.github+json" },
             .{ .name = "user-agent", .value = "noctty-updater" },
             .{ .name = "x-github-api-version", .value = "2022-11-28" },
         },
-        .response_writer = &response_buf.writer,
-    });
-
-    try requireOkHttpStatus("release metadata", latest_stable_api_url, result.status);
+        &response_buf.writer,
+    );
 
     const body = try response_buf.toOwnedSlice();
     defer alloc.free(body);
@@ -956,6 +1097,7 @@ fn parseLatestStableReleaseResponse(alloc: Allocator, body: []const u8) !Release
         .string => |value| value,
         else => return error.InvalidReleaseResponse,
     };
+    _ = try validateHttpsUrl(html_url);
 
     const version_text = try canonicalVersionText(alloc, tag_name);
     errdefer alloc.free(version_text);
@@ -1008,10 +1150,12 @@ fn parseWindowsInstallCandidate(
         };
 
         if (std.mem.eql(u8, name, expected_installer_name)) {
+            _ = try validateHttpsUrl(browser_download_url);
             installer_url = browser_download_url;
             continue;
         }
         if (std.mem.eql(u8, name, expected_checksums_name)) {
+            _ = try validateHttpsUrl(browser_download_url);
             checksums_url = browser_download_url;
             continue;
         }
@@ -1019,6 +1163,7 @@ fn parseWindowsInstallCandidate(
             std.mem.eql(u8, windowsInstallerArch(), "x64") and
             std.mem.eql(u8, name, windows_checksums_asset_name_legacy))
         {
+            _ = try validateHttpsUrl(browser_download_url);
             checksums_url = browser_download_url;
             continue;
         }
@@ -1061,6 +1206,14 @@ fn parseVersionText(version_text: []const u8) !std.SemanticVersion {
     return std.SemanticVersion.parse(version_text);
 }
 
+fn validateHttpsUrl(url: []const u8) !std.Uri {
+    const uri = std.Uri.parse(url) catch return error.InvalidUpdateUrl;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return error.InvalidUpdateUrl;
+    const host = uri.host orelse return error.InvalidUpdateUrl;
+    if (host.isEmpty()) return error.InvalidUpdateUrl;
+    return uri;
+}
+
 test "canonical version strips v prefix" {
     const alloc = std.testing.allocator;
     const version_text = try canonicalVersionText(alloc, "v1.2.3");
@@ -1068,16 +1221,97 @@ test "canonical version strips v prefix" {
     try std.testing.expectEqualStrings("1.2.3", version_text);
 }
 
+test "update release feed resolution" {
+    const alloc = std.testing.allocator;
+    const env_name = "NOCTTY_UPDATE_FEED_URL";
+    const saved_env = std.process.getEnvVarOwned(alloc, env_name) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    defer {
+        if (saved_env) |value| {
+            const sentinel = alloc.dupeZ(u8, value) catch unreachable;
+            defer alloc.free(sentinel);
+            _ = internal_os.setenv(env_name, sentinel);
+            alloc.free(value);
+        } else {
+            _ = internal_os.unsetenv(env_name);
+        }
+    }
+
+    const cases = [_]struct {
+        env: ?[:0]const u8,
+        configured: ?[]const u8,
+        expected: []const u8,
+    }{
+        .{ .env = "https://env.example/latest", .configured = "https://config.example/latest", .expected = "https://env.example/latest" },
+        .{ .env = null, .configured = "https://config.example/latest", .expected = "https://config.example/latest" },
+        .{ .env = null, .configured = null, .expected = latest_stable_api_url },
+        .{ .env = " \t\r\n ", .configured = "  https://config.example/latest  ", .expected = "https://config.example/latest" },
+        .{ .env = " \t\r\n ", .configured = " \t\r\n ", .expected = latest_stable_api_url },
+        .{ .env = "http://env.example/latest", .configured = "https://config.example/latest", .expected = latest_stable_api_url },
+        .{ .env = null, .configured = "file:///tmp/latest", .expected = latest_stable_api_url },
+    };
+
+    for (cases) |case| {
+        if (case.env) |value| {
+            _ = internal_os.setenv(env_name, value);
+        } else {
+            _ = internal_os.unsetenv(env_name);
+        }
+
+        const resolved = try resolveReleaseFeedUrl(alloc, case.configured);
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings(case.expected, resolved);
+    }
+}
+
 test "cached update respects dismissal" {
     const alloc = std.testing.allocator;
     var state: State = .{
         .last_seen_version = try alloc.dupe(u8, "1.2.3"),
+        .release_url = try alloc.dupe(u8, "https://updates.example/releases/1.2.3"),
         .dismissed_version = try alloc.dupe(u8, "1.2.3"),
     };
     defer state.deinit(alloc);
 
     const current = try std.SemanticVersion.parse("1.2.2");
     try std.testing.expect((try cachedAvailableRelease(alloc, &state, current, true)) == null);
+}
+
+test "cached update returns persisted release URL" {
+    const alloc = std.testing.allocator;
+    var state: State = .{
+        .last_seen_version = try alloc.dupe(u8, "1.2.3"),
+        .release_url = try alloc.dupe(u8, "https://updates.example/releases/1.2.3"),
+    };
+    defer state.deinit(alloc);
+
+    const current = try std.SemanticVersion.parse("1.2.2");
+    var release = (try cachedAvailableRelease(alloc, &state, current, true)).?;
+    defer release.deinit(alloc);
+    try std.testing.expectEqualStrings(state.release_url.?, release.release_url);
+}
+
+test "changed release feed bypasses throttle" {
+    const alloc = std.testing.allocator;
+    const now: i64 = 1_000_000;
+    var state: State = .{
+        .last_checked_at = now - 1,
+        .release_feed_url = try alloc.dupe(u8, "https://updates.example/feed-a"),
+        .release_url = try alloc.dupe(u8, "https://updates.example/releases/1.2.3"),
+    };
+    defer state.deinit(alloc);
+
+    try std.testing.expect(!shouldCheckNetwork(&state, "https://updates.example/feed-a", now));
+    try std.testing.expect(shouldCheckNetwork(&state, "https://updates.example/feed-b", now));
+
+    const legacy_state: State = .{ .last_checked_at = now - 1 };
+    try std.testing.expect(shouldCheckNetwork(&legacy_state, "https://updates.example/feed-a", now));
+
+    alloc.free(state.release_url.?);
+    state.release_url = null;
+    try std.testing.expect(shouldCheckNetwork(&state, "https://updates.example/feed-a", now));
 }
 
 test "state persists staged windows install metadata with escaped path" {
@@ -1093,6 +1327,8 @@ test "state persists staged windows install metadata with escaped path" {
     var state: State = .{
         .last_checked_at = 123,
         .last_seen_version = try alloc.dupe(u8, "1.3.100"),
+        .release_feed_url = try alloc.dupe(u8, "https://updates.example/latest?channel=\"stable\""),
+        .release_url = try alloc.dupe(u8, "https://updates.example/releases/1.3.100"),
         .staged_version = try alloc.dupe(u8, "1.3.101"),
         .staged_installer_path = try alloc.dupe(u8, "C:\\Users\\Aman\\updates\\noctty-1.3.101-windows-x64-setup.exe"),
         .staged_sha256 = try alloc.dupe(u8, "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
@@ -1108,6 +1344,8 @@ test "state persists staged windows install metadata with escaped path" {
     try std.testing.expectEqual(@as(i64, 123), loaded.last_checked_at);
     try std.testing.expectEqual(@as(i64, 456), loaded.staged_at);
     try std.testing.expectEqual(@as(i64, 789), loaded.apply_requested_at);
+    try std.testing.expectEqualStrings(state.release_feed_url.?, loaded.release_feed_url.?);
+    try std.testing.expectEqualStrings(state.release_url.?, loaded.release_url.?);
     try std.testing.expectEqualStrings("1.3.101", loaded.staged_version.?);
     try std.testing.expectEqualStrings(state.staged_installer_path.?, loaded.staged_installer_path.?);
     try std.testing.expectEqualStrings(state.staged_sha256.?, loaded.staged_sha256.?);
@@ -1253,6 +1491,13 @@ test "http status mapping distinguishes update response failures" {
     );
 }
 
+test "redirect URL validation refuses plaintext HTTP" {
+    try std.testing.expectError(
+        error.InvalidUpdateUrl,
+        validateHttpsUrl("http://updates.example/releases/latest"),
+    );
+}
+
 test "windows install staging rejects relative state path before download" {
     const alloc = std.testing.allocator;
     var release: Release = .{
@@ -1306,6 +1551,75 @@ test "release parser accepts checksum metadata without detached signature" {
     defer release.deinit(alloc);
 
     try std.testing.expect(release.windows_install != null);
+}
+
+test "release parser rejects non-HTTPS release URL" {
+    try std.testing.expectError(
+        error.InvalidUpdateUrl,
+        parseLatestStableReleaseResponse(
+            std.testing.allocator,
+            \\{
+            \\  "tag_name": "v1.3.100",
+            \\  "html_url": "http://updates.example/releases/1.3.100",
+            \\  "assets": []
+            \\}
+            ,
+        ),
+    );
+}
+
+test "release parser rejects non-HTTPS Windows asset URLs" {
+    const alloc = std.testing.allocator;
+    const installer_name = try std.fmt.allocPrint(
+        alloc,
+        "noctty-1.3.100-windows-{s}-setup.exe",
+        .{windowsInstallerArch()},
+    );
+    defer alloc.free(installer_name);
+    const checksum_name = windowsChecksumsAssetName();
+
+    const cases = [_]struct {
+        installer_scheme: []const u8,
+        checksums_scheme: []const u8,
+    }{
+        .{ .installer_scheme = "http", .checksums_scheme = "https" },
+        .{ .installer_scheme = "https", .checksums_scheme = "http" },
+    };
+
+    for (cases) |case| {
+        const body = try std.fmt.allocPrint(
+            alloc,
+            \\{{
+            \\  "tag_name": "v1.3.100",
+            \\  "html_url": "https://updates.example/releases/1.3.100",
+            \\  "assets": [
+            \\    {{
+            \\      "name": "{s}",
+            \\      "browser_download_url": "{s}://updates.example/{s}"
+            \\    }},
+            \\    {{
+            \\      "name": "{s}",
+            \\      "browser_download_url": "{s}://updates.example/{s}"
+            \\    }}
+            \\  ]
+            \\}}
+        ,
+            .{
+                installer_name,
+                case.installer_scheme,
+                installer_name,
+                checksum_name,
+                case.checksums_scheme,
+                checksum_name,
+            },
+        );
+        defer alloc.free(body);
+
+        try std.testing.expectError(
+            error.InvalidUpdateUrl,
+            parseLatestStableReleaseResponse(alloc, body),
+        );
+    }
 }
 
 test "release parser selects windows install candidate when checksum metadata is present" {

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -7,8 +7,6 @@ const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const log = std.log.scoped(.update_github_releases);
 
-pub const repo_owner = "amanthanvi";
-pub const repo_name = "noctty";
 pub const latest_stable_api_url = "https://api.github.com/repos/amanthanvi/noctty/releases/latest";
 pub const releases_url = "https://github.com/amanthanvi/noctty/releases";
 pub const windows_checksums_asset_name_legacy = "SHA256SUMS.txt";
@@ -128,16 +126,23 @@ pub const CheckOptions = struct {
 };
 
 pub fn resolveReleaseFeedUrl(alloc: Allocator, configured: ?[]const u8) ![]u8 {
-    const env_value = try internal_os.getEnvVarOwnedTrimmedNotEmpty(
-        alloc,
-        "NOCTTY_UPDATE_FEED_URL",
-    );
-    defer if (env_value) |value| alloc.free(value);
-
-    const candidate = env_value orelse if (configured) |value|
+    const configured_value = if (configured) |value|
         std.mem.trim(u8, value, &std.ascii.whitespace)
     else
         "";
+    const env_value = if (configured_value.len == 0)
+        try internal_os.getEnvVarOwnedTrimmedNotEmpty(
+            alloc,
+            "NOCTTY_UPDATE_FEED_URL",
+        )
+    else
+        null;
+    defer if (env_value) |value| alloc.free(value);
+
+    const candidate = if (configured_value.len > 0)
+        configured_value
+    else
+        env_value orelse "";
     if (candidate.len == 0) return alloc.dupe(u8, latest_stable_api_url);
     _ = validateHttpsUrl(candidate) catch {
         log.warn("ignoring non-HTTPS update feed URL; using the default release feed", .{});
@@ -337,14 +342,6 @@ pub fn checkLatestStableRelease(
     return .{ .update_available = release };
 }
 
-pub fn releaseUrlForVersion(alloc: Allocator, version_text: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        alloc,
-        "https://github.com/{s}/{s}/releases/tag/v{s}",
-        .{ repo_owner, repo_name, version_text },
-    );
-}
-
 pub fn stageWindowsInstall(
     alloc: Allocator,
     state_path: []const u8,
@@ -377,6 +374,12 @@ pub fn stageWindowsInstall(
         try verifyAuthenticodeSignature(installer_path, null);
     } else {
         return error.AuthenticodeRequiresWindows;
+    }
+
+    const installer_version = try readWindowsFileVersion(alloc, installer_path);
+    const claimed_version = try parseVersionText(release.version_text);
+    if (!installerVersionAtLeastClaim(installer_version, claimed_version)) {
+        return error.InstallerVersionOlderThanRelease;
     }
 
     const sha256_hex = try alloc.dupe(u8, &std.fmt.bytesToHex(actual_digest, .lower));
@@ -487,6 +490,39 @@ fn replaceOptionalOwned(alloc: Allocator, slot: *?[]u8, value: []u8) void {
     slot.* = value;
 }
 
+fn resolveRedirectTarget(
+    alloc: Allocator,
+    base_url: []const u8,
+    location: []const u8,
+) ![]u8 {
+    const base_uri = try validateHttpsUrl(base_url);
+    const combined_len = std.math.add(
+        usize,
+        base_url.len,
+        location.len,
+    ) catch return error.OutOfMemory;
+    const resolution_len = std.math.mul(
+        usize,
+        3,
+        std.math.add(usize, combined_len, 1) catch return error.OutOfMemory,
+    ) catch return error.OutOfMemory;
+    const resolution_buf = try alloc.alloc(u8, resolution_len);
+    defer alloc.free(resolution_buf);
+    @memcpy(resolution_buf[0..location.len], location);
+    var aux_buf = resolution_buf;
+    const resolved = base_uri.resolveInPlace(location.len, &aux_buf) catch
+        return error.InvalidUpdateUrl;
+
+    const resolved_url = try std.fmt.allocPrint(
+        alloc,
+        "{f}",
+        .{resolved.fmt(.all)},
+    );
+    errdefer alloc.free(resolved_url);
+    _ = try validateHttpsUrl(resolved_url);
+    return resolved_url;
+}
+
 fn fetchHttps(
     alloc: Allocator,
     context: []const u8,
@@ -519,32 +555,7 @@ fn fetchHttps(
             if (response.head.status.class() == .redirect) {
                 if (redirect_count >= 3) return error.TooManyHttpRedirects;
                 const location = response.head.location orelse return error.HttpRedirectLocationMissing;
-
-                const combined_len = std.math.add(
-                    usize,
-                    current_url.len,
-                    location.len,
-                ) catch return error.OutOfMemory;
-                const resolution_len = std.math.mul(
-                    usize,
-                    3,
-                    std.math.add(usize, combined_len, 1) catch return error.OutOfMemory,
-                ) catch return error.OutOfMemory;
-                const resolution_buf = try alloc.alloc(u8, resolution_len);
-                defer alloc.free(resolution_buf);
-                @memcpy(resolution_buf[0..location.len], location);
-                var aux_buf = resolution_buf;
-                const resolved = uri.resolveInPlace(location.len, &aux_buf) catch
-                    return error.InvalidUpdateUrl;
-
-                const resolved_url = try std.fmt.allocPrint(
-                    alloc,
-                    "{f}",
-                    .{resolved.fmt(.all)},
-                );
-                errdefer alloc.free(resolved_url);
-                _ = try validateHttpsUrl(resolved_url);
-                next_url = resolved_url;
+                next_url = try resolveRedirectTarget(alloc, current_url, location);
 
                 const redirect_reader = response.reader(&.{});
                 _ = redirect_reader.discardRemaining() catch |err| switch (err) {
@@ -770,6 +781,94 @@ fn lockedHandleMatchesPath(alloc: Allocator, path: []const u8, handle: std.os.wi
     return std.ascii.eqlIgnoreCase(final_path, path);
 }
 
+const WindowsFileVersion = struct {
+    major: u16,
+    minor: u16,
+    patch: u16,
+    build: u16,
+};
+
+fn installerVersionAtLeastClaim(
+    installer: WindowsFileVersion,
+    claimed: std.SemanticVersion,
+) bool {
+    const installer_parts = [_]u64{
+        installer.major,
+        installer.minor,
+        installer.patch,
+        installer.build,
+    };
+    const claimed_parts = [_]u64{
+        claimed.major,
+        claimed.minor,
+        claimed.patch,
+        0,
+    };
+    for (installer_parts, claimed_parts) |actual, expected| {
+        if (actual != expected) return actual > expected;
+    }
+    return true;
+}
+
+fn readWindowsFileVersion(alloc: Allocator, path: []const u8) !WindowsFileVersion {
+    if (builtin.os.tag != .windows) return error.AuthenticodeRequiresWindows;
+
+    const windows = std.os.windows;
+    const GetFileVersionInfoSizeWFn = *const fn ([*:0]const u16, *u32) callconv(.winapi) u32;
+    const GetFileVersionInfoWFn = *const fn ([*:0]const u16, u32, u32, *anyopaque) callconv(.winapi) windows.BOOL;
+    const VerQueryValueWFn = *const fn (*const anyopaque, [*:0]const u16, *?*anyopaque, *u32) callconv(.winapi) windows.BOOL;
+
+    const module = windows.LoadLibraryW(
+        std.unicode.utf8ToUtf16LeStringLiteral("version.dll"),
+    ) catch return error.InstallerVersionInfoUnavailable;
+    defer windows.FreeLibrary(module);
+
+    const size_proc = windows.kernel32.GetProcAddress(module, "GetFileVersionInfoSizeW") orelse
+        return error.InstallerVersionInfoUnavailable;
+    const info_proc = windows.kernel32.GetProcAddress(module, "GetFileVersionInfoW") orelse
+        return error.InstallerVersionInfoUnavailable;
+    const query_proc = windows.kernel32.GetProcAddress(module, "VerQueryValueW") orelse
+        return error.InstallerVersionInfoUnavailable;
+    const getFileVersionInfoSize: GetFileVersionInfoSizeWFn = @ptrCast(@alignCast(size_proc));
+    const getFileVersionInfo: GetFileVersionInfoWFn = @ptrCast(@alignCast(info_proc));
+    const verQueryValue: VerQueryValueWFn = @ptrCast(@alignCast(query_proc));
+
+    const path_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, path);
+    defer alloc.free(path_w);
+
+    var unused_handle: u32 = 0;
+    const info_size = getFileVersionInfoSize(path_w.ptr, &unused_handle);
+    if (info_size == 0) return error.InstallerVersionInfoUnavailable;
+
+    const info = try alloc.alignedAlloc(u8, std.mem.Alignment.of(VsFixedFileInfo), info_size);
+    defer alloc.free(info);
+    if (getFileVersionInfo(path_w.ptr, 0, info_size, info.ptr) == 0) {
+        return error.InstallerVersionInfoUnavailable;
+    }
+
+    var fixed_raw: ?*anyopaque = null;
+    var fixed_len: u32 = 0;
+    if (verQueryValue(
+        info.ptr,
+        std.unicode.utf8ToUtf16LeStringLiteral("\\"),
+        &fixed_raw,
+        &fixed_len,
+    ) == 0 or fixed_raw == null or fixed_len < @sizeOf(VsFixedFileInfo)) {
+        return error.InstallerVersionInfoUnavailable;
+    }
+
+    const fixed: *const VsFixedFileInfo = @ptrCast(@alignCast(fixed_raw.?));
+    if (fixed.signature != vs_fixed_file_info_signature) {
+        return error.InstallerVersionInfoUnavailable;
+    }
+    return .{
+        .major = @truncate(fixed.file_version_ms >> 16),
+        .minor = @truncate(fixed.file_version_ms),
+        .patch = @truncate(fixed.file_version_ls >> 16),
+        .build = @truncate(fixed.file_version_ls),
+    };
+}
+
 fn verifyAuthenticodeSignature(
     path: []const u8,
     file_handle: ?std.os.windows.HANDLE,
@@ -952,6 +1051,22 @@ const WTD_CHOICE_FILE: u32 = 1;
 const WTD_STATEACTION_VERIFY: u32 = 1;
 const WTD_STATEACTION_CLOSE: u32 = 2;
 const cert_e_untrusted_root: i32 = @bitCast(@as(u32, 0x800B0109));
+const vs_fixed_file_info_signature: u32 = 0xFEEF04BD;
+const VsFixedFileInfo = extern struct {
+    signature: u32,
+    struct_version: u32,
+    file_version_ms: u32,
+    file_version_ls: u32,
+    product_version_ms: u32,
+    product_version_ls: u32,
+    file_flags_mask: u32,
+    file_flags: u32,
+    file_os: u32,
+    file_type: u32,
+    file_subtype: u32,
+    file_date_ms: u32,
+    file_date_ls: u32,
+};
 const WinTrustFileInfo = extern struct {
     cbStruct: u32,
     pcwszFilePath: [*:0]const u16,
@@ -1244,12 +1359,15 @@ test "update release feed resolution" {
         configured: ?[]const u8,
         expected: []const u8,
     }{
-        .{ .env = "https://env.example/latest", .configured = "https://config.example/latest", .expected = "https://env.example/latest" },
+        .{ .env = "https://env.example/latest", .configured = "https://config.example/latest", .expected = "https://config.example/latest" },
         .{ .env = null, .configured = "https://config.example/latest", .expected = "https://config.example/latest" },
         .{ .env = null, .configured = null, .expected = latest_stable_api_url },
         .{ .env = " \t\r\n ", .configured = "  https://config.example/latest  ", .expected = "https://config.example/latest" },
+        .{ .env = "https://env.example/latest", .configured = " \t\r\n ", .expected = "https://env.example/latest" },
         .{ .env = " \t\r\n ", .configured = " \t\r\n ", .expected = latest_stable_api_url },
-        .{ .env = "http://env.example/latest", .configured = "https://config.example/latest", .expected = latest_stable_api_url },
+        .{ .env = "http://env.example/latest", .configured = "https://config.example/latest", .expected = "https://config.example/latest" },
+        .{ .env = "https://env.example/latest", .configured = "file:///tmp/latest", .expected = latest_stable_api_url },
+        .{ .env = "http://env.example/latest", .configured = null, .expected = latest_stable_api_url },
         .{ .env = null, .configured = "file:///tmp/latest", .expected = latest_stable_api_url },
     };
 
@@ -1264,6 +1382,34 @@ test "update release feed resolution" {
         defer alloc.free(resolved);
         try std.testing.expectEqualStrings(case.expected, resolved);
     }
+}
+
+test "update installer version must meet the claimed release version" {
+    const claimed = try std.SemanticVersion.parse("1.3.100");
+    try std.testing.expect(installerVersionAtLeastClaim(.{
+        .major = 1,
+        .minor = 3,
+        .patch = 100,
+        .build = 0,
+    }, claimed));
+    try std.testing.expect(installerVersionAtLeastClaim(.{
+        .major = 1,
+        .minor = 3,
+        .patch = 100,
+        .build = 7,
+    }, claimed));
+    try std.testing.expect(installerVersionAtLeastClaim(.{
+        .major = 1,
+        .minor = 4,
+        .patch = 0,
+        .build = 0,
+    }, claimed));
+    try std.testing.expect(!installerVersionAtLeastClaim(.{
+        .major = 1,
+        .minor = 3,
+        .patch = 99,
+        .build = 65535,
+    }, claimed));
 }
 
 test "cached update respects dismissal" {
@@ -1491,10 +1637,47 @@ test "http status mapping distinguishes update response failures" {
     );
 }
 
-test "redirect URL validation refuses plaintext HTTP" {
+test "update redirect target resolution accepts absolute HTTPS URL" {
+    const alloc = std.testing.allocator;
+    const resolved = try resolveRedirectTarget(
+        alloc,
+        "https://updates.example/releases/latest",
+        "https://cdn.example/noctty/latest.json",
+    );
+    defer alloc.free(resolved);
+    try std.testing.expectEqualStrings("https://cdn.example/noctty/latest.json", resolved);
+}
+
+test "update redirect target resolution resolves a relative URL" {
+    const alloc = std.testing.allocator;
+    const resolved = try resolveRedirectTarget(
+        alloc,
+        "https://updates.example/releases/stable/latest.json",
+        "../next.json",
+    );
+    defer alloc.free(resolved);
+    try std.testing.expectEqualStrings("https://updates.example/releases/next.json", resolved);
+}
+
+test "update redirect target resolution refuses plaintext HTTP" {
     try std.testing.expectError(
         error.InvalidUpdateUrl,
-        validateHttpsUrl("http://updates.example/releases/latest"),
+        resolveRedirectTarget(
+            std.testing.allocator,
+            "https://updates.example/releases/latest",
+            "http://updates.example/releases/latest",
+        ),
+    );
+}
+
+test "update redirect target resolution refuses garbage target" {
+    try std.testing.expectError(
+        error.InvalidUpdateUrl,
+        resolveRedirectTarget(
+            std.testing.allocator,
+            "https://updates.example/releases/latest",
+            "//[",
+        ),
     );
 }
 

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -45,8 +45,39 @@ pub const State = struct {
     staged_version: ?[]u8 = null,
     staged_installer_path: ?[]u8 = null,
     staged_sha256: ?[]u8 = null,
+    /// Feed URL the staged installer came from. State written before this
+    /// field existed has no value; that state can only have come from the
+    /// compiled-in default, so `stagedFeedUrl` reports the default for it.
+    staged_feed_url: ?[]u8 = null,
     staged_at: i64 = 0,
     apply_requested_at: i64 = 0,
+
+    pub fn stagedFeedUrl(self: *const State) []const u8 {
+        return self.staged_feed_url orelse latest_stable_api_url;
+    }
+
+    /// Drop every staged-install field. Returns true when something was
+    /// cleared, so the caller knows the on-disk state must be rewritten and
+    /// any live update notice for that staged install is now stale.
+    pub fn clearStagedInstall(self: *State, alloc: Allocator) bool {
+        var cleared = false;
+        inline for (.{ "staged_version", "staged_installer_path", "staged_sha256", "staged_feed_url" }) |field| {
+            if (@field(self, field)) |value| {
+                alloc.free(value);
+                @field(self, field) = null;
+                cleared = true;
+            }
+        }
+        if (self.staged_at != 0) {
+            self.staged_at = 0;
+            cleared = true;
+        }
+        if (self.apply_requested_at != 0) {
+            self.apply_requested_at = 0;
+            cleared = true;
+        }
+        return cleared;
+    }
 
     pub fn deinit(self: *State, alloc: Allocator) void {
         if (self.last_seen_version) |value| alloc.free(value);
@@ -56,6 +87,7 @@ pub const State = struct {
         if (self.staged_version) |value| alloc.free(value);
         if (self.staged_installer_path) |value| alloc.free(value);
         if (self.staged_sha256) |value| alloc.free(value);
+        if (self.staged_feed_url) |value| alloc.free(value);
         self.* = undefined;
     }
 };
@@ -117,6 +149,22 @@ pub const CheckResult = union(enum) {
     }
 };
 
+/// Outcome of one check, plus whatever the caller has to react to beyond the
+/// result itself.
+pub const CheckOutcome = struct {
+    result: CheckResult,
+    /// State belonging to a previously configured feed (a cached release, a
+    /// dismissal, or a staged installer) was discarded during this check.
+    /// Any live update notice came from that same feed, so the caller must
+    /// drop it.
+    feed_state_invalidated: bool = false,
+
+    pub fn deinit(self: *CheckOutcome, alloc: Allocator) void {
+        self.result.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
 pub const CheckOptions = struct {
     current_version: std.SemanticVersion,
     release_feed_url: []const u8,
@@ -125,7 +173,28 @@ pub const CheckOptions = struct {
     now: i64 = 0,
 };
 
-pub fn resolveReleaseFeedUrl(alloc: Allocator, configured: ?[]const u8) ![]u8 {
+/// Which of the three precedence levels supplied the effective feed URL.
+pub const FeedSource = enum { configured, environment, default };
+
+pub const ResolvedFeed = struct {
+    url: []u8,
+    source: FeedSource,
+    /// Set when a feed URL was supplied but rejected because it is not a
+    /// valid HTTPS URL. `url` is then the compiled-in default and this names
+    /// the level whose value was ignored.
+    ignored_non_https: ?FeedSource = null,
+
+    pub fn deinit(self: *ResolvedFeed, alloc: Allocator) void {
+        alloc.free(self.url);
+        self.* = undefined;
+    }
+};
+
+/// Resolve the effective release feed URL. Precedence is the explicit
+/// `auto-update-feed-url`, then a non-empty `NOCTTY_UPDATE_FEED_URL`, then
+/// the compiled-in default; a blank value at either level falls through to
+/// the next, and a non-HTTPS value falls back to the default.
+pub fn resolveReleaseFeed(alloc: Allocator, configured: ?[]const u8) !ResolvedFeed {
     const configured_value = if (configured) |value|
         std.mem.trim(u8, value, &std.ascii.whitespace)
     else
@@ -139,17 +208,37 @@ pub fn resolveReleaseFeedUrl(alloc: Allocator, configured: ?[]const u8) ![]u8 {
         null;
     defer if (env_value) |value| alloc.free(value);
 
-    const candidate = if (configured_value.len > 0)
-        configured_value
+    const source: FeedSource = if (configured_value.len > 0)
+        .configured
+    else if (env_value != null)
+        .environment
     else
-        env_value orelse "";
-    if (candidate.len == 0) return alloc.dupe(u8, latest_stable_api_url);
-    _ = validateHttpsUrl(candidate) catch {
-        log.warn("ignoring non-HTTPS update feed URL; using the default release feed", .{});
-        return alloc.dupe(u8, latest_stable_api_url);
+        .default;
+    const candidate = switch (source) {
+        .configured => configured_value,
+        .environment => env_value.?,
+        .default => "",
+    };
+    if (source == .default) return .{
+        .url = try alloc.dupe(u8, latest_stable_api_url),
+        .source = .default,
     };
 
-    return alloc.dupe(u8, candidate);
+    _ = validateHttpsUrl(candidate) catch {
+        log.warn("ignoring non-HTTPS update feed URL; using the default release feed", .{});
+        return .{
+            .url = try alloc.dupe(u8, latest_stable_api_url),
+            .source = .default,
+            .ignored_non_https = source,
+        };
+    };
+
+    return .{ .url = try alloc.dupe(u8, candidate), .source = source };
+}
+
+pub fn resolveReleaseFeedUrl(alloc: Allocator, configured: ?[]const u8) ![]u8 {
+    const resolved = try resolveReleaseFeed(alloc, configured);
+    return resolved.url;
 }
 
 pub fn defaultStatePath(alloc: Allocator) ![]u8 {
@@ -229,6 +318,12 @@ pub fn loadState(alloc: Allocator, path: []const u8) !State {
             else => {},
         }
     }
+    if (root.get("staged_feed_url")) |value| {
+        switch (value) {
+            .string => |text| state.staged_feed_url = try alloc.dupe(u8, text),
+            else => {},
+        }
+    }
     if (root.get("staged_at")) |value| {
         switch (value) {
             .integer => |integer| state.staged_at = @intCast(integer),
@@ -273,6 +368,8 @@ pub fn saveState(path: []const u8, state: *const State) !void {
     try writeOptionalJsonString(writer, state.staged_installer_path);
     try writer.writeAll(",\"staged_sha256\":");
     try writeOptionalJsonString(writer, state.staged_sha256);
+    try writer.writeAll(",\"staged_feed_url\":");
+    try writeOptionalJsonString(writer, state.staged_feed_url);
     try writer.writeAll(",\"staged_at\":");
     try writer.print("{d}", .{state.staged_at});
     try writer.writeAll(",\"apply_requested_at\":");
@@ -303,16 +400,28 @@ pub fn checkLatestStableRelease(
     alloc: Allocator,
     state_path: []const u8,
     options: CheckOptions,
-) !CheckResult {
+) !CheckOutcome {
     var state = try loadState(alloc, state_path);
     defer state.deinit(alloc);
     const now = if (options.now > 0) options.now else std.time.timestamp();
 
+    // Staged installers, the dismissal, and the cached release all describe
+    // one feed. Once the effective feed URL changes, none of them say
+    // anything about the new feed, and leaving the staged installer around
+    // would keep an Install action from the old feed live. Drop them before
+    // anything else looks at them.
+    const feed_state_invalidated = try invalidateForeignFeedState(
+        alloc,
+        state_path,
+        &state,
+        options.release_feed_url,
+    );
+
     if (!options.force and !shouldCheckNetwork(&state, options.release_feed_url, now)) {
         if (try cachedAvailableRelease(alloc, &state, options.current_version, options.respect_dismissal)) |release| {
-            return .{ .update_available = release };
+            return .{ .result = .{ .update_available = release }, .feed_state_invalidated = feed_state_invalidated };
         }
-        return .throttled;
+        return .{ .result = .throttled, .feed_state_invalidated = feed_state_invalidated };
     }
 
     var release = try fetchLatestStableRelease(alloc, options.release_feed_url);
@@ -327,24 +436,70 @@ pub fn checkLatestStableRelease(
     const latest_version = try parseVersionText(release.version_text);
     if (options.current_version.order(latest_version) != .lt) {
         release.deinit(alloc);
-        return .up_to_date;
+        return .{ .result = .up_to_date, .feed_state_invalidated = feed_state_invalidated };
     }
 
     if (options.respect_dismissal) {
         if (state.dismissed_version) |dismissed| {
             if (std.mem.eql(u8, dismissed, release.version_text)) {
                 release.deinit(alloc);
-                return .up_to_date;
+                return .{ .result = .up_to_date, .feed_state_invalidated = feed_state_invalidated };
             }
         }
     }
 
-    return .{ .update_available = release };
+    return .{ .result = .{ .update_available = release }, .feed_state_invalidated = feed_state_invalidated };
+}
+
+/// Drop state that belongs to a feed other than `release_feed_url` and
+/// persist the result. Returns true when a staged install was discarded.
+fn invalidateForeignFeedState(
+    alloc: Allocator,
+    state_path: []const u8,
+    state: *State,
+    release_feed_url: []const u8,
+) !bool {
+    const cached_feed_url = state.release_feed_url orelse return false;
+    if (std.mem.eql(u8, cached_feed_url, release_feed_url)) return false;
+
+    var dirty = false;
+    if (state.staged_version != null or
+        state.staged_installer_path != null or
+        state.staged_sha256 != null)
+    {
+        // Best-effort: the download can be re-staged from the new feed, and
+        // a leftover file under the stage directory is never trusted without
+        // the metadata that clearStagedInstall removes.
+        if (state.staged_installer_path) |path| {
+            if (std.fs.path.isAbsolute(path)) {
+                std.fs.deleteFileAbsolute(path) catch {};
+            }
+        }
+    }
+    if (state.clearStagedInstall(alloc)) dirty = true;
+    if (state.dismissed_version) |value| {
+        alloc.free(value);
+        state.dismissed_version = null;
+        dirty = true;
+    }
+    if (state.last_seen_version) |value| {
+        alloc.free(value);
+        state.last_seen_version = null;
+        dirty = true;
+    }
+    if (state.release_url) |value| {
+        alloc.free(value);
+        state.release_url = null;
+        dirty = true;
+    }
+    if (dirty) try saveState(state_path, state);
+    return dirty;
 }
 
 pub fn stageWindowsInstall(
     alloc: Allocator,
     state_path: []const u8,
+    release_feed_url: []const u8,
     release: *const Release,
 ) !StagedWindowsInstall {
     const candidate = release.windows_install orelse return error.WindowsInstallNotEligible;
@@ -390,6 +545,7 @@ pub fn stageWindowsInstall(
     replaceOptionalOwned(alloc, &state.staged_version, try alloc.dupe(u8, release.version_text));
     replaceOptionalOwned(alloc, &state.staged_installer_path, try alloc.dupe(u8, installer_path));
     replaceOptionalOwned(alloc, &state.staged_sha256, try alloc.dupe(u8, sha256_hex));
+    replaceOptionalOwned(alloc, &state.staged_feed_url, try alloc.dupe(u8, release_feed_url));
     state.staged_at = std.time.timestamp();
     state.apply_requested_at = 0;
     try saveState(state_path, &state);
@@ -401,12 +557,21 @@ pub fn stageWindowsInstall(
     };
 }
 
+/// `release_feed_url` is the feed in effect right now. A staged installer
+/// that came from a different feed is refused rather than applied: the user
+/// re-pointed the updater, so nothing the old feed vouched for is still
+/// authoritative.
 pub fn verifyStagedWindowsInstall(
     alloc: Allocator,
     state_path: []const u8,
+    release_feed_url: []const u8,
 ) !StagedWindowsInstall {
     var state = try loadState(alloc, state_path);
     defer state.deinit(alloc);
+
+    if (!std.mem.eql(u8, state.stagedFeedUrl(), release_feed_url)) {
+        return error.StagedInstallFeedMismatch;
+    }
 
     const version_text = state.staged_version orelse return error.NoStagedWindowsInstall;
     const installer_path = state.staged_installer_path orelse return error.NoStagedWindowsInstall;
@@ -523,12 +688,41 @@ fn resolveRedirectTarget(
     return resolved_url;
 }
 
+/// Response body caps. `std.Io.Reader.streamRemaining` pumps until EOF with
+/// no limit, so an oversized or hostile response would otherwise grow the
+/// caller's buffer (metadata) or the staged file (download) without bound.
+/// Every body read below goes through `streamBounded` with one of these.
+const max_metadata_response_bytes: u64 = 4 * 1024 * 1024;
+const max_download_response_bytes: u64 = 512 * 1024 * 1024;
+const max_redirect_body_bytes: u64 = 1024 * 1024;
+
+/// Pump `reader` into `writer`, refusing a body longer than `max_bytes`.
+/// At most one byte past the cap reaches `writer` before the error, and
+/// every caller discards its destination on error.
+fn streamBounded(
+    reader: *std.Io.Reader,
+    writer: *std.Io.Writer,
+    max_bytes: u64,
+) !void {
+    var streamed: u64 = 0;
+    while (true) {
+        const room = max_bytes + 1 - streamed;
+        if (room == 0) return error.HttpResponseTooLarge;
+        streamed += reader.stream(writer, .limited64(room)) catch |err| switch (err) {
+            error.EndOfStream => return,
+            else => |other| return other,
+        };
+        if (streamed > max_bytes) return error.HttpResponseTooLarge;
+    }
+}
+
 fn fetchHttps(
     alloc: Allocator,
     context: []const u8,
     initial_url: []const u8,
     extra_headers: []const std.http.Header,
     response_writer: *std.Io.Writer,
+    max_response_bytes: u64,
 ) !void {
     _ = try validateHttpsUrl(initial_url);
 
@@ -556,11 +750,19 @@ fn fetchHttps(
                 if (redirect_count >= 3) return error.TooManyHttpRedirects;
                 const location = response.head.location orelse return error.HttpRedirectLocationMissing;
                 next_url = try resolveRedirectTarget(alloc, current_url, location);
+                errdefer if (next_url) |value| alloc.free(value);
 
                 const redirect_reader = response.reader(&.{});
-                _ = redirect_reader.discardRemaining() catch |err| switch (err) {
-                    error.ReadFailed => return response.bodyErr().?,
-                };
+                var discarded: u64 = 0;
+                while (true) {
+                    const room = max_redirect_body_bytes + 1 - discarded;
+                    if (room == 0) return error.HttpResponseTooLarge;
+                    discarded += redirect_reader.discard(.limited64(room)) catch |err| switch (err) {
+                        error.EndOfStream => break,
+                        error.ReadFailed => return response.bodyErr().?,
+                    };
+                    if (discarded > max_redirect_body_bytes) return error.HttpResponseTooLarge;
+                }
                 redirect_count += 1;
             } else {
                 try requireOkHttpStatus(context, current_url, response.head.status);
@@ -580,9 +782,9 @@ fn fetchHttps(
                     &decompress,
                     decompress_buffer,
                 );
-                _ = body_reader.streamRemaining(response_writer) catch |err| switch (err) {
+                streamBounded(body_reader, response_writer, max_response_bytes) catch |err| switch (err) {
                     error.ReadFailed => return response.bodyErr().?,
-                    else => |write_err| return write_err,
+                    else => |other| return other,
                 };
                 return;
             }
@@ -627,6 +829,7 @@ fn downloadUrlToFile(alloc: Allocator, url: []const u8, dest_path: []const u8) !
             .{ .name = "user-agent", .value = "noctty-updater" },
         },
         &file_writer.interface,
+        max_download_response_bytes,
     );
     try file_writer.interface.flush();
     file.close();
@@ -1187,6 +1390,7 @@ fn fetchLatestStableRelease(alloc: Allocator, release_feed_url: []const u8) !Rel
             .{ .name = "x-github-api-version", .value = "2022-11-28" },
         },
         &response_buf.writer,
+        max_metadata_response_bytes,
     );
 
     const body = try response_buf.toOwnedSlice();
@@ -1382,6 +1586,60 @@ test "update release feed resolution" {
         defer alloc.free(resolved);
         try std.testing.expectEqualStrings(case.expected, resolved);
     }
+
+    // The ignored-feed signal names the level whose value was dropped, not
+    // just the configuration level: an environment feed is also a feed.
+    const signal_cases = [_]struct {
+        env: ?[:0]const u8,
+        configured: ?[]const u8,
+        source: FeedSource,
+        ignored: ?FeedSource,
+    }{
+        .{ .env = null, .configured = null, .source = .default, .ignored = null },
+        .{ .env = null, .configured = "https://config.example/latest", .source = .configured, .ignored = null },
+        .{ .env = "https://env.example/latest", .configured = null, .source = .environment, .ignored = null },
+        .{ .env = null, .configured = "http://config.example/latest", .source = .default, .ignored = .configured },
+        .{ .env = "http://env.example/latest", .configured = null, .source = .default, .ignored = .environment },
+        .{ .env = "not a url", .configured = null, .source = .default, .ignored = .environment },
+    };
+
+    for (signal_cases) |case| {
+        if (case.env) |value| {
+            _ = internal_os.setenv(env_name, value);
+        } else {
+            _ = internal_os.unsetenv(env_name);
+        }
+
+        var resolved = try resolveReleaseFeed(alloc, case.configured);
+        defer resolved.deinit(alloc);
+        try std.testing.expectEqual(case.source, resolved.source);
+        try std.testing.expectEqual(case.ignored, resolved.ignored_non_https);
+    }
+}
+
+test "bounded response streaming refuses an oversized body" {
+    const alloc = std.testing.allocator;
+    const body = "0123456789";
+
+    // Exactly at the cap is accepted.
+    {
+        var reader: std.Io.Reader = .fixed(body);
+        var out: std.Io.Writer.Allocating = .init(alloc);
+        defer out.deinit();
+        try streamBounded(&reader, &out.writer, body.len);
+        try std.testing.expectEqualStrings(body, out.written());
+    }
+
+    // One byte over the cap is refused.
+    {
+        var reader: std.Io.Reader = .fixed(body);
+        var out: std.Io.Writer.Allocating = .init(alloc);
+        defer out.deinit();
+        try std.testing.expectError(
+            error.HttpResponseTooLarge,
+            streamBounded(&reader, &out.writer, body.len - 1),
+        );
+    }
 }
 
 test "update installer version must meet the claimed release version" {
@@ -1478,6 +1736,7 @@ test "state persists staged windows install metadata with escaped path" {
         .staged_version = try alloc.dupe(u8, "1.3.101"),
         .staged_installer_path = try alloc.dupe(u8, "C:\\Users\\Aman\\updates\\noctty-1.3.101-windows-x64-setup.exe"),
         .staged_sha256 = try alloc.dupe(u8, "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+        .staged_feed_url = try alloc.dupe(u8, "https://updates.example/latest?channel=\"stable\""),
         .staged_at = 456,
         .apply_requested_at = 789,
     };
@@ -1495,6 +1754,122 @@ test "state persists staged windows install metadata with escaped path" {
     try std.testing.expectEqualStrings("1.3.101", loaded.staged_version.?);
     try std.testing.expectEqualStrings(state.staged_installer_path.?, loaded.staged_installer_path.?);
     try std.testing.expectEqualStrings(state.staged_sha256.?, loaded.staged_sha256.?);
+    try std.testing.expectEqualStrings(state.staged_feed_url.?, loaded.staged_feed_url.?);
+}
+
+test "staged install without a recorded feed is attributed to the default feed" {
+    const alloc = std.testing.allocator;
+    var legacy: State = .{
+        .staged_version = try alloc.dupe(u8, "1.3.101"),
+    };
+    defer legacy.deinit(alloc);
+    try std.testing.expectEqualStrings(latest_stable_api_url, legacy.stagedFeedUrl());
+
+    var bound: State = .{
+        .staged_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_feed_url = try alloc.dupe(u8, "https://updates.example/feed-b"),
+    };
+    defer bound.deinit(alloc);
+    try std.testing.expectEqualStrings("https://updates.example/feed-b", bound.stagedFeedUrl());
+}
+
+test "changing the feed discards the previous feed's staged install and notice state" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    const state_path = try std.fs.path.join(alloc, &.{ tmp_path, "noctty-test", "update-state.json" });
+    defer alloc.free(state_path);
+    const installer_path = try std.fs.path.join(alloc, &.{ tmp_path, "staged-installer.exe" });
+    defer alloc.free(installer_path);
+    try tmp.dir.writeFile(.{ .sub_path = "staged-installer.exe", .data = "not a real installer" });
+
+    var state: State = .{
+        .last_checked_at = 123,
+        .last_seen_version = try alloc.dupe(u8, "1.3.101"),
+        .release_feed_url = try alloc.dupe(u8, "https://updates.example/feed-a"),
+        .release_url = try alloc.dupe(u8, "https://updates.example/releases/1.3.101"),
+        .dismissed_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_installer_path = try alloc.dupe(u8, installer_path),
+        .staged_sha256 = try alloc.dupe(u8, "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+        .staged_feed_url = try alloc.dupe(u8, "https://updates.example/feed-a"),
+        .staged_at = 456,
+        .apply_requested_at = 789,
+    };
+    defer state.deinit(alloc);
+
+    // Same feed: nothing is touched.
+    try std.testing.expect(!try invalidateForeignFeedState(
+        alloc,
+        state_path,
+        &state,
+        "https://updates.example/feed-a",
+    ));
+    try std.testing.expect(state.staged_version != null);
+
+    // Different feed: the staged install, the dismissal, and the cached
+    // release all belonged to feed A and are dropped.
+    try std.testing.expect(try invalidateForeignFeedState(
+        alloc,
+        state_path,
+        &state,
+        "https://updates.example/feed-b",
+    ));
+    try std.testing.expect(state.staged_version == null);
+    try std.testing.expect(state.staged_installer_path == null);
+    try std.testing.expect(state.staged_sha256 == null);
+    try std.testing.expect(state.staged_feed_url == null);
+    try std.testing.expectEqual(@as(i64, 0), state.staged_at);
+    try std.testing.expectEqual(@as(i64, 0), state.apply_requested_at);
+    try std.testing.expect(state.dismissed_version == null);
+    try std.testing.expect(state.last_seen_version == null);
+    try std.testing.expect(state.release_url == null);
+    try std.testing.expectError(
+        error.FileNotFound,
+        tmp.dir.access("staged-installer.exe", .{}),
+    );
+
+    // It was persisted, not just cleared in memory.
+    var loaded = try loadState(alloc, state_path);
+    defer loaded.deinit(alloc);
+    try std.testing.expect(loaded.staged_version == null);
+    try std.testing.expect(loaded.dismissed_version == null);
+
+    // Idempotent: a second pass has nothing left to discard.
+    try std.testing.expect(!try invalidateForeignFeedState(
+        alloc,
+        state_path,
+        &state,
+        "https://updates.example/feed-b",
+    ));
+}
+
+test "staged install from another feed is refused at apply time" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    const state_path = try std.fs.path.join(alloc, &.{ tmp_path, "noctty-test", "update-state.json" });
+    defer alloc.free(state_path);
+
+    var state: State = .{
+        .staged_version = try alloc.dupe(u8, "1.3.101"),
+        .staged_installer_path = try alloc.dupe(u8, "C:\\updates\\noctty-setup.exe"),
+        .staged_sha256 = try alloc.dupe(u8, "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+        .staged_feed_url = try alloc.dupe(u8, "https://updates.example/feed-a"),
+    };
+    defer state.deinit(alloc);
+    try saveState(state_path, &state);
+
+    try std.testing.expectError(
+        error.StagedInstallFeedMismatch,
+        verifyStagedWindowsInstall(alloc, state_path, "https://updates.example/feed-b"),
+    );
 }
 
 test "record staged apply request requires staged installer metadata" {
@@ -1696,7 +2071,7 @@ test "windows install staging rejects relative state path before download" {
 
     try std.testing.expectError(
         error.InvalidStatePath,
-        stageWindowsInstall(alloc, "relative-update-state.json", &release),
+        stageWindowsInstall(alloc, "relative-update-state.json", latest_stable_api_url, &release),
     );
 }
 


### PR DESCRIPTION
## Summary

The updater hardcoded `https://api.github.com/repos/amanthanvi/noctty/releases/latest`. Upstream Ghostty is leaving GitHub with no announced destination, so the release feed now has to be re-pointable without a code change. This also turns the feed into untrusted input, so the trust boundary around it is tightened at the same time.

Fixes #140

## Changes

- One resolved feed URL with precedence `auto-update-feed-url` config > `NOCTTY_UPDATE_FEED_URL` env > compile-time GitHub default. A blank or whitespace-only value at either level falls through to the next; a value that is not a valid HTTPS URL logs a warning, falls back to the default, and is named in a manual check's status message.
- New config key `auto-update-feed-url` (documented alongside `auto-update` / `auto-update-channel`); the resolved value is threaded through `UpdateCheckRequest` -> `CheckOptions`, so `src/update/` never reads config.
- Feed-provided URLs (`html_url`, installer and checksums `browser_download_url`) must parse as absolute HTTPS URLs with a host before they can reach `ShellExecuteW` or a download. Previously any string from the feed was passed straight to the shell.
- All updater HTTP goes through one HTTPS-only fetch helper: redirects are handled explicitly (`redirect_behavior = .unhandled`), every `Location` target is re-validated as HTTPS, and at most 3 redirects are followed. Zig 0.15.2's default client silently allows an https -> http redirect.
- The 24-hour throttle cache now persists the feed URL and the release URL that produced it. A changed feed forces a fresh check instead of serving stale state, and the cached notice uses the persisted release URL instead of synthesizing a github.com tag URL. State files without the new fields force a check (backward compatible).
- Checksum, Authenticode, and pinned-publisher-SPKI verification are unchanged.
- Staged update state is bound to the feed that produced it. `State.staged_feed_url` records that feed; changing the effective feed discards the previous feed's staged installer (file included), dismissal, cached release URL, and last-seen version before anything reads them, and the Win32 app drops the live update notice on that signal. `verifyStagedWindowsInstall` re-checks the feed at apply time and refuses a staged installer the current feed never vouched for.
- Every updater response body is bounded. `fetchHttps` takes an explicit cap and streams through `std.Io.Reader.stream` (4 MiB for release metadata, 512 MiB for a download, 1 MiB for a discarded redirect body) instead of `streamRemaining`, which pumps to EOF with no limit.
- Docs: `docs/windows.md` Updates section (configurable feed + the manual upstream-mirror monitor step), `docs/status.md` Updater bullet.

No provider abstraction, no interfaces, no new files, no build options — one constant, one resolver, one fetch helper.

## Validation

Rebased onto `main` @ `4bcab3464`. Gates on this head:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4188 passed, 71 skipped, 0 failed |
| `pwsh -NoProfile -File scripts/check-zig-format.ps1` | `Zig formatting checks passed (696 tracked sources).` |
| `pwsh -NoProfile -File scripts/check-source-format.ps1` | `PowerShell syntax and JSON validity checks passed.` |
| `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` | `flagship verification contracts: PASS (2 scenarios)` |
| `npx prettier@3 --check docs/status.md docs/windows.md` | `All matched files use Prettier code style!` |
| `zig build test -Dtest-filter=` for the feed, staged-install, and bounded-stream tests | exit 0 |

The `error.Unexpected` stack printed during the suite is the pre-existing
locked-installer negative test's expected output, not a failure.

Tests: table-driven feed resolution (config/env/default precedence, blank
values, non-HTTPS rejection, and which source was ignored), non-HTTPS
`html_url` and asset URL rejection, redirect-target validation, cached release
URL reuse, throttle bypass on feed change, staged-state invalidation on a feed
change, staged-install feed mismatch at apply time, legacy state attributed to
the default feed, and bounded response streaming.

## Residuals / user steps

- A custom feed must serve the same JSON shape as the GitHub latest-release API; no alternate provider implementation exists.
- No live request against a non-GitHub feed was made from this machine.
- No mirror-freshness script was added: nothing comparable exists in the repo to extend, so the monitor step is documented as a manual maintainer task in `docs/windows.md`.
- `patchOrAppendEdits` in `src/apprt/win32.zig` needed an explicit
  `@setEvalBranchQuota`: the new config key pushed its three `inline for`s over
  `Config` past Zig's default 1000-branch comptime limit, which surfaced as a
  compile error in that file rather than at the option.
- A staged install left by an older build has no recorded feed. It is
  attributed to the compiled-in default rather than invalidated, so upgrading
  does not throw away a valid staged installer.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Make Windows update checks re-pointable while enforcing HTTPS and preserving the trust boundary for feed-provided data.

New Features:
- Allow the updater’s release feed to be selected through configuration or the environment, with the GitHub endpoint retained as the fallback.
- Persist feed and release provenance so changing feeds invalidates cached releases, dismissals, and staged installers.

Bug Fixes:
- Reject non-HTTPS feed, release, asset, and redirect URLs and enforce HTTPS-only updater requests with bounded redirect and response handling.
- Prevent installers older than their claimed release from being staged and refuse staged installers originating from another feed.

Enhancements:
- Centralize updater networking and preserve feed-provided release URLs for cached update notices.

Documentation:
- Document configurable release feeds, HTTPS and verification guarantees, and the manual upstream-feed monitoring task.

Tests:
- Add coverage for feed resolution, URL validation, redirect handling, cache invalidation, persisted release URLs, response limits, and installer version checks.

## Stack-wide residuals (recorded on every PR in this stack)

- **Nothing in this stack has run in a real release.** All release-pipeline work was validated locally against a throwaway self-signed certificate and fixture payload trees. The first tag cut with #181 is the real test of manifest generation, signing, attestation and the ten-asset gate.
- **`$firstAttestedVersion = [version]'1.3.124'` in `scripts/verify-published-release.ps1` assumes the next release is 1.3.124.** If a tag is cut with a different number, provenance verification silently skips instead of failing. Move that constant with the tag.
- A working Windows code-signing certificate has existed in the `release` environment since 2026-04-30 (self-signed `CN=winghostty Local Dev Signing`, SPKI pinned in `src/update/github_releases.zig` and ADR-0005). The open SignPath-vs-OV decision governs SmartScreen **reputation**, not signing capability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable HTTPS release feeds for automatic updates.
  - Configure the feed with `auto-update-feed-url` or `NOCTTY_UPDATE_FEED_URL`.
  - Update checks now validate redirects, release metadata, downloads, and cached URLs.
  - Windows installers are rejected when their embedded version is older than the advertised release.

- **Bug Fixes**
  - Improved update state handling and error reporting.
  - Manual checks now explain when an insecure configured feed was ignored.

- **Documentation**
  - Updated status and Windows documentation to describe feed configuration, verification, throttling, and replacement safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
