### PR TITLE
test(font): pin Nerd Font PUA resolution and shaping; diagnose #152

### DIFF
--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -556,3 +556,80 @@ test "getIndex box glyph" {
     try testing.expectEqual(Style.regular, idx.style);
     try testing.expectEqual(@intFromEnum(Collection.Index.Special.sprite), idx.idx);
 }
+
+test "getIndex nerd font PUA fallback order" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var lib = try Library.init(alloc);
+    defer lib.deinit();
+
+    var c = Collection.init();
+    c.load_options = .{ .library = lib };
+
+    const primary_idx = try c.add(alloc, try .init(
+        lib,
+        font.embedded.test_nerd_font,
+        .{ .size = .{ .points = 12 } },
+    ), .{
+        .style = .regular,
+        .fallback = false,
+        .size_adjustment = .none,
+    });
+    _ = try c.add(alloc, try .init(
+        lib,
+        font.embedded.variable,
+        .{ .size = .{ .points = 12 } },
+    ), .{
+        .style = .regular,
+        .fallback = true,
+        .size_adjustment = font.default_fallback_adjustment,
+    });
+    const symbols_idx = try c.add(alloc, try .init(
+        lib,
+        font.embedded.symbols_nerd_font,
+        .{ .size = .{ .points = 12 } },
+    ), .{
+        .style = .regular,
+        .fallback = true,
+        .size_adjustment = .none,
+    });
+
+    var r: CodepointResolver = .{
+        .collection = c,
+        .sprite = .{
+            .metrics = font.Metrics.calc(.{
+                .px_per_em = 30.0,
+                .cell_width = 18.0,
+                .ascent = 30.0,
+                .descent = -6.0,
+                .line_gap = 0.0,
+            }),
+        },
+    };
+    defer r.deinit(alloc);
+
+    var powerline_cp: u32 = 0xE0B0;
+    while (powerline_cp <= 0xE0B6) : (powerline_cp += 1) {
+        try testing.expectEqual(
+            font.sprite_index,
+            r.getIndex(alloc, powerline_cp, .regular, null).?,
+        );
+    }
+
+    for ([_]u32{ 0xF023, 0xE5FF }) |cp| {
+        try testing.expectEqual(
+            primary_idx,
+            r.getIndex(alloc, cp, .regular, null).?,
+        );
+    }
+
+    // U+E6B6 is absent from the embedded Nerd primary but present in the
+    // embedded Symbols Nerd Font, so it pins the final fallback outcome.
+    try testing.expect((try r.collection.getFace(primary_idx)).glyphIndex(0xE6B6) == null);
+    try testing.expect((try r.collection.getFace(symbols_idx)).glyphIndex(0xE6B6) != null);
+    try testing.expectEqual(
+        symbols_idx,
+        r.getIndex(alloc, 0xE6B6, .regular, null).?,
+    );
+}

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1520,10 +1520,10 @@ test "shape nerd font PUA glyphs without notdef" {
     defer testdata.deinit();
 
     const codepoints = [_]u21{
-        'A',    ' ', 0xE0B0, ' ', 0xE0B1, ' ',
-        0xE0B2, ' ', 0xE0B3, ' ', 0xE0B4, ' ',
-        0xE0B5, ' ', 0xE0B6, ' ', 0xF023, ' ',
-        0xE5FF,
+        'A',    ' ', 0xE0B0,  ' ', 0xE0B1, ' ',
+        0xE0B2, ' ', 0xE0B3,  ' ', 0xE0B4, ' ',
+        0xE0B5, ' ', 0xE0B6,  ' ', 0xF023, ' ',
+        0xE5FF, ' ', 0xF02A2,
     };
     var text: [128]u8 = undefined;
     var text_len: usize = 0;

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1513,6 +1513,164 @@ test "shape box glyphs" {
     try testing.expectEqual(@as(usize, 1), count);
 }
 
+test "shape nerd font PUA glyphs without notdef" {
+    const alloc = std.testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .nerd_font);
+    defer testdata.deinit();
+
+    const codepoints = [_]u21{
+        'A',    ' ', 0xE0B0, ' ', 0xE0B1, ' ',
+        0xE0B2, ' ', 0xE0B3, ' ', 0xE0B4, ' ',
+        0xE0B5, ' ', 0xE0B6, ' ', 0xF023, ' ',
+        0xE5FF,
+    };
+    var text: [128]u8 = undefined;
+    var text_len: usize = 0;
+    for (codepoints) |cp| {
+        text_len += try std.unicode.utf8Encode(cp, text[text_len..]);
+    }
+
+    var t = try terminal.Terminal.init(alloc, .{
+        .cols = codepoints.len,
+        .rows = 1,
+    });
+    defer t.deinit(alloc);
+
+    var stream = t.vtStream();
+    defer stream.deinit();
+    stream.nextSlice(text[0..text_len]);
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    _ = try expectNerdFontShaping(
+        alloc,
+        &testdata,
+        state.row_data.get(0).cells.slice(),
+        &codepoints,
+    );
+}
+
+test "shape nerd font PUA boundary cases without notdef" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .nerd_font);
+    defer testdata.deinit();
+
+    // PUA glyphs immediately adjacent to ASCII and each other.
+    {
+        const codepoints = [_]u21{ 'A', 0xF023, 0xE5FF, 0xE0B0, 'Z' };
+        var text: [32]u8 = undefined;
+        var text_len: usize = 0;
+        for (codepoints) |cp| {
+            text_len += try std.unicode.utf8Encode(cp, text[text_len..]);
+        }
+
+        var t = try terminal.Terminal.init(alloc, .{
+            .cols = codepoints.len,
+            .rows = 1,
+        });
+        defer t.deinit(alloc);
+
+        var stream = t.vtStream();
+        defer stream.deinit();
+        stream.nextSlice(text[0..text_len]);
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        try testing.expectEqual(
+            @as(usize, 3),
+            try expectNerdFontShaping(
+                alloc,
+                &testdata,
+                state.row_data.get(0).cells.slice(),
+                &codepoints,
+            ),
+        );
+    }
+
+    // A PUA glyph followed immediately by VS16 remains on a face that has it.
+    // PUA+VS16 isn't a valid Unicode emoji variation sequence, so the terminal
+    // parser normally drops the selector. Attach it directly to exercise the
+    // shaper boundary with the retained cell state that the shaper accepts.
+    {
+        var text: [8]u8 = undefined;
+        const text_len = try std.unicode.utf8Encode(0xF023, &text);
+
+        var t = try terminal.Terminal.init(alloc, .{ .cols = 2, .rows = 1 });
+        defer t.deinit(alloc);
+
+        var stream = t.vtStream();
+        defer stream.deinit();
+        stream.nextSlice(text[0..text_len]);
+        const list_cell = t.screens.active.pages.getCell(.{
+            .screen = .{ .x = 0, .y = 0 },
+        }).?;
+        try t.screens.active.appendGrapheme(list_cell.cell, 0xFE0F);
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        const row = state.row_data.get(0).cells.slice();
+        try testing.expect(row.items(.raw)[0].hasGrapheme());
+        try testing.expectEqualSlices(u21, &.{0xFE0F}, row.items(.grapheme)[0]);
+
+        var shaper = &testdata.shaper;
+        var it = shaper.runIterator(.{
+            .grid = testdata.grid,
+            .cells = row,
+        });
+        const run = (try it.next(alloc)).?;
+        const resolved = (try testdata.grid.getIndex(
+            alloc,
+            0xF023,
+            .regular,
+            .emoji,
+        )).?;
+        try testing.expectEqual(resolved, run.font_index);
+
+        const cells = try shaper.shape(run);
+        try testing.expectEqual(@as(usize, 1), cells.len);
+        try testing.expect(cells[0].glyph_index != 0);
+        try testing.expect(try it.next(alloc) == null);
+    }
+
+    // A foreground-color boundary immediately before a PUA glyph splits the
+    // run without changing the resolver-selected face or producing .notdef.
+    {
+        var pua: [4]u8 = undefined;
+        const pua_len = try std.unicode.utf8Encode(0xF023, &pua);
+
+        var t = try terminal.Terminal.init(alloc, .{ .cols = 2, .rows = 1 });
+        defer t.deinit(alloc);
+
+        var stream = t.vtStream();
+        defer stream.deinit();
+        stream.nextSlice("A\x1b[38;2;1;2;3m");
+        stream.nextSlice(pua[0..pua_len]);
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        try testing.expectEqual(
+            @as(usize, 2),
+            try expectNerdFontShaping(
+                alloc,
+                &testdata,
+                state.row_data.get(0).cells.slice(),
+                &.{ 'A', 0xF023 },
+            ),
+        );
+    }
+}
+
 test "shape selection boundary" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -2021,10 +2179,58 @@ const TestShaper = struct {
     }
 };
 
