### PR TITLE
spike: conpty-host feasibility increment, verdict GREEN (#132)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -84,6 +84,27 @@ pub fn build(b: *std.Build) !void {
     else
         null;
 
+    // Standalone feasibility spike. This artifact is intentionally absent
+    // from the normal build and every product packaging path.
+    if (config.emit_conpty_host) {
+        const conpty_host = b.addExecutable(.{
+            .name = "conpty-host",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/conpty_host.zig"),
+                .target = config.target,
+                .optimize = config.optimize,
+                .strip = config.strip,
+                .omit_frame_pointer = config.strip,
+                .unwind_tables = if (config.strip) .none else .sync,
+            }),
+            .use_llvm = true,
+        });
+        conpty_host.subsystem = .Console;
+        conpty_host.linkSystemLibrary("advapi32");
+        _ = try deps.add(conpty_host);
+        b.installArtifact(conpty_host);
+    }
+
     // libghostty-vt is retained in this fork, but normal app builds
     // shouldn't pay to build/install it unless explicitly requested.
     if (want_lib_vt_graph) {

--- a/plans/2026-competitive-roadmap.md
+++ b/plans/2026-competitive-roadmap.md
@@ -257,6 +257,8 @@ shell survived and the viewport repaints on a resize nudge. Green
 graduates durable-session planning (C16); red caps the aspiration
 honestly. Evidence:
 [durable-session-spike report](wayfinder/competitive-analysis/research/durable-session-spike.md).
+**Result (2026-08-21): GREEN; C16 may graduate to planning, while the
+XL implementation remains deferred and unscheduled.**
 
 ### C17 · Named layouts: profile + split tree + hotkey in one object — M · [#133](https://github.com/amanthanvi/noctty/issues/133)
 

--- a/plans/2026-competitive-roadmap.md
+++ b/plans/2026-competitive-roadmap.md
@@ -252,8 +252,9 @@ Terminal's #20077 proposal). This increment validates the third tier
 of the session promise without committing the XL build. **Shape:**
 standalone `conpty-host` exe reusing `src/pty.zig`/`Command.zig`:
 owns one pwsh under ConPTY, ring-buffers output, serves a named pipe;
-test = attach, run a TUI, hard-kill the client, reattach, confirm the
-shell survived and the viewport repaints on a resize nudge. Green
+test = attach, run a synthetic alt-screen TUI, hard-kill the client,
+reattach, confirm the shell survived, and receive a cursor-addressed
+redraw containing the same pre-kill content after a resize nudge. Green
 graduates durable-session planning (C16); red caps the aspiration
 honestly. Evidence:
 [durable-session-spike report](wayfinder/competitive-analysis/research/durable-session-spike.md).

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -317,3 +317,70 @@ only as an open proposal
 ([#20077](https://github.com/microsoft/terminal/issues/20077)). That is
 the line noctty would be crossing first among native Windows
 terminals.
+
+## Feasibility increment result (2026-08-21)
+
+**Verdict: GREEN.** The broker shape works on the tested Windows 25H2
+build 26200.9168. The opt-in `conpty-host` spike is one console
+executable with `serve` and `attach` modes. The host directly reuses
+`Pty.open` / `WindowsPty` from `src/pty.zig` and the ConPTY launch path
+in `src/Command.zig`, owns one `pwsh.exe`, drains ConPTY output on a
+dedicated thread even with no client, retains raw output in a
+preallocated 1 MiB overwrite ring, and accepts one client at a time on
+a `LOCAL` named pipe protected by an explicit current-user DACL and
+`PIPE_REJECT_REMOTE_CLIENTS`. Its deliberately disposable protocol has
+only attach, detach, resize, input, and output frames.
+
+`test/windows/conpty-host-spike.ps1` asserted the experiment end to
+end. It started and recorded every process it controlled; attached to
+the shell; recorded the shell PID and a shell variable; ran a
+five-second viewport-reporting command; force-killed the exact first
+client PID while that command was active; proved the shell PID remained
+live; attached a fresh client; resized from 80x24 to 100x31 and observed
+the running command repaint at 100x31; waited for that command to
+finish; queried and matched the original PID and variable; detached
+again; generated more than the 1 MiB ring capacity; and reattached to
+prove the detached command's completion sentinel existed before
+reattach, the client received at least the full 1 MiB retained replay,
+the newest marker and completion marker were present, and the oldest
+marker had been overwritten. Before that final attach, it required the
+host's drained-output total to remain unchanged for 750 ms after the
+shell wrote its out-of-band completion file, preventing trailing output
+from satisfying the marker assertions as live traffic instead of replay.
+It also checked every emitted ring stat for `retained <= capacity`,
+sampled host private memory throughout detached overflow, exercised the
+explicit detach frame, and cleaned up only retained process objects for
+recorded PIDs.
+
+The final hardened green run reported:
+
+```text
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":82080,"killed_client_pid":76568,"shell_pid":48160,"same_shell_pid":true,"shell_state_intact":true,"viewport_repaint":"100x31","detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2574025,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"host_private_baseline_bytes":21626880,"host_private_max_detached_bytes":21626880,"host_private_growth_bytes":0,"private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+```
+
+The memory claim is intentionally precise: total process private memory
+was 21,626,880 bytes before detached overflow, so the whole process was
+not and cannot be under a 1 MiB ring cap. The retained-output allocation
+never exceeded 1,048,576 bytes, and private-memory growth while draining
+at least 2,574,025 bytes detached was 0 bytes. This proves bounded retained
+output for this run, not a long-duration whole-process memory budget. An
+attached client also causes a transient, capacity-sized replay snapshot;
+the snapshot is copied under the ring mutex and sent after unlocking so a
+slow replay cannot stop the continuously running ConPTY drain thread.
+
+Residual unknowns remain product-sized: alt-screen TUI replay fidelity
+beyond the viewport-repaint probe; a stalled attached client can still
+monopolize the spike's single connection until it disconnects, although
+it no longer blocks ConPTY draining; multi-session and multi-client
+lifecycle; broker crashes; elevation and integrity-level separation;
+upgrade/protocol migration; long-duration memory behavior; and
+adversarial validation from another user or integrity level. The DACL
+construction was exercised only by the owning user. No application
+integration was attempted.
+
+The ceiling is unchanged and absolute: this design can survive UI
+restarts and crashes only while the broker remains alive in the same
+logon session. It can never survive logoff or reboot, and a broker crash
+still kills its ConPTY and shell. With that ceiling, deferred C16
+durable-session planning may graduate; the XL implementation remains
+unscheduled.

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -386,13 +386,15 @@ process private memory was 38,445,056 bytes before detached overflow, so
 the whole process was not and cannot be under a 1 MiB ring cap. The
 retained-output allocation never exceeded 1,048,576 bytes, and the
 sampled private-memory growth while draining at least 2,575,370 bytes
-detached was 0 bytes. That figure is not merely observed: the harness
-enforces sampled growth under the ring cap as a hard failure, so a run
-that breached it would fail rather than report. The caveat is narrower
-than "one observation" — sampling every 25 ms can miss a transient peak
-between samples, and neither the check nor the figure is a
-long-duration whole-process memory budget. The structural guarantee
-remains the ring's retained-byte bound. An
+detached was 0 bytes. That figure is recorded, not enforced: the harness
+reports `observed_host_private_growth_bytes` and derives
+`observed_private_growth_within_ring_cap` from it, but neither can fail
+the run. `PrivateMemorySize64` is whole-process private memory, so
+unrelated heap or runtime page commits can move it by more than the
+ring capacity while `retained <= capacity` stays true, and sampling
+every 25 ms can miss a transient peak in either direction. The only
+memory gate is the ring's retained-byte bound, checked on every emitted
+`RING_STATS` line. An
 attached client also causes a transient, capacity-sized replay snapshot;
 the snapshot is copied under the ring mutex and sent after unlocking so a
 slow replay cannot stop the continuously running ConPTY drain thread.
@@ -434,8 +436,8 @@ listing `\\.\pipe` returned 542 entries including this spike's randomly
 named instance,
 `\\.\pipe\LOCAL\noctty-conpty-host-probe-52876839e78448b49d07ef7589cebee7`.
 An unguessable name is therefore not a control. The DACL protects the
-object this host creates; it never reserves the name. So a *different,
-lower-privileged* local user — not merely a same-user process — could
+object this host creates; it never reserves the name. So a _different,
+lower-privileged_ local user — not merely a same-user process — could
 have claimed the name in any window where no instance existed. This
 host's `FILE_FLAG_FIRST_PIPE_INSTANCE` would fail it closed on the next
 accept, but the client performs no server authentication, so a
@@ -450,8 +452,11 @@ while the host lives. `DisconnectNamedPipe` discards data still buffered
 in the instance, and all per-client state is local to `serveClient`, so
 a new client cannot observe the previous client's bytes. Max instances
 stays 1, preserving one client at a time. Clients also connect with
-`SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, so no server can
-capture an impersonation token from a client that reaches it.
+`SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, which caps the token
+a server can obtain from a connecting client at identification level:
+the server can still obtain such a token and learn who the client is,
+but it cannot act as the client. Without the SQOS flags the default is
+`SecurityImpersonation`, which would let it.
 
 This reuse is not only a design change; it is execution-verified. Every
 green run drives four successive reattaches (clients 2 through 5,
@@ -479,7 +484,7 @@ from probes rather than asserted.
 A second correction is needed, because the revision that introduced the
 persistent instance then claimed the remaining cases were "fail closed,
 no disclosure". That was also wrong. `FILE_FLAG_FIRST_PIPE_INSTANCE`
-fails the *host* closed; it says nothing about the *client*. When an
+fails the _host_ closed; it says nothing about the _client_. When an
 attacker owns the name before the host starts, or when `attach` runs
 with no host at all, the client's open still succeeds against the
 attacker's pipe and the client then sends its attach frame and its
@@ -487,7 +492,7 @@ stdin. Confirmed directly: with no host running and an impostor holding
 `\\.\pipe\LOCAL\noctty-conpty-host-<name>`, the client connected and the
 impostor received the attach frame `01 00 00 00 00`. That is disclosure,
 not denial of service, and `SECURITY_IDENTIFICATION` does not help — it
-prevents impersonation, not capture.
+stops the server acting as the client; it does nothing about capture.
 
 So the client now authenticates the server before sending any frame:
 `GetNamedPipeServerProcessId` on the opened handle, then `OpenProcess`,
@@ -505,12 +510,31 @@ instance in a short-lived process, `DuplicateHandle` the server end into
 a long-lived one, let the creator exit, and groom PID reuse so a
 victim-user process holds that PID when `OpenProcess` runs. That is
 esoteric and race-dependent, but it is why the claim is bounded rather
-than absolute. There is no TOCTOU *after* the check — the handle stays
+than absolute. There is no TOCTOU _after_ the check — the handle stays
 bound to the verified instance. A same-user impostor still passes
 outright, as does a same-user impostor at a different integrity level;
-integrity-level separation stays on the residual list above. Synchronous `ConnectNamedPipe`
-also has no timeout, so the host can remain blocked if the shell exits
-while no client is attached. No application integration was attempted.
+integrity-level separation stays on the residual list above.
+
+The accept is cancellable. The host's instance is created with
+`FILE_FLAG_OVERLAPPED`, `ConnectNamedPipe` is issued with an
+`OVERLAPPED` event, and the host waits on that event and the shell's
+process handle together; when the shell exits first the pending accept
+is cancelled with `CancelIoEx`, its completion is awaited, and teardown
+proceeds. An earlier revision used a synchronous accept, so a shell
+that exited with no client attached left the host parked until some
+client happened to connect. The wait/select logic is covered by four
+hermetic Zig tests in `src/conpty_host.zig` (client connected before
+the accept, client connecting during the accept, shell exit cancelling
+a pending accept and leaving the instance reusable, and shell exit
+winning while the accept is pending), using an event in place of the
+process handle. The end-to-end case is asserted by the harness as its
+final stage: a sixth client sends `exit` to the shell and detaches on
+EOF, so the shell dies with no client attached, and the run requires
+the host process to exit on its own with code 0 within ten seconds
+(`shell_exit_released_host`, `host_exit_code`). Because the instance is
+overlapped, every host-side pipe read and write is now issued
+overlapped as well, each awaited on the same event before returning.
+No application integration was attempted.
 
 The ceiling is unchanged and absolute: this design can survive UI
 restarts and crashes only while the broker remains alive in the same

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -5,8 +5,10 @@ Research date: 2026-08-19. Resolves ticket
 research (Microsoft console docs, microsoft/terminal source and issues,
 competitor docs/issues) plus local code reading (`src/pty.zig`,
 `src/termio/Exec.zig`, `src/Command.zig`, `src/apprt/win32_session_*.zig`).
-No experiments were run; every load-bearing external claim carries a URL.
-Uncertainty is marked inline.
+The original research sections did not run experiments; every
+load-bearing external claim carries a URL. The dated feasibility
+increment appended below records the later local experiment. Uncertainty
+is marked inline.
 
 ## Executive summary (verdict first)
 
@@ -138,7 +140,8 @@ one seam (`Subprocess.start`), not a rewrite of the IO stack.
 process (same codebase, second exe or `--session-host` mode) owns
 `Pty.open`, `Command` spawn, the Job Object, and a bounded raw-VT ring
 buffer per session; the UI connects over a named pipe (per-user
-namespace, DACL'd to the user), speaking a small protocol:
+access is enforced by an owning-user DACL, not by the pipe-name
+namespace), speaking a small protocol:
 `list/spawn/attach/detach/resize/kill` + raw byte streams. On UI
 restart, the UI reattaches, replays the ring buffer into a fresh
 `Screen`, and resumes. This is exactly VS Code's shipped design: pty
@@ -218,7 +221,8 @@ Changes:
   Terminal's answer is separate elevated windows/process trees — mirror
   it: one broker instance per integrity level, elevated sessions
   explicitly badged; v1 can scope durability to non-elevated only.
-  Pipe DACLs must restrict to the owning user + integrity level.
+  Pipe DACLs must restrict to the owning user; separate broker instances
+  enforce the integrity-level boundary.
 - **Scrollback ownership during detach:** while no UI is attached,
   _someone_ must drain the output pipe (otherwise child output
   backpressures; pre-24H2, close paths can deadlock —
@@ -226,11 +230,11 @@ Changes:
   The broker's ring buffer is therefore mandatory, not an optimization.
   Replay fidelity is bounded: alt-screen TUIs won't replay perfectly
   from a byte ring (VS Code caps restored scrollback and accepts this;
-  [docs](https://code.visualstudio.com/docs/terminal/advanced)); a
-  resize nudge on reattach makes ConPTY repaint the live viewport,
-  which is what makes TUIs usable again (behavior widely relied on;
-  exact repaint guarantees undocumented — uncertain). Full fidelity =
-  option C's cost.
+  [docs](https://code.visualstudio.com/docs/terminal/advanced)). The
+  feasibility increment below shows that a live polling TUI can observe
+  a resize nudge and emit a fresh cursor-addressed redraw; it does not
+  establish a generic ConPTY-driven repaint guarantee for arbitrary
+  TUIs. Full fidelity = option C's cost.
 - **Job objects / orphan control:** the `KILL_ON_JOB_CLOSE` job must be
   owned by the broker, and "close all sessions on real quit" becomes an
   explicit broker verb — otherwise durable sessions become orphan
@@ -250,8 +254,16 @@ shipped art (VS Code), not research risk.
 **Smallest testable increment (M):** a standalone `conpty-host` spike —
 one Zig exe reusing `pty.zig`+`Command.zig` that spawns pwsh under a
 ConPTY it owns, ring-buffers output, and serves one named pipe; plus a
-trivial attach client. Test: attach, run a TUI, hard-kill the client,
-reattach from a new client, confirm the shell and TUI survived and the viewport repaints after a resize nudge. Bounded-buffer acceptance criterion: a fixed-size per-session ring (default 1 MiB, configurable) that overwrites oldest data on overflow, replays its full contents on attach, and is tested by generating more output than the ring holds while detached — reattach must show the newest data with host memory never exceeding the cap. That one artifact retires the
+trivial attach client. Test: attach, run a synthetic alt-screen TUI,
+hard-kill the client, reattach from a new client, confirm the shell and
+TUI survived, and receive a cursor-addressed redraw containing the same
+pre-kill content after a resize nudge. Bounded-buffer acceptance
+criterion: a fixed-size per-session ring (default 1 MiB, configurable)
+that overwrites oldest data on overflow, replays its full contents on
+attach, and is tested by generating more output than the ring holds
+while detached — reattach must show the newest data, retained ring bytes
+must never exceed the cap, and process-private-memory growth is recorded
+as a one-run diagnostic rather than a guarantee. That one artifact retires the
 core risk (lifetime semantics, drain-while-detached, replay adequacy)
 before any noctty integration, and its protocol can be thrown away.
 Second increment: swap `Subprocess.start` to attach mode behind a
@@ -327,19 +339,27 @@ executable with `serve` and `attach` modes. The host directly reuses
 in `src/Command.zig`, owns one `pwsh.exe`, drains ConPTY output on a
 dedicated thread even with no client, retains raw output in a
 preallocated 1 MiB overwrite ring, and accepts one client at a time on
-a `LOCAL` named pipe protected by an explicit current-user DACL and
-`PIPE_REJECT_REMOTE_CLIENTS`. Its deliberately disposable protocol has
+a named pipe. Its actual security controls are an explicit protected
+current-user SDDL DACL, `FILE_FLAG_FIRST_PIPE_INSTANCE`, and
+`PIPE_REJECT_REMOTE_CLIENTS`. The retained `LOCAL` prefix only affects
+AppContainer name resolution; it is not an access-control property for
+ordinary desktop processes. Its deliberately disposable protocol has
 only attach, detach, resize, input, and output frames.
 
 `test/windows/conpty-host-spike.ps1` asserted the experiment end to
 end. It started and recorded every process it controlled; attached to
-the shell; recorded the shell PID and a shell variable; ran a
-five-second viewport-reporting command; force-killed the exact first
-client PID while that command was active; proved the shell PID remained
-live; attached a fresh client; resized from 80x24 to 100x31 and observed
-the running command repaint at 100x31; waited for that command to
-finish; queried and matched the original PID and variable; detached
-again; generated more than the 1 MiB ring capacity; and reattached to
+the shell; recorded the shell PID and a shell variable; entered the
+alternate screen with `CSI ?1049h`; and ran a synthetic polling TUI that
+drew a cursor-addressed box containing a unique content token at 80x24.
+It force-killed the exact first client PID while that TUI was active,
+proved the shell PID remained live, attached a fresh client, and resized
+from 80x24 to 100x31. The new client then received a normalized
+cursor-addressed redraw containing the same pre-kill content token and a
+new unique 100x31 redraw token, followed by `CSI ?1049l`. The 100x31
+token did not exist before reattach, so it could not be old ring replay.
+The script then queried and matched the original PID and shell variable,
+detached again, generated more than the 1 MiB ring capacity, and
+reattached to
 prove the detached command's completion sentinel existed before
 reattach, the client received at least the full 1 MiB retained replay,
 the newest marker and completion marker were present, and the oldest
@@ -352,31 +372,38 @@ sampled host private memory throughout detached overflow, exercised the
 explicit detach frame, and cleaned up only retained process objects for
 recorded PIDs.
 
-The final hardened green run reported:
+The latest hardened green run reported:
 
 ```text
-CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":82080,"killed_client_pid":76568,"shell_pid":48160,"same_shell_pid":true,"shell_state_intact":true,"viewport_repaint":"100x31","detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2574025,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"host_private_baseline_bytes":21626880,"host_private_max_detached_bytes":21626880,"host_private_growth_bytes":0,"private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":71240,"killed_client_pid":46576,"shell_pid":61236,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2581541,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":21626880,"observed_host_private_max_detached_bytes":21626880,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
 ```
 
-The memory claim is intentionally precise: total process private memory
-was 21,626,880 bytes before detached overflow, so the whole process was
-not and cannot be under a 1 MiB ring cap. The retained-output allocation
-never exceeded 1,048,576 bytes, and private-memory growth while draining
-at least 2,574,025 bytes detached was 0 bytes. This proves bounded retained
-output for this run, not a long-duration whole-process memory budget. An
+The memory evidence is intentionally precise and observational: total
+process private memory was 21,626,880 bytes before detached overflow, so
+the whole process was not and cannot be under a 1 MiB ring cap. The
+retained-output allocation never exceeded 1,048,576 bytes, and the
+sampled private-memory growth while draining at least 2,581,541 bytes
+detached was 0 bytes in this one run. The structural guarantee is the
+ring's retained-byte bound; the process-memory figure is not a guarantee
+or a long-duration whole-process memory budget. An
 attached client also causes a transient, capacity-sized replay snapshot;
 the snapshot is copied under the ring mutex and sent after unlocking so a
 slow replay cannot stop the continuously running ConPTY drain thread.
 
-Residual unknowns remain product-sized: alt-screen TUI replay fidelity
-beyond the viewport-repaint probe; a stalled attached client can still
+Residual unknowns remain product-sized: arbitrary third-party and
+complex TUI behavior beyond this synthetic polling alt-screen probe; a
+stalled attached client can still
 monopolize the spike's single connection until it disconnects, although
 it no longer blocks ConPTY draining; multi-session and multi-client
 lifecycle; broker crashes; elevation and integrity-level separation;
 upgrade/protocol migration; long-duration memory behavior; and
 adversarial validation from another user or integrity level. The DACL
-construction was exercised only by the owning user. No application
-integration was attempted.
+construction was exercised only by the owning user. The pipe instance is
+closed and recreated between clients, so a same-user process can squat
+the name during that gap; same-user attackers are explicitly outside
+this feasibility spike's threat model. Synchronous `ConnectNamedPipe`
+also has no timeout, so the host can remain blocked if the shell exits
+while no client is attached. No application integration was attempted.
 
 The ceiling is unchanged and absolute: this design can survive UI
 restarts and crashes only while the broker remains alive in the same

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -378,17 +378,21 @@ recorded PIDs.
 The latest hardened green run reported:
 
 ```text
-CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":38276,"killed_client_pid":24636,"shell_pid":14080,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2579093,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38449152,"observed_host_private_max_detached_bytes":38449152,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":588,"killed_client_pid":47372,"shell_pid":39000,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2575370,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38445056,"observed_host_private_max_detached_bytes":38445056,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid","pipe_security_evidence":"mechanism-inventory-not-derived","pipe_security_execution_verified":"current-user-DACL-accept;server-sid-accept;persistent-instance-reuse","pipe_security_by_construction":"first-instance-collision;reject-remote;cross-user-DACL-denial;untrusted-server-rejection","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
 ```
 
 The memory evidence is intentionally precise and observational: total
-process private memory was 38,449,152 bytes before detached overflow, so
+process private memory was 38,445,056 bytes before detached overflow, so
 the whole process was not and cannot be under a 1 MiB ring cap. The
 retained-output allocation never exceeded 1,048,576 bytes, and the
-sampled private-memory growth while draining at least 2,579,093 bytes
-detached was 0 bytes in this one run. The structural guarantee is the
-ring's retained-byte bound; the process-memory figure is not a guarantee
-or a long-duration whole-process memory budget. An
+sampled private-memory growth while draining at least 2,575,370 bytes
+detached was 0 bytes. That figure is not merely observed: the harness
+enforces sampled growth under the ring cap as a hard failure, so a run
+that breached it would fail rather than report. The caveat is narrower
+than "one observation" — sampling every 25 ms can miss a transient peak
+between samples, and neither the check nor the figure is a
+long-duration whole-process memory budget. The structural guarantee
+remains the ring's retained-byte bound. An
 attached client also causes a transient, capacity-sized replay snapshot;
 the snapshot is copied under the ring mutex and sent after unlocking so a
 slow replay cannot stop the continuously running ConPTY drain thread.
@@ -449,6 +453,29 @@ stays 1, preserving one client at a time. Clients also connect with
 `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, so no server can
 capture an impersonation token from a client that reaches it.
 
+This reuse is not only a design change; it is execution-verified. Every
+green run drives four successive reattaches (clients 2 through 5,
+including one after a hard PID kill) through the
+`DisconnectNamedPipe` → `ConnectNamedPipe` path on the same handle, so
+the reused instance is exercised on the normal path of every run rather
+than reasoned about.
+
+One caveat about the evidence itself, so the verdict line is not read
+for more than it says: `pipe_security` is a hard-coded constant in the
+harness. It is a fair inventory of mechanisms that all exist in the
+code, but it is not derived — deleting `verifyPipeServer` from the
+client would not change the emitted string, and the harness's only
+related assertion regexes the host's own `security=current-user`
+self-report. Of the listed tokens, only the current-user DACL accept
+path, the server-SID accept path and the persistent-instance reuse are
+execution-verified. First-instance collision, reject-remote, cross-user
+DACL denial and the `UntrustedPipeServer` rejection branch hold by
+construction and code review only. The run now emits
+`pipe_security_evidence`, `pipe_security_execution_verified` and
+`pipe_security_by_construction` so this distinction travels with the
+result. If any of this graduates to product, the field must be derived
+from probes rather than asserted.
+
 A second correction is needed, because the revision that introduced the
 persistent instance then claimed the remaining cases were "fail closed,
 no disclosure". That was also wrong. `FILE_FLAG_FIRST_PIPE_INSTANCE`
@@ -470,14 +497,18 @@ confirm — including an `OpenProcess` that fails because the server
 belongs to another user. The green run below exercised the accepting
 path across all five clients.
 
-What remains is now stated exactly: this closes the *cross-user* case.
-A same-user impostor still passes the SID comparison, as does a
-same-user impostor at a different integrity level. Those are real and
-unclosed, and integrity-level separation stays on the residual list
-above. The honest summary is that a different local user can no longer
-capture terminal input in any of these windows, and a same-user attacker
-still can — which is consistent with the spike's stated threat model
-rather than an unexamined assumption about it. Synchronous `ConnectNamedPipe`
+What remains is now stated exactly. This closes the cross-user case up
+to a PID-reuse race between the pipe's recorded server PID and
+`OpenProcess`: the check authenticates the process currently holding
+that PID, not the pipe endpoint itself. An attacker can create the
+instance in a short-lived process, `DuplicateHandle` the server end into
+a long-lived one, let the creator exit, and groom PID reuse so a
+victim-user process holds that PID when `OpenProcess` runs. That is
+esoteric and race-dependent, but it is why the claim is bounded rather
+than absolute. There is no TOCTOU *after* the check — the handle stays
+bound to the verified instance. A same-user impostor still passes
+outright, as does a same-user impostor at a different integrity level;
+integrity-level separation stays on the residual list above. Synchronous `ConnectNamedPipe`
 also has no timeout, so the host can remain blocked if the shell exits
 while no client is attached. No application integration was attempted.
 

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -342,8 +342,9 @@ preallocated 1 MiB overwrite ring, and accepts one client at a time on
 a named pipe. Its actual security controls are an explicit protected
 current-user SDDL DACL, `FILE_FLAG_FIRST_PIPE_INSTANCE`,
 `PIPE_REJECT_REMOTE_CLIENTS`, a single pipe instance created before the
-name is advertised and held for the host's lifetime, and clients that
-connect at `SECURITY_IDENTIFICATION`. The retained `LOCAL` prefix only affects
+name is advertised and held for the host's lifetime, clients that
+connect at `SECURITY_IDENTIFICATION`, and clients that authenticate the
+server's owner SID before sending any frame. The retained `LOCAL` prefix only affects
 AppContainer name resolution; it is not an access-control property for
 ordinary desktop processes. Its deliberately disposable protocol has
 only attach, detach, resize, input, and output frames.
@@ -377,14 +378,14 @@ recorded PIDs.
 The latest hardened green run reported:
 
 ```text
-CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":5724,"killed_client_pid":58092,"shell_pid":65196,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2575980,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38436864,"observed_host_private_max_detached_bytes":38436864,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":38276,"killed_client_pid":24636,"shell_pid":14080,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2579093,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38449152,"observed_host_private_max_detached_bytes":38449152,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
 ```
 
 The memory evidence is intentionally precise and observational: total
-process private memory was 38,436,864 bytes before detached overflow, so
+process private memory was 38,449,152 bytes before detached overflow, so
 the whole process was not and cannot be under a 1 MiB ring cap. The
 retained-output allocation never exceeded 1,048,576 bytes, and the
-sampled private-memory growth while draining at least 2,575,980 bytes
+sampled private-memory growth while draining at least 2,579,093 bytes
 detached was 0 bytes in this one run. The structural guarantee is the
 ring's retained-byte bound; the process-memory figure is not a guarantee
 or a long-duration whole-process memory budget. An
@@ -398,6 +399,18 @@ the ring every 20 ms, because a synchronous stderr write on the drain
 thread would block whenever stderr is a pipe whose reader stops
 consuming — which would backpressure ConPTY through the very
 measurement instrument used to prove detached draining.
+
+That sampler is detached and is never joined at teardown. The same
+blocking write that must stay off the drain thread would otherwise stall
+shutdown instead: a thread already inside `WriteFile` cannot observe a
+stop flag, so joining it would hang teardown and leave a broker alive
+after its shell had exited — the one lifetime property this spike
+exists to claim. Teardown therefore signals the sampler and abandons it.
+Abandoning it is only safe because the ring, its backing bytes and the
+sampler's context are allocated from the page allocator and never freed;
+the host is a one-shot process and the OS reclaims them at exit. Keeping
+them out of the GPA also stops its leak report from firing at teardown,
+which would itself be another blocking write to the same stderr.
 
 Residual unknowns remain product-sized: arbitrary third-party and
 complex TUI behavior beyond this synthetic polling alt-screen probe; a
@@ -436,12 +449,35 @@ stays 1, preserving one client at a time. Clients also connect with
 `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, so no server can
 capture an impersonation token from a client that reaches it.
 
-Two related gaps stay open deliberately. An attacker who owns the name
-*before* this host starts still denies service — fail closed, no
-disclosure. And a client launched when no host is running has nothing to
-authenticate against. Closing that needs client-side server
-authentication, such as `GetNamedPipeServerProcessId` plus an owner-SID
-comparison, which is product work rather than spike work. Synchronous `ConnectNamedPipe`
+A second correction is needed, because the revision that introduced the
+persistent instance then claimed the remaining cases were "fail closed,
+no disclosure". That was also wrong. `FILE_FLAG_FIRST_PIPE_INSTANCE`
+fails the *host* closed; it says nothing about the *client*. When an
+attacker owns the name before the host starts, or when `attach` runs
+with no host at all, the client's open still succeeds against the
+attacker's pipe and the client then sends its attach frame and its
+stdin. Confirmed directly: with no host running and an impostor holding
+`\\.\pipe\LOCAL\noctty-conpty-host-<name>`, the client connected and the
+impostor received the attach frame `01 00 00 00 00`. That is disclosure,
+not denial of service, and `SECURITY_IDENTIFICATION` does not help — it
+prevents impersonation, not capture.
+
+So the client now authenticates the server before sending any frame:
+`GetNamedPipeServerProcessId` on the opened handle, then `OpenProcess`,
+then a token-user SID comparison against the current user, failing
+closed as `error.UntrustedPipeServer` on any step it cannot positively
+confirm — including an `OpenProcess` that fails because the server
+belongs to another user. The green run below exercised the accepting
+path across all five clients.
+
+What remains is now stated exactly: this closes the *cross-user* case.
+A same-user impostor still passes the SID comparison, as does a
+same-user impostor at a different integrity level. Those are real and
+unclosed, and integrity-level separation stays on the residual list
+above. The honest summary is that a different local user can no longer
+capture terminal input in any of these windows, and a same-user attacker
+still can — which is consistent with the spike's stated threat model
+rather than an unexamined assumption about it. Synchronous `ConnectNamedPipe`
 also has no timeout, so the host can remain blocked if the shell exits
 while no client is attached. No application integration was attempted.
 

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -340,8 +340,10 @@ in `src/Command.zig`, owns one `pwsh.exe`, drains ConPTY output on a
 dedicated thread even with no client, retains raw output in a
 preallocated 1 MiB overwrite ring, and accepts one client at a time on
 a named pipe. Its actual security controls are an explicit protected
-current-user SDDL DACL, `FILE_FLAG_FIRST_PIPE_INSTANCE`, and
-`PIPE_REJECT_REMOTE_CLIENTS`. The retained `LOCAL` prefix only affects
+current-user SDDL DACL, `FILE_FLAG_FIRST_PIPE_INSTANCE`,
+`PIPE_REJECT_REMOTE_CLIENTS`, a single pipe instance created before the
+name is advertised and held for the host's lifetime, and clients that
+connect at `SECURITY_IDENTIFICATION`. The retained `LOCAL` prefix only affects
 AppContainer name resolution; it is not an access-control property for
 ordinary desktop processes. Its deliberately disposable protocol has
 only attach, detach, resize, input, and output frames.
@@ -375,14 +377,14 @@ recorded PIDs.
 The latest hardened green run reported:
 
 ```text
-CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":68268,"killed_client_pid":58724,"shell_pid":23320,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2576380,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38449152,"observed_host_private_max_detached_bytes":38449152,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":5724,"killed_client_pid":58092,"shell_pid":65196,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2575980,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38436864,"observed_host_private_max_detached_bytes":38436864,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
 ```
 
 The memory evidence is intentionally precise and observational: total
-process private memory was 38,449,152 bytes before detached overflow, so
+process private memory was 38,436,864 bytes before detached overflow, so
 the whole process was not and cannot be under a 1 MiB ring cap. The
 retained-output allocation never exceeded 1,048,576 bytes, and the
-sampled private-memory growth while draining at least 2,576,380 bytes
+sampled private-memory growth while draining at least 2,575,980 bytes
 detached was 0 bytes in this one run. The structural guarantee is the
 ring's retained-byte bound; the process-memory figure is not a guarantee
 or a long-duration whole-process memory budget. An
@@ -405,10 +407,41 @@ it no longer blocks ConPTY draining; multi-session and multi-client
 lifecycle; broker crashes; elevation and integrity-level separation;
 upgrade/protocol migration; long-duration memory behavior; and
 adversarial validation from another user or integrity level. The DACL
-construction was exercised only by the owning user. The pipe instance is
-closed and recreated between clients, so a same-user process can squat
-the name during that gap; same-user attackers are explicitly outside
-this feasibility spike's threat model. Synchronous `ConnectNamedPipe`
+construction was exercised only by the owning user.
+
+An earlier revision described the pipe-name gap as a same-user squat and
+dismissed it as out of scope. That was wrong, and the correction matters.
+The `\\.\pipe` namespace is machine-global, creating a name in it needs
+no privilege, and the namespace is enumerable: from an ordinary process,
+listing `\\.\pipe` returned 542 entries including this spike's randomly
+named instance,
+`\\.\pipe\LOCAL\noctty-conpty-host-probe-52876839e78448b49d07ef7589cebee7`.
+An unguessable name is therefore not a control. The DACL protects the
+object this host creates; it never reserves the name. So a *different,
+lower-privileged* local user — not merely a same-user process — could
+have claimed the name in any window where no instance existed. This
+host's `FILE_FLAG_FIRST_PIPE_INSTANCE` would fail it closed on the next
+accept, but the client performs no server authentication, so a
+reconnecting client would have disclosed its terminal input to the
+impostor. That is a cross-user disclosure path, and it was outside what
+the stated same-user scope covered.
+
+The host now creates its one instance before advertising the name and
+reuses it across clients via `DisconnectNamedPipe` and a fresh
+`ConnectNamedPipe` on the same handle, so the name is never unowned
+while the host lives. `DisconnectNamedPipe` discards data still buffered
+in the instance, and all per-client state is local to `serveClient`, so
+a new client cannot observe the previous client's bytes. Max instances
+stays 1, preserving one client at a time. Clients also connect with
+`SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, so no server can
+capture an impersonation token from a client that reaches it.
+
+Two related gaps stay open deliberately. An attacker who owns the name
+*before* this host starts still denies service — fail closed, no
+disclosure. And a client launched when no host is running has nothing to
+authenticate against. Closing that needs client-side server
+authentication, such as `GetNamedPipeServerProcessId` plus an owner-SID
+comparison, which is product work rather than spike work. Synchronous `ConnectNamedPipe`
 also has no timeout, so the host can remain blocked if the shell exits
 while no client is attached. No application integration was attempted.
 

--- a/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
+++ b/plans/wayfinder/competitive-analysis/research/durable-session-spike.md
@@ -375,20 +375,27 @@ recorded PIDs.
 The latest hardened green run reported:
 
 ```text
-CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":71240,"killed_client_pid":46576,"shell_pid":61236,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2581541,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":21626880,"observed_host_private_max_detached_bytes":21626880,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
+CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":68268,"killed_client_pid":58724,"shell_pid":23320,"same_shell_pid":true,"shell_state_intact":true,"alt_screen_entered":true,"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31","alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,"ring_total_bytes":2576380,"replay_bytes":1048576,"oldest_replay_absent":true,"newest_replay_present":true,"observed_host_private_baseline_bytes":38449152,"observed_host_private_max_detached_bytes":38449152,"observed_host_private_growth_bytes":0,"observed_private_growth_within_ring_cap":true,"pipe_security":"current-user-DACL+first-instance+reject-remote","detach_frame":true,"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
 ```
 
 The memory evidence is intentionally precise and observational: total
-process private memory was 21,626,880 bytes before detached overflow, so
+process private memory was 38,449,152 bytes before detached overflow, so
 the whole process was not and cannot be under a 1 MiB ring cap. The
 retained-output allocation never exceeded 1,048,576 bytes, and the
-sampled private-memory growth while draining at least 2,581,541 bytes
+sampled private-memory growth while draining at least 2,576,380 bytes
 detached was 0 bytes in this one run. The structural guarantee is the
 ring's retained-byte bound; the process-memory figure is not a guarantee
 or a long-duration whole-process memory budget. An
 attached client also causes a transient, capacity-sized replay snapshot;
 the snapshot is copied under the ring mutex and sent after unlocking so a
 slow replay cannot stop the continuously running ConPTY drain thread.
+
+The drain thread also performs no diagnostics I/O. The `RING_STATS`
+lines the harness parses are published by a separate thread that samples
+the ring every 20 ms, because a synchronous stderr write on the drain
+thread would block whenever stderr is a pipe whose reader stops
+consuming — which would backpressure ConPTY through the very
+measurement instrument used to prove detached draining.
 
 Residual unknowns remain product-sized: arbitrary third-party and
 complex TUI behavior beyond this synthetic polling alt-screen probe; a

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -37,6 +37,7 @@ strip: bool = false,
 
 /// Artifacts
 emit_bench: bool = false,
+emit_conpty_host: bool = false,
 emit_docs: bool = false,
 emit_exe: bool = false,
 emit_helpgen: bool = false,
@@ -244,6 +245,16 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
         "Build and install the benchmark executables.",
     ) orelse false;
 
+    config.emit_conpty_host = b.option(
+        bool,
+        "emit-conpty-host",
+        "Build and install the standalone Windows ConPTY host spike.",
+    ) orelse false;
+
+    if (config.emit_conpty_host and target.result.os.tag != .windows) {
+        return error.ConptyHostRequiresWindowsTarget;
+    }
+
     config.emit_helpgen = b.option(
         bool,
         "emit-helpgen",
@@ -257,6 +268,7 @@ pub fn init(b: *std.Build, appVersion: []const u8) !Config {
     ) orelse emit_docs: {
         // If we are emitting any other artifacts then we default to false.
         if (config.emit_bench or
+            config.emit_conpty_host or
             config.emit_test_exe or
             config.emit_helpgen or
             config.emit_lib_vt) break :emit_docs false;

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -31,6 +31,8 @@ const error_file_not_found = 2;
 const error_pipe_connected = 535;
 const error_pipe_busy = 231;
 const still_active = 259;
+const security_sqos_present = 0x00100000;
+const security_identification = 0x00010000;
 
 const Tag = enum(u8) {
     attach = 1,
@@ -387,6 +389,33 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
 
     var security = try PipeSecurity.init(alloc);
     defer security.deinit();
+
+    // Create the one pipe instance before advertising the name, and keep it alive
+    // for the whole host lifetime. The \\.\pipe namespace is machine-global and
+    // any local user can both enumerate it and create a name in it, so the DACL
+    // below protects the object this process created but never reserves the name
+    // itself. Destroying and recreating the instance between clients would leave
+    // the name unowned in the gap, letting a different, lower-privileged user
+    // stand up a permissive pipe of the same name; FIRST_PIPE_INSTANCE would then
+    // fail this host closed, but a reconnecting client does not authenticate the
+    // server and would hand its keystrokes to the impostor. Reusing one instance
+    // removes that window entirely.
+    var security_attributes = security.attributes();
+    const pipe = windows.kernel32.CreateNamedPipeW(
+        pipe_name_w.ptr,
+        pipe_access_duplex | file_flag_first_pipe_instance,
+        windows.PIPE_TYPE_BYTE | pipe_reject_remote_clients,
+        1,
+        max_frame_payload,
+        max_frame_payload,
+        0,
+        &security_attributes,
+    );
+    if (pipe == windows.INVALID_HANDLE_VALUE) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+    defer _ = windows.CloseHandle(pipe);
+
     var stdout_buffer: [1024]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
     try stdout_writer.interface.print(
@@ -396,25 +425,6 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     try stdout_writer.interface.flush();
 
     while (shellRunning(command.pid.?)) {
-        var security_attributes = security.attributes();
-        // FIRST_PIPE_INSTANCE fails closed on a collision. It does not prevent a
-        // same-user process from squatting this name between recreated instances;
-        // same-user attackers are outside this feasibility spike's threat model.
-        const pipe = windows.kernel32.CreateNamedPipeW(
-            pipe_name_w.ptr,
-            pipe_access_duplex | file_flag_first_pipe_instance,
-            windows.PIPE_TYPE_BYTE | pipe_reject_remote_clients,
-            1,
-            max_frame_payload,
-            max_frame_payload,
-            0,
-            &security_attributes,
-        );
-        if (pipe == windows.INVALID_HANDLE_VALUE) {
-            return windows.unexpectedError(windows.kernel32.GetLastError());
-        }
-        defer _ = windows.CloseHandle(pipe);
-
         // Spike limitation: this synchronous accept has no cancellation. If the
         // shell exits with no client attached, the host waits here until a client
         // connects. Product code would need an overlapped, cancellable accept.
@@ -427,6 +437,15 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
             error.BrokenPipe, error.NoData, error.PipeNotConnected => {},
             else => return err,
         };
+
+        // Discards whatever is still buffered in the instance, so the next client
+        // cannot observe the previous client's bytes, and returns the instance to
+        // a listening state for the next accept. All other per-client state
+        // (replay snapshot, ring cursor, frame buffers) is local to serveClient
+        // and is rebuilt on the next call. Max instances stays 1, so the
+        // one-client-at-a-time invariant is unchanged; a second client now sees
+        // ERROR_PIPE_BUSY instead of ERROR_FILE_NOT_FOUND, and connectClient
+        // already retries on both.
         _ = DisconnectNamedPipe(pipe);
     }
 }
@@ -649,13 +668,19 @@ fn attachInput(context: InputContext) void {
 fn connectClient(pipe_name: [:0]const u16) !windows.HANDLE {
     const deadline = std.time.nanoTimestamp() + (10 * std.time.ns_per_s);
     while (true) {
+        // Named pipes default to SecurityImpersonation when the caller supplies no
+        // SQOS, which would let any server on the other end impersonate this
+        // client. Pin identification level so a server can learn who we are but
+        // cannot act as us. This does NOT authenticate the server; the host keeps
+        // its single pipe instance alive precisely so the name is never available
+        // for an impostor to claim.
         const pipe = windows.kernel32.CreateFileW(
             pipe_name.ptr,
             windows.GENERIC_READ | windows.GENERIC_WRITE,
             0,
             null,
             windows.OPEN_EXISTING,
-            windows.FILE_ATTRIBUTE_NORMAL,
+            windows.FILE_ATTRIBUTE_NORMAL | security_sqos_present | security_identification,
             null,
         );
         if (pipe != windows.INVALID_HANDLE_VALUE) return pipe;

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -172,7 +172,7 @@ const Ring = struct {
         cursor: u64,
     };
 
-    fn append(self: *Ring, src: []const u8) Stats {
+    fn append(self: *Ring, src: []const u8) void {
         self.mutex.lock();
         defer self.mutex.unlock();
 
@@ -181,7 +181,7 @@ const Ring = struct {
             @memcpy(self.bytes, src[src.len - self.bytes.len ..]);
             self.head = 0;
             self.len = self.bytes.len;
-            return self.statsLocked();
+            return;
         }
 
         const free = self.bytes.len - self.len;
@@ -196,6 +196,11 @@ const Ring = struct {
         @memcpy(self.bytes[write_at .. write_at + first_len], src[0..first_len]);
         @memcpy(self.bytes[0 .. src.len - first_len], src[first_len..]);
         self.len += src.len;
+    }
+
+    fn stats(self: *Ring) Stats {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         return self.statsLocked();
     }
 
@@ -242,6 +247,11 @@ const DrainContext = struct {
     ring: *Ring,
 };
 
+// Keep all diagnostics off this thread. Anything the host writes to stderr can
+// block indefinitely when stderr is a pipe whose reader stops consuming, and
+// this is the only thread draining ConPTY. Blocking here would backpressure the
+// shell even with no client attached, which is the load-bearing property this
+// spike exists to measure.
 fn drainConpty(context: *DrainContext) void {
     var buffer: [64 * 1024]u8 = undefined;
     while (true) {
@@ -254,11 +264,34 @@ fn drainConpty(context: *DrainContext) void {
             null,
         ) == 0 or read_len == 0) return;
 
-        const stats = context.ring.append(buffer[0..read_len]);
-        std.debug.print(
-            "RING_STATS total={} retained={} capacity={}\n",
-            .{ stats.total, stats.retained, stats.capacity },
-        );
+        context.ring.append(buffer[0..read_len]);
+    }
+}
+
+const stats_sample_interval_ns = 20 * std.time.ns_per_ms;
+
+const StatsContext = struct {
+    ring: *Ring,
+    stop: std.atomic.Value(bool) = .init(false),
+};
+
+// Samples the ring on its own thread so a stalled stderr consumer can only
+// stall diagnostics, never ConPTY draining. One final sample is published after
+// `stop` is observed so the last totals are never lost on shutdown.
+fn reportRingStats(context: *StatsContext) void {
+    var last_total: u64 = 0;
+    while (true) {
+        const stopping = context.stop.load(.acquire);
+        const stats = context.ring.stats();
+        if (stats.total != last_total) {
+            last_total = stats.total;
+            std.debug.print(
+                "RING_STATS total={} retained={} capacity={}\n",
+                .{ stats.total, stats.retained, stats.capacity },
+            );
+        }
+        if (stopping) return;
+        std.Thread.sleep(stats_sample_interval_ns);
     }
 }
 
@@ -331,10 +364,16 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
         .rt_post_fork_info = undefined,
     };
     var drain_thread: ?std.Thread = null;
+    var stats_context = StatsContext{ .ring = &ring };
+    var stats_thread: ?std.Thread = null;
     defer {
         command.closeWindowsJobObject();
         pty.deinit();
         if (drain_thread) |thread| thread.join();
+        if (stats_thread) |thread| {
+            stats_context.stop.store(true, .release);
+            thread.join();
+        }
         if (command.pid) |process| _ = windows.CloseHandle(process);
     }
 
@@ -344,6 +383,7 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
 
     var drain_context = DrainContext{ .output = pty.out_pipe, .ring = &ring };
     drain_thread = try std.Thread.spawn(.{}, drainConpty, .{&drain_context});
+    stats_thread = try std.Thread.spawn(.{}, reportRingStats, .{&stats_context});
 
     var security = try PipeSecurity.init(alloc);
     defer security.deinit();

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -33,6 +33,7 @@ const error_pipe_busy = 231;
 const still_active = 259;
 const security_sqos_present = 0x00100000;
 const security_identification = 0x00010000;
+const process_query_limited_information = 0x1000;
 
 const Tag = enum(u8) {
     attach = 1,
@@ -91,35 +92,49 @@ extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
     descriptor: *?*anyopaque,
     descriptor_size: ?*windows.DWORD,
 ) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetNamedPipeServerProcessId(
+    pipe: windows.HANDLE,
+    process_id: *windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn OpenProcess(
+    access: windows.DWORD,
+    inherit_handle: windows.BOOL,
+    process_id: windows.DWORD,
+) callconv(.winapi) ?windows.HANDLE;
+
+// Token user SID of `process` in canonical string form. Callers compare these
+// strings to decide whether two handles belong to the same user.
+fn tokenUserSidAlloc(alloc: Allocator, process: windows.HANDLE) ![]u8 {
+    var token: ?windows.HANDLE = null;
+    if (OpenProcessToken(process, token_query, &token) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+    defer _ = windows.CloseHandle(token.?);
+
+    var token_buffer: [512]u8 align(@alignOf(TokenUser)) = undefined;
+    var token_len: windows.DWORD = 0;
+    if (GetTokenInformation(
+        token.?,
+        token_user_class,
+        &token_buffer,
+        token_buffer.len,
+        &token_len,
+    ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+    const token_user: *const TokenUser = @ptrCast(&token_buffer);
+    var sid_w: ?[*:0]u16 = null;
+    if (ConvertSidToStringSidW(token_user.user.sid, &sid_w) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+    defer _ = LocalFree(sid_w);
+    return std.unicode.utf16LeToUtf8Alloc(alloc, std.mem.span(sid_w.?));
+}
 
 const PipeSecurity = struct {
     descriptor: *anyopaque,
 
     fn init(alloc: Allocator) !PipeSecurity {
-        var token: ?windows.HANDLE = null;
-        if (OpenProcessToken(windows.GetCurrentProcess(), token_query, &token) == 0) {
-            return windows.unexpectedError(windows.kernel32.GetLastError());
-        }
-        defer _ = windows.CloseHandle(token.?);
-
-        var token_buffer: [512]u8 align(@alignOf(TokenUser)) = undefined;
-        var token_len: windows.DWORD = 0;
-        if (GetTokenInformation(
-            token.?,
-            token_user_class,
-            &token_buffer,
-            token_buffer.len,
-            &token_len,
-        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
-
-        const token_user: *const TokenUser = @ptrCast(&token_buffer);
-        var sid_w: ?[*:0]u16 = null;
-        if (ConvertSidToStringSidW(token_user.user.sid, &sid_w) == 0) {
-            return windows.unexpectedError(windows.kernel32.GetLastError());
-        }
-        defer _ = LocalFree(sid_w);
-
-        const sid = try std.unicode.utf16LeToUtf8Alloc(alloc, std.mem.span(sid_w.?));
+        const sid = try tokenUserSidAlloc(alloc, windows.GetCurrentProcess());
         defer alloc.free(sid);
         const sddl = try std.fmt.allocPrintSentinel(
             alloc,
@@ -277,9 +292,12 @@ const StatsContext = struct {
     stop: std.atomic.Value(bool) = .init(false),
 };
 
-// Samples the ring on its own thread so a stalled stderr consumer can only
-// stall diagnostics, never ConPTY draining. One final sample is published after
-// `stop` is observed so the last totals are never lost on shutdown.
+// Samples the ring on its own thread so a stalled stderr consumer can only stall
+// diagnostics, never ConPTY draining. This thread is detached and never joined:
+// the print below can block indefinitely on a stderr pipe nobody reads, and a
+// thread already inside WriteFile cannot observe `stop`, so teardown must not
+// wait on it. `stop` is still honoured for the ordinary case, where it lets the
+// sampler publish one last set of totals and exit promptly.
 fn reportRingStats(context: *StatsContext) void {
     var last_total: u64 = 0;
     while (true) {
@@ -346,8 +364,17 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     const pipe_name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
     defer alloc.free(pipe_name_w);
 
-    var ring = Ring{ .bytes = try alloc.alloc(u8, ring_size) };
-    defer alloc.free(ring.bytes);
+    // The stats sampler is deliberately never joined (see the teardown below), so
+    // it can still be running when serve returns. Everything it reads therefore
+    // has to outlive this frame: the ring, its backing bytes, and the sampler
+    // context come from the page allocator and are never freed. This host is a
+    // one-shot process, so the OS reclaims them at exit. Keeping them out of the
+    // GPA also stops its leak report from firing at teardown, which would itself
+    // be another blocking write to the stderr we may already be stuck on.
+    const ring = try std.heap.page_allocator.create(Ring);
+    ring.* = .{ .bytes = try std.heap.page_allocator.alloc(u8, ring_size) };
+    const stats_context = try std.heap.page_allocator.create(StatsContext);
+    stats_context.* = .{ .ring = ring };
 
     var pty = try Pty.open(.{ .ws_row = 24, .ws_col = 80 });
     var command: Command = .{
@@ -366,16 +393,18 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
         .rt_post_fork_info = undefined,
     };
     var drain_thread: ?std.Thread = null;
-    var stats_context = StatsContext{ .ring = &ring };
-    var stats_thread: ?std.Thread = null;
     defer {
         command.closeWindowsJobObject();
         pty.deinit();
+        // Joining the drain thread is safe: pty.deinit closed the handle it reads,
+        // so its ReadFile returns and it exits.
         if (drain_thread) |thread| thread.join();
-        if (stats_thread) |thread| {
-            stats_context.stop.store(true, .release);
-            thread.join();
-        }
+        // Signal the stats sampler but never join it. If stderr is a pipe nobody
+        // drains, the sampler can be blocked inside a write, and no signal wakes a
+        // thread already inside WriteFile, so joining it would hang teardown and
+        // leave this broker alive after its shell exited. Abandoning it is safe
+        // because everything it touches is intentionally never freed.
+        stats_context.stop.store(true, .release);
         if (command.pid) |process| _ = windows.CloseHandle(process);
     }
 
@@ -383,9 +412,10 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     const shell_pid = win32_job_object.GetProcessId(command.pid.?);
     if (shell_pid == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
 
-    var drain_context = DrainContext{ .output = pty.out_pipe, .ring = &ring };
+    var drain_context = DrainContext{ .output = pty.out_pipe, .ring = ring };
     drain_thread = try std.Thread.spawn(.{}, drainConpty, .{&drain_context});
-    stats_thread = try std.Thread.spawn(.{}, reportRingStats, .{&stats_context});
+    const stats_thread = try std.Thread.spawn(.{}, reportRingStats, .{stats_context});
+    stats_thread.detach();
 
     var security = try PipeSecurity.init(alloc);
     defer security.deinit();
@@ -433,7 +463,7 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
             return windows.unexpectedError(windows.kernel32.GetLastError());
         }
 
-        serveClient(alloc, pipe, &pty, &ring, command.pid.?) catch |err| switch (err) {
+        serveClient(alloc, pipe, &pty, ring, command.pid.?) catch |err| switch (err) {
             error.BrokenPipe, error.NoData, error.PipeNotConnected => {},
             else => return err,
         };
@@ -621,7 +651,7 @@ fn attach(alloc: Allocator, args: []const [:0]u8) !void {
     defer alloc.free(pipe_name);
     const pipe_name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
     defer alloc.free(pipe_name_w);
-    const pipe = try connectClient(pipe_name_w);
+    const pipe = try connectClient(alloc, pipe_name_w);
     defer _ = windows.CloseHandle(pipe);
 
     try sendFrame(pipe, .attach, "");
@@ -665,7 +695,39 @@ fn attachInput(context: InputContext) void {
     }
 }
 
-fn connectClient(pipe_name: [:0]const u16) !windows.HANDLE {
+// A client must not hand its keystrokes to whatever happens to own the pipe name.
+// The host holding one instance for its lifetime closes the between-client gap,
+// but that says nothing about a name an attacker owned *before* the host started,
+// nor about running `attach` when no host is running at all. In both cases the
+// open below succeeds against the attacker's pipe and the host's own fail-closed
+// behaviour protects only the host. So confirm the server process runs as this
+// user before any frame is sent. Anything that cannot be positively confirmed is
+// untrusted, including an OpenProcess that fails because the server belongs to
+// another user.
+fn verifyPipeServer(alloc: Allocator, pipe: windows.HANDLE) !void {
+    var server_pid: windows.DWORD = 0;
+    if (GetNamedPipeServerProcessId(pipe, &server_pid) == 0) {
+        return error.UntrustedPipeServer;
+    }
+    const server = OpenProcess(
+        process_query_limited_information,
+        windows.FALSE,
+        server_pid,
+    ) orelse return error.UntrustedPipeServer;
+    defer _ = windows.CloseHandle(server);
+
+    const server_sid = tokenUserSidAlloc(alloc, server) catch return error.UntrustedPipeServer;
+    defer alloc.free(server_sid);
+    const own_sid = try tokenUserSidAlloc(alloc, windows.GetCurrentProcess());
+    defer alloc.free(own_sid);
+
+    // This closes the cross-user path only. A same-user attacker, and a
+    // same-user attacker at a different integrity level, both still pass; those
+    // stay explicit residuals of the spike.
+    if (!std.mem.eql(u8, server_sid, own_sid)) return error.UntrustedPipeServer;
+}
+
+fn connectClient(alloc: Allocator, pipe_name: [:0]const u16) !windows.HANDLE {
     const deadline = std.time.nanoTimestamp() + (10 * std.time.ns_per_s);
     while (true) {
         // Named pipes default to SecurityImpersonation when the caller supplies no
@@ -683,7 +745,11 @@ fn connectClient(pipe_name: [:0]const u16) !windows.HANDLE {
             windows.FILE_ATTRIBUTE_NORMAL | security_sqos_present | security_identification,
             null,
         );
-        if (pipe != windows.INVALID_HANDLE_VALUE) return pipe;
+        if (pipe != windows.INVALID_HANDLE_VALUE) {
+            errdefer _ = windows.CloseHandle(pipe);
+            try verifyPipeServer(alloc, pipe);
+            return pipe;
+        }
 
         const last_error = windows.kernel32.GetLastError();
         const last_error_int = @intFromEnum(last_error);

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -18,11 +18,10 @@ comptime {
 
 const default_ring_size = 1024 * 1024;
 const max_frame_payload = 64 * 1024;
+// LOCAL affects AppContainer pipe-name resolution, not desktop-process security.
 const pipe_prefix = "\\\\.\\pipe\\LOCAL\\noctty-conpty-host-";
 const pipe_access_duplex = 0x00000003;
 const file_flag_first_pipe_instance = 0x00080000;
-const pipe_readmode_byte = 0x00000000;
-const pipe_wait = 0x00000000;
 const pipe_reject_remote_clients = 0x00000008;
 const token_query = 0x0008;
 const token_user_class = 1;
@@ -200,16 +199,15 @@ const Ring = struct {
         return self.statsLocked();
     }
 
-    fn readUntil(self: *Ring, cursor: *u64, end: ?u64, dst: []u8) usize {
+    fn read(self: *Ring, cursor: *u64, dst: []u8) usize {
         self.mutex.lock();
         defer self.mutex.unlock();
 
         const retained_start = self.total - self.len;
         if (cursor.* < retained_start) cursor.* = retained_start;
-        const available_end = @min(self.total, end orelse self.total);
-        if (cursor.* >= available_end) return 0;
+        if (cursor.* >= self.total) return 0;
 
-        const read_len: usize = @intCast(@min(available_end - cursor.*, dst.len));
+        const read_len: usize = @intCast(@min(self.total - cursor.*, dst.len));
         const offset: usize = @intCast(cursor.* - retained_start);
         const read_at = (self.head + offset) % self.bytes.len;
         const first_len = @min(read_len, self.bytes.len - read_at);
@@ -349,17 +347,23 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
 
     var security = try PipeSecurity.init(alloc);
     defer security.deinit();
-    try printStdout(
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    try stdout_writer.interface.print(
         "CONPTY_HOST_READY pipe={s} host_pid={} shell_pid={} ring_capacity={} security=current-user\n",
         .{ pipe_name, windows.GetCurrentProcessId(), shell_pid, ring_size },
     );
+    try stdout_writer.interface.flush();
 
     while (shellRunning(command.pid.?)) {
         var security_attributes = security.attributes();
+        // FIRST_PIPE_INSTANCE fails closed on a collision. It does not prevent a
+        // same-user process from squatting this name between recreated instances;
+        // same-user attackers are outside this feasibility spike's threat model.
         const pipe = windows.kernel32.CreateNamedPipeW(
             pipe_name_w.ptr,
             pipe_access_duplex | file_flag_first_pipe_instance,
-            windows.PIPE_TYPE_BYTE | pipe_readmode_byte | pipe_wait | pipe_reject_remote_clients,
+            windows.PIPE_TYPE_BYTE | pipe_reject_remote_clients,
             1,
             max_frame_payload,
             max_frame_payload,
@@ -371,6 +375,9 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
         }
         defer _ = windows.CloseHandle(pipe);
 
+        // Spike limitation: this synchronous accept has no cancellation. If the
+        // shell exits with no client attached, the host waits here until a client
+        // connects. Product code would need an overlapped, cancellable accept.
         const connected = ConnectNamedPipe(pipe, null);
         if (connected == 0 and @intFromEnum(windows.kernel32.GetLastError()) != error_pipe_connected) {
             return windows.unexpectedError(windows.kernel32.GetLastError());
@@ -411,7 +418,7 @@ fn serveClient(
 
     var payload: [max_frame_payload]u8 = undefined;
     while (shellRunning(shell)) {
-        const read_len = ring.readUntil(&cursor, null, &output);
+        const read_len = ring.read(&cursor, &output);
         if (read_len > 0) try sendFrame(pipe, .output, output[0..read_len]);
 
         var available: windows.DWORD = 0;
@@ -640,11 +647,4 @@ fn makePipeName(alloc: Allocator, name: []const u8) ![:0]u8 {
         }
     }
     return std.fmt.allocPrintSentinel(alloc, pipe_prefix ++ "{s}", .{name}, 0);
-}
-
-fn printStdout(comptime format: []const u8, args: anytype) !void {
-    var buffer: [1024]u8 = undefined;
-    var writer = std.fs.File.stdout().writer(&buffer);
-    try writer.interface.print(format, args);
-    try writer.interface.flush();
 }

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -425,11 +425,12 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     // any local user can both enumerate it and create a name in it, so the DACL
     // below protects the object this process created but never reserves the name
     // itself. Destroying and recreating the instance between clients would leave
-    // the name unowned in the gap, letting a different, lower-privileged user
-    // stand up a permissive pipe of the same name; FIRST_PIPE_INSTANCE would then
-    // fail this host closed, but a reconnecting client does not authenticate the
-    // server and would hand its keystrokes to the impostor. Reusing one instance
-    // removes that window entirely.
+    // the name unowned in the gap, letting any local user stand up a permissive
+    // pipe of the same name; FIRST_PIPE_INSTANCE would then fail this host closed,
+    // which protects the host but not a reconnecting client. That client does
+    // authenticate the server (see verifyPipeServer), but only by user, so a
+    // different-user impostor is rejected while a same-user one would still
+    // capture keystrokes. Reusing one instance removes the window for both cases.
     var security_attributes = security.attributes();
     const pipe = windows.kernel32.CreateNamedPipeW(
         pipe_name_w.ptr,
@@ -721,9 +722,15 @@ fn verifyPipeServer(alloc: Allocator, pipe: windows.HANDLE) !void {
     const own_sid = try tokenUserSidAlloc(alloc, windows.GetCurrentProcess());
     defer alloc.free(own_sid);
 
-    // This closes the cross-user path only. A same-user attacker, and a
-    // same-user attacker at a different integrity level, both still pass; those
-    // stay explicit residuals of the spike.
+    // Scope, stated precisely: this authenticates the process currently holding
+    // the PID that NPFS recorded as the instance's creator. It does not bind to
+    // the pipe endpoint. An attacker can create the instance in a short-lived
+    // process, DuplicateHandle the server end into a long-lived one, let the
+    // creator exit, and groom PID reuse so that a victim-user process holds that
+    // PID by the time OpenProcess runs. So this closes the cross-user case only
+    // up to that PID-reuse race. A same-user attacker, and a same-user attacker
+    // at a different integrity level, both still pass outright. There is no
+    // TOCTOU after the check: the handle stays bound to the verified instance.
     if (!std.mem.eql(u8, server_sid, own_sid)) return error.UntrustedPipeServer;
 }
 

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -1,0 +1,650 @@
+//! Standalone issue #132 feasibility spike. This is intentionally a small,
+//! disposable host/client pair, not a product session protocol.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Command = @import("Command.zig");
+const Pty = @import("pty.zig").Pty;
+const win32_job_object = @import("apprt/win32_job_object.zig");
+
+const windows = std.os.windows;
+const Allocator = std.mem.Allocator;
+
+comptime {
+    if (builtin.os.tag != .windows) {
+        @compileError("conpty-host is a Windows-only feasibility spike");
+    }
+}
+
+const default_ring_size = 1024 * 1024;
+const max_frame_payload = 64 * 1024;
+const pipe_prefix = "\\\\.\\pipe\\LOCAL\\noctty-conpty-host-";
+const pipe_access_duplex = 0x00000003;
+const file_flag_first_pipe_instance = 0x00080000;
+const pipe_readmode_byte = 0x00000000;
+const pipe_wait = 0x00000000;
+const pipe_reject_remote_clients = 0x00000008;
+const token_query = 0x0008;
+const token_user_class = 1;
+const sddl_revision_1 = 1;
+const error_io_pending = 997;
+const error_file_not_found = 2;
+const error_pipe_connected = 535;
+const error_pipe_busy = 231;
+const still_active = 259;
+
+const Tag = enum(u8) {
+    attach = 1,
+    detach = 2,
+    resize = 3,
+    input = 4,
+    output = 5,
+};
+
+const Resize = struct {
+    columns: u16,
+    rows: u16,
+};
+
+const TokenUser = extern struct {
+    user: extern struct {
+        sid: *anyopaque,
+        attributes: windows.DWORD,
+    },
+};
+
+extern "kernel32" fn ConnectNamedPipe(
+    pipe: windows.HANDLE,
+    overlapped: ?*windows.OVERLAPPED,
+) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn DisconnectNamedPipe(pipe: windows.HANDLE) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn PeekNamedPipe(
+    pipe: windows.HANDLE,
+    buffer: ?*anyopaque,
+    buffer_size: windows.DWORD,
+    bytes_read: ?*windows.DWORD,
+    total_available: ?*windows.DWORD,
+    bytes_left: ?*windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn WaitNamedPipeW(name: [*:0]const u16, timeout_ms: windows.DWORD) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn LocalFree(memory: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+extern "advapi32" fn OpenProcessToken(
+    process: windows.HANDLE,
+    access: windows.DWORD,
+    token: *?windows.HANDLE,
+) callconv(.winapi) windows.BOOL;
+extern "advapi32" fn GetTokenInformation(
+    token: windows.HANDLE,
+    information_class: windows.DWORD,
+    information: ?*anyopaque,
+    information_len: windows.DWORD,
+    return_len: *windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+extern "advapi32" fn ConvertSidToStringSidW(
+    sid: *anyopaque,
+    string_sid: *?[*:0]u16,
+) callconv(.winapi) windows.BOOL;
+extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
+    sddl: [*:0]const u16,
+    revision: windows.DWORD,
+    descriptor: *?*anyopaque,
+    descriptor_size: ?*windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+
+const PipeSecurity = struct {
+    descriptor: *anyopaque,
+
+    fn init(alloc: Allocator) !PipeSecurity {
+        var token: ?windows.HANDLE = null;
+        if (OpenProcessToken(windows.GetCurrentProcess(), token_query, &token) == 0) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        defer _ = windows.CloseHandle(token.?);
+
+        var token_buffer: [512]u8 align(@alignOf(TokenUser)) = undefined;
+        var token_len: windows.DWORD = 0;
+        if (GetTokenInformation(
+            token.?,
+            token_user_class,
+            &token_buffer,
+            token_buffer.len,
+            &token_len,
+        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+        const token_user: *const TokenUser = @ptrCast(&token_buffer);
+        var sid_w: ?[*:0]u16 = null;
+        if (ConvertSidToStringSidW(token_user.user.sid, &sid_w) == 0) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        defer _ = LocalFree(sid_w);
+
+        const sid = try std.unicode.utf16LeToUtf8Alloc(alloc, std.mem.span(sid_w.?));
+        defer alloc.free(sid);
+        const sddl = try std.fmt.allocPrintSentinel(
+            alloc,
+            "O:{s}D:P(A;;GA;;;{s})",
+            .{ sid, sid },
+            0,
+        );
+        defer alloc.free(sddl);
+        const sddl_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, sddl);
+        defer alloc.free(sddl_w);
+
+        var descriptor: ?*anyopaque = null;
+        if (ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_w.ptr,
+            sddl_revision_1,
+            &descriptor,
+            null,
+        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+        return .{ .descriptor = descriptor.? };
+    }
+
+    fn deinit(self: *PipeSecurity) void {
+        _ = LocalFree(self.descriptor);
+        self.* = undefined;
+    }
+
+    fn attributes(self: *PipeSecurity) windows.SECURITY_ATTRIBUTES {
+        return .{
+            .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+            .lpSecurityDescriptor = self.descriptor,
+            .bInheritHandle = windows.FALSE,
+        };
+    }
+};
+
+const Ring = struct {
+    bytes: []u8,
+    head: usize = 0,
+    len: usize = 0,
+    total: u64 = 0,
+    mutex: std.Thread.Mutex = .{},
+
+    const Stats = struct {
+        total: u64,
+        retained: usize,
+        capacity: usize,
+    };
+
+    const Snapshot = struct {
+        len: usize,
+        cursor: u64,
+    };
+
+    fn append(self: *Ring, src: []const u8) Stats {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.total += src.len;
+        if (src.len >= self.bytes.len) {
+            @memcpy(self.bytes, src[src.len - self.bytes.len ..]);
+            self.head = 0;
+            self.len = self.bytes.len;
+            return self.statsLocked();
+        }
+
+        const free = self.bytes.len - self.len;
+        if (src.len > free) {
+            const dropped = src.len - free;
+            self.head = (self.head + dropped) % self.bytes.len;
+            self.len -= dropped;
+        }
+
+        const write_at = (self.head + self.len) % self.bytes.len;
+        const first_len = @min(src.len, self.bytes.len - write_at);
+        @memcpy(self.bytes[write_at .. write_at + first_len], src[0..first_len]);
+        @memcpy(self.bytes[0 .. src.len - first_len], src[first_len..]);
+        self.len += src.len;
+        return self.statsLocked();
+    }
+
+    fn readUntil(self: *Ring, cursor: *u64, end: ?u64, dst: []u8) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const retained_start = self.total - self.len;
+        if (cursor.* < retained_start) cursor.* = retained_start;
+        const available_end = @min(self.total, end orelse self.total);
+        if (cursor.* >= available_end) return 0;
+
+        const read_len: usize = @intCast(@min(available_end - cursor.*, dst.len));
+        const offset: usize = @intCast(cursor.* - retained_start);
+        const read_at = (self.head + offset) % self.bytes.len;
+        const first_len = @min(read_len, self.bytes.len - read_at);
+        @memcpy(dst[0..first_len], self.bytes[read_at .. read_at + first_len]);
+        @memcpy(dst[first_len..read_len], self.bytes[0 .. read_len - first_len]);
+        cursor.* += read_len;
+        return read_len;
+    }
+
+    fn snapshotInto(self: *Ring, dst: []u8) Snapshot {
+        std.debug.assert(dst.len >= self.bytes.len);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const first_len = @min(self.len, self.bytes.len - self.head);
+        @memcpy(dst[0..first_len], self.bytes[self.head .. self.head + first_len]);
+        @memcpy(dst[first_len..self.len], self.bytes[0 .. self.len - first_len]);
+        return .{ .len = self.len, .cursor = self.total };
+    }
+
+    fn statsLocked(self: *Ring) Stats {
+        return .{
+            .total = self.total,
+            .retained = self.len,
+            .capacity = self.bytes.len,
+        };
+    }
+};
+
+const DrainContext = struct {
+    output: windows.HANDLE,
+    ring: *Ring,
+};
+
+fn drainConpty(context: *DrainContext) void {
+    var buffer: [64 * 1024]u8 = undefined;
+    while (true) {
+        var read_len: windows.DWORD = 0;
+        if (windows.kernel32.ReadFile(
+            context.output,
+            &buffer,
+            buffer.len,
+            &read_len,
+            null,
+        ) == 0 or read_len == 0) return;
+
+        const stats = context.ring.append(buffer[0..read_len]);
+        std.debug.print(
+            "RING_STATS total={} retained={} capacity={}\n",
+            .{ stats.total, stats.retained, stats.capacity },
+        );
+    }
+}
+
+pub fn main() !void {
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+    if (args.len < 2) return usage();
+
+    if (std.mem.eql(u8, args[1], "serve")) {
+        try serve(alloc, args[2..]);
+    } else if (std.mem.eql(u8, args[1], "attach")) {
+        try attach(alloc, args[2..]);
+    } else {
+        return usage();
+    }
+}
+
+fn usage() error{InvalidArguments} {
+    std.debug.print(
+        \\usage: conpty-host serve --pipe <name> [--ring-size <bytes>]
+        \\       conpty-host attach --pipe <name> [--resize <columns>x<rows>] [--stay-on-eof]
+        \\
+    , .{});
+    return error.InvalidArguments;
+}
+
+fn serve(alloc: Allocator, args: []const [:0]u8) !void {
+    var pipe_name_arg: ?[]const u8 = null;
+    var ring_size: usize = default_ring_size;
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (std.mem.eql(u8, args[i], "--pipe") and i + 1 < args.len) {
+            i += 1;
+            pipe_name_arg = args[i];
+        } else if (std.mem.eql(u8, args[i], "--ring-size") and i + 1 < args.len) {
+            i += 1;
+            ring_size = try std.fmt.parseInt(usize, args[i], 10);
+        } else {
+            return usage();
+        }
+    }
+    if (ring_size == 0) return error.InvalidRingSize;
+
+    const pipe_name = try makePipeName(alloc, pipe_name_arg orelse return usage());
+    defer alloc.free(pipe_name);
+    const pipe_name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
+    defer alloc.free(pipe_name_w);
+
+    var ring = Ring{ .bytes = try alloc.alloc(u8, ring_size) };
+    defer alloc.free(ring.bytes);
+
+    var pty = try Pty.open(.{ .ws_row = 24, .ws_col = 80 });
+    var command: Command = .{
+        .path = "pwsh.exe",
+        .args = &.{ "pwsh.exe", "-NoLogo", "-NoProfile" },
+        .pseudo_console = pty.pseudo_console,
+        .windows_job_object_plan = .{
+            .mode = .always,
+            .attach_policy = .hard_fail,
+            .kill_on_close = true,
+        },
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+    var drain_thread: ?std.Thread = null;
+    defer {
+        command.closeWindowsJobObject();
+        pty.deinit();
+        if (drain_thread) |thread| thread.join();
+        if (command.pid) |process| _ = windows.CloseHandle(process);
+    }
+
+    try command.start(alloc);
+    const shell_pid = win32_job_object.GetProcessId(command.pid.?);
+    if (shell_pid == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+    var drain_context = DrainContext{ .output = pty.out_pipe, .ring = &ring };
+    drain_thread = try std.Thread.spawn(.{}, drainConpty, .{&drain_context});
+
+    var security = try PipeSecurity.init(alloc);
+    defer security.deinit();
+    try printStdout(
+        "CONPTY_HOST_READY pipe={s} host_pid={} shell_pid={} ring_capacity={} security=current-user\n",
+        .{ pipe_name, windows.GetCurrentProcessId(), shell_pid, ring_size },
+    );
+
+    while (shellRunning(command.pid.?)) {
+        var security_attributes = security.attributes();
+        const pipe = windows.kernel32.CreateNamedPipeW(
+            pipe_name_w.ptr,
+            pipe_access_duplex | file_flag_first_pipe_instance,
+            windows.PIPE_TYPE_BYTE | pipe_readmode_byte | pipe_wait | pipe_reject_remote_clients,
+            1,
+            max_frame_payload,
+            max_frame_payload,
+            0,
+            &security_attributes,
+        );
+        if (pipe == windows.INVALID_HANDLE_VALUE) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        defer _ = windows.CloseHandle(pipe);
+
+        const connected = ConnectNamedPipe(pipe, null);
+        if (connected == 0 and @intFromEnum(windows.kernel32.GetLastError()) != error_pipe_connected) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+
+        serveClient(alloc, pipe, &pty, &ring, command.pid.?) catch |err| switch (err) {
+            error.BrokenPipe, error.NoData, error.PipeNotConnected => {},
+            else => return err,
+        };
+        _ = DisconnectNamedPipe(pipe);
+    }
+}
+
+fn serveClient(
+    alloc: Allocator,
+    pipe: windows.HANDLE,
+    pty: *Pty,
+    ring: *Ring,
+    shell: windows.HANDLE,
+) !void {
+    const first = try readHeader(pipe);
+    if (first.tag != .attach or first.len != 0) return error.ExpectedAttach;
+
+    // Never hold the ring lock across a pipe write. A client that stops reading
+    // must not be able to stop the load-bearing ConPTY drain thread.
+    const replay_bytes = try alloc.alloc(u8, ring.bytes.len);
+    defer alloc.free(replay_bytes);
+    const snapshot = ring.snapshotInto(replay_bytes);
+    var replay_offset: usize = 0;
+    while (replay_offset < snapshot.len) {
+        const frame_len = @min(max_frame_payload, snapshot.len - replay_offset);
+        try sendFrame(pipe, .output, replay_bytes[replay_offset .. replay_offset + frame_len]);
+        replay_offset += frame_len;
+    }
+
+    var output: [32 * 1024]u8 = undefined;
+    var cursor = snapshot.cursor;
+
+    var payload: [max_frame_payload]u8 = undefined;
+    while (shellRunning(shell)) {
+        const read_len = ring.readUntil(&cursor, null, &output);
+        if (read_len > 0) try sendFrame(pipe, .output, output[0..read_len]);
+
+        var available: windows.DWORD = 0;
+        if (PeekNamedPipe(pipe, null, 0, null, &available, null) == 0) {
+            return pipeError();
+        }
+        if (available >= 5) {
+            const header = try readHeader(pipe);
+            if (header.len > payload.len) return error.FrameTooLarge;
+            try readExact(pipe, payload[0..header.len]);
+            switch (header.tag) {
+                .detach => {
+                    if (header.len != 0) return error.InvalidFrame;
+                    return;
+                },
+                .resize => {
+                    if (header.len != 4) return error.InvalidFrame;
+                    const columns = std.mem.readInt(u16, payload[0..2], .little);
+                    const rows = std.mem.readInt(u16, payload[2..4], .little);
+                    if (columns == 0 or rows == 0) return error.InvalidResize;
+                    try pty.setSize(.{ .ws_col = columns, .ws_row = rows });
+                },
+                .input => try writePtyInput(pty.in_pipe, payload[0..header.len]),
+                else => return error.InvalidFrame,
+            }
+        }
+
+        if (read_len == 0 and available < 5) {
+            std.Thread.sleep(2 * std.time.ns_per_ms);
+        }
+    }
+}
+
+const FrameHeader = struct { tag: Tag, len: usize };
+
+fn readHeader(pipe: windows.HANDLE) !FrameHeader {
+    var header: [5]u8 = undefined;
+    try readExact(pipe, &header);
+    return .{
+        .tag = std.meta.intToEnum(Tag, header[0]) catch return error.InvalidFrame,
+        .len = std.mem.readInt(u32, header[1..5], .little),
+    };
+}
+
+fn sendFrame(pipe: windows.HANDLE, tag: Tag, payload: []const u8) !void {
+    if (payload.len > max_frame_payload) return error.FrameTooLarge;
+    var header: [5]u8 = undefined;
+    header[0] = @intFromEnum(tag);
+    std.mem.writeInt(u32, header[1..5], @intCast(payload.len), .little);
+    try writeAll(pipe, &header);
+    try writeAll(pipe, payload);
+}
+
+fn readExact(handle: windows.HANDLE, dst: []u8) !void {
+    var offset: usize = 0;
+    while (offset < dst.len) {
+        var read_len: windows.DWORD = 0;
+        if (windows.kernel32.ReadFile(
+            handle,
+            dst[offset..].ptr,
+            @intCast(dst.len - offset),
+            &read_len,
+            null,
+        ) == 0) return pipeError();
+        if (read_len == 0) return error.BrokenPipe;
+        offset += read_len;
+    }
+}
+
+fn writeAll(handle: windows.HANDLE, src: []const u8) !void {
+    var offset: usize = 0;
+    while (offset < src.len) {
+        var write_len: windows.DWORD = 0;
+        if (windows.kernel32.WriteFile(
+            handle,
+            src[offset..].ptr,
+            @intCast(src.len - offset),
+            &write_len,
+            null,
+        ) == 0) return pipeError();
+        if (write_len == 0) return error.BrokenPipe;
+        offset += write_len;
+    }
+}
+
+fn writePtyInput(handle: windows.HANDLE, src: []const u8) !void {
+    var offset: usize = 0;
+    while (offset < src.len) {
+        var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+        const submitted = windows.kernel32.WriteFile(
+            handle,
+            src[offset..].ptr,
+            @intCast(src.len - offset),
+            null,
+            &overlapped,
+        );
+        if (submitted == 0 and @intFromEnum(windows.kernel32.GetLastError()) != error_io_pending) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        const write_len = try windows.GetOverlappedResult(handle, &overlapped, true);
+        if (write_len == 0) return error.BrokenPipe;
+        offset += write_len;
+    }
+}
+
+fn pipeError() anyerror {
+    return switch (windows.kernel32.GetLastError()) {
+        .BROKEN_PIPE => error.BrokenPipe,
+        .NO_DATA => error.NoData,
+        .PIPE_NOT_CONNECTED => error.PipeNotConnected,
+        else => |err| windows.unexpectedError(err),
+    };
+}
+
+fn shellRunning(process: windows.HANDLE) bool {
+    var exit_code: windows.DWORD = 0;
+    if (windows.kernel32.GetExitCodeProcess(process, &exit_code) == 0) return false;
+    return exit_code == still_active;
+}
+
+fn attach(alloc: Allocator, args: []const [:0]u8) !void {
+    var pipe_name_arg: ?[]const u8 = null;
+    var resize: ?Resize = null;
+    var stay_on_eof = false;
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (std.mem.eql(u8, args[i], "--pipe") and i + 1 < args.len) {
+            i += 1;
+            pipe_name_arg = args[i];
+        } else if (std.mem.eql(u8, args[i], "--resize") and i + 1 < args.len) {
+            i += 1;
+            resize = try parseResize(args[i]);
+        } else if (std.mem.eql(u8, args[i], "--stay-on-eof")) {
+            stay_on_eof = true;
+        } else {
+            return usage();
+        }
+    }
+
+    const pipe_name = try makePipeName(alloc, pipe_name_arg orelse return usage());
+    defer alloc.free(pipe_name);
+    const pipe_name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
+    defer alloc.free(pipe_name_w);
+    const pipe = try connectClient(pipe_name_w);
+    defer _ = windows.CloseHandle(pipe);
+
+    try sendFrame(pipe, .attach, "");
+    if (resize) |size| {
+        var payload: [4]u8 = undefined;
+        std.mem.writeInt(u16, payload[0..2], size.columns, .little);
+        std.mem.writeInt(u16, payload[2..4], size.rows, .little);
+        try sendFrame(pipe, .resize, &payload);
+    }
+
+    const input_context = InputContext{ .pipe = pipe, .detach_on_eof = !stay_on_eof };
+    const input_thread = try std.Thread.spawn(.{}, attachInput, .{input_context});
+    input_thread.detach();
+
+    var payload: [max_frame_payload]u8 = undefined;
+    while (true) {
+        const header = readHeader(pipe) catch |err| switch (err) {
+            error.BrokenPipe, error.NoData, error.PipeNotConnected => return,
+            else => return err,
+        };
+        if (header.tag != .output or header.len > payload.len) return error.InvalidFrame;
+        try readExact(pipe, payload[0..header.len]);
+        try std.fs.File.stdout().writeAll(payload[0..header.len]);
+    }
+}
+
+const InputContext = struct {
+    pipe: windows.HANDLE,
+    detach_on_eof: bool,
+};
+
+fn attachInput(context: InputContext) void {
+    var input: [16 * 1024]u8 = undefined;
+    while (true) {
+        const read_len = std.fs.File.stdin().read(&input) catch return;
+        if (read_len == 0) {
+            if (context.detach_on_eof) sendFrame(context.pipe, .detach, "") catch {};
+            return;
+        }
+        sendFrame(context.pipe, .input, input[0..read_len]) catch return;
+    }
+}
+
+fn connectClient(pipe_name: [:0]const u16) !windows.HANDLE {
+    const deadline = std.time.nanoTimestamp() + (10 * std.time.ns_per_s);
+    while (true) {
+        const pipe = windows.kernel32.CreateFileW(
+            pipe_name.ptr,
+            windows.GENERIC_READ | windows.GENERIC_WRITE,
+            0,
+            null,
+            windows.OPEN_EXISTING,
+            windows.FILE_ATTRIBUTE_NORMAL,
+            null,
+        );
+        if (pipe != windows.INVALID_HANDLE_VALUE) return pipe;
+
+        const last_error = windows.kernel32.GetLastError();
+        const last_error_int = @intFromEnum(last_error);
+        if ((last_error_int != error_pipe_busy and last_error_int != error_file_not_found) or
+            std.time.nanoTimestamp() >= deadline)
+        {
+            return windows.unexpectedError(last_error);
+        }
+        _ = WaitNamedPipeW(pipe_name.ptr, 100);
+    }
+}
+
+fn parseResize(value: []const u8) !Resize {
+    const separator = std.mem.indexOfScalar(u8, value, 'x') orelse return error.InvalidResize;
+    const columns = try std.fmt.parseInt(u16, value[0..separator], 10);
+    const rows = try std.fmt.parseInt(u16, value[separator + 1 ..], 10);
+    if (columns == 0 or rows == 0) return error.InvalidResize;
+    return .{ .columns = columns, .rows = rows };
+}
+
+fn makePipeName(alloc: Allocator, name: []const u8) ![:0]u8 {
+    if (name.len == 0 or name.len > 100) return error.InvalidPipeName;
+    for (name) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and byte != '-' and byte != '_') {
+            return error.InvalidPipeName;
+        }
+    }
+    return std.fmt.allocPrintSentinel(alloc, pipe_prefix ++ "{s}", .{name}, 0);
+}
+
+fn printStdout(comptime format: []const u8, args: anytype) !void {
+    var buffer: [1024]u8 = undefined;
+    var writer = std.fs.File.stdout().writer(&buffer);
+    try writer.interface.print(format, args);
+    try writer.interface.flush();
+}

--- a/src/conpty_host.zig
+++ b/src/conpty_host.zig
@@ -28,7 +28,6 @@ const token_user_class = 1;
 const sddl_revision_1 = 1;
 const error_io_pending = 997;
 const error_file_not_found = 2;
-const error_pipe_connected = 535;
 const error_pipe_busy = 231;
 const still_active = 259;
 const security_sqos_present = 0x00100000;
@@ -60,6 +59,8 @@ extern "kernel32" fn ConnectNamedPipe(
     overlapped: ?*windows.OVERLAPPED,
 ) callconv(.winapi) windows.BOOL;
 extern "kernel32" fn DisconnectNamedPipe(pipe: windows.HANDLE) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn SetEvent(event: windows.HANDLE) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn ResetEvent(event: windows.HANDLE) callconv(.winapi) windows.BOOL;
 extern "kernel32" fn PeekNamedPipe(
     pipe: windows.HANDLE,
     buffer: ?*anyopaque,
@@ -380,7 +381,7 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     var command: Command = .{
         .path = "pwsh.exe",
         .args = &.{ "pwsh.exe", "-NoLogo", "-NoProfile" },
-        .pseudo_console = pty.pseudo_console,
+        .pseudo_console = pty.pseudoConsole(),
         .windows_job_object_plan = .{
             .mode = .always,
             .attach_policy = .hard_fail,
@@ -432,20 +433,11 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     // different-user impostor is rejected while a same-user one would still
     // capture keystrokes. Reusing one instance removes the window for both cases.
     var security_attributes = security.attributes();
-    const pipe = windows.kernel32.CreateNamedPipeW(
-        pipe_name_w.ptr,
-        pipe_access_duplex | file_flag_first_pipe_instance,
-        windows.PIPE_TYPE_BYTE | pipe_reject_remote_clients,
-        1,
-        max_frame_payload,
-        max_frame_payload,
-        0,
-        &security_attributes,
-    );
-    if (pipe == windows.INVALID_HANDLE_VALUE) {
-        return windows.unexpectedError(windows.kernel32.GetLastError());
-    }
+    const pipe = try createHostPipe(pipe_name_w.ptr, &security_attributes);
     defer _ = windows.CloseHandle(pipe);
+    const accept_event = try createManualResetEvent();
+    defer _ = windows.CloseHandle(accept_event);
+    const server = OverlappedPipe{ .handle = pipe, .event = accept_event };
 
     var stdout_buffer: [1024]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
@@ -456,15 +448,20 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
     try stdout_writer.interface.flush();
 
     while (shellRunning(command.pid.?)) {
-        // Spike limitation: this synchronous accept has no cancellation. If the
-        // shell exits with no client attached, the host waits here until a client
-        // connects. Product code would need an overlapped, cancellable accept.
-        const connected = ConnectNamedPipe(pipe, null);
-        if (connected == 0 and @intFromEnum(windows.kernel32.GetLastError()) != error_pipe_connected) {
-            return windows.unexpectedError(windows.kernel32.GetLastError());
-        }
+        // The accept is overlapped and waits on the shell's process handle as
+        // well, so a shell that exits while no client is attached releases the
+        // host into teardown instead of leaving it parked until some client
+        // happens to connect.
+        const outcome = acceptClientOrShellExit(pipe, accept_event, command.pid.?) catch |err| switch (err) {
+            error.BrokenPipe, error.NoData, error.PipeNotConnected => {
+                _ = DisconnectNamedPipe(pipe);
+                continue;
+            },
+            else => return err,
+        };
+        if (outcome == .shell_exited) break;
 
-        serveClient(alloc, pipe, &pty, ring, command.pid.?) catch |err| switch (err) {
+        serveClient(alloc, server, &pty, ring, command.pid.?) catch |err| switch (err) {
             error.BrokenPipe, error.NoData, error.PipeNotConnected => {},
             else => return err,
         };
@@ -483,7 +480,7 @@ fn serve(alloc: Allocator, args: []const [:0]u8) !void {
 
 fn serveClient(
     alloc: Allocator,
-    pipe: windows.HANDLE,
+    pipe: OverlappedPipe,
     pty: *Pty,
     ring: *Ring,
     shell: windows.HANDLE,
@@ -512,7 +509,7 @@ fn serveClient(
         if (read_len > 0) try sendFrame(pipe, .output, output[0..read_len]);
 
         var available: windows.DWORD = 0;
-        if (PeekNamedPipe(pipe, null, 0, null, &available, null) == 0) {
+        if (PeekNamedPipe(pipe.handle, null, 0, null, &available, null) == 0) {
             return pipeError();
         }
         if (available >= 5) {
@@ -542,9 +539,177 @@ fn serveClient(
     }
 }
 
+// The client's handle is an ordinary synchronous file handle.
+const SyncPipe = struct {
+    handle: windows.HANDLE,
+
+    fn read(self: SyncPipe, dst: []u8) !usize {
+        var read_len: windows.DWORD = 0;
+        if (windows.kernel32.ReadFile(
+            self.handle,
+            dst.ptr,
+            @intCast(dst.len),
+            &read_len,
+            null,
+        ) == 0) return pipeError();
+        return read_len;
+    }
+
+    fn write(self: SyncPipe, src: []const u8) !usize {
+        var write_len: windows.DWORD = 0;
+        if (windows.kernel32.WriteFile(
+            self.handle,
+            src.ptr,
+            @intCast(src.len),
+            &write_len,
+            null,
+        ) == 0) return pipeError();
+        return write_len;
+    }
+};
+
+// The host's instance is FILE_FLAG_OVERLAPPED so that its accept can be
+// cancelled, which means every read and write on it must be issued overlapped
+// too. One thread performs all host-side pipe I/O, so a single manual-reset
+// event is enough to serialise it; each call waits for its own completion
+// before returning, so the OVERLAPPED never outlives the frame that owns it.
+const OverlappedPipe = struct {
+    handle: windows.HANDLE,
+    event: windows.HANDLE,
+
+    fn read(self: OverlappedPipe, dst: []u8) !usize {
+        var request = try self.beginRequest();
+        return self.finish(windows.kernel32.ReadFile(
+            self.handle,
+            dst.ptr,
+            @intCast(dst.len),
+            null,
+            &request,
+        ), &request);
+    }
+
+    fn write(self: OverlappedPipe, src: []const u8) !usize {
+        var request = try self.beginRequest();
+        return self.finish(windows.kernel32.WriteFile(
+            self.handle,
+            src.ptr,
+            @intCast(src.len),
+            null,
+            &request,
+        ), &request);
+    }
+
+    fn beginRequest(self: OverlappedPipe) !windows.OVERLAPPED {
+        if (ResetEvent(self.event) == 0) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        var result: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+        result.hEvent = self.event;
+        return result;
+    }
+
+    fn finish(
+        self: OverlappedPipe,
+        issued: windows.BOOL,
+        overlapped: *windows.OVERLAPPED,
+    ) !usize {
+        if (issued == 0) {
+            const err = windows.kernel32.GetLastError();
+            if (err != .IO_PENDING) return pipeErrorFrom(err);
+        }
+        var transferred: windows.DWORD = 0;
+        if (windows.kernel32.GetOverlappedResult(
+            self.handle,
+            overlapped,
+            &transferred,
+            windows.TRUE,
+        ) == 0) return pipeError();
+        return transferred;
+    }
+};
+
+const AcceptOutcome = enum { client_connected, shell_exited };
+
+// Creates the host's single pipe instance. Overlapped mode is what makes the
+// accept cancellable: a synchronous ConnectNamedPipe has no cancellation path,
+// so a host whose shell exited with no client attached would otherwise sit in
+// the accept until some arbitrary client happened to connect.
+fn createHostPipe(
+    pipe_name_w: [*:0]const u16,
+    security_attributes: ?*windows.SECURITY_ATTRIBUTES,
+) !windows.HANDLE {
+    const pipe = windows.kernel32.CreateNamedPipeW(
+        pipe_name_w,
+        pipe_access_duplex | file_flag_first_pipe_instance | windows.FILE_FLAG_OVERLAPPED,
+        windows.PIPE_TYPE_BYTE | pipe_reject_remote_clients,
+        1,
+        max_frame_payload,
+        max_frame_payload,
+        0,
+        security_attributes,
+    );
+    if (pipe == windows.INVALID_HANDLE_VALUE) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+    return pipe;
+}
+
+fn createManualResetEvent() !windows.HANDLE {
+    return windows.CreateEventExW(
+        null,
+        null,
+        windows.CREATE_EVENT_MANUAL_RESET,
+        windows.EVENT_ALL_ACCESS,
+    );
+}
+
+// Waits for whichever happens first: a client connects to `pipe`, or `shell`
+// becomes signalled. A process handle signals when the process exits; the
+// tests pass an event so the select logic is exercised without a shell. When
+// the shell wins, the pending accept is cancelled and its completion is waited
+// for before returning, so the stack OVERLAPPED is never referenced afterwards.
+fn acceptClientOrShellExit(
+    pipe: windows.HANDLE,
+    accept_event: windows.HANDLE,
+    shell: windows.HANDLE,
+) !AcceptOutcome {
+    if (ResetEvent(accept_event) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+    var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+    overlapped.hEvent = accept_event;
+
+    if (ConnectNamedPipe(pipe, &overlapped) != 0) return .client_connected;
+    switch (windows.kernel32.GetLastError()) {
+        .IO_PENDING => {},
+        // A client opened the instance before this accept was issued.
+        .PIPE_CONNECTED => return .client_connected,
+        else => |err| return pipeErrorFrom(err),
+    }
+
+    const handles = [_]windows.HANDLE{ accept_event, shell };
+    const signalled = try windows.WaitForMultipleObjectsEx(&handles, false, windows.INFINITE, false);
+    if (signalled == 0) {
+        var transferred: windows.DWORD = 0;
+        if (windows.kernel32.GetOverlappedResult(pipe, &overlapped, &transferred, windows.FALSE) == 0) {
+            return pipeError();
+        }
+        return .client_connected;
+    }
+
+    // The shell exited first. CancelIoEx reports NOT_FOUND if the accept raced
+    // to completion in the meantime; either way GetOverlappedResult returns
+    // promptly once the request is no longer in flight. Its result is
+    // irrelevant because the host is tearing down.
+    _ = windows.kernel32.CancelIoEx(pipe, &overlapped);
+    var transferred: windows.DWORD = 0;
+    _ = windows.kernel32.GetOverlappedResult(pipe, &overlapped, &transferred, windows.TRUE);
+    return .shell_exited;
+}
+
 const FrameHeader = struct { tag: Tag, len: usize };
 
-fn readHeader(pipe: windows.HANDLE) !FrameHeader {
+fn readHeader(pipe: anytype) !FrameHeader {
     var header: [5]u8 = undefined;
     try readExact(pipe, &header);
     return .{
@@ -553,7 +718,7 @@ fn readHeader(pipe: windows.HANDLE) !FrameHeader {
     };
 }
 
-fn sendFrame(pipe: windows.HANDLE, tag: Tag, payload: []const u8) !void {
+fn sendFrame(pipe: anytype, tag: Tag, payload: []const u8) !void {
     if (payload.len > max_frame_payload) return error.FrameTooLarge;
     var header: [5]u8 = undefined;
     header[0] = @intFromEnum(tag);
@@ -562,33 +727,19 @@ fn sendFrame(pipe: windows.HANDLE, tag: Tag, payload: []const u8) !void {
     try writeAll(pipe, payload);
 }
 
-fn readExact(handle: windows.HANDLE, dst: []u8) !void {
+fn readExact(pipe: anytype, dst: []u8) !void {
     var offset: usize = 0;
     while (offset < dst.len) {
-        var read_len: windows.DWORD = 0;
-        if (windows.kernel32.ReadFile(
-            handle,
-            dst[offset..].ptr,
-            @intCast(dst.len - offset),
-            &read_len,
-            null,
-        ) == 0) return pipeError();
+        const read_len = try pipe.read(dst[offset..]);
         if (read_len == 0) return error.BrokenPipe;
         offset += read_len;
     }
 }
 
-fn writeAll(handle: windows.HANDLE, src: []const u8) !void {
+fn writeAll(pipe: anytype, src: []const u8) !void {
     var offset: usize = 0;
     while (offset < src.len) {
-        var write_len: windows.DWORD = 0;
-        if (windows.kernel32.WriteFile(
-            handle,
-            src[offset..].ptr,
-            @intCast(src.len - offset),
-            &write_len,
-            null,
-        ) == 0) return pipeError();
+        const write_len = try pipe.write(src[offset..]);
         if (write_len == 0) return error.BrokenPipe;
         offset += write_len;
     }
@@ -615,7 +766,11 @@ fn writePtyInput(handle: windows.HANDLE, src: []const u8) !void {
 }
 
 fn pipeError() anyerror {
-    return switch (windows.kernel32.GetLastError()) {
+    return pipeErrorFrom(windows.kernel32.GetLastError());
+}
+
+fn pipeErrorFrom(last_error: windows.Win32Error) anyerror {
+    return switch (last_error) {
         .BROKEN_PIPE => error.BrokenPipe,
         .NO_DATA => error.NoData,
         .PIPE_NOT_CONNECTED => error.PipeNotConnected,
@@ -652,8 +807,9 @@ fn attach(alloc: Allocator, args: []const [:0]u8) !void {
     defer alloc.free(pipe_name);
     const pipe_name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
     defer alloc.free(pipe_name_w);
-    const pipe = try connectClient(alloc, pipe_name_w);
-    defer _ = windows.CloseHandle(pipe);
+    const handle = try connectClient(alloc, pipe_name_w);
+    defer _ = windows.CloseHandle(handle);
+    const pipe = SyncPipe{ .handle = handle };
 
     try sendFrame(pipe, .attach, "");
     if (resize) |size| {
@@ -680,7 +836,7 @@ fn attach(alloc: Allocator, args: []const [:0]u8) !void {
 }
 
 const InputContext = struct {
-    pipe: windows.HANDLE,
+    pipe: SyncPipe,
     detach_on_eof: bool,
 };
 
@@ -785,4 +941,142 @@ fn makePipeName(alloc: Allocator, name: []const u8) ![:0]u8 {
         }
     }
     return std.fmt.allocPrintSentinel(alloc, pipe_prefix ++ "{s}", .{name}, 0);
+}
+
+// Hermetic tests for the accept/select logic: a real overlapped instance under
+// a random name, a real client open, and an event standing in for the shell's
+// process handle. No shell, no ConPTY, no external process.
+const TestPipe = struct {
+    name_w: [:0]u16,
+    security: PipeSecurity,
+    pipe: windows.HANDLE,
+    accept_event: windows.HANDLE,
+    shell_event: windows.HANDLE,
+
+    fn init(alloc: Allocator) !TestPipe {
+        var random: [8]u8 = undefined;
+        std.crypto.random.bytes(&random);
+        const name = try std.fmt.allocPrint(alloc, "test-{x}", .{&random});
+        defer alloc.free(name);
+        const pipe_name = try makePipeName(alloc, name);
+        defer alloc.free(pipe_name);
+        const name_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name);
+        errdefer alloc.free(name_w);
+
+        var security = try PipeSecurity.init(alloc);
+        errdefer security.deinit();
+        var security_attributes = security.attributes();
+        const pipe = try createHostPipe(name_w.ptr, &security_attributes);
+        errdefer _ = windows.CloseHandle(pipe);
+        const accept_event = try createManualResetEvent();
+        errdefer _ = windows.CloseHandle(accept_event);
+        const shell_event = try createManualResetEvent();
+        errdefer _ = windows.CloseHandle(shell_event);
+
+        return .{
+            .name_w = name_w,
+            .security = security,
+            .pipe = pipe,
+            .accept_event = accept_event,
+            .shell_event = shell_event,
+        };
+    }
+
+    fn deinit(self: *TestPipe, alloc: Allocator) void {
+        _ = windows.CloseHandle(self.shell_event);
+        _ = windows.CloseHandle(self.accept_event);
+        _ = windows.CloseHandle(self.pipe);
+        self.security.deinit();
+        alloc.free(self.name_w);
+        self.* = undefined;
+    }
+
+    fn accept(self: *TestPipe) !AcceptOutcome {
+        return acceptClientOrShellExit(self.pipe, self.accept_event, self.shell_event);
+    }
+
+    fn openClient(self: *TestPipe) !windows.HANDLE {
+        const client = windows.kernel32.CreateFileW(
+            self.name_w.ptr,
+            windows.GENERIC_READ | windows.GENERIC_WRITE,
+            0,
+            null,
+            windows.OPEN_EXISTING,
+            windows.FILE_ATTRIBUTE_NORMAL | security_sqos_present | security_identification,
+            null,
+        );
+        if (client == windows.INVALID_HANDLE_VALUE) {
+            return windows.unexpectedError(windows.kernel32.GetLastError());
+        }
+        return client;
+    }
+
+    fn openClientAfterDelay(self: *TestPipe, client: *windows.HANDLE) void {
+        std.Thread.sleep(50 * std.time.ns_per_ms);
+        client.* = self.openClient() catch windows.INVALID_HANDLE_VALUE;
+    }
+};
+
+test "conpty-host accept: client already connected before the accept is issued" {
+    const alloc = std.testing.allocator;
+    var fixture = try TestPipe.init(alloc);
+    defer fixture.deinit(alloc);
+
+    const client = try fixture.openClient();
+    defer _ = windows.CloseHandle(client);
+
+    try std.testing.expectEqual(AcceptOutcome.client_connected, try fixture.accept());
+}
+
+test "conpty-host accept: client connecting while the accept is pending" {
+    const alloc = std.testing.allocator;
+    var fixture = try TestPipe.init(alloc);
+    defer fixture.deinit(alloc);
+
+    var client: windows.HANDLE = windows.INVALID_HANDLE_VALUE;
+    const opener = try std.Thread.spawn(.{}, TestPipe.openClientAfterDelay, .{ &fixture, &client });
+    const outcome = try fixture.accept();
+    opener.join();
+    defer if (client != windows.INVALID_HANDLE_VALUE) {
+        _ = windows.CloseHandle(client);
+    };
+
+    try std.testing.expect(client != windows.INVALID_HANDLE_VALUE);
+    try std.testing.expectEqual(AcceptOutcome.client_connected, outcome);
+}
+
+test "conpty-host accept: shell exit cancels a pending accept and leaves the instance usable" {
+    const alloc = std.testing.allocator;
+    var fixture = try TestPipe.init(alloc);
+    defer fixture.deinit(alloc);
+
+    // No client will ever connect; the only way out is the shell handle.
+    try std.testing.expect(SetEvent(fixture.shell_event) != 0);
+    try std.testing.expectEqual(AcceptOutcome.shell_exited, try fixture.accept());
+
+    // The cancelled accept must not have wedged the instance: a later client
+    // still connects and a later accept still completes on the same handle.
+    try std.testing.expect(ResetEvent(fixture.shell_event) != 0);
+    const client = try fixture.openClient();
+    defer _ = windows.CloseHandle(client);
+    try std.testing.expectEqual(AcceptOutcome.client_connected, try fixture.accept());
+}
+
+test "conpty-host accept: shell exit wins while the accept is pending" {
+    const alloc = std.testing.allocator;
+    var fixture = try TestPipe.init(alloc);
+    defer fixture.deinit(alloc);
+
+    // Signal the shell while the accept is pending on another thread; the
+    // accept must return shell_exited rather than wait for a client forever.
+    const Signaller = struct {
+        fn run(event: windows.HANDLE) void {
+            std.Thread.sleep(50 * std.time.ns_per_ms);
+            _ = SetEvent(event);
+        }
+    };
+    const signaller = try std.Thread.spawn(.{}, Signaller.run, .{fixture.shell_event});
+    defer signaller.join();
+
+    try std.testing.expectEqual(AcceptOutcome.shell_exited, try fixture.accept());
 }

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -91,6 +91,9 @@ pub const std_options: std.Options = process_shared.std_options;
 test {
     _ = @import("pty.zig");
     _ = @import("Command.zig");
+    // Not part of the app; rooted here only so the spike's hermetic
+    // accept/select tests run with the suite.
+    _ = @import("conpty_host.zig");
     _ = @import("font/main.zig");
     _ = @import("apprt.zig");
     _ = @import("renderer.zig");

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -413,7 +413,16 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         observed_host_private_max_detached_bytes = $maxPrivate
         observed_host_private_growth_bytes = $privateGrowth
         observed_private_growth_within_ring_cap = $true
+        # Mechanism inventory, NOT a derived test result. This string is a
+        # constant: deleting verifyPipeServer from the client, or the
+        # reject-remote flag from the host, would not change what is emitted
+        # here. Every token does correspond to real code, but only the tokens
+        # in pipe_security_execution_verified are exercised by this run. If any
+        # of this graduates to product, the field must be derived from probes.
         pipe_security = 'current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid'
+        pipe_security_evidence = 'mechanism-inventory-not-derived'
+        pipe_security_execution_verified = 'current-user-DACL-accept;server-sid-accept;persistent-instance-reuse'
+        pipe_security_by_construction = 'first-instance-collision;reject-remote;cross-user-DACL-denial;untrusted-server-rejection'
         detach_frame = $true
         ceiling = 'same-logon-session-only;never-logoff-or-reboot'
     }

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -1,0 +1,470 @@
+[CmdletBinding()]
+param(
+    [int] $TimeoutSeconds = 60
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TimeoutSeconds -le 0) {
+    throw 'TimeoutSeconds must be greater than 0.'
+}
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$exePath = Join-Path $repoRoot 'zig-out\bin\conpty-host.exe'
+$sandboxParent = Join-Path $repoRoot '.sandbox'
+$sandboxName = "conpty-host-spike-$([Guid]::NewGuid().ToString('N'))"
+$sandbox = Join-Path $sandboxParent $sandboxName
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+$startedProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
+$hostProcess = $null
+$shellProcess = $null
+$shellPid = $null
+$stage = 'preflight'
+$failure = $null
+$failureKind = 'harness'
+$cleanupFailure = $null
+$result = $null
+$ringCapacity = 1024 * 1024
+
+function Get-SharedText {
+    param([Parameter(Mandatory)][string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return '' }
+    $stream = [System.IO.File]::Open(
+        $Path,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::ReadWrite
+    )
+    try {
+        $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true)
+        try { return $reader.ReadToEnd() }
+        finally { $reader.Dispose() }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Wait-TextPattern {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $Pattern,
+        [Parameter(Mandatory)][string] $Description,
+        [System.Diagnostics.Process] $Process,
+        [string] $StderrPath
+    )
+
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $text = Get-SharedText -Path $Path
+        $match = [regex]::Match($text, $Pattern)
+        if ($match.Success) { return $match }
+        if ($Process) {
+            $Process.Refresh()
+            if ($Process.HasExited) {
+                $stderr = if ($StderrPath) { Get-SharedText -Path $StderrPath } else { '' }
+                throw "$Description process exited early (pid=$($Process.Id), exit=$($Process.ExitCode), stderr=$stderr)"
+            }
+        }
+        Start-Sleep -Milliseconds 50
+    }
+    throw "timed out waiting for $Description in $Path"
+}
+
+function Stop-ExactProcess {
+    param([System.Diagnostics.Process] $Process)
+
+    if (-not $Process) { return }
+    $Process.Refresh()
+    if (-not $Process.HasExited) {
+        Stop-Process -Id $Process.Id -Force
+        if (-not $Process.WaitForExit(5000)) {
+            throw "exact-PID process did not exit after forced stop: pid=$($Process.Id)"
+        }
+    }
+}
+
+function Start-AttachClient {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $PipeName,
+        [Parameter(Mandatory)][string] $InputPath,
+        [string] $Resize,
+        [switch] $StayOnEof
+    )
+
+    $stdoutPath = Join-Path $sandbox "$Name.stdout.log"
+    $stderrPath = Join-Path $sandbox "$Name.stderr.log"
+    $arguments = @('attach', '--pipe', $PipeName)
+    if ($Resize) { $arguments += @('--resize', $Resize) }
+    if ($StayOnEof) { $arguments += '--stay-on-eof' }
+
+    $process = Start-Process `
+        -FilePath $exePath `
+        -ArgumentList $arguments `
+        -WorkingDirectory $repoRoot `
+        -RedirectStandardInput $InputPath `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -PassThru
+    $startedProcesses.Add($process)
+    return [pscustomobject]@{
+        Process = $process
+        Stdout = $stdoutPath
+        Stderr = $stderrPath
+    }
+}
+
+try {
+    if ($env:OS -ne 'Windows_NT') {
+        $failureKind = 'environmental'
+        throw 'Windows is required; this is an environmental failure, not an architectural verdict.'
+    }
+    if (-not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+        $failureKind = 'environmental'
+        throw "missing spike executable: $exePath (run zig build -Demit-conpty-host=true first)"
+    }
+    if (-not (Get-Command pwsh.exe -ErrorAction SilentlyContinue)) {
+        $failureKind = 'environmental'
+        throw 'pwsh.exe is unavailable; this is an environmental failure, not an architectural verdict.'
+    }
+
+    [void](New-Item -ItemType Directory -Path $sandboxParent -Force)
+    [void](New-Item -ItemType Directory -Path $sandbox)
+    $emptyInput = Join-Path $sandbox 'empty.input'
+    [System.IO.File]::WriteAllBytes($emptyInput, [byte[]]::new(0))
+
+    $pipeName = "spike-$([Guid]::NewGuid().ToString('N'))"
+    $hostStdout = Join-Path $sandbox 'host.stdout.log'
+    $hostStderr = Join-Path $sandbox 'host.stderr.log'
+
+    $stage = 'start-host'
+    $failureKind = 'feasibility'
+    $hostProcess = Start-Process `
+        -FilePath $exePath `
+        -ArgumentList @('serve', '--pipe', $pipeName) `
+        -WorkingDirectory $repoRoot `
+        -RedirectStandardOutput $hostStdout `
+        -RedirectStandardError $hostStderr `
+        -PassThru
+    $startedProcesses.Add($hostProcess)
+
+    $ready = Wait-TextPattern `
+        -Path $hostStdout `
+        -Pattern 'CONPTY_HOST_READY .*shell_pid=(\d+) ring_capacity=(\d+) security=current-user' `
+        -Description 'host readiness' `
+        -Process $hostProcess `
+        -StderrPath $hostStderr
+    $hostReportedShellPid = [int]$ready.Groups[1].Value
+    if ([int]$ready.Groups[2].Value -ne $ringCapacity) {
+        throw "host used unexpected ring capacity: $($ready.Groups[2].Value)"
+    }
+
+    $stage = 'initial-attach'
+    $stateToken = "STATE_$([Guid]::NewGuid().ToString('N'))"
+    $initialInput = Join-Path $sandbox 'initial.input'
+    $initialCommand = @"
+`$global:ConptySpikeState='$stateToken'; Write-Output ('SHELL_PID={0}' -f `$PID); Write-Output ('STATE_SET={0}' -f `$global:ConptySpikeState); for (`$iteration=0; `$iteration -lt 50; `$iteration++) { `$size=`$Host.UI.RawUI.WindowSize; Write-Output ('VIEWPORT={0}x{1}' -f `$size.Width,`$size.Height); Start-Sleep -Milliseconds 100 }; Write-Output 'LONG_RUNNING_DONE'
+"@.Trim() + "`r"
+    [System.IO.File]::WriteAllText($initialInput, $initialCommand, [System.Text.UTF8Encoding]::new($false))
+
+    $client1 = Start-AttachClient `
+        -Name 'client1' `
+        -PipeName $pipeName `
+        -InputPath $initialInput `
+        -StayOnEof
+    $shellMatch = Wait-TextPattern `
+        -Path $client1.Stdout `
+        -Pattern 'SHELL_PID=(\d+)' `
+        -Description 'initial shell PID' `
+        -Process $client1.Process `
+        -StderrPath $client1.Stderr
+    $shellPid = [int]$shellMatch.Groups[1].Value
+    $shellProcess = Get-Process -Id $shellPid -ErrorAction Stop
+    if ($shellProcess.HasExited) { throw "shell exited before the initial assertion: pid=$shellPid" }
+    [void](Wait-TextPattern `
+        -Path $client1.Stdout `
+        -Pattern "STATE_SET=$([regex]::Escape($stateToken))" `
+        -Description 'initial shell state' `
+        -Process $client1.Process `
+        -StderrPath $client1.Stderr)
+    [void](Wait-TextPattern `
+        -Path $client1.Stdout `
+        -Pattern 'VIEWPORT=80x24' `
+        -Description 'initial long-running viewport loop' `
+        -Process $client1.Process `
+        -StderrPath $client1.Stderr)
+    if ($shellPid -ne $hostReportedShellPid) {
+        throw "shell PID disagreement: shell=$shellPid host=$hostReportedShellPid"
+    }
+
+    $stage = 'hard-kill-first-client'
+    $firstClientPid = $client1.Process.Id
+    Stop-Process -Id $firstClientPid -Force
+    if (-not $client1.Process.WaitForExit(5000)) {
+        throw "hard-killed client did not exit: pid=$firstClientPid"
+    }
+    $shellProcess.Refresh()
+    if ($shellProcess.HasExited) { throw "shell exited after client hard kill: pid=$shellPid" }
+
+    $stage = 'reattach-resize'
+    $client2 = Start-AttachClient `
+        -Name 'client2' `
+        -PipeName $pipeName `
+        -InputPath $emptyInput `
+        -Resize '100x31' `
+        -StayOnEof
+    [void](Wait-TextPattern `
+        -Path $client2.Stdout `
+        -Pattern 'VIEWPORT=100x31' `
+        -Description 'reattached viewport repaint after resize' `
+        -Process $client2.Process `
+        -StderrPath $client2.Stderr)
+    [void](Wait-TextPattern `
+        -Path $client2.Stdout `
+        -Pattern 'LONG_RUNNING_DONE' `
+        -Description 'long-running shell command completion after reattach' `
+        -Process $client2.Process `
+        -StderrPath $client2.Stderr)
+    Stop-ExactProcess -Process $client2.Process
+
+    $stage = 'state-and-overflow-command'
+    $oldestToken = "OLDEST_$([Guid]::NewGuid().ToString('N'))"
+    $newestToken = "NEWEST_$([Guid]::NewGuid().ToString('N'))"
+    $overflowInput = Join-Path $sandbox 'overflow.input'
+    $overflowDonePath = Join-Path $sandbox 'overflow.done'
+    $overflowDoneLiteral = $overflowDonePath.Replace("'", "''")
+    $overflowCommand = @"
+Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -f `$global:ConptySpikeState); Write-Output '$oldestToken'; Start-Sleep -Seconds 2; `$payload='X' * 180; for (`$i=0; `$i -lt 12000; `$i++) { Write-Output ('BUFFER_{0:D5}_{1}' -f `$i,`$payload) }; Write-Output '$newestToken'; Write-Output 'OVERFLOW_DONE'; [System.IO.File]::WriteAllText('$overflowDoneLiteral','done')
+"@.Trim() + "`r"
+    [System.IO.File]::WriteAllText($overflowInput, $overflowCommand, [System.Text.UTF8Encoding]::new($false))
+
+    $client3 = Start-AttachClient `
+        -Name 'client3' `
+        -PipeName $pipeName `
+        -InputPath $overflowInput `
+        -StayOnEof
+    $reattachPid = Wait-TextPattern `
+        -Path $client3.Stdout `
+        -Pattern 'REATTACH_PID=(\d+)' `
+        -Description 'reattached shell PID' `
+        -Process $client3.Process `
+        -StderrPath $client3.Stderr
+    $reattachState = Wait-TextPattern `
+        -Path $client3.Stdout `
+        -Pattern "REATTACH_STATE=$([regex]::Escape($stateToken))" `
+        -Description 'reattached shell state' `
+        -Process $client3.Process `
+        -StderrPath $client3.Stderr
+    if ([int]$reattachPid.Groups[1].Value -ne $shellPid) {
+        throw "reattached shell PID changed: before=$shellPid after=$($reattachPid.Groups[1].Value)"
+    }
+    [void](Wait-TextPattern `
+        -Path $client3.Stdout `
+        -Pattern ([regex]::Escape($oldestToken)) `
+        -Description 'oldest overflow marker before detach' `
+        -Process $client3.Process `
+        -StderrPath $client3.Stderr)
+
+    $hostProcess.Refresh()
+    $privateBaseline = [long]$hostProcess.PrivateMemorySize64
+    $maxPrivate = $privateBaseline
+    Stop-ExactProcess -Process $client3.Process
+
+    $stage = 'detached-ring-overflow'
+    $lastRingTotal = 0L
+    $lastRingRetained = 0L
+    $stableTotal = -1L
+    $stableSince = $null
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $hostProcess.Refresh()
+        if ($hostProcess.HasExited) { throw "host exited during detached output (exit=$($hostProcess.ExitCode))" }
+        $maxPrivate = [Math]::Max($maxPrivate, [long]$hostProcess.PrivateMemorySize64)
+
+        $statsText = Get-SharedText -Path $hostStderr
+        $statsMatches = [regex]::Matches($statsText, 'RING_STATS total=(\d+) retained=(\d+) capacity=(\d+)')
+        foreach ($stats in $statsMatches) {
+            $total = [long]$stats.Groups[1].Value
+            $retained = [long]$stats.Groups[2].Value
+            $capacity = [long]$stats.Groups[3].Value
+            if ($retained -gt $capacity -or $capacity -ne $ringCapacity) {
+                throw "ring exceeded its bound: total=$total retained=$retained capacity=$capacity"
+            }
+            if ($total -gt $lastRingTotal) {
+                $lastRingTotal = $total
+                $lastRingRetained = $retained
+            }
+        }
+        if ($lastRingTotal -ge ($ringCapacity + ($ringCapacity / 2)) -and
+            (Test-Path -LiteralPath $overflowDonePath -PathType Leaf)) {
+            if ($lastRingTotal -ne $stableTotal) {
+                $stableTotal = $lastRingTotal
+                $stableSince = [DateTime]::UtcNow
+            }
+            elseif ($stableSince -and ([DateTime]::UtcNow - $stableSince).TotalMilliseconds -ge 750) {
+                break
+            }
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    if ($lastRingTotal -lt ($ringCapacity + ($ringCapacity / 2))) {
+        throw "detached output did not overflow the ring: total=$lastRingTotal capacity=$ringCapacity"
+    }
+    if (-not (Test-Path -LiteralPath $overflowDonePath -PathType Leaf)) {
+        throw 'detached overflow command did not reach its completion sentinel'
+    }
+    if (-not $stableSince -or ([DateTime]::UtcNow - $stableSince).TotalMilliseconds -lt 750) {
+        throw 'detached ConPTY drain did not reach a stable output-total barrier before reattach'
+    }
+    $privateGrowth = [Math]::Max(0L, $maxPrivate - $privateBaseline)
+    if ($privateGrowth -gt $ringCapacity) {
+        throw "host private-memory growth exceeded ring cap while detached: growth=$privateGrowth cap=$ringCapacity"
+    }
+
+    $stage = 'bounded-ring-replay'
+    $client4 = Start-AttachClient `
+        -Name 'client4' `
+        -PipeName $pipeName `
+        -InputPath $emptyInput `
+        -StayOnEof
+    [void](Wait-TextPattern `
+        -Path $client4.Stdout `
+        -Pattern ([regex]::Escape($newestToken)) `
+        -Description 'newest overflow marker on replay' `
+        -Process $client4.Process `
+        -StderrPath $client4.Stderr)
+    [void](Wait-TextPattern `
+        -Path $client4.Stdout `
+        -Pattern 'OVERFLOW_DONE' `
+        -Description 'overflow completion on replay' `
+        -Process $client4.Process `
+        -StderrPath $client4.Stderr)
+    $replayBytes = 0L
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $replayBytes = (Get-Item -LiteralPath $client4.Stdout).Length
+        if ($replayBytes -ge $ringCapacity) { break }
+        Start-Sleep -Milliseconds 25
+    }
+    if ($replayBytes -lt $ringCapacity) {
+        throw "full retained ring was not replayed: bytes=$replayBytes capacity=$ringCapacity"
+    }
+    $replayText = Get-SharedText -Path $client4.Stdout
+    if ($replayText.Contains($oldestToken)) {
+        throw 'oldest overflow marker survived despite more than one ring capacity of newer output'
+    }
+    Stop-ExactProcess -Process $client4.Process
+
+    $stage = 'detach-frame'
+    $client5 = Start-AttachClient `
+        -Name 'client5' `
+        -PipeName $pipeName `
+        -InputPath $emptyInput
+    if (-not $client5.Process.WaitForExit(10000)) {
+        throw "detach-on-EOF client did not exit: pid=$($client5.Process.Id)"
+    }
+    if ($client5.Process.ExitCode -ne 0) {
+        throw "detach-on-EOF client failed: exit=$($client5.Process.ExitCode) stderr=$(Get-SharedText -Path $client5.Stderr)"
+    }
+    $shellProcess.Refresh()
+    if ($shellProcess.HasExited) { throw "shell exited after detach frame: pid=$shellPid" }
+
+    $result = [ordered]@{
+        result = 'PASS'
+        verdict = 'GREEN'
+        host_pid = $hostProcess.Id
+        killed_client_pid = $firstClientPid
+        shell_pid = $shellPid
+        same_shell_pid = $true
+        shell_state_intact = $true
+        viewport_repaint = '100x31'
+        detached_drain = $true
+        detached_output_completed = $true
+        ring_capacity_bytes = $ringCapacity
+        ring_retained_bytes = $lastRingRetained
+        ring_total_bytes = $lastRingTotal
+        replay_bytes = $replayBytes
+        oldest_replay_absent = $true
+        newest_replay_present = $true
+        host_private_baseline_bytes = $privateBaseline
+        host_private_max_detached_bytes = $maxPrivate
+        host_private_growth_bytes = $privateGrowth
+        private_growth_within_ring_cap = $true
+        pipe_security = 'current-user-DACL+reject-remote'
+        detach_frame = $true
+        ceiling = 'same-logon-session-only;never-logoff-or-reboot'
+    }
+}
+catch {
+    $failure = $_
+}
+finally {
+    for ($index = $startedProcesses.Count - 1; $index -ge 0; $index--) {
+        $process = $startedProcesses[$index]
+        try {
+            Stop-ExactProcess -Process $process
+        }
+        catch {
+            $message = "exact-PID cleanup failed for pid=$($process.Id): $($_.Exception.Message)"
+            $cleanupFailure = if ($cleanupFailure) { "$cleanupFailure; $message" } else { $message }
+        }
+        $process.Dispose()
+    }
+
+    if ($shellProcess) {
+        try {
+            Stop-ExactProcess -Process $shellProcess
+        }
+        catch {
+            $message = "exact shell-PID cleanup failed for pid=$shellPid`: $($_.Exception.Message)"
+            $cleanupFailure = if ($cleanupFailure) { "$cleanupFailure; $message" } else { $message }
+        }
+        $shellProcess.Dispose()
+    }
+
+    if (-not $failure -and (Test-Path -LiteralPath $sandbox)) {
+        $resolvedParent = [System.IO.Path]::GetFullPath($sandboxParent).TrimEnd('\') + '\'
+        $resolvedSandbox = [System.IO.Path]::GetFullPath($sandbox)
+        if (-not $resolvedSandbox.StartsWith($resolvedParent, [StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedSandbox)).StartsWith('conpty-host-spike-', [StringComparison]::Ordinal)) {
+            $cleanupFailure = "refusing to remove unexpected sandbox path: $resolvedSandbox"
+        }
+        else {
+            for ($attempt = 0; $attempt -lt 20 -and (Test-Path -LiteralPath $resolvedSandbox); $attempt++) {
+                try {
+                    [System.IO.Directory]::Delete($resolvedSandbox, $true)
+                }
+                catch {
+                    if ($attempt -eq 19) {
+                        $cleanupFailure = "sandbox cleanup failed: $($_.Exception.Message)"
+                    }
+                    else {
+                        Start-Sleep -Milliseconds 100
+                    }
+                }
+            }
+        }
+    }
+}
+
+if (-not $failure -and $cleanupFailure) {
+    $stage = 'cleanup'
+    $failureKind = 'cleanup'
+    $failure = [System.Management.Automation.RuntimeException]::new($cleanupFailure)
+}
+
+if ($failure) {
+    $failureResult = [ordered]@{
+        result = 'FAIL'
+        verdict = if ($failureKind -eq 'feasibility') { 'RED' } else { 'INCONCLUSIVE' }
+        failure_kind = $failureKind
+        stage = $stage
+        error = $failure.Exception.Message
+        shell_pid = $shellPid
+        cleanup_error = $cleanupFailure
+    }
+    Write-Output "CONPTY_HOST_SPIKE_RESULT $($failureResult | ConvertTo-Json -Compress)"
+    exit 1
+}
+
+Write-Output "CONPTY_HOST_SPIKE_RESULT $($result | ConvertTo-Json -Compress)"
+exit 0

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -338,10 +338,14 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
     if (-not $stableSince -or ([DateTime]::UtcNow - $stableSince).TotalMilliseconds -lt 750) {
         throw 'detached ConPTY drain did not reach a stable output-total barrier before reattach'
     }
+    # Diagnostic only, never a gate. PrivateMemorySize64 is whole-process
+    # private memory: unrelated heap or runtime page commits can move it by
+    # more than the ring capacity while retained <= capacity stays true, and
+    # the 25 ms sampling can miss a transient peak either way. The structural
+    # guarantee is the ring bound asserted above; this number is recorded so a
+    # reader can see what one run observed, not to decide the verdict.
     $privateGrowth = [Math]::Max(0L, $maxPrivate - $privateBaseline)
-    if ($privateGrowth -gt $ringCapacity) {
-        throw "host private-memory growth exceeded ring cap while detached: growth=$privateGrowth cap=$ringCapacity"
-    }
+    $privateGrowthWithinRingCap = $privateGrowth -le $ringCapacity
 
     $stage = 'bounded-ring-replay'
     $client4 = Start-AttachClient `
@@ -390,6 +394,32 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
     $shellProcess.Refresh()
     if ($shellProcess.HasExited) { throw "shell exited after detach frame: pid=$shellPid" }
 
+    # The host must not outlive its shell. This client tells the shell to exit
+    # and then detaches on EOF, so the shell dies while no client is attached
+    # and the host is parked in its accept. A synchronous accept has no
+    # cancellation path and would leave the host alive until some client
+    # happened to connect; the overlapped accept waits on the shell's process
+    # handle too and must release the host into teardown on its own.
+    $stage = 'shell-exit-releases-host'
+    $exitInput = Join-Path $sandbox 'exit.input'
+    [System.IO.File]::WriteAllText($exitInput, "exit`r", [System.Text.UTF8Encoding]::new($false))
+    $client6 = Start-AttachClient `
+        -Name 'client6' `
+        -PipeName $pipeName `
+        -InputPath $exitInput
+    if (-not $client6.Process.WaitForExit(10000)) {
+        throw "exit-sending client did not exit: pid=$($client6.Process.Id)"
+    }
+    if (-not $shellProcess.WaitForExit(10000)) {
+        throw "shell did not exit after receiving exit: pid=$shellPid"
+    }
+    if (-not $hostProcess.WaitForExit(10000)) {
+        throw "host outlived its shell with no client attached: host_pid=$($hostProcess.Id) shell_pid=$shellPid"
+    }
+    if ($hostProcess.ExitCode -ne 0) {
+        throw "host exited with code $($hostProcess.ExitCode) after shell exit; stderr=$(Get-SharedText -Path $hostStderr)"
+    }
+
     $result = [ordered]@{
         result = 'PASS'
         verdict = 'GREEN'
@@ -412,7 +442,7 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         observed_host_private_baseline_bytes = $privateBaseline
         observed_host_private_max_detached_bytes = $maxPrivate
         observed_host_private_growth_bytes = $privateGrowth
-        observed_private_growth_within_ring_cap = $true
+        observed_private_growth_within_ring_cap = $privateGrowthWithinRingCap
         # Mechanism inventory, NOT a derived test result. This string is a
         # constant: deleting verifyPipeServer from the client, or the
         # reject-remote flag from the host, would not change what is emitted
@@ -424,6 +454,8 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         pipe_security_execution_verified = 'current-user-DACL-accept;server-sid-accept;persistent-instance-reuse'
         pipe_security_by_construction = 'first-instance-collision;reject-remote;cross-user-DACL-denial;untrusted-server-rejection'
         detach_frame = $true
+        shell_exit_released_host = $true
+        host_exit_code = $hostProcess.ExitCode
         ceiling = 'same-logon-session-only;never-logoff-or-reboot'
     }
 }

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -413,7 +413,7 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         observed_host_private_max_detached_bytes = $maxPrivate
         observed_host_private_growth_bytes = $privateGrowth
         observed_private_growth_within_ring_cap = $true
-        pipe_security = 'current-user-DACL+first-instance+reject-remote+persistent-instance'
+        pipe_security = 'current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid'
         detach_frame = $true
         ceiling = 'same-logon-session-only;never-logoff-or-reboot'
     }

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -413,7 +413,7 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         observed_host_private_max_detached_bytes = $maxPrivate
         observed_host_private_growth_bytes = $privateGrowth
         observed_private_growth_within_ring_cap = $true
-        pipe_security = 'current-user-DACL+first-instance+reject-remote'
+        pipe_security = 'current-user-DACL+first-instance+reject-remote+persistent-instance'
         detach_frame = $true
         ceiling = 'same-logon-session-only;never-logoff-or-reboot'
     }

--- a/test/windows/conpty-host-spike.ps1
+++ b/test/windows/conpty-host-spike.ps1
@@ -162,9 +162,25 @@ try {
 
     $stage = 'initial-attach'
     $stateToken = "STATE_$([Guid]::NewGuid().ToString('N'))"
+    $tuiProbeId = [Guid]::NewGuid().ToString('N')
+    $tuiContentToken = "TUI_CONTENT_$tuiProbeId"
+    $tuiInitialRedrawToken = "TUI_REDRAW_80x24_$tuiProbeId"
+    $tuiResizedRedrawToken = "TUI_REDRAW_100x31_$tuiProbeId"
+    $escape = [char]27
+    $boxTop = '+----------------------------------------------------------+'
+    # ConPTY consumes the application's VT and emits a normalized redraw. Match
+    # the cursor-home redraw plus the unique content/size tokens, not the exact
+    # application byte sequence that conhost intentionally normalizes.
+    $cursorHomeBox = [regex]::Escape("$escape[H$boxTop")
+    $initialTuiPattern = '(?s)' + [regex]::Escape("$escape[?1049h") +
+        '.{0,256}' + $cursorHomeBox + '.{0,2048}' +
+        [regex]::Escape($tuiContentToken) + '.{0,2048}' + [regex]::Escape($tuiInitialRedrawToken)
+    $resizedTuiPattern = '(?s)' + [regex]::Escape("$escape[2J") +
+        '.{0,256}' + $cursorHomeBox + '.{0,2048}' +
+        [regex]::Escape($tuiContentToken) + '.{0,2048}' + [regex]::Escape($tuiResizedRedrawToken)
     $initialInput = Join-Path $sandbox 'initial.input'
     $initialCommand = @"
-`$global:ConptySpikeState='$stateToken'; Write-Output ('SHELL_PID={0}' -f `$PID); Write-Output ('STATE_SET={0}' -f `$global:ConptySpikeState); for (`$iteration=0; `$iteration -lt 50; `$iteration++) { `$size=`$Host.UI.RawUI.WindowSize; Write-Output ('VIEWPORT={0}x{1}' -f `$size.Width,`$size.Height); Start-Sleep -Milliseconds 100 }; Write-Output 'LONG_RUNNING_DONE'
+`$global:ConptySpikeState='$stateToken'; `$escape=[char]27; `$lastWidth=0; `$lastHeight=0; `$resizeSeen=`$false; Write-Output ('SHELL_PID={0}' -f `$PID); Write-Output ('STATE_SET={0}' -f `$global:ConptySpikeState); try { [Console]::Write("`$escape[?1049h"); for (`$iteration=0; `$iteration -lt 400; `$iteration++) { `$size=`$Host.UI.RawUI.WindowSize; if (`$size.Width -ne `$lastWidth -or `$size.Height -ne `$lastHeight) { `$redrawToken='TUI_REDRAW_{0}x{1}_$tuiProbeId' -f `$size.Width,`$size.Height; [Console]::Write(("`$escape[2J`$escape[1;1H$boxTop`$escape[2;1H| $tuiContentToken |`$escape[3;1H$boxTop`$escape[4;1H{0}" -f `$redrawToken)); `$lastWidth=`$size.Width; `$lastHeight=`$size.Height; if (`$size.Width -eq 100 -and `$size.Height -eq 31) { `$resizeSeen=`$true; break } }; Start-Sleep -Milliseconds 50 } } finally { [Console]::Write("`$escape[?1049l") }; if (-not `$resizeSeen) { throw 'synthetic TUI did not observe 100x31' }; Write-Output 'LONG_RUNNING_DONE'
 "@.Trim() + "`r"
     [System.IO.File]::WriteAllText($initialInput, $initialCommand, [System.Text.UTF8Encoding]::new($false))
 
@@ -190,8 +206,8 @@ try {
         -StderrPath $client1.Stderr)
     [void](Wait-TextPattern `
         -Path $client1.Stdout `
-        -Pattern 'VIEWPORT=80x24' `
-        -Description 'initial long-running viewport loop' `
+        -Pattern $initialTuiPattern `
+        -Description 'initial cursor-addressed alt-screen box' `
         -Process $client1.Process `
         -StderrPath $client1.Stderr)
     if ($shellPid -ne $hostReportedShellPid) {
@@ -216,8 +232,14 @@ try {
         -StayOnEof
     [void](Wait-TextPattern `
         -Path $client2.Stdout `
-        -Pattern 'VIEWPORT=100x31' `
-        -Description 'reattached viewport repaint after resize' `
+        -Pattern $resizedTuiPattern `
+        -Description 'reattached cursor-addressed alt-screen redraw after resize' `
+        -Process $client2.Process `
+        -StderrPath $client2.Stderr)
+    [void](Wait-TextPattern `
+        -Path $client2.Stdout `
+        -Pattern ([regex]::Escape("$escape[?1049l")) `
+        -Description 'alt-screen exit after resized redraw' `
         -Process $client2.Process `
         -StderrPath $client2.Stderr)
     [void](Wait-TextPattern `
@@ -376,7 +398,9 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         shell_pid = $shellPid
         same_shell_pid = $true
         shell_state_intact = $true
-        viewport_repaint = '100x31'
+        alt_screen_entered = $true
+        alt_screen_redraw = 'cursor-addressed-preexisting-content@100x31'
+        alt_screen_exited = $true
         detached_drain = $true
         detached_output_completed = $true
         ring_capacity_bytes = $ringCapacity
@@ -385,11 +409,11 @@ Write-Output ('REATTACH_PID={0}' -f `$PID); Write-Output ('REATTACH_STATE={0}' -
         replay_bytes = $replayBytes
         oldest_replay_absent = $true
         newest_replay_present = $true
-        host_private_baseline_bytes = $privateBaseline
-        host_private_max_detached_bytes = $maxPrivate
-        host_private_growth_bytes = $privateGrowth
-        private_growth_within_ring_cap = $true
-        pipe_security = 'current-user-DACL+reject-remote'
+        observed_host_private_baseline_bytes = $privateBaseline
+        observed_host_private_max_detached_bytes = $maxPrivate
+        observed_host_private_growth_bytes = $privateGrowth
+        observed_private_growth_within_ring_cap = $true
+        pipe_security = 'current-user-DACL+first-instance+reject-remote'
         detach_frame = $true
         ceiling = 'same-logon-session-only;never-logoff-or-reboot'
     }


### PR DESCRIPTION
## Summary

Builds the smallest artifact that answers the durable-session question: can a separate process own a ConPTY + shell such that the UI client can die and a new client reattaches to the same live shell?

**Verdict: GREEN**, reproduced on Windows 25H2 build 26200.9168 by the implementer, the manager, and the adversarial reviewer independently, and re-run green on every round since.

This is a feasibility artifact, not a product feature. It is not built by default, not packaged, and not integrated into the app.

Fixes #132

## Changes

- `src/build/Config.zig` + `build.zig`: new `-Demit-conpty-host` option, default false, Windows-only, following the existing `emit_bench` plumbing. No packaging path references it.
- `src/conpty_host.zig`: standalone console exe with `serve` and `attach` modes. Reuses `Pty.open` / `WindowsPty.setSize` / `pseudoConsole()` from `src/pty.zig` and the ConPTY launch path in `src/Command.zig` **without modifying either**. Owns one `pwsh.exe`, drains ConPTY output on a dedicated thread even with no client attached, retains raw output in a preallocated 1 MiB overwrite ring, serves one client at a time on an overlapped pipe instance with a cancellable accept. Protocol is deliberately disposable: attach, detach, resize, input, output. Four hermetic tests for the accept/select logic live at the bottom of the file.
- `src/main_ghostty.zig`: one `_ = @import("conpty_host.zig")` in the test root so those tests run with the suite. Nothing else in the app references the file.
- `test/windows/conpty-host-spike.ps1`: the experiment, with a machine-readable verdict line and PID-exact cleanup on success and failure paths.
- `plans/wayfinder/competitive-analysis/research/durable-session-spike.md`: dated "Feasibility increment result (2026-08-21)" section with assertions, observed output, ceiling, and residual unknowns.
- `plans/2026-competitive-roadmap.md`: one line recording the GREEN result on the increment's entry.

`PRODUCT.md` is unchanged because the verdict is green — the session-tier aspiration sentence still holds.

## Named pipe security

The actual controls are: an SDDL security descriptor `O:<user-sid>D:P(A;;GA;;;<user-sid>)` (protected DACL, single current-user ACE); `FILE_FLAG_FIRST_PIPE_INSTANCE`; `PIPE_REJECT_REMOTE_CLIENTS`; non-inheritable handles; **a single pipe instance created before the name is advertised and held for the host's lifetime**; clients that connect at `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`; and **clients that authenticate the server's owner SID before sending any frame**.

`SECURITY_IDENTIFICATION` caps the token a server obtains from a connecting client at identification level: the server can still obtain such a token and learn who the client is, but cannot act as the client. It does nothing about a server capturing what the client sends; that is what the server-SID check is for.

The `LOCAL` prefix is **not** a security property for ordinary desktop processes — it only affects AppContainer name resolution.

Two claims in an earlier version of this description were wrong and are retracted:

- It said the pipe instance is closed and recreated between clients. That was accurate then and is fixed now: `d2f9cb4da` holds one instance for the host's lifetime, so the name is never unowned while the host lives.
- It said the resulting squat gap was a **same-user** risk and therefore out of scope. That was wrong. `\\.\pipe` is machine-global, needs no privilege to create a name in, and is enumerable: a probe with a live host listed 542 pipes including this spike's own randomly-named instance, so an unguessable name is not a control. The gap was a **cross-user** disclosure path.

A later claim that the remaining pre-start / no-host cases were "fail closed, no disclosure" was **also wrong**, and is retracted too. `FIRST_PIPE_INSTANCE` fails the *host* closed and says nothing about the *client*. Verified directly: with no host running and an impostor holding the name, the client connected and the impostor received the attach frame `01 00 00 00 00`. `f04a789e4` fixes this by having the client authenticate the server before sending any frame.

Scope of that fix, stated precisely rather than absolutely: it closes the cross-user case **up to a PID-reuse race** between the pipe's recorded server PID and `OpenProcess` — the check authenticates the process currently holding that PID, not the pipe endpoint itself. There is no TOCTOU after the check; the handle stays bound to the verified instance. **A same-user impostor still passes outright**, as does a same-user impostor at a different integrity level. Same-user attackers remain out of scope for this spike; integrity-level separation remains a residual.

## Validation

Rebased onto `main` at `e3a38268e`; head `a572f7edd`.

```
CONPTY_HOST_SPIKE_RESULT {"result":"PASS","verdict":"GREEN","host_pid":17776,
"killed_client_pid":12608,"shell_pid":72012,"same_shell_pid":true,
"shell_state_intact":true,"alt_screen_entered":true,
"alt_screen_redraw":"cursor-addressed-preexisting-content@100x31",
"alt_screen_exited":true,"detached_drain":true,"detached_output_completed":true,
"ring_capacity_bytes":1048576,"ring_retained_bytes":1048576,
"ring_total_bytes":2572756,"replay_bytes":1048576,"oldest_replay_absent":true,
"newest_replay_present":true,"observed_host_private_baseline_bytes":38445056,
"observed_host_private_max_detached_bytes":38445056,
"observed_host_private_growth_bytes":0,
"observed_private_growth_within_ring_cap":true,
"pipe_security":"current-user-DACL+first-instance+reject-remote+persistent-instance+client-verifies-server-sid",
"pipe_security_evidence":"mechanism-inventory-not-derived",
"pipe_security_execution_verified":"current-user-DACL-accept;server-sid-accept;persistent-instance-reuse",
"pipe_security_by_construction":"first-instance-collision;reject-remote;cross-user-DACL-denial;untrusted-server-rejection",
"detach_frame":true,"shell_exit_released_host":true,"host_exit_code":0,
"ceiling":"same-logon-session-only;never-logoff-or-reboot"}
```

A real TUI is exercised: the shell enters the alternate screen (`CSI ?1049h`) and draws a cursor-addressed box carrying a unique content token. Client 1 is force-killed by PID while the TUI is live; client 2 reattaches and resizes to 100x31; the test requires a fresh cursor-addressed frame containing both the pre-kill content token **and** a resize-specific token that could not have existed before client 2 sent the resize — so it cannot be satisfied by replayed output. Exit via `CSI ?1049l` is asserted. The shell PID was identical before and after reattach and its shell variable survived.

The ring is also overflowed while detached: 2.5 MB drained, retained bytes stayed at the 1 MiB cap, newest replay present and oldest gone.

The final stage sends `exit` to the shell from a sixth client that then detaches, so the shell dies with no client attached, and requires the host to exit on its own with code 0 within 10 s. That is the cancellable-accept property, asserted end to end.

Note on `pipe_security`: it is a **hard-coded constant**, so it is a fair inventory of mechanisms that all exist in the code, but it is **not derived** — deleting `verifyPipeServer` would not change the emitted string. Only the DACL accept path, the server-SID accept path and persistent-instance reuse are execution-verified; first-instance collision, reject-remote, cross-user DACL denial and the `UntrustedPipeServer` rejection branch hold by construction and code review only. The `pipe_security_*` companion fields carry that distinction with the result. If this graduates to product, the field must be derived from probes.

Note on memory: `observed_host_private_growth_bytes` is whole-process `PrivateMemorySize64` and is **recorded only** — the harness never throws on it, and `observed_private_growth_within_ring_cap` is derived from the number rather than asserted. The only memory gate is `retained <= capacity` on every emitted `RING_STATS` line.

Gates on `a572f7edd`:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` + emitted exe | 4076 passed, 70 skipped, 0 failed |
| `zig build test -Dtest-filter="conpty-host accept"` | 4 run, 4 pass (72 passed, 1 skipped, 0 failed in the filtered exe) |
| `scripts/check-zig-format.ps1` | passed (694 tracked sources) |
| `scripts/check-source-format.ps1` | passed |
| `prettier@3 --check` on the two touched `.md` | passed |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| `zig build -Demit-conpty-host=true -Demit-exe=false` | exit 0, produced `zig-out\bin\conpty-host.exe` |
| `pwsh -NoProfile -File test/windows/conpty-host-spike.ps1` | exit 0, verdict line above |

No `conpty-host` processes remained after any run; all spawned processes cleaned by exact PID.

## Adversarial review history

- `36b22743c` — added the alt-screen TUI coverage the original harness was missing, corrected pipe-security wording, documented the uncancellable accept, renamed memory fields to `observed_*`, removed dead code.
- `a6cd9a0c1` — moved `RING_STATS` publication off the ConPTY drain thread. A synchronous per-read stderr write on the only drain thread could block on a pipe nobody drains, backpressuring ConPTY through the very instrument used to measure detached draining.
- `d2f9cb4da` — hold one pipe instance for the host's lifetime so the name is never unowned; pin clients to `SECURITY_IDENTIFICATION`. Includes the `\\.\pipe` enumeration evidence above.
- `f04a789e4` — authenticate the pipe server from the client before sending any frame; stop the stats sampler from being able to hang teardown (a thread parked inside `WriteFile` can never observe a stop flag, so teardown signals and abandons it rather than joining).
- `5fbc4705f` — bound the security claims to what is actually verified: the PID-reuse caveat above, a stale code comment corrected, and `pipe_security` annotated as a mechanism inventory rather than a test result.
- `a572f7edd` — overlapped, cancellable accept that also waits on the shell's process handle, with four hermetic tests and an end-to-end harness stage; private-memory growth made record-only; `SECURITY_IDENTIFICATION` claim bounded to "cannot act as the client"; rebased onto `main` (`pty.pseudoConsole()` accessor from `dae792245`).

## Residuals / user steps

- **Ceiling, unchanged and absolute:** this design survives UI restarts and crashes only while the broker stays alive in the same logon session. It can never survive logoff or reboot, and a broker crash still kills its ConPTY and shell.
- Residual unknowns are product-sized, not feasibility-sized: fidelity for arbitrary third-party TUIs beyond this cursor-addressed probe (ConPTY normalizes VT, so the test matches normalized frames and unique tokens rather than byte-for-byte application output); a stalled attached client can monopolize the spike's single connection (it no longer blocks ConPTY draining); multi-session/multi-client lifecycle; broker crash handling; elevation and integrity-level separation; protocol migration; long-duration memory behavior.
- Memory: sampling every 25 ms can miss a transient peak, and the private-memory figure is whole-process, so it is a diagnostic rather than a budget. The structural guarantee is the ring's retained-byte bound.
- Adversarial validation was run only as the owning user. No cross-user or cross-integrity-level test was executed — that needs a second local account, so the `UntrustedPipeServer` rejection branch is verified by construction and code review, not by execution.
- Green means deferred **C16 durable-session planning may graduate**; the XL implementation remains unscheduled. No user action required.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Windows ConPTY host for persistent terminal sessions.
  - Supports client attachment and reattachment, terminal resizing, input forwarding, output replay, and graceful shell shutdown.
  - Includes safeguards for client isolation, same-user access, bounded output buffering, and recovery after client termination.

- **Tests**
  - Added end-to-end coverage for session reattachment, alternate-screen redraws, resizing, buffer limits, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->