### PR TITLE
fix(windows): run shell-form commands verbatim and surface launch failures (#151)

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -118,6 +118,16 @@ windows_job_object_plan: if (builtin.os.tag == .windows) apprt.win32_job_object.
 windows_job_object_handle: if (builtin.os.tag == .windows) ?windows.HANDLE else void =
     if (builtin.os.tag == .windows) null else {},
 
+/// Set as soon as `CreateProcessW` returns successfully, before any of the
+/// post-creation launch setup (job object attach, exit-code probe, initial
+/// thread resume) that can still fail. Those failures unwind through the
+/// errdefer that terminates the child, so `start` returns an error even
+/// though Windows *did* create a process. Callers need this to tell "the
+/// command never launched" apart from "the command launched and we tore it
+/// down", because the two need different error reports. Inert on non-Windows.
+windows_process_created: if (builtin.os.tag == .windows) bool else void =
+    if (builtin.os.tag == .windows) false else {},
+
 /// The various methods a process may exit.
 pub const Exit = if (builtin.os.tag == .windows) union(enum) {
     Exited: u32,
@@ -385,6 +395,10 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         @ptrCast(&startup_info_ex.StartupInfo),
         &process_information,
     );
+    // Past this point a child exists. Everything below can still fail and
+    // unwind through the errdefer below, which terminates it — but the
+    // failure is no longer "no child process was created".
+    self.windows_process_created = true;
     errdefer {
         _ = windows.kernel32.TerminateProcess(process_information.hProcess, 1);
         _ = windows.CloseHandle(process_information.hThread);
@@ -1284,6 +1298,54 @@ test "Command: windows job object plan attaches to local child process" {
     const exit = try cmd.wait(true);
     try testing.expect(exit == .Exited);
     try testing.expectEqual(@as(u32, 0), @as(u32, exit.Exited));
+}
+
+// `windows_process_created` is what lets termio tell "the command never
+// launched" apart from "the command launched and setup failed, so we killed
+// it". Those two produce different reports, so the flag has to be false for
+// every failure before CreateProcessW and true the moment it succeeds.
+test "Command: windows_process_created discriminates pre- and post-creation failures" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // Pre-creation failure: CreateProcessW itself fails, no child exists.
+    {
+        const missing = "C:\\Windows\\System32\\noctty-does-not-exist.exe";
+        var cmd: Command = .{
+            .path = missing,
+            .args = &.{missing},
+            .os_pre_exec = null,
+            .rt_pre_exec = null,
+            .rt_post_fork = null,
+            .rt_pre_exec_info = undefined,
+            .rt_post_fork_info = undefined,
+        };
+        defer cmd.closeWindowsJobObject();
+
+        try testing.expect(!cmd.windows_process_created);
+        try testing.expectError(error.FileNotFound, cmd.testingStart());
+        try testing.expect(!cmd.windows_process_created);
+        try testing.expect(cmd.pid == null);
+    }
+
+    // Creation succeeds: the flag is set even though the post-creation setup
+    // steps run afterwards.
+    {
+        var cmd: Command = .{
+            .path = "C:\\Windows\\System32\\cmd.exe",
+            .args = &.{ "C:\\Windows\\System32\\cmd.exe", "/C", "exit", "0" },
+            .os_pre_exec = null,
+            .rt_pre_exec = null,
+            .rt_post_fork = null,
+            .rt_pre_exec_info = undefined,
+            .rt_post_fork_info = undefined,
+        };
+        defer cmd.closeWindowsJobObject();
+
+        try testing.expect(!cmd.windows_process_created);
+        try cmd.testingStart();
+        try testing.expect(cmd.windows_process_created);
+        _ = try cmd.wait(true);
+    }
 }
 
 test "Command: windows job object kill-on-close terminates local child" {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -1316,9 +1316,10 @@ test "Command: windows job object plan attaches to local child process" {
 }
 
 // `windows_process_created` is what lets termio tell "the command never
-// launched" apart from "the command launched and setup failed, so we killed
-// it". Those two produce different reports, so the flag has to be false for
-// every failure before CreateProcessW and true the moment it succeeds.
+// launched" apart from "the command launched and setup failed, so cleanup
+// attempted to stop it". Those two produce different reports, so the flag has
+// to be false for every failure before CreateProcessW and true the moment it
+// succeeds.
 test "Command: windows_process_created discriminates pre- and post-creation failures" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -118,13 +118,19 @@ windows_job_object_plan: if (builtin.os.tag == .windows) apprt.win32_job_object.
 windows_job_object_handle: if (builtin.os.tag == .windows) ?windows.HANDLE else void =
     if (builtin.os.tag == .windows) null else {},
 
-/// Set as soon as `CreateProcessW` returns successfully, before any of the
+/// Whether `CreateProcessW` returned successfully. That is the whole
+/// meaning: it says a process was created, and says nothing about whether
+/// one still exists.
+///
+/// Set immediately after `CreateProcessW` returns and before any of the
 /// post-creation launch setup (job object attach, exit-code probe, initial
-/// thread resume) that can still fail. Those failures unwind through the
-/// errdefer that terminates the child, so `start` returns an error even
-/// though Windows *did* create a process. Callers need this to tell "the
-/// command never launched" apart from "the command launched and we tore it
-/// down", because the two need different error reports. Inert on non-Windows.
+/// thread resume) that can still fail. Those failures unwind through an
+/// errdefer that *attempts* to terminate the child — `TerminateProcess`'s
+/// result is discarded, and in the exit-code-probe case the child had
+/// already exited on its own. So do not read `true` as "the child is gone";
+/// read it only as "the command did launch", which is what distinguishes a
+/// failure that needs the no-child report from one that does not. Inert on
+/// non-Windows, where a failed `start` always means no child exists.
 windows_process_created: if (builtin.os.tag == .windows) bool else void =
     if (builtin.os.tag == .windows) false else {},
 
@@ -395,9 +401,10 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         @ptrCast(&startup_info_ex.StartupInfo),
         &process_information,
     );
-    // Past this point a child exists. Everything below can still fail and
-    // unwind through the errdefer below, which terminates it — but the
-    // failure is no longer "no child process was created".
+    // Past this point a child was created. Everything below can still fail
+    // and unwind through the errdefer below, which attempts to terminate it
+    // — but whatever the outcome of that attempt, "no child process was
+    // created" is no longer a true statement about the failure.
     self.windows_process_created = true;
     errdefer {
         _ = windows.kernel32.TerminateProcess(process_information.hProcess, 1);

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -54,10 +54,12 @@ const PostForkFn = fn (*Command) PostForkError!void;
 /// adding a null terminator since POSIX systems are so common.
 path: [:0]const u8,
 
-/// Command-line arguments. It is the responsibility of the caller to set
-/// args[0] to the command. If args is empty then args[0] will automatically
-/// be set to equal path.
+/// Command-line arguments. The caller must set args[0] to a non-empty command.
 args: []const [:0]const u8,
+
+/// On Windows, the final argument is a raw cmd.exe `/C` command string.
+/// It must bypass argv quoting because cmd.exe uses its own quote rules.
+windows_cmd_shell: bool = false,
 
 /// Environment variables for the child process. If this is null, inherits
 /// the environment variables from this process. These are the exact
@@ -266,6 +268,8 @@ fn startPosix(self: *Command, arena: Allocator) !void {
 }
 
 fn startWindows(self: *Command, arena: Allocator) !void {
+    if (self.args.len == 0 or self.args[0].len == 0) return error.InvalidExe;
+
     const application_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, self.path);
     const application_name_w: ?[*:0]u16 = if (windowsShouldSearchPath(self.path))
         null
@@ -274,7 +278,11 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     const cwd = try safeWindowsCurrentDirectory(arena, self.path, self.cwd);
     const cwd_w = if (cwd) |v| try std.unicode.utf8ToUtf16LeAllocZ(arena, v) else null;
     const command_line_w = if (self.args.len > 0) b: {
-        const command_line = try windowsCreateCommandLine(arena, self.args);
+        const command_line = try windowsCreateCommandLine(
+            arena,
+            self.args,
+            self.windows_cmd_shell,
+        );
         break :b try std.unicode.utf8ToUtf16LeAllocZ(arena, command_line);
     } else null;
     const env_w = if (self.env) |env_map| try createWindowsEnvBlock(arena, env_map) else null;
@@ -358,12 +366,14 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         if (job_handle) |handle| _ = windows.CloseHandle(handle);
     }
 
-    var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
-    if (attribute_list != null) flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
-    if (job_handle != null) flags |= windows.exp.CREATE_SUSPENDED;
+    const flags: std.os.windows.CreateProcessFlags = .{
+        .create_unicode_environment = true,
+        .extended_startupinfo_present = attribute_list != null,
+        .create_suspended = job_handle != null,
+    };
 
     var process_information: windows.PROCESS_INFORMATION = undefined;
-    if (windows.exp.kernel32.CreateProcessW(
+    try std.os.windows.CreateProcessW(
         application_name_w,
         if (command_line_w) |w| w.ptr else null,
         null,
@@ -374,7 +384,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         if (cwd_w) |w| w.ptr else null,
         @ptrCast(&startup_info_ex.StartupInfo),
         &process_information,
-    ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+    );
     errdefer {
         _ = windows.kernel32.TerminateProcess(process_information.hProcess, 1);
         _ = windows.CloseHandle(process_information.hThread);
@@ -678,13 +688,33 @@ fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) ![]u1
 }
 
 /// Copied from Zig. This function could be made public in child_process.zig instead.
-fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) ![:0]u8 {
+fn windowsCreateCommandLine(
+    allocator: mem.Allocator,
+    argv: []const []const u8,
+    cmd_shell: bool,
+) ![:0]u8 {
     var buf: std.Io.Writer.Allocating = .init(allocator);
     defer buf.deinit();
     const writer = &buf.writer;
 
+    if (cmd_shell) {
+        debug.assert(argv.len == 3);
+        debug.assert(mem.eql(u8, argv[1], "/C"));
+    }
+
     for (argv, 0..) |arg, arg_i| {
         if (arg_i != 0) try writer.writeByte(' ');
+
+        // cmd.exe applies its own quote rules to the raw command after `/C`.
+        // Applying MSVCRT quoting here would turn inner quotes into literal
+        // `\"` bytes, which cmd.exe does not treat as escapes.
+        if (cmd_shell and arg_i == 2) {
+            try writer.writeByte('"');
+            try writer.writeAll(arg);
+            try writer.writeByte('"');
+            continue;
+        }
+
         if (mem.indexOfAny(u8, arg, " \t\n\"") == null) {
             try writer.writeAll(arg);
             continue;
@@ -711,6 +741,156 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
     }
 
     return buf.toOwnedSliceSentinel(0);
+}
+
+test "Command: windows-cmd-shell-command-line preserves cmd tail" {
+    const allocator = testing.allocator;
+
+    const cases = [_]struct {
+        argv: []const []const u8,
+        expected: []const u8,
+    }{
+        .{
+            .argv = &.{
+                "C:\\Windows\\System32\\cmd.exe",
+                "/C",
+                "cmd.exe /c \"chcp 65001 >nul && wsl.exe -- tmux new-session -A -s main\"",
+            },
+            .expected = "C:\\Windows\\System32\\cmd.exe /C \"cmd.exe /c \"chcp 65001 >nul && wsl.exe -- tmux new-session -A -s main\"\"",
+        },
+        .{
+            .argv = &.{
+                "C:\\Windows\\System32\\cmd.exe",
+                "/C",
+                "cmd.exe /c \"echo a && echo b\"",
+            },
+            .expected = "C:\\Windows\\System32\\cmd.exe /C \"cmd.exe /c \"echo a && echo b\"\"",
+        },
+        .{
+            .argv = &.{
+                "C:\\Windows\\System32\\cmd.exe",
+                "/C",
+                "echo hello world > \"C:\\Program Files\\Noctty Logs\\output.txt\"",
+            },
+            .expected = "C:\\Windows\\System32\\cmd.exe /C \"echo hello world > \"C:\\Program Files\\Noctty Logs\\output.txt\"\"",
+        },
+        .{
+            .argv = &.{
+                "C:\\Windows\\System32\\cmd.exe",
+                "/C",
+                "echo \"C:\\Program Files\\noctty\\\"",
+            },
+            .expected = "C:\\Windows\\System32\\cmd.exe /C \"echo \"C:\\Program Files\\noctty\\\"\"",
+        },
+        .{
+            .argv = &.{
+                "C:\\Windows Root\\System32\\cmd.exe",
+                "/C",
+                "\"C:\\Program Files\\Noctty Tools\\probe.exe\" --message \"hello world\"",
+            },
+            .expected = "\"C:\\Windows Root\\System32\\cmd.exe\" /C \"\"C:\\Program Files\\Noctty Tools\\probe.exe\" --message \"hello world\"\"",
+        },
+        .{
+            .argv = &.{
+                "C:\\Windows\\System32\\cmd.exe",
+                "/C",
+                "C:\\Program Files\\Git\\usr\\bin\\echo.exe",
+            },
+            .expected = "C:\\Windows\\System32\\cmd.exe /C \"C:\\Program Files\\Git\\usr\\bin\\echo.exe\"",
+        },
+    };
+
+    for (cases) |case| {
+        const actual = try windowsCreateCommandLine(allocator, case.argv, true);
+        defer allocator.free(actual);
+        try testing.expectEqualStrings(case.expected, actual);
+    }
+}
+
+test "Command: windows-direct-command-line keeps argv quoting" {
+    const allocator = testing.allocator;
+    const actual = try windowsCreateCommandLine(
+        allocator,
+        &.{
+            "C:\\Program Files\\Noctty Tools\\probe.exe",
+            "--message",
+            "say \"hello\"",
+            "C:\\Program Files\\noctty\\",
+        },
+        false,
+    );
+    defer allocator.free(actual);
+
+    try testing.expectEqualStrings(
+        "\"C:\\Program Files\\Noctty Tools\\probe.exe\" --message \"say \\\"hello\\\"\" \"C:\\Program Files\\noctty\\\\\"",
+        actual,
+    );
+}
+
+test "Command: windows-command-line rejects empty executable argument" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const cases = [_][]const [:0]const u8{
+        &.{},
+        &.{""},
+    };
+
+    for (cases) |args| {
+        var cmd: Command = .{
+            .path = "cmd.exe",
+            .args = args,
+            .os_pre_exec = null,
+            .rt_pre_exec = null,
+            .rt_post_fork = null,
+            .rt_pre_exec_info = undefined,
+            .rt_post_fork_info = undefined,
+        };
+
+        try testing.expectError(error.InvalidExe, cmd.start(testing.allocator));
+    }
+}
+
+test "Command: windows-cmd-shell-command-line executes quoted command" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const windir = try std.process.getEnvVarOwned(testing.allocator, "WINDIR");
+    defer testing.allocator.free(windir);
+    const cmd_path = try std.fs.path.joinZ(testing.allocator, &.{
+        windir,
+        "System32",
+        "cmd.exe",
+    });
+    defer testing.allocator.free(cmd_path);
+
+    var td = try TempDir.init();
+    defer td.deinit();
+    var stdout = try createTestStdout(td.dir);
+    defer stdout.close();
+
+    var cmd: Command = .{
+        .path = cmd_path,
+        .args = &.{
+            cmd_path,
+            "/C",
+            "cmd.exe /d /c \"echo QUOTED_A && echo QUOTED_B\"",
+        },
+        .windows_cmd_shell = true,
+        .stdout = stdout,
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+
+    try cmd.testingStart();
+    const exit = try cmd.wait(true);
+    try testing.expectEqual(@as(u32, 0), exit.Exited);
+
+    try stdout.seekTo(0);
+    const contents = try stdout.readToEndAlloc(testing.allocator, 1024);
+    defer testing.allocator.free(contents);
+    try testing.expectEqualStrings("QUOTED_A \r\nQUOTED_B\r\n", contents);
 }
 
 test "createNullDelimitedEnvMap" {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -421,6 +421,14 @@ fn startWindows(self: *Command, arena: Allocator) !void {
                 return windows.unexpectedError(windows.kernel32.GetLastError());
             }
             if (exit_code != windows.exp.STILL_ACTIVE) {
+                // This branch is the one post-creation failure where the
+                // child exited on its own and its exit code is known. Log it
+                // rather than discarding it: the launch still fails, so the
+                // code never reaches the normal child-exit reporting path.
+                log.warn(
+                    "windows job object attach target already exited exit_code={d}",
+                    .{exit_code},
+                );
                 return error.WindowsJobObjectAttachExitedChild;
             }
         }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1509,7 +1509,10 @@ fn childExited(self: *Surface, info: apprt.surface.Message.ChildExited) void {
 
         log.warn("abnormal process exit detected, showing error message", .{});
 
-        // Try and show a GUI message. If it returns true, don't do anything else.
+        // Win32 banners are transient and omit the command and close
+        // instructions, so this fork also writes the actionable report in the
+        // terminal on Windows. Other apprts retain the native-or-terminal
+        // fallback contract.
         if (self.rt_app.performAction(
             .{ .surface = self },
             .show_child_exited,
@@ -1517,14 +1520,19 @@ fn childExited(self: *Surface, info: apprt.surface.Message.ChildExited) void {
         ) catch |err| gui: {
             log.err("error trying to show native child exited GUI err={}", .{err});
             break :gui false;
-        }) return;
+        }) {
+            if (comptime builtin.os.tag != .windows) return;
+        }
 
-        // If a native GUI notification was not shown, update our terminal to
-        // note the abnormal exit.
         self.childExitedAbnormally(info) catch |err| {
             log.err("error handling abnormal child exit err={}", .{err});
             return;
         };
+        if (comptime builtin.os.tag == .windows) {
+            self.queueRender() catch |err| {
+                log.warn("failed to notify renderer of abnormal child exit err={}", .{err});
+            };
+        }
 
         return;
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1220,7 +1220,8 @@ const Subprocess = struct {
             // `cmd` is a stack local that is about to go away, so lift the
             // "did Windows create a child?" answer onto the Subprocess before
             // unwinding. Without this the caller cannot distinguish a launch
-            // that never happened from one torn down during setup.
+            // that never happened from one that failed during setup after
+            // the child was created (cleanup only attempts to stop it).
             if (comptime builtin.os.tag == .windows) {
                 self.windows_process_created = cmd.windows_process_created;
             }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -177,6 +177,17 @@ pub fn threadEnter(
             else => {
                 self.process_start_error = err;
                 log.warn("failed to start subprocess err={}", .{err});
+
+                // On Windows the launch can fail *after* CreateProcessW has
+                // already produced a child (job object attach, exit-code
+                // probe, initial thread resume). That child is terminated
+                // during unwind, so it is gone by the time we get here — but
+                // "no child process was created" would be a false statement,
+                // so those failures get their own report.
+                if (self.subprocess.windows_process_created) {
+                    return error.ProcessStartedThenFailed;
+                }
+
                 return error.ProcessNotStarted;
             },
         }
@@ -694,6 +705,11 @@ const Subprocess = struct {
     process: ?Process = null,
     adopted_client_process: if (builtin.os.tag == .windows) ?windows.HANDLE else void = if (builtin.os.tag == .windows) null else {},
 
+    /// Whether a failed `start` got far enough that Windows actually created
+    /// a child process. See `Command.windows_process_created`. Always false
+    /// on other platforms, where `start` failing means no child exists.
+    windows_process_created: bool = false,
+
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
     windows_job_object_plan: WindowsJobObjectPlan,
@@ -1200,6 +1216,14 @@ const Subprocess = struct {
         };
 
         cmd.start(alloc) catch |err| {
+            // `cmd` is a stack local that is about to go away, so lift the
+            // "did Windows create a child?" answer onto the Subprocess before
+            // unwinding. Without this the caller cannot distinguish a launch
+            // that never happened from one torn down during setup.
+            if (comptime builtin.os.tag == .windows) {
+                self.windows_process_created = cmd.windows_process_created;
+            }
+
             // We have to do this because start on Windows can't
             // ever return ExecFailedInChild
             const StartError = error{ExecFailedInChild} || @TypeOf(err);

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -180,10 +180,11 @@ pub fn threadEnter(
 
                 // On Windows the launch can fail *after* CreateProcessW has
                 // already produced a child (job object attach, exit-code
-                // probe, initial thread resume). That child is terminated
-                // during unwind, so it is gone by the time we get here — but
-                // "no child process was created" would be a false statement,
-                // so those failures get their own report.
+                // probe, initial thread resume). Unwind attempts to terminate
+                // that child, and in the exit-code-probe case it had already
+                // exited on its own — either way we do not own it by the time
+                // we get here, but "no child process was created" would be a
+                // false statement, so those failures get their own report.
                 if (self.subprocess.windows_process_created) {
                     return error.ProcessStartedThenFailed;
                 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -111,6 +111,9 @@ const FlatpakHostCommand = if (!flatpak_support) struct {
 /// The subprocess state for our exec backend.
 subprocess: Subprocess,
 
+/// The original error that was classified as ProcessNotStarted.
+process_start_error: ?anyerror = null,
+
 /// Initialize the exec state. This will NOT start it, this only sets
 /// up the internal state necessary to start it later.
 pub fn init(
@@ -158,16 +161,25 @@ pub fn threadEnter(
     td: *termio.Termio.ThreadData,
 ) !void {
     // Start our subprocess
+    self.process_start_error = null;
     const pty_fds = self.subprocess.start(alloc) catch |err| {
-        // If we specifically got this error then we are in the forked
-        // process and our child failed to execute. If we DIDN'T
-        // get this specific error then we're in the parent and
-        // we need to bubble it up.
-        if (err != error.ExecFailedInChild) return err;
+        const StartError = @TypeOf(err) || error{ OpenptyFailed, ExecFailedInChild };
+        switch (@as(StartError, @errorCast(err))) {
+            // We're in the child. Nothing more we can do but abnormal exit.
+            // The Command will output some additional information.
+            error.ExecFailedInChild => posix.exit(1),
 
-        // We're in the child. Nothing more we can do but abnormal exit.
-        // The Command will output some additional information.
-        posix.exit(1);
+            // Keep the tailored pty exhaustion message in Thread.
+            error.OpenptyFailed => return error.OpenptyFailed,
+
+            // Only errors from the subprocess start boundary use the
+            // confirmed no-child wording in Thread.
+            else => {
+                self.process_start_error = err;
+                log.warn("failed to start subprocess err={}", .{err});
+                return error.ProcessNotStarted;
+            },
+        }
     };
     errdefer self.subprocess.stop();
 
@@ -675,6 +687,7 @@ const Subprocess = struct {
     cwd: ?[:0]const u8,
     env: ?EnvMap,
     args: []const [:0]const u8,
+    windows_cmd_shell: bool,
     grid_size: renderer.GridSize,
     screen_size: renderer.ScreenSize,
     pty: ?Pty = null,
@@ -720,6 +733,9 @@ const Subprocess = struct {
                 .env = cfg.env,
                 .cwd = null,
                 .args = &.{},
+                // An adopted session never spawns anything, so there is no
+                // command line to wrap in `cmd.exe /C`.
+                .windows_cmd_shell = false,
                 .grid_size = .{},
                 .screen_size = .{ .width = 1, .height = 1 },
                 .pty = session.pty,
@@ -917,7 +933,7 @@ const Subprocess = struct {
         }
 
         // Build our args list
-        const args: []const [:0]const u8 = execCommand(
+        const exec_command = execCommand(
             alloc,
             launch_command,
             internal_os.passwd,
@@ -932,9 +948,12 @@ const Subprocess = struct {
 
                 // The comptime here is important to ensure the full slice
                 // is put into the binary data and not the stack.
-                break :oom comptime switch (builtin.os.tag) {
-                    .windows => &.{"cmd.exe"},
-                    else => &.{"/bin/sh"},
+                break :oom ExecCommand{
+                    .args = comptime switch (builtin.os.tag) {
+                        .windows => &.{"cmd.exe"},
+                        else => &.{"/bin/sh"},
+                    },
+                    .windows_cmd_shell = false,
                 };
             },
 
@@ -990,7 +1009,8 @@ const Subprocess = struct {
             .arena = arena,
             .env = env,
             .cwd = cwd,
-            .args = args,
+            .args = exec_command.args,
+            .windows_cmd_shell = exec_command.windows_cmd_shell,
 
             .rt_pre_exec_info = cfg.rt_pre_exec_info,
             .rt_post_fork_info = cfg.rt_post_fork_info,
@@ -1148,6 +1168,7 @@ const Subprocess = struct {
         var cmd: Command = .{
             .path = self.args[0],
             .args = self.args,
+            .windows_cmd_shell = self.windows_cmd_shell,
             .env = if (self.env) |*env| env else null,
             .cwd = cwd,
             .stdin = if (builtin.os.tag == .windows) null else .{ .handle = pty.slave },
@@ -1703,11 +1724,16 @@ test "handoff adopted execution reuses pipes without spawn job or terminate" {
 /// may not be allocated and args may or may not be allocated (or copied).
 /// Pointers in the return value may point to pointers in the command
 /// struct.
+const ExecCommand = struct {
+    args: []const [:0]const u8,
+    windows_cmd_shell: bool = false,
+};
+
 fn execCommand(
     alloc: Allocator,
     command: configpkg.Command,
     comptime passwdpkg: type,
-) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
+) (Allocator.Error || error{SystemError})!ExecCommand {
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
     // hushlogin behavior.
@@ -1826,12 +1852,12 @@ fn execCommand(
             },
         }
 
-        return try args.toOwnedSlice(alloc);
+        return .{ .args = try args.toOwnedSlice(alloc) };
     }
 
     return switch (command) {
         // We need to clone the command since there's no guarantee the config remains valid.
-        .direct => |_| (try command.clone(alloc)).direct,
+        .direct => |_| .{ .args = (try command.clone(alloc)).direct },
 
         .shell => |v| shell: {
             var args: std.ArrayList([:0]const u8) = try .initCapacity(alloc, 4);
@@ -1872,7 +1898,10 @@ fn execCommand(
             }
 
             try args.append(alloc, v);
-            break :shell try args.toOwnedSlice(alloc);
+            break :shell .{
+                .args = try args.toOwnedSlice(alloc),
+                .windows_cmd_shell = builtin.os.tag == .windows,
+            };
         },
     };
 }
@@ -1882,6 +1911,46 @@ fn execCommand(
 /// not available on a particular platform.
 pub fn getProcessInfo(self: *Exec, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.subprocess.getProcessInfo(info);
+}
+
+test "execCommand windows-cmd-shell-command-line builds raw trampoline" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var arena = ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .shell = "cmd.exe /c \"echo a && echo b\"" },
+        internal_os.passwd,
+    );
+
+    try std.testing.expect(result.windows_cmd_shell);
+    try std.testing.expectEqual(@as(usize, 3), result.args.len);
+    try std.testing.expectEqualStrings("cmd.exe", std.fs.path.basename(result.args[0]));
+    try std.testing.expectEqualStrings("/C", result.args[1]);
+    try std.testing.expectEqualStrings("cmd.exe /c \"echo a && echo b\"", result.args[2]);
+}
+
+test "execCommand windows-direct-command-line keeps argv" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var arena = ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .direct = &.{
+            "C:\\Program Files\\Noctty Tools\\probe.exe",
+            "--message",
+            "hello world",
+        } },
+        internal_os.passwd,
+    );
+
+    try std.testing.expect(!result.windows_cmd_shell);
+    try std.testing.expectEqual(@as(usize, 3), result.args.len);
+    try std.testing.expectEqualStrings("C:\\Program Files\\Noctty Tools\\probe.exe", result.args[0]);
+    try std.testing.expectEqualStrings("--message", result.args[1]);
+    try std.testing.expectEqualStrings("hello world", result.args[2]);
 }
 
 test "execCommand darwin: shell command" {
@@ -1900,15 +1969,15 @@ test "execCommand darwin: shell command" {
         }
     });
 
-    try testing.expectEqual(8, result.len);
-    try testing.expectEqualStrings(result[0], "/usr/bin/login");
-    try testing.expectEqualStrings(result[1], "-flp");
-    try testing.expectEqualStrings(result[2], "testuser");
-    try testing.expectEqualStrings(result[3], "/bin/bash");
-    try testing.expectEqualStrings(result[4], "--noprofile");
-    try testing.expectEqualStrings(result[5], "--norc");
-    try testing.expectEqualStrings(result[6], "-c");
-    try testing.expectEqualStrings(result[7], "exec -l foo bar baz");
+    try testing.expectEqual(8, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "/usr/bin/login");
+    try testing.expectEqualStrings(result.args[1], "-flp");
+    try testing.expectEqualStrings(result.args[2], "testuser");
+    try testing.expectEqualStrings(result.args[3], "/bin/bash");
+    try testing.expectEqualStrings(result.args[4], "--noprofile");
+    try testing.expectEqualStrings(result.args[5], "--norc");
+    try testing.expectEqualStrings(result.args[6], "-c");
+    try testing.expectEqualStrings(result.args[7], "exec -l foo bar baz");
 }
 
 test "execCommand darwin: direct command" {
@@ -1930,12 +1999,12 @@ test "execCommand darwin: direct command" {
         }
     });
 
-    try testing.expectEqual(5, result.len);
-    try testing.expectEqualStrings(result[0], "/usr/bin/login");
-    try testing.expectEqualStrings(result[1], "-flp");
-    try testing.expectEqualStrings(result[2], "testuser");
-    try testing.expectEqualStrings(result[3], "foo");
-    try testing.expectEqualStrings(result[4], "bar baz");
+    try testing.expectEqual(5, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "/usr/bin/login");
+    try testing.expectEqualStrings(result.args[1], "-flp");
+    try testing.expectEqualStrings(result.args[2], "testuser");
+    try testing.expectEqualStrings(result.args[3], "foo");
+    try testing.expectEqualStrings(result.args[4], "bar baz");
 }
 
 test "execCommand: shell command, empty passwd" {
@@ -1958,10 +2027,10 @@ test "execCommand: shell command, empty passwd" {
         },
     );
 
-    try testing.expectEqual(3, result.len);
-    try testing.expectEqualStrings(result[0], "/bin/sh");
-    try testing.expectEqualStrings(result[1], "-c");
-    try testing.expectEqualStrings(result[2], "foo bar baz");
+    try testing.expectEqual(3, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "/bin/sh");
+    try testing.expectEqualStrings(result.args[1], "-c");
+    try testing.expectEqualStrings(result.args[2], "foo bar baz");
 }
 
 test "execCommand: shell command, error passwd" {
@@ -1984,10 +2053,10 @@ test "execCommand: shell command, error passwd" {
         },
     );
 
-    try testing.expectEqual(3, result.len);
-    try testing.expectEqualStrings(result[0], "/bin/sh");
-    try testing.expectEqualStrings(result[1], "-c");
-    try testing.expectEqualStrings(result[2], "foo bar baz");
+    try testing.expectEqual(3, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "/bin/sh");
+    try testing.expectEqualStrings(result.args[1], "-c");
+    try testing.expectEqualStrings(result.args[2], "foo bar baz");
 }
 
 test "execCommand: direct command, error passwd" {
@@ -2011,9 +2080,9 @@ test "execCommand: direct command, error passwd" {
         }
     });
 
-    try testing.expectEqual(2, result.len);
-    try testing.expectEqualStrings(result[0], "foo");
-    try testing.expectEqualStrings(result[1], "bar baz");
+    try testing.expectEqual(2, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "foo");
+    try testing.expectEqualStrings(result.args[1], "bar baz");
 }
 
 test "execCommand: direct command, config freed" {
@@ -2043,9 +2112,9 @@ test "execCommand: direct command, config freed" {
 
     command_arena.deinit();
 
-    try testing.expectEqual(2, result.len);
-    try testing.expectEqualStrings(result[0], "foo");
-    try testing.expectEqualStrings(result[1], "bar baz");
+    try testing.expectEqual(2, result.args.len);
+    try testing.expectEqualStrings(result.args[0], "foo");
+    try testing.expectEqualStrings(result.args[1], "bar baz");
 }
 
 test "addGhosttyBinToPath prepends on windows" {

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -284,12 +284,14 @@ pub fn threadMain(self: *Thread, io: *termio.Termio) void {
                     cause,
                     "noctty failed to launch the requested command:",
                     \\The child process was created, but noctty could not
-                    \\finish setting it up, so it was terminated. It never ran
-                    \\to completion and has no meaningful exit code.
+                    \\finish launching it. Depending on the cause above, the
+                    \\child either exited on its own during launch setup or
+                    \\was stopped during cleanup, so no exit code is reported
+                    \\for it here.
                     \\
-                    \\Check the reported cause above. This happens during the
-                    \\post-creation launch steps, so a common cause is the
-                    \\optional Windows Job Object limits failing to apply.
+                    \\This happens during the post-creation launch steps, so a
+                    \\common cause is the optional Windows Job Object limits
+                    \\failing to apply.
                     ,
                 );
             },

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -273,6 +273,27 @@ pub fn threadMain(self: *Thread, io: *termio.Termio) void {
                 );
             },
 
+            error.ProcessStartedThenFailed => {
+                const cause = switch (io.backend) {
+                    .exec => |*exec| exec.process_start_error,
+                } orelse err;
+                writeCommandError(
+                    alloc,
+                    io,
+                    err,
+                    cause,
+                    "noctty failed to launch the requested command:",
+                    \\The child process was created, but noctty could not
+                    \\finish setting it up, so it was terminated. It never ran
+                    \\to completion and has no meaningful exit code.
+                    \\
+                    \\Check the reported cause above. This happens during the
+                    \\post-creation launch steps, so a common cause is the
+                    \\optional Windows Job Object limits failing to apply.
+                    ,
+                );
+            },
+
             else => {
                 writeCommandError(
                     alloc,

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -286,8 +286,8 @@ pub fn threadMain(self: *Thread, io: *termio.Termio) void {
                     \\The child process was created, but noctty could not
                     \\finish launching it. Depending on the cause above, the
                     \\child either exited on its own during launch setup or
-                    \\was stopped during cleanup, so no exit code is reported
-                    \\for it here.
+                    \\cleanup attempted to stop it, so no exit code is
+                    \\reported for it here.
                     \\
                     \\This happens during the post-creation launch steps, so a
                     \\common cause is the optional Windows Job Object limits

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -138,11 +138,60 @@ pub fn deinit(self: *Thread) void {
     self.loop.deinit();
 }
 
+fn writeCommandError(
+    alloc: Allocator,
+    io: *termio.Termio,
+    err: anyerror,
+    cause: ?anyerror,
+    heading: []const u8,
+    detail: []const u8,
+) void {
+    const command = std.mem.join(alloc, " ", switch (io.backend) {
+        .exec => |*exec| exec.subprocess.args,
+    }) catch "<command unavailable>";
+    const error_heading = if (cause != null)
+        "error starting IO thread"
+    else
+        "error in IO thread";
+    const cause_suffix = if (cause) |value|
+        std.fmt.allocPrint(alloc, " (cause: {})", .{value}) catch
+            " (underlying error unavailable)"
+    else
+        "";
+    const str = std.fmt.allocPrint(
+        alloc,
+        \\{s}: {}{s}
+        \\
+        \\{s}
+        \\
+        \\{s}
+        \\
+        \\{s}
+        \\If this looks like a bug, please report it.
+        \\
+        \\This terminal is non-functional. Please close it and try again.
+    ,
+        .{ error_heading, err, cause_suffix, heading, command, detail },
+    ) catch
+        \\Out of memory. This terminal is non-functional. Please close it and try again.
+    ;
+
+    const t = io.renderer_state.terminal;
+    t.eraseDisplay(.complete, false);
+    t.printString(str) catch {};
+}
+
 /// The main entrypoint for the thread.
 pub fn threadMain(self: *Thread, io: *termio.Termio) void {
     // Call child function so we can use errors...
     self.threadMain_(io) catch |err| {
         log.warn("error in io thread err={}", .{err});
+
+        // Register this before the cleanup defers below so the terminal mutex
+        // is released before the renderer wakes and reads the error surface.
+        defer io.renderer_wakeup.notify() catch |notify_err| {
+            log.warn("failed to render io thread error err={}", .{notify_err});
+        };
 
         // Use an arena to simplify memory management below
         var arena = ArenaAllocator.init(self.alloc);
@@ -205,24 +254,34 @@ pub fn threadMain(self: *Thread, io: *termio.Termio) void {
                 t.printString(str) catch {};
             },
 
-            else => {
-                const str = std.fmt.allocPrint(
+            error.ProcessNotStarted => {
+                const cause = switch (io.backend) {
+                    .exec => |*exec| exec.process_start_error,
+                } orelse err;
+                writeCommandError(
                     alloc,
-                    \\error starting IO thread: {}
+                    io,
+                    err,
+                    cause,
+                    "noctty failed to launch the requested command:",
+                    \\No child process was created, so there is no exit code.
                     \\
                     \\The underlying shell or command was unable to be started.
-                    \\This error is usually due to exhausting a system resource.
-                    \\If this looks like a bug, please report it.
-                    \\
-                    \\This terminal is non-functional. Please close it and try again.
-                ,
-                    .{err},
-                ) catch
-                    \\Out of memory. This terminal is non-functional. Please close it and try again.
-                ;
+                    \\Check the reported cause above; common causes include a
+                    \\missing, inaccessible, or invalid executable.
+                    ,
+                );
+            },
 
-                t.eraseDisplay(.complete, false);
-                t.printString(str) catch {};
+            else => {
+                writeCommandError(
+                    alloc,
+                    io,
+                    err,
+                    null,
+                    "noctty encountered an IO-thread failure while running the requested command:",
+                    "The command or its terminal IO could not continue.",
+                );
             },
         }
     };

--- a/test/windows/flagship/contracts/Contracts.10-KeyInput.ps1
+++ b/test/windows/flagship/contracts/Contracts.10-KeyInput.ps1
@@ -378,17 +378,31 @@ try {
     }
     catch { $timeoutMessage = $_.Exception.Message }
 
-    if ($passSentinelStartCalls.Count -ne 4 -or
+    # A harness that runs several scenarios sequentially applies -TimeoutSeconds
+    # to each one, so the outer kill deadline has to be stated separately or a
+    # run in which no scenario was late still gets killed. The override must
+    # replace the budget outright, not add to the per-scenario default.
+    $budgetMessage = ''
+    try {
+        Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 17 `
+            -WaitTimeoutSeconds 115 -ScenarioSlug 'budget'
+    }
+    catch { $budgetMessage = $_.Exception.Message }
+
+    if ($passSentinelStartCalls.Count -ne 5 -or
         $passSentinelStartCalls[0].ScenarioSlug -cne 'control-lf' -or
         $passSentinelStartCalls[0].AdditionalArguments -cnotcontains 'unicode-lf' -or
-        $passSentinelLogCalls -ne 8 -or
+        $passSentinelLogCalls -ne 10 -or
         $passSentinelSummaryCalls -ne 3 -or
-        $passSentinelWaitCalls.Count -ne 4 -or
-        @($passSentinelWaitCalls | Where-Object { $_ -ne 22000 }).Count -ne 0 -or
+        $passSentinelWaitCalls.Count -ne 5 -or
+        @($passSentinelWaitCalls[0..3] | Where-Object { $_ -ne 22000 }).Count -ne 0 -or
+        $passSentinelWaitCalls[4] -ne 115000 -or
+        $passSentinelStartCalls[4].TimeoutSeconds -ne 17 -or
         $missingPassMessage -notlike '*did not report PASS*' -or
         $nonzeroMessage -notlike '*exited with code 23*' -or
         $timeoutMessage -notlike '*timed out after 17s*' -or
-        $script:passSentinelStopCalls -ne 1 -or
+        $budgetMessage -notlike '*timed out after 115s total budget (per-scenario deadline 17s)*' -or
+        $script:passSentinelStopCalls -ne 2 -or
         -not [object]::ReferenceEquals($script:passSentinelStoppedProcess, $processProbe) -or
         -not $script:passSentinelStopRequiredLiveRoot) {
         throw 'Pass-sentinel runner must reject missing PASS, nonzero exit, and timeout; timeout must stop the exact live root.'

--- a/test/windows/interactive-win11-shell-command-live.ps1
+++ b/test/windows/interactive-win11-shell-command-live.ps1
@@ -5,7 +5,8 @@ param(
     [string] $CommandText = '',
     [string] $ExePathOverride = '',
     [int] $SeedTabs = 1,
-    [int] $TimeoutSeconds = 20
+    [int] $TimeoutSeconds = 20,
+    [switch] $ConfiguredScenariosOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,6 +45,7 @@ if (-not [string]::IsNullOrWhiteSpace($ExePathOverride)) {
 }
 if ($Rebuild) { $forwardedArgs += '-Rebuild' }
 if ($ResetState) { $forwardedArgs += '-ResetState' }
+if ($ConfiguredScenariosOnly) { $forwardedArgs += '-ConfiguredScenariosOnly' }
 Invoke-InteractiveWin11HarnessMain `
     -RepoRoot $repoRoot `
     -LauncherPath $launcherPath `
@@ -89,6 +91,9 @@ public static class Win11ShellCommandLiveNative {
     public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
     [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
     public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
     [DllImport("user32.dll", SetLastError = true)]
@@ -127,6 +132,11 @@ public static class Win11ShellCommandLiveNative {
 
 if (-not ('System.Drawing.Bitmap' -as [type])) {
     Add-Type -AssemblyName System.Drawing
+}
+
+if (-not ('System.Windows.Automation.AutomationElement' -as [type])) {
+    Add-Type -AssemblyName UIAutomationClient
+    Add-Type -AssemblyName UIAutomationTypes
 }
 
 $MAPVK_VK_TO_VSC = 0
@@ -466,7 +476,8 @@ function Send-Line {
 function Save-WindowCapture {
     param(
         [Parameter(Mandatory)] [IntPtr] $Hwnd,
-        [Parameter(Mandatory)] [string] $Path
+        [Parameter(Mandatory)] [string] $Path,
+        [switch] $Offscreen
     )
 
     $rect = [Win11ShellCommandLiveNative+RECT]::new()
@@ -485,7 +496,21 @@ function Save-WindowCapture {
     try {
         $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
         try {
-            $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
+            if ($Offscreen) {
+                $hdc = $graphics.GetHdc()
+                try {
+                    if (-not [Win11ShellCommandLiveNative]::PrintWindow($Hwnd, $hdc, 2)) {
+                        $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                        throw "PrintWindow failed for hwnd=$Hwnd (error=$lastError)"
+                    }
+                }
+                finally {
+                    $graphics.ReleaseHdc($hdc)
+                }
+            }
+            else {
+                $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
+            }
         }
         finally {
             $graphics.Dispose()
@@ -569,6 +594,138 @@ function Measure-ImageDelta {
     }
 }
 
+function Get-BoundedTerminalTextSnapshot {
+    param(
+        [Parameter(Mandatory)] [IntPtr] $HostHwnd,
+        [Parameter(Mandatory)] [System.Diagnostics.Process] $Process,
+        [int] $TimeoutSeconds = 5
+    )
+
+    $probe = Start-Job -ScriptBlock {
+        param([long] $HwndValue, [int] $TargetProcessId)
+
+        Add-Type -AssemblyName UIAutomationClient
+        Add-Type -AssemblyName UIAutomationTypes
+        $root = [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr] $HwndValue)
+        if ($null -eq $root) { return $null }
+
+        $documents = @($root.FindAll(
+            [System.Windows.Automation.TreeScope]::Descendants,
+            [System.Windows.Automation.PropertyCondition]::new(
+                [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                [System.Windows.Automation.ControlType]::Text
+            )
+        ) | Where-Object {
+            $_.Current.ProcessId -eq $TargetProcessId -and
+            $_.Current.LocalizedControlType -eq 'terminal'
+        })
+        if ($documents.Count -eq 0) { return $null }
+
+        $textPattern = $null
+        if (-not $documents[0].TryGetCurrentPattern(
+            [System.Windows.Automation.TextPattern]::Pattern,
+            [ref] $textPattern
+        )) {
+            return $null
+        }
+
+        return $textPattern.DocumentRange.GetText(-1)
+    } -ArgumentList $HostHwnd.ToInt64(), $Process.Id
+
+    try {
+        if ($null -eq (Wait-Job -Job $probe -Timeout $TimeoutSeconds)) {
+            return $null
+        }
+        return [string] (Receive-Job -Job $probe -ErrorAction Stop)
+    }
+    catch {
+        return $null
+    }
+    finally {
+        Stop-Job -Job $probe -ErrorAction SilentlyContinue
+        Remove-Job -Job $probe -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-ConfiguredShellCommandScenario {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string] $ConfigPath,
+        [Parameter(Mandatory)] [string[]] $ExpectedText,
+        [string[]] $RejectedText = @(),
+        [Parameter(Mandatory)] [string] $CapturePath,
+        [Parameter(Mandatory)] [string] $StdoutPath,
+        [Parameter(Mandatory)] [string] $StderrPath
+    )
+
+    Remove-Item -LiteralPath $CapturePath, $StdoutPath, $StderrPath -ErrorAction SilentlyContinue
+    $scenarioArgs = @(
+        Get-InteractiveWin11ContainmentArguments
+        '--single-instance=false'
+        "--class=noctty-shell-config-$Name-$($layout.SandboxId)"
+        '--config-default-files=false'
+        "--config-file=$ConfigPath"
+    )
+    $scenarioProcess = Start-Process -FilePath $exePath `
+        -ArgumentList $scenarioArgs `
+        -WorkingDirectory $repoRoot `
+        -RedirectStandardOutput $StdoutPath `
+        -RedirectStandardError $StderrPath `
+        -PassThru
+    Write-Host "$Name configured shell scenario launched pid=$($scenarioProcess.Id)"
+
+    $scenarioHostHwnd = [IntPtr]::Zero
+    try {
+        $scenarioDeadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        Wait-InteractiveWin11Until -Deadline $scenarioDeadline -Description "$Name host window" -Process $scenarioProcess -Condition {
+            (Find-HostWindow -ProcessId $scenarioProcess.Id) -ne [IntPtr]::Zero
+        }
+        $scenarioHostHwnd = Find-HostWindow -ProcessId $scenarioProcess.Id
+
+        Wait-InteractiveWin11Until -Deadline $scenarioDeadline -Description "$Name terminal output" -Process $scenarioProcess -Condition {
+            $script:Win11ShellCommandScenarioText = Get-BoundedTerminalTextSnapshot -HostHwnd $scenarioHostHwnd -Process $scenarioProcess
+            if ($null -eq $script:Win11ShellCommandScenarioText) { return $false }
+            foreach ($expected in $ExpectedText) {
+                if (-not $script:Win11ShellCommandScenarioText.Contains($expected)) { return $false }
+            }
+            foreach ($rejected in $RejectedText) {
+                if ($script:Win11ShellCommandScenarioText.Contains($rejected)) { return $false }
+            }
+            return $true
+        }
+
+        Save-WindowCapture -Hwnd $scenarioHostHwnd -Path $CapturePath -Offscreen
+
+        $scenarioStderr = Get-InteractiveWin11TextFile -Path $StderrPath
+        if ($scenarioStderr -match 'panic: reached unreachable code') {
+            throw "$Name reported a runtime panic"
+        }
+
+        return [pscustomobject]@{
+            Name = $Name
+            ProcessId = $scenarioProcess.Id
+            Text = $script:Win11ShellCommandScenarioText
+            Capture = $CapturePath
+            Stdout = $StdoutPath
+            Stderr = $StderrPath
+        }
+    }
+    finally {
+        if ($scenarioHostHwnd -ne [IntPtr]::Zero) {
+            [void] [Win11ShellCommandLiveNative]::SetWindowPos(
+                $scenarioHostHwnd,
+                $HWND_NOTOPMOST,
+                0,
+                0,
+                0,
+                0,
+                [uint32] ($SWP_NOMOVE -bor $SWP_NOSIZE)
+            )
+        }
+        Stop-InteractiveWin11Process -Process $scenarioProcess -Contained
+    }
+}
+
 $useRepoResources = [string]::IsNullOrWhiteSpace($ExePathOverride)
 $harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'shell-command-live' -ResetState:$ResetState -IncludeResourcesDir:$useRepoResources
 $repoRoot = $harness.RepoRoot
@@ -596,6 +753,22 @@ $resolvedPath = Join-Path $layout.Temp 'interactive-win11-shell-command-live-res
 $postPath = Join-Path $layout.Temp 'interactive-win11-shell-command-live-post.txt'
 $beforeCapturePath = Join-Path $layout.Temp 'interactive-win11-shell-command-live-before.png'
 $afterCapturePath = Join-Path $layout.Temp 'interactive-win11-shell-command-live-after.png'
+$quotedConfigPath = Join-Path $layout.Temp 'interactive-win11-shell-command-quoted.conf'
+$quotedCapturePath = Join-Path $layout.Temp 'interactive-win11-shell-command-quoted.png'
+$quotedStdoutPath = Join-Path $layout.Logs 'interactive-win11-shell-command-quoted-stdout.log'
+$quotedStderrPath = Join-Path $layout.Logs 'interactive-win11-shell-command-quoted-stderr.log'
+$abnormalConfigPath = Join-Path $layout.Temp 'interactive-win11-shell-command-abnormal.conf'
+$abnormalCapturePath = Join-Path $layout.Temp 'interactive-win11-shell-command-abnormal.png'
+$abnormalStdoutPath = Join-Path $layout.Logs 'interactive-win11-shell-command-abnormal-stdout.log'
+$abnormalStderrPath = Join-Path $layout.Logs 'interactive-win11-shell-command-abnormal-stderr.log'
+$failedStartConfigPath = Join-Path $layout.Temp 'interactive-win11-shell-command-failed-start.conf'
+$failedStartCapturePath = Join-Path $layout.Temp 'interactive-win11-shell-command-failed-start.png'
+$failedStartStdoutPath = Join-Path $layout.Logs 'interactive-win11-shell-command-failed-start-stdout.log'
+$failedStartStderrPath = Join-Path $layout.Logs 'interactive-win11-shell-command-failed-start-stderr.log'
+$missingExecutablePath = "C:\noctty-issue151-missing-$([Guid]::NewGuid().ToString('N')).exe"
+if (Test-Path -LiteralPath $missingExecutablePath) {
+    throw "Failed-start validation path unexpectedly exists: $missingExecutablePath"
+}
 
 if ($launchAction -eq 'build') {
     Invoke-InteractiveWin11Build -RepoRoot $repoRoot
@@ -614,13 +787,77 @@ if (-not [string]::IsNullOrWhiteSpace($ExePathOverride)) {
     }
 }
 
-Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath, $readyPath, $controlPath, $resolvedPath, $postPath, $beforeCapturePath, $afterCapturePath -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $stdoutPath, $stderrPath, $payloadPath, $readyPath, $controlPath, $resolvedPath, $postPath, $beforeCapturePath, $afterCapturePath, $quotedConfigPath, $quotedCapturePath, $quotedStdoutPath, $quotedStderrPath, $abnormalConfigPath, $abnormalCapturePath, $abnormalStdoutPath, $abnormalStderrPath, $failedStartConfigPath, $failedStartCapturePath, $failedStartStdoutPath, $failedStartStderrPath -ErrorAction SilentlyContinue
 
 @(
     '@echo off'
     "cd /d `"$($layout.Temp)`""
     'echo READY>interactive-win11-shell-command-live-ready.txt'
 ) | Set-Content -LiteralPath $payloadPath -Encoding ASCII
+
+@(
+    'command = cmd.exe /d /c "echo CONFIG_QUOTED_^A && echo CONFIG_QUOTED_^B"'
+    'wait-after-command = true'
+    'abnormal-command-exit-runtime = 5000'
+) | Set-Content -LiteralPath $quotedConfigPath -Encoding ASCII
+
+@(
+    'command = cmd.exe /d /c "exit /b 37"'
+    'wait-after-command = true'
+    'abnormal-command-exit-runtime = 5000'
+) | Set-Content -LiteralPath $abnormalConfigPath -Encoding ASCII
+
+@(
+    "command = direct:`"$missingExecutablePath`""
+    'wait-after-command = true'
+) | Set-Content -LiteralPath $failedStartConfigPath -Encoding ASCII
+
+if ($ConfiguredScenariosOnly) {
+    $quotedResult = Invoke-ConfiguredShellCommandScenario `
+        -Name 'quoted' `
+        -ConfigPath $quotedConfigPath `
+        -ExpectedText @('CONFIG_QUOTED_A', 'CONFIG_QUOTED_B') `
+        -RejectedText @('Ghostty failed to launch the requested command:') `
+        -CapturePath $quotedCapturePath `
+        -StdoutPath $quotedStdoutPath `
+        -StderrPath $quotedStderrPath
+
+    $abnormalResult = Invoke-ConfiguredShellCommandScenario `
+        -Name 'abnormal' `
+        -ConfigPath $abnormalConfigPath `
+        -ExpectedText @(
+            'Ghostty failed to launch the requested command:',
+            'cmd.exe /d /c "exit /b 37"',
+            'Exit Code: 37',
+            'Press any key to close the window.'
+        ) `
+        -CapturePath $abnormalCapturePath `
+        -StdoutPath $abnormalStdoutPath `
+        -StderrPath $abnormalStderrPath
+
+    $failedStartResult = Invoke-ConfiguredShellCommandScenario `
+        -Name 'failed-start' `
+        -ConfigPath $failedStartConfigPath `
+        -ExpectedText @(
+            'error starting IO thread: error.ProcessNotStarted (cause: error.FileNotFound)',
+            'noctty failed to launch the requested command:',
+            $missingExecutablePath,
+            'No child process was created, so there is no exit code.',
+            'common causes include a',
+            'missing, inaccessible, or invalid executable.',
+            'This terminal is non-functional. Please close it and try again.'
+        ) `
+        -CapturePath $failedStartCapturePath `
+        -StdoutPath $failedStartStdoutPath `
+        -StderrPath $failedStartStderrPath
+
+    Write-Host (
+        'interactive-win11 configured shell command validation: PASS ' +
+        "(quoted_pid=$($quotedResult.ProcessId), abnormal_pid=$($abnormalResult.ProcessId), " +
+        "failed_start_pid=$($failedStartResult.ProcessId), offscreen_captures=true)"
+    )
+    return
+}
 
 $launchArgs = @(
     (Get-InteractiveWin11LaunchArguments -Layout $layout)
@@ -639,6 +876,7 @@ $process = Start-Process -FilePath $exePath `
     -RedirectStandardOutput $stdoutPath `
     -RedirectStandardError $stderrPath `
     -PassThru
+Write-Host "interactive-win11 shell command live launched pid=$($process.Id)"
 
 $hostHwnd = [IntPtr]::Zero
 try {
@@ -718,7 +956,7 @@ try {
         throw 'noctty live shell command run reported a runtime failure'
     }
 
-    Write-Host ("interactive-win11 shell command live validation: PASS (command={0}, action={1}, seed_tabs={2}, changed={3}, sampled={4}, stdout={5}, stderr={6}, ready={7}, control={8}, resolved={9}, post={10}, before={11}, after={12})" -f $typedCommandText, $CliAction, $SeedTabs, $imageDelta.ChangedPixels, $imageDelta.SampledPixels, $stdoutPath, $stderrPath, $readyPath, $controlPath, $resolvedPath, $postPath, $beforeCapturePath, $afterCapturePath)
+    Write-Host ("interactive-win11 shell command live validation: PASS (pid={0}, command={1}, action={2}, seed_tabs={3}, changed={4}, sampled={5}, stdout={6}, stderr={7}, ready={8}, control={9}, resolved={10}, post={11}, before={12}, after={13})" -f $process.Id, $typedCommandText, $CliAction, $SeedTabs, $imageDelta.ChangedPixels, $imageDelta.SampledPixels, $stdoutPath, $stderrPath, $readyPath, $controlPath, $resolvedPath, $postPath, $beforeCapturePath, $afterCapturePath)
 }
 finally {
     if ($hostHwnd -ne [IntPtr]::Zero) {

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -215,6 +215,7 @@ Invoke-Harness -ScriptName 'vt-probe-win32-conformance.ps1' -TimeoutSeconds 10 -
 Invoke-Harness -ScriptName 'interactive-win11-smoke.ps1' -TimeoutSeconds 10 -PassResetState
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-configured-size.ps1' -TimeoutSeconds 15
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command.ps1' -TimeoutSeconds 20
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command-live.ps1' -TimeoutSeconds 30 -AdditionalArguments @('-ConfiguredScenariosOnly') -ScenarioSlug 'configured'
 if ($env:NOCTTY_INTERACTIVE_RUN_FOREGROUND_HARNESS -eq '1') {
     Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command-live.ps1' -TimeoutSeconds 25
 }

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -102,15 +102,31 @@ function Invoke-HarnessWithPassSentinel {
         [Parameter(Mandatory)] [string] $ScriptName,
         [Parameter(Mandatory)] [int] $TimeoutSeconds,
         [string[]] $AdditionalArguments = @(),
-        [string] $ScenarioSlug = ''
+        [string] $ScenarioSlug = '',
+        # Outer kill deadline for the whole harness process. Defaults to one
+        # scenario plus slack, which is right for the single-scenario harnesses.
+        # A harness that runs several scenarios sequentially applies
+        # -TimeoutSeconds to each of them, so its total budget has to be stated
+        # explicitly or the runner kills a run in which no scenario was late.
+        [int] $WaitTimeoutSeconds = 0
     )
 
     $run = Start-Harness -ScriptName $ScriptName -TimeoutSeconds $TimeoutSeconds -AdditionalArguments $AdditionalArguments -ScenarioSlug $ScenarioSlug
-    $waitMilliseconds = [int][Math]::Ceiling(($TimeoutSeconds + 5) * 1000)
+    $waitBudgetSeconds = if ($WaitTimeoutSeconds -gt 0) { $WaitTimeoutSeconds } else { $TimeoutSeconds + 5 }
+    $waitMilliseconds = [int][Math]::Ceiling($waitBudgetSeconds * 1000)
+    # Single-scenario harnesses report the per-scenario deadline, which is the
+    # only number that means anything for them. Multi-scenario runs report the
+    # whole budget so the message is not mistaken for a scenario timeout.
+    $timeoutDetail = if ($WaitTimeoutSeconds -gt 0) {
+        "${waitBudgetSeconds}s total budget (per-scenario deadline ${TimeoutSeconds}s)"
+    }
+    else {
+        "${TimeoutSeconds}s"
+    }
     if (-not $run.Process.WaitForExit($waitMilliseconds)) {
         Stop-InteractiveWin11Process -Process $run.Process -RequireLiveRoot
         throw @"
-$($run.Script) timed out after ${TimeoutSeconds}s
+$($run.Script) timed out after ${timeoutDetail}
 stdout ($($run.Stdout)):
 $(Get-HarnessLog -Path $run.Stdout)
 
@@ -215,7 +231,9 @@ Invoke-Harness -ScriptName 'vt-probe-win32-conformance.ps1' -TimeoutSeconds 10 -
 Invoke-Harness -ScriptName 'interactive-win11-smoke.ps1' -TimeoutSeconds 10 -PassResetState
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-configured-size.ps1' -TimeoutSeconds 15
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command.ps1' -TimeoutSeconds 20
-Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command-live.ps1' -TimeoutSeconds 30 -AdditionalArguments @('-ConfiguredScenariosOnly') -ScenarioSlug 'configured'
+# Three configured scenarios run sequentially in one process, each with its
+# own 30s deadline, so the outer budget covers all three plus startup.
+Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command-live.ps1' -TimeoutSeconds 30 -WaitTimeoutSeconds 115 -AdditionalArguments @('-ConfiguredScenariosOnly') -ScenarioSlug 'configured'
 if ($env:NOCTTY_INTERACTIVE_RUN_FOREGROUND_HARNESS -eq '1') {
     Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-shell-command-live.ps1' -TimeoutSeconds 25
 }


### PR DESCRIPTION
## Summary

A shell-form `command` containing a quoted argument was mangled before it reached `cmd.exe`, so the configured command never ran and nothing told the user why. This restores verbatim shell-form execution and makes every launch/exit failure visible in the window.

Fixes #151

## Changes

**Root cause 1 — quoting.** `windowsCreateCommandLine` serialized the whole `/C` tail as an ordinary argv element using MSVCRT rules, producing:

```
C:\WINDOWS\System32\cmd.exe /C "cmd.exe /c \"chcp 65001 >nul && wsl.exe -- tmux new-session -A -s main\""
```

`cmd.exe` does not parse its `/C` tail with MSVCRT rules, so those `\"` bytes stayed literal. A runtime probe of the old string exits 1 with `'\"echo QUOTED_A && echo QUOTED_B\"' is not recognized as an internal or external command`. The tail is now wrapped **raw** — no MSVCRT escaping — as `cmd.exe /C "<raw tail>"`, and cmd applies its own quote rules to it. Direct-form (`direct:`) and POSIX paths are unchanged.

> An earlier revision of this branch used `/S /C`. That was wrong and has been reverted. `/S` is not what fixes #151 (the raw wrap is), and it additionally forces cmd to strip the outer quotes unconditionally, which broke the previously working bare-path form: `cmd.exe /S /C "C:\Program Files\Git\usr\bin\echo.exe"` exits 1 with `'C:\Program' is not recognized`, while plain `/C` exits 0 because cmd preserves the quotes when there are exactly two and no special characters between them. Both cases now have runtime probes and unit fixtures.

**Root cause 2 — silent failure.** Three paths swallowed the error:

- The Win32 `.show_child_exited` action always returned `true`, which made `Surface.childExited` skip `childExitedAbnormally()` — the report carrying the command, runtime, exit code and close instruction. Windows now gets both the banner and the terminal report; this is an explicit **win32-only opt-in**, so other apprts keep the upstream native-or-terminal contract.
- Nothing woke the renderer after that report was written into terminal state. The Win32 banner only invalidates top-level chrome, not the child renderer, so a child that exited quickly with **no output** could leave the report unpainted. `queueRender()` is now called after the abnormal report.
- `Exec.threadEnter` classifies failures from `subprocess.start()` as `error.ProcessNotStarted`, so `Thread` only says "no child process was created" when that is true; later watcher, pipe, timer, reader-thread and event-loop failures get a generic IO-thread message that still names the command. The original error is retained and shown next to the classification (`error.ProcessNotStarted (cause: error.FileNotFound)`), and the spawn goes through Zig's typed `CreateProcessW` wrapper so a missing, inaccessible or invalid executable stays `FileNotFound` / `AccessDenied` / `InvalidExe` instead of collapsing to `Unexpected`.

## Validation

| Command | Result |
|---|---|
| `zig build -Demit-exe=true` (this branch, clean worktree) | pass |
| `zig build test -Dtest-filter=command-line --summary all` | 74 passed, 1 skipped, 0 failed |
| `zig build test -Dtest-filter=windows_process_created --summary all` | 69 passed, 1 skipped, 0 failed |
| `zig build test -Demit-test-exe=true` (full suite) | **4079 passed, 70 skipped, 0 failed** (4149 tests) |
| `pwsh -NoProfile -File scripts/check-zig-format.ps1` | pass (693 tracked sources) |
| `pwsh -NoProfile -File scripts/check-source-format.ps1` | pass |
| `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| `test/windows/interactive-win11-shell-command-live.ps1 -ResetState -TimeoutSeconds 40 -ConfiguredScenariosOnly` | PASS (quoted / abnormal / failed-start) at `cad37b7d3`; **not re-run on the rebased head** — the merge gate runs it before merge |

**Correction to an earlier revision of this body**, stated as a retraction rather than silently overwritten. It previously reported "3770/3841 passed, 70 skipped, 1 failed" and described `Command: custom env vars` as a documented pre-existing baseline failure. That is no longer true and must not be relied on: `b1739a731` on `main` fixed that test by changing its argv from `/C` to `/D /C` to defeat a user `cmd.exe` AutoRun hook, and this branch is based on `e3a38268e`, which contains it. The invariant here is **zero failures**, not a pass count — a body still calling a failure "the known baseline" would lead a merger to wave through a genuinely failing suite.

The figures in the table above are for the current head `83003440c`, rebased onto `main` at `e3a38268e` and run locally on Windows 11.

**Rebase note.** `dae792245` (#188) added an adopted-session early return in `Subprocess.init` that constructs the struct without this branch's `windows_cmd_shell` field, so the textual rebase was clean but the build was not. The fix is one line — `.windows_cmd_shell = false`, since an adopted session never spawns anything — folded into the first commit rather than appended, so every commit on the branch builds.

New unit tests pin the exact command line for shell-form commands with embedded quotes, `&&`, redirection, trailing backslashes, spaces in paths, and a quote-free tail containing spaces; the unchanged direct-form argv construction; and a real `cmd.exe` execution capturing stdout from a quoted nested command. They were confirmed red against the previous serializer.

The Win11 harness gains three non-foreground configured scenarios, each with its own deadline. The abnormal scenario deliberately emits **no** output before exiting (`cmd.exe /d /c "exit /b 37"`) so its assertion depends on the renderer wake rather than an incidental output-driven repaint.

## Residuals / user steps

- The spawn path now uses `std.os.windows.CreateProcessW` instead of a raw kernel32 call. That is what preserves the specific spawn error, but it is a change to process creation itself and deserves review attention. The ConPTY attribute list, job object and suspended-start behaviour are passed through unchanged, and the three interactive scenarios plus the full suite exercise it.
- The foreground-sensitive screenshot phase of the Win11 harness could not run under the automation desktop (`GetForegroundWindow()` returns null there). The configured scenarios assert UI Automation terminal text and capture offscreen images instead; there is no strict framebuffer-mutation assertion.
- POSIX behaviour was not executed (Windows-only host). The POSIX branch is unmodified.
- Nothing here changes `+validate-config`: the shell form now runs, so the issue's "or reject it at config time" alternative is moot.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Fix Windows command launching and failure reporting so configured shell commands run as written and users receive visible, actionable diagnostics when launches or exits fail.

Bug Fixes:
- Execute Windows shell-form commands verbatim so quoted commands, redirection, chaining, and paths are interpreted correctly by cmd.exe.
- Surface Windows launch failures with actionable command details, preserved underlying error causes, and correct differentiation between pre-creation and post-creation failures.
- Display abnormal child-exit reports alongside Windows notifications and wake the renderer so failures are visible even when the child produces no output.

Enhancements:
- Preserve existing direct-form and POSIX command behavior while improving Windows process creation error classification.

Tests:
- Add unit, runtime, and interactive Windows coverage for quoted shell commands, abnormal exits, failed launches, command-line construction, and multi-scenario harness timeouts.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Windows shell commands can now execute quoted command strings more reliably.
  - Windows process failures now distinguish between commands that never started and those that started but failed during setup.

- **Bug Fixes**
  - Empty Windows command arguments are rejected with a clear error.
  - Failed process launches now display more actionable error messages, including the affected command and underlying cause.
  - Abnormal exits on Windows are reported in the terminal even when a native notification is shown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->