+fn expectNerdFontShaping(
+    alloc: Allocator,
+    testdata: *TestShaper,
+    row_cells: anytype,
+    codepoints: []const u21,
+) !usize {
+    const testing = std.testing;
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = row_cells,
+    });
+    var run_count: usize = 0;
+    var shaped_count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        run_count += 1;
+        const cells = try shaper.shape(run);
+        for (cells) |cell| {
+            try testing.expect(cell.glyph_index != 0);
+
+            const x: usize = run.offset + cell.x;
+            try testing.expect(x < codepoints.len);
+            const cp: u32 = codepoints[x];
+            const resolved = (try testdata.grid.getIndex(
+                alloc,
+                cp,
+                .regular,
+                null,
+            )).?;
+            try testing.expectEqual(resolved, run.font_index);
+
+            if (cp >= 0xE0B0 and cp <= 0xE0B6) {
+                try testing.expectEqual(font.sprite_index, run.font_index);
+                try testing.expectEqual(cp, cell.glyph_index);
+            } else {
+                try testing.expect(run.font_index.special() == null);
+            }
+
+            shaped_count += 1;
+        }
+    }
+    try testing.expectEqual(codepoints.len, shaped_count);
+
+    return run_count;
+}
+
 const TestFont = enum {
     inconsolata,
     monaspace_neon,
     arabic,
+    nerd_font,
 };
 
 /// Helper to return a fully initialized shaper.
