### PR TITLE
renderer: document the GPU floor and report detected OpenGL on startup failure (#122)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -254,6 +254,9 @@ lands incrementally.
 - GitHub Issues are for reproducible bugs. For questions, feature
   discussion, and feedback, use
   [Discussions](https://github.com/amanthanvi/noctty/discussions).
+- OpenGL 4.3 through WGL is a hard floor with no software fallback renderer.
+  Below it, noctty shows a startup diagnostic with the detected version and
+  does not start; see [windows.md](windows.md#gpu-floor-and-opengl-driver-issues).
 - No supported Linux application packaging. Upstream's Flatpak and Snap
   surfaces are removed; the curated Nix flake supports only `libghostty-vt`.
 - A few generated artifacts still reference upstream: the `libghostty-vt`

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -139,7 +139,9 @@ Terminal presentation is owned by WGL `SwapBuffers`. A separate
 D3D11/DirectComposition shell pipeline owns recoverable top-level targets and
 transparent DPI-sized D2D surfaces; host banner and operation text is the
 first DirectWrite production zone, with per-paint GDI fallback. That pipeline
-does not replace or call the terminal renderer.
+does not replace or call the terminal renderer. The terminal path has a hard
+OpenGL 4.3-via-WGL floor and no software fallback; below it, noctty shows a
+startup diagnostic naming the detected version and does not launch.
 
 ### Universal palette
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -773,23 +773,34 @@ noctty warns in-app when it falls back; the shell still works, but the tested
 in-box conhost strips Kitty-graphics APC and Sixel DCS payloads. See the
 [transport catalog](windows-vt-conformance.md#conpty-transport-generations-and-mangling-catalog).
 
-### OpenGL driver issues
+### GPU floor and OpenGL driver issues
 
-noctty needs OpenGL 4.3 or newer. If the window fails to render or exits
-early on older hardware, update GPU drivers before filing a rendering bug.
+noctty needs OpenGL 4.3 or newer through WGL and has no software, DirectX,
+or ANGLE fallback renderer, so it cannot start when the active OpenGL
+implementation is below that floor. That is common in RDP sessions that fall
+back to software GL (often `GDI Generic` at OpenGL 1.1), VMs without 3D
+acceleration or a guest GPU driver, and older integrated GPUs whose driver
+stops before 4.3.
+
+Below the floor, noctty stops before showing its window and the startup
+dialog lists the required and detected OpenGL versions plus the renderer and
+vendor strings the driver reports. Failures later in OpenGL initialization
+use the same dialog to name the failed step and any Win32 or Zig error. Try,
+in order:
+
+1. End the Remote Desktop session and launch noctty locally.
+2. In a VM, enable 3D acceleration and install the guest graphics driver.
+3. Update or reinstall the OEM graphics driver for the active GPU; on an
+   AMD+NVIDIA hybrid system, the AMD driver first, then NVIDIA.
+4. On a hybrid-GPU system, force `noctty.exe` to the discrete or integrated
+   GPU in Windows Graphics settings.
 
 If startup fails with `LoadLibrary failed with error 126` or the startup
 dialog reports `Win32 error: 126 (ERROR_MOD_NOT_FOUND)` during OpenGL/WGL
 initialization, Windows could not load a graphics-driver DLL or one of its
 dependencies. This shows up most often on AMD+NVIDIA hybrid-GPU laptops
-while WGL loads the AMD OpenGL ICD from DriverStore. Try, in order:
-
-1. Update or reinstall the OEM AMD graphics driver, then the NVIDIA driver.
-2. Force `noctty.exe` to the discrete or integrated GPU in Windows Graphics
-   settings.
-
-noctty ships only the OpenGL/WGL renderer on Windows. There is no DirectX or
-ANGLE fallback renderer in this build.
+while WGL loads the AMD OpenGL ICD from DriverStore; use the driver order in
+step 3 before retrying.
 
 ### Stale installed build
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -211,6 +211,8 @@ const beginOpenGLStartupDiagnostics = gl_startup.beginOpenGLStartupDiagnostics;
 pub const clearOpenGLStartupFailure = gl_startup.clearOpenGLStartupFailure;
 const recordOpenGLStartupWin32Failure = gl_startup.recordOpenGLStartupWin32Failure;
 pub const recordOpenGLStartupError = gl_startup.recordOpenGLStartupError;
+pub const recordOpenGLStartupVersionError = gl_startup.recordOpenGLStartupVersionError;
+pub const OpenGLStartupString = gl_startup.OpenGLStartupString;
 pub const reportStartupFailure = gl_startup.reportStartupFailure;
 
 const ATOM = win32_types.ATOM;
@@ -541,10 +543,6 @@ fn sizeLimitEquals(a: apprt.action.SizeLimit, b: apprt.action.SizeLimit) bool {
 
 fn shouldShowSurfaceImmediately(host_id: ?u32) bool {
     return host_id == null;
-}
-
-fn shouldActivateSurfaceDuringInit(host_id: ?u32, passive_show: bool) bool {
-    return shouldShowSurfaceImmediately(host_id) and !passive_show;
 }
 
 fn shouldResizeHostForInitialSize(host_surface_count: usize) bool {
@@ -7633,7 +7631,7 @@ pub const App = struct {
         if (mapped_hosts != state.windows.items.len) return error.WindowCountMismatch;
     }
 
-    fn createHost(self: *App, title: LPCWSTR, clone_state_from: ?*const Surface, passive_show: bool) !*Host {
+    fn createHost(self: *App, title: LPCWSTR, clone_state_from: ?*const Surface) !*Host {
         try self.ensureHostWindowClass();
         try self.ensurePaletteListClass();
         try self.ensureScrollbarClass();
@@ -7705,14 +7703,9 @@ pub const App = struct {
 
         host.power_notifications = win32_power.Notifications.init(hwnd);
 
-        // Passive first-show for quick-terminal-keyboard-interactivity
-        // = none: `SW_SHOWNOACTIVATE` makes the window visible but
-        // does NOT bring it to the foreground, so the user's current
-        // typing context stays intact. `SW_SHOW` would activate the
-        // new HWND and steal focus.
-        _ = sys.ShowWindow(hwnd, if (passive_show) c.SW_SHOWNOACTIVATE else c.SW_SHOW);
-        _ = sys.UpdateWindow(hwnd);
-        self.maybeScheduleAutomaticUpdateCheck();
+        // The host stays hidden here. `Surface.init` shows it only after GL
+        // and core initialization succeed, so a below-floor GPU reaches the
+        // startup dialog without first flashing a blank window.
         return host;
     }
 
@@ -8760,12 +8753,11 @@ pub const App = struct {
         defer config.deinit();
         const surface = try self.createWindowSurface(&config, quick_terminal_title, .{
             .quick_terminal = true,
-            // Passive first-show: `createHost` uses `SW_SHOWNOACTIVATE`
-            // so the new HWND appears without taking focus. Without
-            // this, the very first toggle-on with
-            // `keyboard-interactivity = none` would still activate
-            // the window even though the later `present()` call is
-            // skipped.
+            // Passive first-show: `Surface.init` uses `SW_SHOWNOACTIVATE`
+            // after GL and core initialization, so the new HWND appears
+            // without taking focus. Without this, the very first toggle-on
+            // with `keyboard-interactivity = none` would still activate the
+            // window even though the later `present()` call is skipped.
             .passive_show = !want_focus,
         });
         try surface.setFloatWindow(.on);
@@ -19020,12 +19012,12 @@ const SurfaceInitOptions = struct {
     tab_insert_index: ?usize = null,
     clone_state_from: ?*const Surface = null,
     split_direction: SplitTreeSurface.Split.Direction = .right,
-    /// Passive first-show: the newly-created host HWND is shown via
-    /// `SW_SHOWNOACTIVATE` instead of `SW_SHOW`, so it becomes
-    /// visible without stealing focus from the caller's current
-    /// foreground window. Used by the quick-terminal passive mode
-    /// (`quick-terminal-keyboard-interactivity = none`) on first
-    /// toggle-on.
+    /// Passive first-show: once GL and core initialization succeed, the
+    /// newly-created host HWND is shown via `SW_SHOWNOACTIVATE` instead of
+    /// being presented with focus, so it becomes visible without stealing
+    /// focus from the caller's current foreground window. Used by the
+    /// quick-terminal passive mode
+    /// (`quick-terminal-keyboard-interactivity = none`) on first toggle-on.
     passive_show: bool = false,
     adopted_session: ?*win32_terminal_handoff.PendingSession = null,
 };
@@ -25451,7 +25443,7 @@ pub const Surface = struct {
         defer if (shell_prepared) |*prepared| prepared.deinit();
 
         const host = existing_host orelse
-            try app.createHost(title, opts.clone_state_from, opts.passive_show);
+            try app.createHost(title, opts.clone_state_from);
         const created_host = existing_host == null;
         errdefer if (created_host) app.removeHost(host);
         self.* = .{
@@ -25675,12 +25667,19 @@ pub const Surface = struct {
         if (activate_during_init) {
             try host.refreshChrome();
             try host.layout();
-            // Passive launches were already shown with SW_SHOWNOACTIVATE when the
-            // host HWND was created. Only run the active present/focus path here
-            // for launches that should take foreground focus during init.
-            if (shouldActivateSurfaceDuringInit(opts.host_id, opts.passive_show)) {
+            // The top-level host was created hidden and stays hidden until GL
+            // and core initialization have succeeded, so a startup failure
+            // reaches the fatal dialog without first presenting a blank host
+            // window. Same-host tabs and splits never take this path.
+            if (opts.passive_show) {
+                if (host.hwnd) |host_hwnd| {
+                    _ = sys.ShowWindow(host_hwnd, c.SW_SHOWNOACTIVATE);
+                    _ = sys.UpdateWindow(host_hwnd);
+                }
+            } else {
                 self.presentWindow();
             }
+            app.maybeScheduleAutomaticUpdateCheck();
             try self.requestRepaint();
         }
 
@@ -33920,15 +33919,6 @@ test "win32 shouldShowSurfaceImmediately only for new hosts" {
     try std.testing.expect(shouldShowSurfaceImmediately(null));
     try std.testing.expect(!shouldShowSurfaceImmediately(1));
     try std.testing.expect(!shouldShowSurfaceImmediately(99));
-}
-
-test "win32 shouldActivateSurfaceDuringInit skips passive new-host activation" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    try std.testing.expect(shouldActivateSurfaceDuringInit(null, false));
-    try std.testing.expect(!shouldActivateSurfaceDuringInit(null, true));
-    try std.testing.expect(!shouldActivateSurfaceDuringInit(7, false));
-    try std.testing.expect(!shouldActivateSurfaceDuringInit(7, true));
 }
 
 test "win32 shouldPropagateSharedHostWindowState only for active shared-host surfaces" {

--- a/src/apprt/win32/gl_startup.zig
+++ b/src/apprt/win32/gl_startup.zig
@@ -84,6 +84,37 @@ const OpenGLStartupFailure = struct {
     step: OpenGLStartupStep,
     win32_error: ?DWORD = null,
     zig_error_name: ?[]const u8 = null,
+    detected: ?DetectedOpenGL = null,
+};
+
+/// Fixed-capacity copy of a driver-reported string (`GL_RENDERER`,
+/// `GL_VENDOR`). The failure path stays allocation-free, and `capacity` is
+/// the single bound the renderer uses when it scans the driver string.
+pub const OpenGLStartupString = struct {
+    pub const capacity = 128;
+
+    bytes: [capacity]u8 = undefined,
+    len: u8 = 0,
+
+    fn init(driver_text: ?[]const u8) OpenGLStartupString {
+        var result: OpenGLStartupString = .{};
+        const source = driver_text orelse return result;
+        const len = @min(source.len, capacity);
+        @memcpy(result.bytes[0..len], source[0..len]);
+        result.len = @intCast(len);
+        return result;
+    }
+
+    fn value(self: *const OpenGLStartupString) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
+const DetectedOpenGL = struct {
+    major: u32,
+    minor: u32,
+    renderer: OpenGLStartupString = .{},
+    vendor: OpenGLStartupString = .{},
 };
 
 var opengl_startup_diagnostics_mutex: std.Thread.Mutex = .{};
@@ -155,6 +186,32 @@ pub fn recordOpenGLStartupError(step: OpenGLStartupStep, err: anyerror) void {
     log.err("Win32 OpenGL startup failed step={s} error={s}", .{ step.label(), @errorName(err) });
 }
 
+/// Record a below-floor version check together with what the machine
+/// actually reported, so the dialog can say "required 4.3, detected 1.1"
+/// instead of only naming the requirement.
+pub fn recordOpenGLStartupVersionError(
+    major: u32,
+    minor: u32,
+    renderer: ?[]const u8,
+    vendor: ?[]const u8,
+) void {
+    if (!recordOpenGLStartupFailure(.{
+        .step = .version_check,
+        .zig_error_name = @errorName(error.OpenGLOutdated),
+        .detected = .{
+            .major = major,
+            .minor = minor,
+            .renderer = .init(renderer),
+            .vendor = .init(vendor),
+        },
+    })) return;
+
+    log.err(
+        "Win32 OpenGL startup version check failed required=4.3 detected={d}.{d} renderer={s} vendor={s}",
+        .{ major, minor, renderer orelse "not reported", vendor orelse "not reported" },
+    );
+}
+
 pub fn reportStartupFailure(err: anyerror) void {
     if (comptime builtin.os.tag != .windows) return;
 
@@ -188,6 +245,40 @@ fn formatStartupFailureMessage(buf: []u8, err: anyerror) []const u8 {
 
 fn formatOpenGLStartupFailureMessage(buf: []u8, err: anyerror, failure: OpenGLStartupFailure) ![]const u8 {
     const zig_error_name = failure.zig_error_name orelse @errorName(err);
+
+    if (failure.detected) |detected| {
+        var win32_error_buf: [64]u8 = undefined;
+        const win32_error_text = if (failure.win32_error) |win32_error|
+            try std.fmt.bufPrint(&win32_error_buf, "{d}{s}", .{ win32_error, win32ErrorSuffix(win32_error) })
+        else
+            "not reported";
+
+        return std.fmt.bufPrint(buf,
+            \\noctty {s} could not initialize the Windows OpenGL renderer while {s}.
+            \\
+            \\Startup error: {s}
+            \\Win32 error: {s}
+            \\Required OpenGL version: 4.3 through WGL
+            \\Detected OpenGL version: {d}.{d}
+            \\Detected renderer: {s}
+            \\Detected vendor: {s}
+            \\
+            \\This build does not include a software, DirectX, or ANGLE fallback renderer, so noctty cannot start below OpenGL 4.3.
+            \\
+            \\Try ending Remote Desktop and launching noctty in a local console session; enabling 3D acceleration and installing the VM guest graphics driver; or updating or reinstalling your GPU driver. On hybrid-GPU systems, you can also force noctty.exe to the discrete or integrated GPU in Windows Graphics settings.
+            \\
+            \\If it still fails, attach this text and the log to https://github.com/amanthanvi/noctty/issues/64.
+        , .{
+            build_config.version_string,
+            failure.step.label(),
+            zig_error_name,
+            win32_error_text,
+            detected.major,
+            detected.minor,
+            if (detected.renderer.len > 0) detected.renderer.value() else "not reported",
+            if (detected.vendor.len > 0) detected.vendor.value() else "not reported",
+        });
+    }
 
     if (failure.win32_error) |win32_error| {
         return std.fmt.bufPrint(buf,
@@ -275,6 +366,55 @@ test "win32-opengl-startup-failure-message-explains-version-floor" {
     try std.testing.expect(std.mem.indexOf(u8, message, "OpenGL 4.3 through WGL") != null);
     try std.testing.expect(std.mem.indexOf(u8, message, "required OpenGL 4.3 feature level") != null);
     try std.testing.expect(std.mem.indexOf(u8, message, "Win32 error: not reported") != null);
+}
+
+test "win32-opengl-startup-failure-message-reports-detected-version" {
+    var buf: [4096]u8 = undefined;
+    const message = try formatOpenGLStartupFailureMessage(&buf, error.OpenGLOutdated, .{
+        .step = .version_check,
+        .zig_error_name = "OpenGLOutdated",
+        .detected = .{
+            .major = 1,
+            .minor = 1,
+            .renderer = .init("GDI Generic"),
+            .vendor = .init("Microsoft Corporation"),
+        },
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, message, "while checking the OpenGL version") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Required OpenGL version: 4.3 through WGL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Detected OpenGL version: 1.1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Detected renderer: GDI Generic") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Detected vendor: Microsoft Corporation") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Win32 error: not reported") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "noctty cannot start below OpenGL 4.3") != null);
+}
+
+// The step label and Win32 error come from the record, not from literal
+// text, so a future caller recording a detected payload for another step
+// gets the right wording.
+test "win32-opengl-startup-detected-version-message-uses-recorded-diagnostics" {
+    var buf: [4096]u8 = undefined;
+    const message = try formatOpenGLStartupFailureMessage(&buf, error.OpenGLOutdated, .{
+        .step = .create_context,
+        .win32_error = c.ERROR_MOD_NOT_FOUND,
+        .zig_error_name = "OpenGLOutdated",
+        .detected = .{ .major = 1, .minor = 1 },
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, message, "while creating the WGL context") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "while checking the OpenGL version") == null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Win32 error: 126 (ERROR_MOD_NOT_FOUND)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Detected renderer: not reported") != null);
+}
+
+test "win32-opengl-startup-failure-bounds-driver-strings" {
+    const value = "x" ** (OpenGLStartupString.capacity + 1);
+    const captured = OpenGLStartupString.init(value);
+
+    try std.testing.expectEqual(OpenGLStartupString.capacity, captured.value().len);
+    try std.testing.expectEqualStrings(value[0..OpenGLStartupString.capacity], captured.value());
+    try std.testing.expectEqual(@as(usize, 0), OpenGLStartupString.init(null).value().len);
 }
 
 test "win32-opengl-startup-failure-recording-is-startup-scoped" {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -40,6 +40,13 @@ const log = std.log.scoped(.opengl);
 const WglSwapIntervalExt = *const fn (interval: c_int) callconv(.winapi) windows.BOOL;
 const wgl_swap_interval_ext_name: [*:0]const u8 = "wglSwapIntervalEXT";
 const enable_gl_debug_output = false;
+/// Bound on the driver strings read for the startup diagnostic. The Win32
+/// failure record owns the real capacity; other targets never reach this
+/// path, so they keep an unbounded scan only to stay compiling.
+const startup_gl_string_max_len: usize = if (apprt.runtime == apprt.win32)
+    apprt.win32.OpenGLStartupString.capacity
+else
+    std.math.maxInt(usize);
 
 /// We require at least OpenGL 4.3
 pub const MIN_VERSION_MAJOR = 4;
@@ -243,10 +250,17 @@ fn prepareContext(getProcAddress: anytype) !void {
         (major == MIN_VERSION_MAJOR and minor < MIN_VERSION_MINOR))
     {
         log.warn(
-            "OpenGL version is too old. Ghostty requires OpenGL {d}.{d}",
+            "OpenGL version is too old. noctty requires OpenGL {d}.{d}",
             .{ MIN_VERSION_MAJOR, MIN_VERSION_MINOR },
         );
-        recordWin32OpenGLStartupError(.version_check, error.OpenGLOutdated);
+        // Queried only on this below-floor branch; a successful start does
+        // no extra work.
+        recordWin32OpenGLStartupVersionError(
+            major,
+            minor,
+            startupGLString(gl.c.GL_RENDERER),
+            startupGLString(gl.c.GL_VENDOR),
+        );
         return error.OpenGLOutdated;
     }
 
@@ -269,6 +283,41 @@ fn recordWin32OpenGLStartupError(step: apprt.win32.OpenGLStartupStep, err: anyer
     if (apprt.runtime == apprt.win32) {
         apprt.win32.recordOpenGLStartupError(step, err);
     }
+}
+
+fn recordWin32OpenGLStartupVersionError(
+    major: u32,
+    minor: u32,
+    renderer: ?[]const u8,
+    vendor: ?[]const u8,
+) void {
+    if (apprt.runtime == apprt.win32) {
+        apprt.win32.recordOpenGLStartupVersionError(major, minor, renderer, vendor);
+    }
+}
+
+/// Read at most `max_len` bytes of a C string, stopping at the first NUL.
+///
+/// The scan itself is bounded, not just its result. Letting `std.mem.span`
+/// find the terminator would be wrong twice over: it is unbounded, so an
+/// unterminated buffer is scanned until it faults; and it is vectorized, so
+/// it can read a whole chunk past the NUL of a short string. This loop reads
+/// one byte at a time and never touches an index at or beyond `max_len`.
+fn boundedCString(ptr: [*]const u8, max_len: usize) []const u8 {
+    var len: usize = 0;
+    while (len < max_len and ptr[len] != 0) len += 1;
+    return ptr[0..len];
+}
+
+fn startupGLString(name: gl.c.GLenum) ?[]const u8 {
+    const get_string = gl.glad.context.GetString orelse return null;
+    const value = get_string(name);
+    if (value == null) return null;
+
+    // This runs only on the below-floor branch, i.e. precisely when the
+    // driver is old or malfunctioning, so do not assume it honoured the
+    // spec's promise of a NUL-terminated string.
+    return boundedCString(@ptrCast(value), startup_gl_string_max_len);
 }
 
 /// This is called early right after surface creation.
@@ -673,6 +722,32 @@ pub inline fn beginFrame(
 ) !Frame {
     _ = self;
     return try Frame.begin(.{}, renderer, target);
+}
+
+test "OpenGL startup driver strings bound the scan, not just the result" {
+    // Terminated and short: stops at the NUL and never reaches the trailing
+    // filler, which stands in for whatever follows the driver's buffer.
+    const terminated = "GDI Generic\x00\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA";
+    try std.testing.expectEqualStrings(
+        "GDI Generic",
+        boundedCString(terminated.ptr, 128),
+    );
+
+    // Unterminated: the scan stops at the cap instead of running on. Sizing
+    // the backing buffer to exactly `max_len` means reading even one byte
+    // past the bound would be an out-of-bounds index.
+    var unterminated: [16]u8 = @splat('x');
+    const bounded = boundedCString(&unterminated, unterminated.len);
+    try std.testing.expectEqual(@as(usize, 16), bounded.len);
+    try std.testing.expectEqualStrings("xxxxxxxxxxxxxxxx", bounded);
+
+    // Truncation still happens when the string is longer than the cap.
+    var long: [64]u8 = @splat('y');
+    try std.testing.expectEqual(@as(usize, 8), boundedCString(&long, 8).len);
+
+    // Degenerate cases.
+    try std.testing.expectEqualStrings("", boundedCString("\x00abc".ptr, 4));
+    try std.testing.expectEqualStrings("", boundedCString("abc".ptr, 0));
 }
 
 test "OpenGL hasVsync requires enabled swap interval" {


### PR DESCRIPTION
Documents the OpenGL 4.3-via-WGL requirement as a real product boundary and makes a below-floor machine say so out loud instead of dying quietly behind a blank window.

S slice only, per the roadmap ruling: **no software, DirectX, or ANGLE fallback renderer**, and no config knob to bypass the floor. C35 stays deferred.

Fixes #122

## State of this branch

- Base branch: `issues/135-ghostty-13-win32-audit` (PR #156), which is itself based on `issues/120-docs-accuracy` (PR #155). Merge order: #155, then #156, then this. Retarget as each one lands.
- Head `e7d8f0441`, one commit on top of `2c04c5e3f` (#156); the stack sits on `main` at `13e07ba35`.
- Re-authored on top of main's `src/apprt/win32/gl_startup.zig` extraction and the docs debloat (#206), so the failure record and its formatter now live in `src/apprt/win32/gl_startup.zig` rather than inline in `src/apprt/win32.zig`. Shas quoted in older review replies on this PR no longer exist.

## Changes

**"What was found", not just "what was required".** The startup dialog already named the 4.3 requirement, but never reported what the machine actually had — which is the whole difference between an actionable message and a dead end on RDP or in a VM. `prepareContext` now passes the glad-reported major/minor plus bounded `GL_RENDERER` / `GL_VENDOR` strings into the existing `OpenGLStartupFailure` record, and the existing formatter prints required versus detected:

```
Required OpenGL version: 4.3 through WGL
Detected OpenGL version: 1.1
Detected renderer: GDI Generic
Detected vendor: Microsoft Corporation

This build does not include a software, DirectX, or ANGLE fallback renderer,
so noctty cannot start below OpenGL 4.3.
```

Driver strings are copied into fixed 128-byte buffers (`OpenGLStartupString.capacity`, `src/apprt/win32/gl_startup.zig:94`), so the failure path stays allocation-free, and they are queried only on the below-floor branch — a successful start does no extra work. Missing values render as `not reported`. This reuses `recordOpenGLStartupFailure` / `formatOpenGLStartupFailureMessage` / `reportStartupFailure`; no new dialog or reporting channel was introduced.

**The blank window was real.** The issue's "instead of a blank window" clause turned out to describe an actual defect, not a hypothetical: `App.createHost` called `ShowWindow` immediately after creating the host HWND, before the renderer was initialized, so a below-floor machine got a visible empty host window and only then the error dialog. Presentation now happens in `Surface.init` after `core_surface.init` succeeds, so a startup failure unwinds while the host is still hidden. Passive quick-terminal launches keep `SW_SHOWNOACTIVATE`; same-host tabs and splits are unaffected because they never took the presentation path (`shouldShowSurfaceImmediately`, `src/apprt/win32.zig:555`, is false when `host_id != null`).

**Docs.** `docs/windows.md` documents the floor, the environments that commonly fall below it (RDP sessions falling back to software GL, VMs without 3D acceleration, pre-4.3 iGPUs, drivers that report a robust context but fail mid-initialization), exactly what noctty does, and what to try. The existing `ERROR_MOD_NOT_FOUND` hybrid-GPU guidance is kept, merged into one ordered remedy list rather than repeated. `docs/status.md` and the capability matrix carry the caveat.

## Review rounds folded into this commit

1. **The driver-string scan is bounded, not just its result.** Two earlier revisions moved the problem instead of removing it: slicing to 128 bytes and then calling the vectorized `std.mem.indexOfScalar` can read past a short string, and `std.mem.span` resolves the length through the equally vectorized `indexOfSentinel` and is unbounded, so an unterminated buffer is walked until it faults. `boundedCString(ptr, max_len)` (`src/renderer/OpenGL.zig:306`) reads one byte at a time and never indexes at or beyond `max_len`; `startupGLString` passes `startup_gl_string_max_len`, so the worst case is 128 single-byte reads. Test `OpenGL startup driver strings bound the scan, not just the result` (`:727`) covers a terminated short string followed by filler, an unterminated buffer sized to exactly `max_len`, truncation of an over-long string, and the empty-string and zero-cap cases.
2. **One source of truth for the 128-byte bound.** `OpenGLStartupString.capacity` is the single source; `src/renderer/OpenGL.zig:46-49` derives `startup_gl_string_max_len` from it, guarded so non-Windows targets still build.
3. **The detected-version branch no longer hardcodes step text.** It uses `failure.step.label()` and renders any recorded `win32_error` through `win32ErrorSuffix`, matching its sibling branches. A test pins this by formatting a `.create_context` + `ERROR_MOD_NOT_FOUND` record and asserting the label and error come from the record.
4. **A dead predicate was removed rather than left in.** The new presentation branch guarded the non-passive case with `shouldActivateSurfaceDuringInit(...)`, which was unconditionally true at that point. Reduced to a plain `else`; the predicate then had no production callers, so it and its test were deleted (`grep -rn shouldActivateSurfaceDuringInit src/` is empty).

**One review nit did not hold, so nothing was changed for it.** The claim was that `new_window` from an existing window shows the host via `inheritHostWindowState` before GL init, making the "host stays hidden until core init succeeds" wording first-launch-only. Rechecked on the rebased tree:

- `App.createHost` contains no `ShowWindow` call at all; its only state-inheritance call is `inheritHostWindowState`.
- `inheritHostWindowState` repositions with `SetWindowPos(..., SWP_NOACTIVATE)` (`src/apprt/win32.zig:7866-7873`) and does **not** pass `SWP_SHOWWINDOW` — that flag is not defined anywhere in the tree. `SetWindowPos` without it leaves a hidden window hidden.
- The host is created from `startupHostWindowStyle` (`:509-511`), which masks out `WS_VISIBLE`.

Every other `ShowWindow` on a host HWND is either the post-core-init presentation in `Surface.init`, or a toggle/fullscreen/session-restore path on an already-initialized surface. `applyRestoredWindowPlacement`'s `SW_MAXIMIZE` is the closest call, and it runs *after* `restoreSessionTab` has returned an initialized surface. So the cloned-window path is hidden until core init succeeds too, and the wording is accurate as written.

## Validation

Run on `e7d8f0441`, Windows 11, clean worktree:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4180 passed; 71 skipped; 0 failed |
| `scripts/check-zig-format.ps1` | passed (696 tracked sources) |
| `scripts/check-source-format.ps1` | passed |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |

Targeted filters, all succeeded: `opengl-startup` (the seven `win32-opengl-startup-*` tests in `src/apprt/win32/gl_startup.zig`), `bound the scan`, `hostPresentShowCommand`, `shouldShowSurfaceImmediately`.

Tests cover the required 4.3 / detected 1.1 / GDI Generic / Microsoft identity message content, the no-fallback consequence, 128-byte truncation of oversized driver strings, and the bounded scan.

## Residuals / user steps

- **Not verified on real hardware.** A genuine sub-4.3 machine, an RDP session, and a VM were not exercised. The detected-version message content is proven by unit test against a synthetic fixture, not by a live below-floor driver.
- **Interactive verification of the presentation change is INCOMPLETE — this is the thing to confirm before merge.** A GUI pass was attempted and was blocked by the agent session having no interactive desktop: `CopyFromScreen` failed with `The handle is invalid`, `PrintWindow(PW_RENDERFULLCONTENT)` returned white pixels for the WGL client, and `GetForegroundWindow()` returned `0` both before and after launch, so no focus assertion was possible.

  What it *did* establish on the plain-launch path: the built binary launches, creates a **visible** host window at (80,80) sized 975x607, initializes OpenGL 4.6, completes repeated frames, and closes cleanly. So presentation is not broken outright on that path.

  Still unproven and needing a real desktop session: absence of a blank-window flash, focus correctness, `new_window`, new tab, split, maximized launch (`IsZoomed` branch), and the passive quick-terminal `SW_SHOWNOACTIVATE` path (must appear *without* stealing focus).
- Drivers that advertise 4.3 and then fail later still use the same dialog and name the failed initialization step, but only the explicit version-check failure carries the detected-version payload.
- If `glGetString` returns null the dialog says `not reported`; no fallback probing is attempted.

## Summary by Sourcery

Make the Windows OpenGL startup floor explicit, provide actionable diagnostics for unsupported systems, and avoid presenting hosts before initialization succeeds.

New Features:
- Report the detected OpenGL version, renderer, and vendor when startup fails below the OpenGL 4.3-via-WGL floor.
- Keep newly created Windows host windows hidden until graphics and core initialization succeeds while preserving passive quick-terminal presentation.

Bug Fixes:
- Prevent below-floor or failed OpenGL startup from briefly displaying a blank host window before the failure dialog.

Enhancements:
- Bound OpenGL driver diagnostic string capture and scanning on the startup failure path.
- Use recorded startup failure metadata for diagnostic step labels and Win32 error details.

Documentation:
- Document the Windows OpenGL hardware floor, unsupported fallback renderers, common failure environments, and recovery steps.

Tests:
- Add coverage for detected OpenGL diagnostics, bounded driver strings, and recorded failure metadata.

New Features:

- Report the detected OpenGL version, renderer, and vendor when startup fails below the OpenGL 4.3-via-WGL requirement.
- Keep Windows host windows hidden until graphics and core initialization succeeds, while preserving passive quick-terminal presentation behavior.

Bug Fixes:

- Prevent below-floor or failed OpenGL startup from briefly displaying a blank host window before showing the failure dialog.
- Bound driver diagnostic string reads and storage to avoid unsafe scans and excessive failure-path data.

Enhancements:

- Make OpenGL startup diagnostics derive failure-step and Win32 error details from the recorded failure data.
- Clarify the Windows OpenGL hardware floor, unsupported fallback renderers, common failure environments, and recovery steps in user documentation.

Documentation:

- Document the OpenGL 4.3-via-WGL requirement and below-floor startup behavior across Windows support documentation and status materials.

Tests:

- Add coverage for detected-version diagnostics, missing and oversized driver strings, recorded failure metadata, and bounded C-string scanning.

---

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed startup diagnostics when the system’s OpenGL version is below 4.3, including required and detected versions, renderer, vendor, and relevant error details.
  - Added guidance for resolving common compatibility issues involving outdated drivers, remote desktop sessions, and virtual machines.

- **Bug Fixes**
  - Windows now remains hidden until graphics initialization completes, preventing premature display during startup.

- **Documentation**
  - Documented the OpenGL 4.3 minimum requirement and the absence of software, DirectX, or ANGLE fallback rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->