@@ -2039,6 +2245,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .inconsolata => font.embedded.inconsolata,
         .monaspace_neon => font.embedded.monaspace_neon,
         .arabic => font.embedded.arabic,
+        .nerd_font => font.embedded.test_nerd_font,
     };
 
     var lib = try Library.init(alloc);
@@ -2057,6 +2264,28 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .fallback = false,
         .size_adjustment = .none,
     });
+
+    if (font_req == .nerd_font) {
+        // Match the regular-style built-in fallback order used by SharedGridSet.
+        _ = try c.add(alloc, try .init(
+            lib,
+            font.embedded.variable,
+            .{ .size = .{ .points = 12 } },
+        ), .{
+            .style = .regular,
+            .fallback = true,
+            .size_adjustment = font.default_fallback_adjustment,
+        });
+        _ = try c.add(alloc, try .init(
+            lib,
+            font.embedded.symbols_nerd_font,
+            .{ .size = .{ .points = 12 } },
+        ), .{
+            .style = .regular,
+            .fallback = true,
+            .size_adjustment = .none,
+        });
+    }
 
     if (comptime !font.options.backend.hasCoretext()) {
         // Coretext doesn't support Noto's format


### PR DESCRIPTION
## Summary

Investigation of #152 (Nerd Font PUA glyphs rendering as tofu) **could not reproduce the bug on any build**, including the exact v1.3.123 the reporter is running. This PR adds the hermetic regression tests that pin the resolution and shaping behaviour, and records the diagnosis plus render evidence.

Refs #152 — deliberately not `Fixes`. No production change was needed and the issue is not reproduced, so the reporter still has to confirm against a current build.

## Changes

Tests only. No production code changed.

- `src/font/CodepointResolver.zig` — pins the fallback order: U+E0B0–U+E0B6 resolve to the built-in sprite face; PUA codepoints present in the primary Nerd face resolve to it; a codepoint proven absent from the primary (U+E6B6, with explicit presence/absence preconditions) falls back to the embedded Symbols Nerd Font.
- `src/font/shaper/harfbuzz.zig` — pins that shaping never yields glyph index 0 (`.notdef`, i.e. the tofu box) for a mixed ASCII/powerline/devicon line, for PUA adjacent to ASCII with no separator, for PUA carrying a variation selector, and across a colour-attribute run boundary immediately before PUA. Each shaped cell is also checked against the face the resolver independently selected.

## Render evidence (A/B, this machine)

Test line printed at a pwsh prompt inside the terminal, covering every glyph class in the issue — powerline separator, devicon, octicon, Material icon, plus an ASCII control:

```
"$([char]0xE0B0) $([char]0xE0B2) $([char]0xE7A8) $([char]0xF418) $([char]0xF0E7) ABC"
```

| Glyph | current build (Meslo genuinely selected) | exact v1.3.123 | installed v1.3.118 | current, family not installed |
|---|---|---|---|---|
| U+E0B0 powerline right | renders | renders | renders | renders |
| U+E0B2 powerline left | renders | renders | renders | renders |
| U+E7A8 devicon | renders | renders | renders | renders |
| U+F418 octicon | renders | renders | renders | renders |
| U+F0E7 Material | renders | renders | renders | renders |
| `ABC` control | renders | renders | renders | renders |

Screenshots (zoomed crops and full frames) are under `evidence/152/` in the campaign worktree: `current-meslo-zoom.png`, `1.3.123-meslo-zoom.png`, `1.3.118-meslo-zoom.png`, `current-missing-family-zoom.png`. **No tofu, blank glyph or hex-box appears in any of them.** The v1.3.123 / v1.3.118 / missing-family crops are byte-identical, confirming all three exercised the same embedded sprite + Symbols Nerd Font fallback; the current-build crop differs (visibly different ASCII shapes) because MesloLGS really was applied — `info(font_shared_grid_set): font regular: MesloLGS Nerd Font Mono`, versus `font-family regular not found: MesloLGS Nerd Font Mono` on the older builds.

Capture method: direct desktop capture was unavailable in the automation session (`PrintWindow` and window-DC `BitBlt` omit the WGL surface; `CopyFromScreen`, Windows Graphics Capture and DXGI Desktop Duplication were all denied). Evidence is therefore OpenGL API traces of each exact executable, replayed on this machine's driver with apitrace 14.0 — renderer-level framebuffer output immediately below presentation.

## Diagnosis

1. Resolver layer, measured at the CLI against the machine's **real** installed fonts. Current build, `--font-family="MesloLGS Nerd Font Mono"`: U+E0B0/E0B2 → "handled by Ghostty's internal sprites"; U+E7A8, U+F418, U+F0E7, U+F031B, U+F08C7, U+F1049 → found in face "MesloLGS Nerd Font Mono". Installed v1.3.118 (same era as the reporter's build): the same PUA codepoints → found in face "Symbols Nerd Font" (the embedded fallback), U+41 → "JetBrains Mono" (the embedded default, i.e. the requested family was **not** applied). Neither build should produce tofu for any of these, and neither does.
2. U+E0B0–U+E0D4 are drawn by the built-in sprite face (`src/font/sprite/draw/powerline.zig`), selected in `CodepointResolver.getIndex` before any font is consulted. Tofu on those codepoints therefore cannot be a font-discovery problem in any build — worth remembering when triaging follow-ups.
3. `ef573dd7f` ("discover per-user and registry-installed Windows fonts", #117) is not an ancestor of tag `v1.3.123` and is the only commit touching `src/font/**` since. Every Nerd Font on the reporting machine is registered per-user (HKCU + `%LOCALAPPDATA%\Microsoft\Windows\Fonts`); `C:\Windows\Fonts` holds only the non-patched `JetBrainsMono-*.ttf`. Confirmed at the CLI: current build's `+list-fonts` lists `MesloLGS Nerd Font Mono`, v1.3.118's does not list it at all. So current `main` genuinely applies the configured Nerd Font where v1.3.123 could not — a real improvement, but **not** an explanation for tofu, since the old build's fallback renders these glyphs correctly anyway.
4. Direct cmap parsing of `MesloLGSNerdFontMono-Regular.ttf` confirms the glyphs exist (U+E0B0→2699, U+E0B2→2701, U+E0B6→2705, U+F023→5013, U+E5FF→3138) across its (3,1) format-4 and (3,10) format-12 subtables.

## Hypothesis round (H1-H6)

The A/B capture above was BMP-only and unstyled, so a second bounded round tested six further hypotheses on the current build with `font-family = "MesloLGS Nerd Font Mono"`. **None reproduced the bug.** Evidence PNGs and per-glyph ledgers are under `evidence/152/hyp/`.

| # | Hypothesis | Result |
|---|---|---|
| H1 | Supplementary-plane PUA (Nerd Fonts v3 Material icons, U+F0001-U+F1AF0) crossing ConPTY as UTF-16 surrogate pairs: U+F02A2, U+F0A40, U+F1AF0 | All three render correctly. Surrogate-pair re-encode, decode, shape and render all clean. U+F02A2 added to the hermetic shaper test regardless. |
| H2 | Bold/italic segments (starship segments are bold), with `font-family-bold` unset and set to the unpatched "JetBrains Mono" | All correct in both configurations; the two renders are byte-identical. |
| H3 | First-frame atlas growth: ~300 distinct glyphs one-shot vs 20-at-a-time at font-size 18 | No atlas-full/grow warning, no one-shot vs paced difference. All 307 codepoints present in the font render correctly in both modes. 89 of the literal requested range are absent from the font *and* every fallback, and correctly show `.notdef` in both modes - not atlas corruption. |
| H4 | Family-name variants: `JetBrainsMono Nerd Font` (proportional) and `JetBrainsMono NF Mono` (short) | Proportional resolves to a patched NF face and renders correctly. `JetBrainsMono NF Mono` is not a real v3.5.1 family name (the short family is `JetBrainsMono NFM`); it is logged not-found and falls back correctly. |
| H5 | Name collision between `JetBrainsMono Nerd Font Mono` and the machine-wide unpatched `JetBrains Mono` on v1.3.123 | **Refuted on the real machine.** See below. |
| H6 | `font-codepoint-map = U+E000-U+F8FF=Symbols Nerd Font Mono` | Mapping applies correctly; BMP PUA resolves to Symbols Nerd Font Mono, supplementary PUA correctly stays on the primary (outside the mapped range). All render. |

### H5 in detail, and the metrics question

The automation session cannot see the machine's real per-user fonts, so its H5 run happened against an isolated font set and concluded a collision had occurred. That does **not** hold on the actual machine. Verified directly against the real installed fonts with the pre-#117 binary (v1.3.118), using codepoints that discriminate the embedded JetBrains Mono from the machine-wide installed one (U+018F is in the embedded only; U+0132 and U+2126 are in the installed only):

| family requested | U+018F (embedded-only) | U+0132 (installed-only) |
|---|---|---|
| `JetBrainsMono Nerd Font Mono` | JetBrains Mono | Book Antiqua (fallback) |
| `MesloLGS Nerd Font Mono` | JetBrains Mono | Book Antiqua (fallback) |
| `ZZZ Bogus Family` (control) | JetBrains Mono | Book Antiqua (fallback) |

All three are identical, and the installed-only codepoint is *not* served by the primary. So on the pre-#117 build every family name - including a deliberately bogus one - resolves to the **embedded** JetBrains Mono. There is no collision with the machine-wide unpatched family.

That leaves the reporter's report that cell metrics visibly changed when switching family still **unexplained**: on their build both Nerd Font family names should resolve to the same embedded default, so metrics should not have changed. This is the single strongest remaining lead and the main reason to keep #152 open.

## Validation

Gates on the current head `9549a7b4d`, rebased onto `main` at `8ffeec4f7`, run locally on Windows 11:

| Command | Result |
|---|---|
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` (full suite) | **4110 passed, 70 skipped, 0 failed** (4180 tests) |
| `zig build test -Dtest-filter=CodepointResolver` | 72 passed, 1 skipped, 0 failed |
| `zig build test -Dtest-filter=harfbuzz` | 87 passed, 8 skipped, 0 failed |
| `zig build test "-Dtest-filter=nerd font"` | 71 passed, 1 skipped, 0 failed |
| `pwsh -NoProfile -File scripts/check-zig-format.ps1` | passed (693 tracked sources) |
| `pwsh -NoProfile -File scripts/check-source-format.ps1` | passed |

The branch still changes only `src/font/CodepointResolver.zig` and `src/font/shaper/harfbuzz.zig` (306 insertions, 0 deletions).

## Residuals / user steps

- [ ] **Reporter to retest on a build from current `main`** with `font-family = "MesloLGS Nerd Font Mono"`, and confirm whether the tofu persists.
- [ ] If it does persist, capture it over the exact **WSL + tmux + starship** stream and attach the screenshot to #152. That is the one variable still untested: the automation session is denied WSL (`Wsl/Service/E_ACCESSDENIED`), so every repro here used a PowerShell-generated ConPTY stream. A failure that only appears over WSL would belong with the ConPTY/UTF-8 pipeline (#124/#129), not the font stack.
- **Unexplained:** the reporter observed that cell metrics visibly changed when switching to `MesloLGS Nerd Font Mono`, which suggests the family was applied on their build. That contradicts the measurement above, where v1.3.118/v1.3.123 cannot see the font at all and log `font-family regular not found`. Attempts to attribute the metrics change to a fuzzy fallback match were inconclusive — on v1.3.118, `JetBrainsMono Nerd Font Mono`, `MesloLGS Nerd Font Mono` and a deliberately bogus family name all report the same face name. This gap is the main reason the issue should not be closed on this PR alone.
- The automation session could not read the real per-user font directory, so the render A/B used an official Nerd Fonts v3.5.1 Meslo (SHA-256 verified) in a redirected `LOCALAPPDATA`. The resolver-layer measurements in the diagnosis above were run by the manager against the genuinely installed fonts, and agree.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Pin Nerd Font PUA resolution and shaping behavior with hermetic regression tests while documenting that issue #152 remains unreproduced.

Enhancements:
- Add hermetic coverage for Nerd Font PUA resolution, fallback ordering, and shaping across adjacency, variation-selector, and attribute-run boundaries.
- Verify that resolved Nerd Font glyphs use the selected face and never produce .notdef glyphs in representative mixed-content lines.

Tests:
- Add regression tests covering built-in powerline sprites, primary Nerd Font glyphs, Symbols Nerd Font fallback, supplementary-plane PUA, and shaping boundary cases.

Chores:
- Document the investigation of issue #152 and preserve its unresolved diagnosis and render evidence without changing production behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for Nerd Font glyph resolution, including Powerline symbols and Private Use Area characters.
  * Added shaping tests to verify correct glyph indices, font fallback selection, and sprite mapping across Nerd Font variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->