### PR TITLE
fix(win32): safe mode silently ignored user config; report OS color scheme (#149)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -886,7 +886,11 @@ pub fn init(
         try termio.Termio.init(&self.io, alloc, .{
             .size = size,
             .full_config = config,
-            .config = try termio.Termio.DerivedConfig.init(alloc, config),
+            .config = try termio.Termio.DerivedConfig.init(
+                alloc,
+                config,
+                app.config_conditional_state,
+            ),
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
@@ -2013,18 +2017,6 @@ fn updateScrollbar(self: *Surface, scrollbar: terminal.Scrollbar) void {
     };
 }
 
-/// This should be called anytime `config_conditional_state` changes
-/// so that the apprt can reload the configuration.
-fn notifyConfigConditionalState(self: *Surface) void {
-    _ = self.rt_app.performAction(
-        .{ .surface = self },
-        .reload_config,
-        .{ .soft = true },
-    ) catch |err| {
-        log.warn("failed to notify app of config state change err={}", .{err});
-    };
-}
-
 /// Update our configuration at runtime. This can be called by the apprt
 /// to set a surface-specific configuration that differs from the app
 /// or other surfaces.
@@ -2116,7 +2108,11 @@ pub fn updateConfig(
         errdefer renderer_message.deinit();
         var termio_config_ptr = try self.alloc.create(termio.Termio.DerivedConfig);
         errdefer self.alloc.destroy(termio_config_ptr);
-        termio_config_ptr.* = try termio.Termio.DerivedConfig.init(self.alloc, config);
+        termio_config_ptr.* = try termio.Termio.DerivedConfig.init(
+            self.alloc,
+            config,
+            self.config_conditional_state,
+        );
         errdefer termio_config_ptr.deinit();
 
         self.renderer_thread.send(renderer_message);
@@ -5869,8 +5865,9 @@ fn mouseSelection(
 }
 
 /// Call to notify Ghostty that the color scheme for the terminal has
-/// changed.
-pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) !void {
+/// changed. The apprt batches configuration reload until every surface has
+/// received the new conditional state.
+pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();
     defer crash.sentry.thread_state = null;
@@ -5885,10 +5882,6 @@ pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) !void {
 
     // Setup our conditional state which has the current color theme.
     self.config_conditional_state.theme = new_scheme;
-    self.notifyConfigConditionalState();
-
-    // If mode 2031 is on, then we report the change live.
-    self.queueIo(.{ .color_scheme_report = .{ .force = false } }, .unlocked);
 }
 
 pub fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordinate {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2585,6 +2585,14 @@ fn recoverySafeModeNotice(decision: win32_recovery.Decision) ?[]const u8 {
 /// launch is given up as unresolved.
 const recovery_ready_persist_attempts: u8 = 3;
 
+/// Delay before a retried ready-marker write. `GetMessageW` blocks, so an
+/// otherwise idle app produces no further ticks on its own and each remaining
+/// attempt has to be scheduled. The delay is what makes these retries able to
+/// outlast a brief anti-virus or backup handle hold; bounded by the retry
+/// budget, the safe-mode notice is released at most
+/// `(recovery_ready_persist_attempts - 1) * this` late.
+const recovery_ready_retry_delay_ms: u32 = 750;
+
 /// Retry budget for the ready marker, spent across message-loop ticks.
 ///
 /// The ready marker is the only thing that breaks a failure streak, so a
@@ -3166,6 +3174,7 @@ pub const App = struct {
     terminal_handoff_idle_timer_id: ?UINT_PTR = null,
     terminal_handoff_server: ?*win32_terminal_handoff.Server = null,
     undo_prune_timer_id: ?UINT_PTR = null,
+    recovery_retry_timer_id: ?UINT_PTR = null,
     next_undo_sequence: u64 = 1,
     running: bool = false,
     /// A normal last-host close destroys the native/session model before
@@ -3501,6 +3510,7 @@ pub const App = struct {
             self.stopUndoPruneTimer();
             self.stopQuitTimer();
             self.stopTerminalHandoffIdleTimer();
+            self.stopRecoveryRetryTimer();
             drainDeferredUiaDisconnects(ui_thread_id);
             @atomicStore(DWORD, &self.ui_thread_id, 0, .release);
             self.running = false;
@@ -3691,6 +3701,13 @@ pub const App = struct {
             }
 
             if (msg.message == c.WM_TIMER) {
+                if (self.recovery_retry_timer_id) |timer_id| {
+                    if (msg.wParam == timer_id) {
+                        self.stopRecoveryRetryTimer();
+                        self.resolveRecoveryStartup();
+                        continue;
+                    }
+                }
                 if (self.terminal_handoff_idle_timer_id) |timer_id| {
                     if (msg.wParam == timer_id) {
                         self.stopTerminalHandoffIdleTimer();
@@ -3790,6 +3807,7 @@ pub const App = struct {
         self.stopUndoPruneTimer();
         self.stopQuitTimer();
         self.stopTerminalHandoffIdleTimer();
+        self.stopRecoveryRetryTimer();
         self.update_check_running.store(false, .release);
         if (self.update_notice) |*notice| {
             notice.deinit(self.core_app.alloc);
@@ -4238,6 +4256,7 @@ pub const App = struct {
         if (!self.recovery_ready_resolved) {
             if (self.markRecoveryReady()) {
                 self.recovery_ready_resolved = true;
+                self.stopRecoveryRetryTimer();
             } else |err| {
                 if (self.recovery_ready_retry.recordFailure(err)) {
                     log.warn(
@@ -4245,11 +4264,13 @@ pub const App = struct {
                         .{ self.recovery_ready_retry.failures, err },
                     );
                     self.recovery_ready_resolved = true;
+                    self.stopRecoveryRetryTimer();
                 } else {
                     log.warn(
-                        "win32 recovery: ready marker attempt {d} failed err={}; retrying next tick",
-                        .{ self.recovery_ready_retry.failures, err },
+                        "win32 recovery: ready marker attempt {d} failed err={}; retrying in {d}ms",
+                        .{ self.recovery_ready_retry.failures, err, recovery_ready_retry_delay_ms },
                     );
+                    self.scheduleRecoveryRetry();
                 }
             }
         }
@@ -5396,6 +5417,38 @@ pub const App = struct {
             log.err("failed to re-register terminal handoff class object err={}", .{err});
         };
         return false;
+    }
+
+    /// Schedule the next ready-marker attempt.
+    ///
+    /// `GetMessageW` blocks, so an idle app generates no further ticks and the
+    /// retry budget would never be spent — an `initial-window = false` launch
+    /// in particular can reach its quit timer without another tick at all,
+    /// leaving the attempt unresolved on disk and the safe-mode notice
+    /// unreleased. The timer both guarantees the attempt and spaces it out;
+    /// a bare wake would busy-retry and could not outlast a handle hold.
+    ///
+    /// Bounded by `RecoveryReadyRetry`: only a failure that has not exhausted
+    /// the budget reaches here, so at most
+    /// `recovery_ready_persist_attempts - 1` timers are ever armed.
+    fn scheduleRecoveryRetry(self: *App) void {
+        self.stopRecoveryRetryTimer();
+        const timer_id = sys.SetTimer(null, 0, recovery_ready_retry_delay_ms, null);
+        if (timer_id == 0) {
+            log.warn("failed to start win32 recovery retry timer err={}", .{windows.kernel32.GetLastError()});
+            // Fall back to an immediate wake: a spaced retry is better, but
+            // an unresolved launch that never retries at all is worse.
+            self.wakeup();
+            return;
+        }
+        self.recovery_retry_timer_id = timer_id;
+    }
+
+    fn stopRecoveryRetryTimer(self: *App) void {
+        if (self.recovery_retry_timer_id) |timer_id| {
+            _ = sys.KillTimer(null, timer_id);
+            self.recovery_retry_timer_id = null;
+        }
     }
 
     fn stopUndoPruneTimer(self: *App) void {
@@ -35140,6 +35193,28 @@ test "win32 recovery ready marker keeps retrying transient write failures" {
     var oom: RecoveryReadyRetry = .{};
     try std.testing.expect(oom.recordFailure(error.OutOfMemory));
     try std.testing.expectEqual(@as(u8, 1), oom.failures);
+}
+
+test "win32 recovery ready marker schedules a bounded number of retries" {
+    // `GetMessageW` blocks, so an attempt that is not scheduled simply never
+    // runs; an unbounded schedule would spin the loop instead. Drive the same
+    // decision `resolveRecoveryStartup` makes: arm another timer only while
+    // the budget survives.
+    var retry: RecoveryReadyRetry = .{};
+    var attempts: u8 = 0;
+    var scheduled: u8 = 0;
+    while (true) {
+        attempts += 1;
+        if (retry.recordFailure(error.AccessDenied)) break;
+        scheduled += 1;
+        try std.testing.expect(scheduled < recovery_ready_persist_attempts);
+    }
+    try std.testing.expectEqual(recovery_ready_persist_attempts, attempts);
+    try std.testing.expectEqual(recovery_ready_persist_attempts - 1, scheduled);
+
+    // OutOfMemory resolves on the first failure, so it arms no timer at all.
+    var oom: RecoveryReadyRetry = .{};
+    try std.testing.expect(oom.recordFailure(error.OutOfMemory));
 }
 
 test "win32 safe mode notice waits for the launch to resolve on disk" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2577,6 +2577,127 @@ const recovery_safe_mode_caption_w = std.unicode.utf8ToUtf16LeStringLiteral("noc
 /// sources so cross-instance cleanup can never delete an in-flight write.
 const recovery_pending_suffix = ".pending-";
 
+/// How long a ledger transaction waits for another instance to finish its own
+/// before giving up. Holders only ever do one small read-merge-write, so a
+/// wait this long means something is wrong on the other side; startup must
+/// not block on it.
+const recovery_ledger_lock_wait_ms: u32 = 2000;
+const recovery_ledger_lock_poll_ms: u32 = 10;
+
+/// Serialises every read-merge-append-replace of the startup ledger across
+/// processes. Two instances launched at once — a double-click, a jump-list
+/// entry plus a shortcut, `wt`-style shell integrations — each load the
+/// ledger, append their own attempt and replace the file; the atomic replace
+/// keeps the file well-formed but the later writer still overwrites the
+/// earlier writer's record. Atomicity was never the problem, serialisation
+/// was.
+///
+/// The lock is a byte-range lock on a sibling `.lock` file. Windows releases
+/// it when the holding process exits by any means, so a crashed holder cannot
+/// wedge later launches. The sibling is never deleted: removing it while
+/// another instance waits on its own handle would let a third instance create
+/// a fresh file and lock that instead, splitting the lock in two.
+const RecoveryLedgerLock = struct {
+    file: std.fs.File,
+
+    /// Returns null when the lock could not be taken inside `wait_ms`; the
+    /// caller decides whether that means skip or retry. Errors are the
+    /// sibling file itself being unusable, which usually means the ledger
+    /// directory is too.
+    fn acquire(alloc: Allocator, ledger_path: []const u8, wait_ms: u32) !?RecoveryLedgerLock {
+        if (std.fs.path.dirname(ledger_path)) |dir| {
+            std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+        }
+        const lock_path = try std.fmt.allocPrint(alloc, "{s}.lock", .{ledger_path});
+        defer alloc.free(lock_path);
+        // Open-if-exists, never truncate: the file's bytes are irrelevant and
+        // every instance must land on the same one.
+        const file = try std.fs.createFileAbsolute(lock_path, .{ .truncate = false, .read = true });
+        errdefer file.close();
+
+        const deadline = std.time.milliTimestamp() + wait_ms;
+        while (true) {
+            if (try tryLockExclusive(file)) return .{ .file = file };
+            if (std.time.milliTimestamp() >= deadline) {
+                file.close();
+                return null;
+            }
+            std.Thread.sleep(recovery_ledger_lock_poll_ms * std.time.ns_per_ms);
+        }
+    }
+
+    fn release(self: *RecoveryLedgerLock) void {
+        var io_status_block: windows.IO_STATUS_BLOCK = undefined;
+        windows.UnlockFile(
+            self.file.handle,
+            &io_status_block,
+            &lock_range_off,
+            &lock_range_len,
+            null,
+        ) catch |err| {
+            // Closing the handle drops the lock regardless.
+            log.warn("win32 recovery: ledger unlock failed err={}", .{err});
+        };
+        self.file.close();
+        self.* = undefined;
+    }
+
+    const lock_range_off: windows.LARGE_INTEGER = 0;
+    const lock_range_len: windows.LARGE_INTEGER = 1;
+
+    /// `std.fs.File.tryLock` does not compile on Windows in Zig 0.15.2 (its
+    /// `.none` arm returns `void` from a `!bool` function), so the NT call is
+    /// made directly with the same one-byte range `std` uses.
+    fn tryLockExclusive(file: std.fs.File) !bool {
+        var io_status_block: windows.IO_STATUS_BLOCK = undefined;
+        windows.LockFile(
+            file.handle,
+            null,
+            null,
+            null,
+            &io_status_block,
+            &lock_range_off,
+            &lock_range_len,
+            null,
+            windows.TRUE, // fail immediately
+            windows.TRUE, // exclusive
+        ) catch |err| switch (err) {
+            error.WouldBlock => return false,
+            else => return err,
+        };
+        return true;
+    }
+};
+
+/// Read and parse the ledger at `path`. Missing, unreadable and invalid
+/// ledgers all read as empty; `context` names the caller in the log line.
+fn readRecoveryLedgerAlloc(
+    alloc: Allocator,
+    path: []const u8,
+    context: []const u8,
+) ?std.json.Parsed(win32_recovery.StartupAttemptRecord) {
+    const file = std.fs.openFileAbsolute(path, .{}) catch |err| {
+        switch (err) {
+            error.FileNotFound => {},
+            else => log.warn("win32 recovery: {s} open failed err={}", .{ context, err }),
+        }
+        return null;
+    };
+    defer file.close();
+    const raw = file.readToEndAlloc(alloc, 64 * 1024) catch |err| {
+        log.warn("win32 recovery: {s} read failed err={}", .{ context, err });
+        return null;
+    };
+    defer alloc.free(raw);
+    return win32_recovery.parseAlloc(alloc, raw) catch |err| {
+        log.warn("win32 recovery: {s} ignored invalid history err={}", .{ context, err });
+        return null;
+    };
+}
+
 fn recoverySafeModeNotice(decision: win32_recovery.Decision) ?[]const u8 {
     return if (decision == .safe_mode) recovery_safe_mode_banner else null;
 }
@@ -2798,35 +2919,44 @@ fn localAppDataPathAlloc(alloc: Allocator, name: []const u8) ?[]u8 {
 fn beginRecoveryStartup(alloc: Allocator) RecoveryStartup {
     const path = localAppDataPathAlloc(alloc, "startup-attempts.json") orelse return .{};
     defer alloc.free(path);
-    return beginRecoveryStartupAtPath(alloc, path, unixMillis());
+    return beginRecoveryStartupAtPath(alloc, path, unixMillis(), recovery_ledger_lock_wait_ms);
 }
 
+/// The whole read -> fold -> append -> replace -> cleanup sequence runs under
+/// `RecoveryLedgerLock`. Without it two instances launching together both
+/// load the same ledger and the second replace silently drops the first
+/// instance's attempt; the `.pending-` fold has the same exposure, since its
+/// delete could remove a record a concurrent startup has not folded yet.
+///
+/// Fail-open: when the lock cannot be taken inside `lock_wait_ms` this launch
+/// still reads the ledger for its safe-mode decision but records nothing, so
+/// `count` stays 0 and no later marker is attempted. An unrecorded launch is
+/// an honest gap in the history; a startup blocked behind a wedged sibling is
+/// the outage this ledger exists to prevent.
 fn beginRecoveryStartupAtPath(
     alloc: Allocator,
     path: []const u8,
     now: u64,
+    lock_wait_ms: u32,
 ) RecoveryStartup {
     var result: RecoveryStartup = .{};
-    var record: win32_recovery.StartupAttemptRecord = .{};
-    var parsed_record: ?std.json.Parsed(win32_recovery.StartupAttemptRecord) = null;
-    defer if (parsed_record) |*parsed| parsed.deinit();
 
-    if (std.fs.openFileAbsolute(path, .{})) |file| {
-        defer file.close();
-        if (file.readToEndAlloc(alloc, 64 * 1024)) |raw| {
-            defer alloc.free(raw);
-            parsed_record = win32_recovery.parseAlloc(alloc, raw) catch |err| invalid: {
-                log.warn("win32 recovery: ignored invalid startup history err={}", .{err});
-                break :invalid null;
-            };
-            if (parsed_record) |*parsed| record = parsed.value;
-        } else |err| {
-            log.warn("win32 recovery: startup history read failed err={}", .{err});
-        }
-    } else |err| switch (err) {
-        error.FileNotFound => {},
-        else => log.warn("win32 recovery: startup history open failed err={}", .{err}),
+    var lock = RecoveryLedgerLock.acquire(alloc, path, lock_wait_ms) catch |err| unlocked: {
+        log.warn("win32 recovery: ledger lock unavailable err={}; startup will not be recorded", .{err});
+        break :unlocked null;
+    };
+    defer if (lock) |*held| held.release();
+    if (lock == null) {
+        log.warn(
+            "win32 recovery: ledger lock not acquired within {d}ms; startup will not be recorded",
+            .{lock_wait_ms},
+        );
     }
+
+    var record: win32_recovery.StartupAttemptRecord = .{};
+    var parsed_record = readRecoveryLedgerAlloc(alloc, path, "startup history");
+    defer if (parsed_record) |*parsed| parsed.deinit();
+    if (parsed_record) |*parsed| record = parsed.value;
 
     var retained_paths: std.ArrayListUnmanaged([]u8) = .empty;
     defer {
@@ -2849,8 +2979,10 @@ fn beginRecoveryStartupAtPath(
         // for whichever process owns them; a concurrently starting instance
         // that deleted one would make that process's ReplaceFileW fail and
         // send it down the in-place fallback, clobbering the record this
-        // process just merged. Keeping the two namespaces disjoint removes
-        // that race without an interprocess lock.
+        // process just merged. The namespaces stay disjoint even though the
+        // ledger lock now serialises ledger transactions: a `.tmp-` can also
+        // be left by a writer that died mid-replace, and nothing here should
+        // have to reason about whether its owner is alive.
         const retained_prefix = std.fmt.allocPrint(
             alloc,
             "{s}" ++ recovery_pending_suffix,
@@ -2898,6 +3030,12 @@ fn beginRecoveryStartupAtPath(
     }
 
     result.decision = win32_recovery.decide(record, now, false, .{});
+    // Everything above was read-only. Nothing below may run unlocked: the
+    // append-and-replace is the lost-update window, and deleting a folded
+    // `.pending-` record is only safe once its contents are on disk under
+    // the same lock.
+    if (lock == null) return result;
+
     const appended = win32_recovery.appendBounded(
         record,
         .{ .started_at_unix_ms = now },
@@ -4341,6 +4479,17 @@ pub const App = struct {
         const path = localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json") orelse return;
         defer self.core_app.alloc.free(path);
 
+        // A phase hint only; a launch that cannot take the lock simply keeps
+        // `init` on disk and the ready marker still resolves it later.
+        var lock = RecoveryLedgerLock.acquire(self.core_app.alloc, path, recovery_ledger_lock_wait_ms) catch |err| {
+            log.warn("win32 recovery: window-created marker skipped, ledger lock unavailable err={}", .{err});
+            return;
+        } orelse {
+            log.warn("win32 recovery: window-created marker skipped, ledger lock busy", .{});
+            return;
+        };
+        defer lock.release();
+
         var persisted: [win32_recovery.max_attempts]win32_recovery.StartupAttempt = undefined;
         @memcpy(persisted[0..current.len], current);
         persisted[current.len - 1].phase = .window_created;
@@ -4363,29 +4512,24 @@ pub const App = struct {
         const memory_attempts = self.recovery_startup.attempts[0..self.recovery_startup.count];
         const target_started_at = memory_attempts[memory_attempts.len - 1].started_at_unix_ms;
         if (memory_attempts[memory_attempts.len - 1].ready_at_unix_ms != null) return;
+        const path = localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json") orelse return;
+        defer self.core_app.alloc.free(path);
+
+        // The disk read and the replace below are one transaction against
+        // other instances' startups and ready markers. A busy lock is
+        // transient in the same way a handle hold is, so it spends a retry
+        // rather than resolving the launch.
+        var lock = (try RecoveryLedgerLock.acquire(
+            self.core_app.alloc,
+            path,
+            recovery_ledger_lock_wait_ms,
+        )) orelse return error.RecoveryLedgerBusy;
+        defer lock.release();
 
         var disk_record: win32_recovery.StartupAttemptRecord = .{};
-        var parsed_record: ?std.json.Parsed(win32_recovery.StartupAttemptRecord) = null;
+        var parsed_record = readRecoveryLedgerAlloc(self.core_app.alloc, path, "ready merge");
         defer if (parsed_record) |*parsed| parsed.deinit();
-        if (localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json")) |path| {
-            defer self.core_app.alloc.free(path);
-            if (std.fs.openFileAbsolute(path, .{})) |file| {
-                defer file.close();
-                if (file.readToEndAlloc(self.core_app.alloc, 64 * 1024)) |raw| {
-                    defer self.core_app.alloc.free(raw);
-                    parsed_record = win32_recovery.parseAlloc(self.core_app.alloc, raw) catch |err| invalid: {
-                        log.warn("win32 recovery: ready merge ignored invalid disk history err={}", .{err});
-                        break :invalid null;
-                    };
-                    if (parsed_record) |*parsed| disk_record = parsed.value;
-                } else |err| {
-                    log.warn("win32 recovery: ready merge read failed err={}", .{err});
-                }
-            } else |err| switch (err) {
-                error.FileNotFound => {},
-                else => log.warn("win32 recovery: ready merge open failed err={}", .{err}),
-            }
-        }
+        if (parsed_record) |*parsed| disk_record = parsed.value;
 
         var merged_attempts: [win32_recovery.max_attempts]win32_recovery.StartupAttempt = undefined;
         const merged = win32_recovery.mergeMarkReady(
@@ -4398,8 +4542,6 @@ pub const App = struct {
             log.warn("win32 recovery: ready marker merge failed err={}", .{err});
             return;
         };
-        const path = localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json") orelse return;
-        defer self.core_app.alloc.free(path);
         persistMergedRecoveryReadyAtPath(
             self.core_app.alloc,
             path,
@@ -35110,7 +35252,7 @@ test "win32 recovery next startup folds retained diagnosis before append" {
     try win32_session_persistence.writeFileInPlace(target, disk_json);
     try win32_session_persistence.writeFileInPlace(pending, pending_json);
 
-    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200, recovery_ledger_lock_wait_ms);
     try std.testing.expectEqual(win32_recovery.Decision.normal, startup.decision);
     try std.testing.expectEqual(@as(usize, 2), startup.count);
     try std.testing.expectEqual(@as(?u64, 150), startup.attempts[0].ready_at_unix_ms);
@@ -35160,7 +35302,7 @@ test "win32 recovery startup leaves another instance's in-flight write temp alon
     try win32_session_persistence.writeFileInPlace(in_flight, in_flight_json);
     try win32_session_persistence.writeFileInPlace(pending, pending_json);
 
-    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200, recovery_ledger_lock_wait_ms);
     try std.testing.expectEqual(@as(usize, 2), startup.count);
 
     // The `.pending-` diagnosis is folded and cleaned up.
@@ -35177,6 +35319,134 @@ test "win32 recovery startup leaves another instance's in-flight write temp alon
     const survivor = try std.fs.cwd().readFileAlloc(std.testing.allocator, in_flight, 64 * 1024);
     defer std.testing.allocator.free(survivor);
     try std.testing.expectEqualStrings(in_flight_json, survivor);
+}
+
+test "win32 recovery ledger lock excludes a second holder until released" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+
+    var first = (try RecoveryLedgerLock.acquire(std.testing.allocator, target, 0)) orelse
+        return error.TestUnexpectedResult;
+    // A second acquisition against the same ledger must time out rather than
+    // succeed, and must time out promptly: the wait is the bound on how long
+    // a startup can be held behind a sibling.
+    const started = std.time.milliTimestamp();
+    try std.testing.expectEqual(
+        @as(?RecoveryLedgerLock, null),
+        try RecoveryLedgerLock.acquire(std.testing.allocator, target, 50),
+    );
+    try std.testing.expect(std.time.milliTimestamp() - started < 1000);
+    first.release();
+
+    // Released, the next taker gets it. The sibling file is left behind on
+    // purpose so every instance keeps locking the same inode.
+    var second = (try RecoveryLedgerLock.acquire(std.testing.allocator, target, 0)) orelse
+        return error.TestUnexpectedResult;
+    second.release();
+    const lock_path = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".lock" });
+    defer std.testing.allocator.free(lock_path);
+    const lock_file = try std.fs.openFileAbsolute(lock_path, .{});
+    lock_file.close();
+}
+
+test "win32 recovery startup fails open when the ledger lock is held" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+    const pending = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".pending-feed" });
+    defer std.testing.allocator.free(pending);
+
+    // Three unresolved attempts on disk: enough for `decide` to pick safe
+    // mode, so the read-only decision is observable even when nothing is
+    // recorded.
+    const disk_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100 },
+        .{ .started_at_unix_ms = 110 },
+        .{ .started_at_unix_ms = 120 },
+    };
+    const disk_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &disk_attempts });
+    defer std.testing.allocator.free(disk_json);
+    try win32_session_persistence.writeFileInPlace(target, disk_json);
+    try win32_session_persistence.writeFileInPlace(pending, disk_json);
+
+    var held = (try RecoveryLedgerLock.acquire(std.testing.allocator, target, 0)) orelse
+        return error.TestUnexpectedResult;
+    const blocked = beginRecoveryStartupAtPath(std.testing.allocator, target, 200, 20);
+    held.release();
+
+    // Decision still made from the ledger; nothing appended, nothing
+    // replaced, nothing folded away.
+    try std.testing.expectEqual(win32_recovery.Decision.safe_mode, blocked.decision);
+    try std.testing.expectEqual(@as(usize, 0), blocked.count);
+    const untouched = try std.fs.cwd().readFileAlloc(std.testing.allocator, target, 64 * 1024);
+    defer std.testing.allocator.free(untouched);
+    try std.testing.expectEqualStrings(disk_json, untouched);
+    const pending_file = try std.fs.openFileAbsolute(pending, .{});
+    pending_file.close();
+
+    // With the lock free the same launch records itself and folds the
+    // retained record.
+    const recorded = beginRecoveryStartupAtPath(std.testing.allocator, target, 200, recovery_ledger_lock_wait_ms);
+    try std.testing.expectEqual(@as(usize, 4), recorded.count);
+    try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(pending, .{}));
+}
+
+const ConcurrentStartupWorker = struct {
+    target: []const u8,
+    now: u64,
+    count: usize = 0,
+
+    fn run(self: *ConcurrentStartupWorker) void {
+        const startup = beginRecoveryStartupAtPath(std.testing.allocator, self.target, self.now, recovery_ledger_lock_wait_ms);
+        self.count = startup.count;
+    }
+};
+
+test "win32 recovery concurrent startups never lose each other's attempt" {
+    // The Greptile reproduction: independent ledger readers that append and
+    // replace the same target. Each worker is a full `beginRecoveryStartupAtPath`
+    // transaction, all released at once; without the lock the final ledger
+    // holds fewer attempts than workers, because a later replace carries only
+    // its own snapshot. One shared timestamp keeps `appendBounded`'s ordering
+    // check out of the picture, so the only thing that can shrink the count
+    // is a lost update.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+
+    const worker_count = 6;
+    var workers: [worker_count]ConcurrentStartupWorker = undefined;
+    var threads: [worker_count]std.Thread = undefined;
+    for (&workers) |*worker| worker.* = .{ .target = target, .now = 500 };
+    for (&threads, &workers) |*thread, *worker| {
+        thread.* = try std.Thread.spawn(.{}, ConcurrentStartupWorker.run, .{worker});
+    }
+    for (&threads) |*thread| thread.join();
+
+    // Every worker got in (nobody timed out), and every worker's snapshot
+    // was one larger than the previous one's — the serialised order.
+    var seen = [_]bool{false} ** worker_count;
+    for (workers) |worker| {
+        try std.testing.expect(worker.count >= 1 and worker.count <= worker_count);
+        try std.testing.expect(!seen[worker.count - 1]);
+        seen[worker.count - 1] = true;
+    }
+
+    const final = try std.fs.cwd().readFileAlloc(std.testing.allocator, target, 64 * 1024);
+    defer std.testing.allocator.free(final);
+    var parsed = try win32_recovery.parseAlloc(std.testing.allocator, final);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, worker_count), parsed.value.attempts.len);
 }
 
 test "win32 recovery fallback failure is consumed by next startup" {
@@ -35223,7 +35493,7 @@ test "win32 recovery fallback failure is consumed by next startup" {
     try std.testing.expectEqual(win32_recovery.StartupPhase.ready_persist_failed, ready_attempts[0].phase);
     try std.testing.expect(ready_attempts[0].last_win32_error != null);
 
-    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200, recovery_ledger_lock_wait_ms);
     try std.testing.expectEqual(win32_recovery.Decision.normal, startup.decision);
     try std.testing.expectEqual(@as(usize, 2), startup.count);
     try std.testing.expectEqual(@as(?u64, 150), startup.attempts[0].ready_at_unix_ms);

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -35241,6 +35241,93 @@ test "win32 recovery fallback failure is consumed by next startup" {
     }
 }
 
+// Why the ready-marker retry below exists.
+//
+// Observed: a ledger write fails in one of two shapes, and only one of them
+// leaves anything behind for a later launch.
+//
+//   C2  `ReplaceFileW`/`MoveFileExW` failed and the in-place fallback also
+//       failed. `writeFileAtomicOrInPlace` has already set `atomic_failure`,
+//       so `persistRecoveryRecordAtPath` takes its retention branch, writes a
+//       `.pending-` record, and the next startup folds it back in. Covered by
+//       "win32 recovery fallback failure is consumed by next startup".
+//
+//   C1  The write failed *before* the replacement was ever attempted: the
+//       temp file could not be created, written or synced. `atomic_failure`
+//       is still null, so `if (atomic_failure) |failure|` is skipped, no
+//       `.pending-` record is written, and the ready marker exists nowhere.
+//       That is what this test pins.
+//
+// What follows from it, separately: the `.pending-` fold is a C2 mechanism
+// only, so C1 has no cross-launch recovery at all and the in-session retry is
+// its only mitigation. A retry rebuilds the temp path from a fresh nonce, so a
+// transient hold on the ledger directory — an anti-virus or backup agent,
+// `ERROR_DELETE_PENDING` on a leftover name, a redirected-profile hiccup — can
+// clear before the next attempt runs.
+//
+// Also inference, not observation: C1 is consistent with #149's reported
+// symptom, a ledger holding 16 attempts and zero ready markers with no
+// recorded cause. It was never confirmed to be C1 — the pre-fix schema
+// recorded no error — so treat this as a reason not to remove the mitigation,
+// not as a diagnosis.
+//
+// Two consequences for anyone editing this area:
+//
+//   - Do not delete the retry on the grounds that the `.pending-` fold already
+//     recovers a failed write. It recovers C2. This test is C1.
+//   - Retaining a `.pending-` record unconditionally, rather than only when
+//     `atomic_failure` is set, looks like a cheaper close but is only partial:
+//     in C1 the directory itself is usually what failed, so writing
+//     `.pending-` into that same directory fails too. It would cover only the
+//     narrow case where one temp filename was unusable but another works.
+test "win32 recovery ready-write failure before atomic replace leaves nothing for the pending fold" {
+    // Hermetic: everything lives under a temp dir this test owns, and
+    // `tmp.cleanup()` runs on the failure path too. The real
+    // `%LOCALAPPDATA%\noctty\` is never touched — `persistRecoveryRecordAtPath`
+    // takes its path as a parameter precisely so this is possible.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    // A regular file where the ledger's parent directory should be. That makes
+    // `makeDirAbsolute` report PathAlreadyExists, which is swallowed, and then
+    // makes the temp-file creation fail — a failure strictly before
+    // `replaceFileAtomic`, so `atomic_failure` is never set. This is the only
+    // way found to reach C1 deterministically; a sharing violation on the temp
+    // name cannot be staged, because the name carries a fresh pid+nonce.
+    {
+        var blocker = try tmp.dir.createFile("blocker", .{});
+        blocker.close();
+    }
+    const target = try std.fs.path.join(
+        std.testing.allocator,
+        &.{ root, "blocker", "startup-attempts.json" },
+    );
+    defer std.testing.allocator.free(target);
+
+    var ready = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .ready_at_unix_ms = 150, .phase = .ready },
+    };
+    // The error must escape: it is what drives `resolveRecoveryStartup` to
+    // spend a retry rather than treat the launch as resolved. The identity of
+    // the error is not the contract — which one Windows reports for a path
+    // under a regular file is its business — only that it is not swallowed.
+    if (persistRecoveryRecordAtPath(std.testing.allocator, target, &ready)) {
+        return error.TestExpectedError;
+    } else |_| {}
+
+    // And nothing was left behind for a later startup to fold, which is the
+    // whole point: without the retry this ready marker is simply gone.
+    var dir = try std.fs.openDirAbsolute(root, .{ .iterate = true });
+    defer dir.close();
+    var entries = dir.iterate();
+    while (try entries.next()) |entry| {
+        try std.testing.expect(std.mem.indexOf(u8, entry.name, recovery_pending_suffix) == null);
+        try std.testing.expect(std.mem.indexOf(u8, entry.name, ".tmp-") == null);
+    }
+}
+
 test "win32 recovery ready marker keeps retrying transient write failures" {
     // A failed attempt must not resolve the launch: latching on the first
     // failure is what leaves an unresolved attempt on disk for the whole

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2563,6 +2563,41 @@ const RecoveryStartup = struct {
     decision: win32_recovery.Decision = .normal,
 };
 
+const recovery_safe_mode_banner =
+    "Safe mode: repeated incomplete startups. Built-in defaults are active; your config and saved session were not loaded. Restart noctty to retry normal startup.";
+const recovery_safe_mode_banner_w = blk: {
+    @setEvalBranchQuota(2_000);
+    break :blk std.unicode.utf8ToUtf16LeStringLiteral(recovery_safe_mode_banner);
+};
+const recovery_safe_mode_caption_w = std.unicode.utf8ToUtf16LeStringLiteral("noctty safe mode");
+
+fn recoverySafeModeNotice(decision: win32_recovery.Decision) ?[]const u8 {
+    return if (decision == .safe_mode) recovery_safe_mode_banner else null;
+}
+
+fn recoverySafeModeNoticeThread() void {
+    _ = sys.MessageBoxW(
+        null,
+        recovery_safe_mode_banner_w,
+        recovery_safe_mode_caption_w,
+        c.MB_OK | c.MB_ICONINFORMATION | c.MB_SETFOREGROUND,
+    );
+}
+
+fn persistMergedRecoveryReadyAtPath(
+    alloc: Allocator,
+    path: []const u8,
+    startup: *RecoveryStartup,
+    merged: win32_recovery.StartupAttemptRecord,
+) !void {
+    var persisted_attempts: [win32_recovery.max_attempts]win32_recovery.StartupAttempt = undefined;
+    @memcpy(persisted_attempts[0..merged.attempts.len], merged.attempts);
+    const persisted = persisted_attempts[0..merged.attempts.len];
+    try persistRecoveryRecordAtPath(alloc, path, persisted);
+    @memcpy(startup.attempts[0..persisted.len], persisted);
+    startup.count = persisted.len;
+}
+
 fn unixMillis() u64 {
     return @intCast(@max(std.time.milliTimestamp(), 0));
 }
@@ -2645,29 +2680,94 @@ fn localAppDataPathAlloc(alloc: Allocator, name: []const u8) ?[]u8 {
 }
 
 fn beginRecoveryStartup(alloc: Allocator) RecoveryStartup {
+    const path = localAppDataPathAlloc(alloc, "startup-attempts.json") orelse return .{};
+    defer alloc.free(path);
+    return beginRecoveryStartupAtPath(alloc, path, unixMillis());
+}
+
+fn beginRecoveryStartupAtPath(
+    alloc: Allocator,
+    path: []const u8,
+    now: u64,
+) RecoveryStartup {
     var result: RecoveryStartup = .{};
-    const now = unixMillis();
     var record: win32_recovery.StartupAttemptRecord = .{};
     var parsed_record: ?std.json.Parsed(win32_recovery.StartupAttemptRecord) = null;
     defer if (parsed_record) |*parsed| parsed.deinit();
 
-    if (localAppDataPathAlloc(alloc, "startup-attempts.json")) |path| {
-        defer alloc.free(path);
-        if (std.fs.openFileAbsolute(path, .{})) |file| {
-            defer file.close();
-            if (file.readToEndAlloc(alloc, 64 * 1024)) |raw| {
-                defer alloc.free(raw);
-                parsed_record = win32_recovery.parseAlloc(alloc, raw) catch |err| invalid: {
-                    log.warn("win32 recovery: ignored invalid startup history err={}", .{err});
-                    break :invalid null;
-                };
-                if (parsed_record) |*parsed| record = parsed.value;
-            } else |err| {
-                log.warn("win32 recovery: startup history read failed err={}", .{err});
-            }
-        } else |err| switch (err) {
-            error.FileNotFound => {},
-            else => log.warn("win32 recovery: startup history open failed err={}", .{err}),
+    if (std.fs.openFileAbsolute(path, .{})) |file| {
+        defer file.close();
+        if (file.readToEndAlloc(alloc, 64 * 1024)) |raw| {
+            defer alloc.free(raw);
+            parsed_record = win32_recovery.parseAlloc(alloc, raw) catch |err| invalid: {
+                log.warn("win32 recovery: ignored invalid startup history err={}", .{err});
+                break :invalid null;
+            };
+            if (parsed_record) |*parsed| record = parsed.value;
+        } else |err| {
+            log.warn("win32 recovery: startup history read failed err={}", .{err});
+        }
+    } else |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("win32 recovery: startup history open failed err={}", .{err}),
+    }
+
+    var retained_paths: std.ArrayListUnmanaged([]u8) = .empty;
+    defer {
+        for (retained_paths.items) |retained_path| alloc.free(retained_path);
+        retained_paths.deinit(alloc);
+    }
+    var retained_merge_buffers: [2][win32_recovery.max_attempts]win32_recovery.StartupAttempt = undefined;
+    var retained_merge_buffer_index: usize = 0;
+    if (std.fs.path.dirname(path)) |dir_path| retained: {
+        var dir = std.fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch |err| {
+            log.warn("win32 recovery: retained history directory open failed err={}", .{err});
+            break :retained;
+        };
+        defer dir.close();
+        const temporary_prefix = std.fmt.allocPrint(
+            alloc,
+            "{s}.tmp-",
+            .{std.fs.path.basename(path)},
+        ) catch break :retained;
+        defer alloc.free(temporary_prefix);
+        var entries = dir.iterate();
+        while (true) {
+            const entry = entries.next() catch |err| {
+                log.warn("win32 recovery: retained history enumeration failed err={}", .{err});
+                break;
+            } orelse break;
+            if (!std.mem.startsWith(u8, entry.name, temporary_prefix)) continue;
+            const retained_path = std.fs.path.join(alloc, &.{ dir_path, entry.name }) catch continue;
+            const retained_file = std.fs.openFileAbsolute(retained_path, .{}) catch {
+                alloc.free(retained_path);
+                continue;
+            };
+            defer retained_file.close();
+            const raw = retained_file.readToEndAlloc(alloc, 64 * 1024) catch {
+                alloc.free(retained_path);
+                continue;
+            };
+            defer alloc.free(raw);
+            var parsed = win32_recovery.parseAlloc(alloc, raw) catch {
+                alloc.free(retained_path);
+                continue;
+            };
+            defer parsed.deinit();
+            const merged = win32_recovery.mergeRecords(
+                record,
+                parsed.value,
+                &retained_merge_buffers[retained_merge_buffer_index],
+            ) catch {
+                alloc.free(retained_path);
+                continue;
+            };
+            retained_paths.append(alloc, retained_path) catch {
+                alloc.free(retained_path);
+                continue;
+            };
+            record = merged;
+            retained_merge_buffer_index = 1 - retained_merge_buffer_index;
         }
     }
 
@@ -2681,21 +2781,93 @@ fn beginRecoveryStartup(alloc: Allocator) RecoveryStartup {
         return result;
     };
     result.count = appended.attempts.len;
-    persistRecoveryRecord(alloc, result.attempts[0..result.count]) catch |err| {
+    persistRecoveryRecordAtPath(alloc, path, result.attempts[0..result.count]) catch |err| {
         log.warn("win32 recovery: startup marker persist failed err={}", .{err});
+        return result;
     };
+    for (retained_paths.items) |retained_path| {
+        win32_session_persistence.deleteFileIfPresent(retained_path) catch |err| {
+            log.warn("win32 recovery: merged retained history cleanup failed path={s} err={}", .{ retained_path, err });
+        };
+    }
     return result;
 }
 
-fn persistRecoveryRecord(
+fn persistRecoveryRecordAtPath(
     alloc: Allocator,
-    attempts: []const win32_recovery.StartupAttempt,
+    path: []const u8,
+    attempts: []win32_recovery.StartupAttempt,
 ) !void {
-    const path = localAppDataPathAlloc(alloc, "startup-attempts.json") orelse return;
-    defer alloc.free(path);
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+    }
     const encoded = try win32_recovery.encodeAlloc(alloc, .{ .attempts = attempts });
     defer alloc.free(encoded);
-    try writePersistentFileAlloc(alloc, path, encoded);
+    const nonce = unixMillis();
+    const temporary_path = try std.fmt.allocPrint(
+        alloc,
+        "{s}.tmp-{x}-{x}",
+        .{ path, sys.GetCurrentProcessId(), nonce },
+    );
+    defer alloc.free(temporary_path);
+    var atomic_failure: ?win32_session_persistence.AtomicReplaceFailure = null;
+    const disposition = win32_session_persistence.writeFileAtomicOrInPlace(
+        path,
+        temporary_path,
+        encoded,
+        &atomic_failure,
+    ) catch |err| {
+        if (atomic_failure) |failure| {
+            recordRecoveryPersistFailure(attempts, failure.move_error);
+            retainRecoveryPersistDiagnosis(
+                alloc,
+                temporary_path,
+                attempts,
+            );
+        }
+        return err;
+    };
+    switch (disposition) {
+        .atomic => {},
+        .in_place => |failure| {
+            recordRecoveryPersistFailure(attempts, failure.move_error);
+            const diagnosed = try win32_recovery.encodeAlloc(alloc, .{ .attempts = attempts });
+            defer alloc.free(diagnosed);
+            win32_session_persistence.writeFileInPlace(path, diagnosed) catch |err| {
+                log.warn("win32 recovery: in-place diagnosis persist failed err={}", .{err});
+                retainRecoveryPersistDiagnosis(
+                    alloc,
+                    temporary_path,
+                    attempts,
+                );
+            };
+        },
+    }
+}
+
+fn recordRecoveryPersistFailure(
+    attempts: []win32_recovery.StartupAttempt,
+    raw_win32_error: u32,
+) void {
+    if (attempts.len == 0) return;
+    const latest = &attempts[attempts.len - 1];
+    if (latest.ready_at_unix_ms != null) latest.phase = .ready_persist_failed;
+    latest.last_win32_error = raw_win32_error;
+}
+
+fn retainRecoveryPersistDiagnosis(
+    alloc: Allocator,
+    temporary_path: []const u8,
+    attempts: []const win32_recovery.StartupAttempt,
+) void {
+    const diagnosed = win32_recovery.encodeAlloc(alloc, .{ .attempts = attempts }) catch return;
+    defer alloc.free(diagnosed);
+    win32_session_persistence.writeFileInPlace(temporary_path, diagnosed) catch |err| {
+        log.warn("win32 recovery: retained diagnosis persist failed err={}", .{err});
+    };
 }
 
 fn writePersistentFileAlloc(alloc: Allocator, path: []const u8, data: []const u8) !void {
@@ -2987,6 +3159,7 @@ pub const App = struct {
     /// never forwarded through the serialized single-instance IPC channel.
     embedding_mode: bool = false,
     recovery_startup: RecoveryStartup = .{},
+    recovery_first_tick_completed: bool = false,
     /// Top-level shell composition only. Terminal child HWNDs retain their
     /// existing WGL/SwapBuffers ownership regardless of this backend state.
     shell_compositor_driver: win32_compositor_native.NativeDriver = undefined,
@@ -3145,6 +3318,15 @@ pub const App = struct {
             @tagName(compositor_status.state),
             if (compositor_status.fallback_reason) |reason| @tagName(reason) else null,
         });
+
+        // Core conditional configuration defaults to light. Synchronize it
+        // with Windows before the first surface is created so conditional
+        // themes and terminal color-scheme reports start on the right branch.
+        // No surfaces or hosts exist yet: the resulting app config-change is
+        // intentionally valid before `run`, and its topology loops are empty.
+        self.syncSystemColorScheme() catch |err| {
+            log.warn("initial win32 color scheme sync failed err={}", .{err});
+        };
     }
 
     /// Bring the STA apartment online for in-process COM consumers
@@ -3176,7 +3358,19 @@ pub const App = struct {
 
         try self.ensureWindowClass();
 
-        if (!self.embedding_mode and !self.safe_mode and try self.tryForwardStartupToExistingInstance()) {
+        const forwarded = if (self.embedding_mode or self.safe_mode)
+            false
+        else
+            self.tryForwardStartupToExistingInstance() catch |err| switch (err) {
+                // A busy or rejecting primary must not turn this launch into
+                // false crash-loop evidence. Continue as a local instance.
+                error.IPCFailed => failed: {
+                    log.warn("win32 startup forwarding failed; continuing locally", .{});
+                    break :failed false;
+                },
+                else => return err,
+            };
+        if (forwarded) {
             // Forwarding is a successful startup outcome for this process.
             // Mark it ready so repeated new-window launches cannot accumulate
             // false crash-loop evidence and trigger automatic safe mode.
@@ -3254,6 +3448,12 @@ pub const App = struct {
             log.info("initial-window is disabled; win32 runtime waiting without a window", .{});
         }
 
+        if (self.windows.items.len > 0) self.markRecoveryWindowCreated();
+
+        if (recoverySafeModeNotice(self.recovery_startup.decision)) |notice| {
+            self.showRecoverySafeModeNotice(notice);
+        }
+
         if (!self.embedding_mode) self.initializeJumpList();
         if (!self.embedding_mode) self.scheduleGlobalHotkeySync();
         if (!self.embedding_mode and self.global_hotkeys_dirty and self.windows.items.len == 0) {
@@ -3263,8 +3463,6 @@ pub const App = struct {
             };
         }
         if (!self.embedding_mode and self.windows.items.len == 0) self.startQuitTimer();
-
-        self.markRecoveryReady();
 
         var msg: MSG = undefined;
         while (true) {
@@ -3279,7 +3477,7 @@ pub const App = struct {
                         log.err("failed to sync win32 global hotkeys err={}", .{err});
                     };
                 }
-                try self.core_app.tick(self);
+                try self.tickCoreApp();
                 if (!self.running and self.windows.items.len == 0) break;
                 continue;
             }
@@ -3291,7 +3489,7 @@ pub const App = struct {
                     self.core_app.alloc.destroy(completion);
                 }
                 self.handleUpdateCheckCompletion(completion);
-                try self.core_app.tick(self);
+                try self.tickCoreApp();
                 if (!self.running and self.windows.items.len == 0) break;
                 continue;
             }
@@ -3303,7 +3501,7 @@ pub const App = struct {
                 if (!self.handleToastActivation(activation.*)) {
                     self.pending_toast_activation = activation.*;
                 }
-                try self.core_app.tick(self);
+                try self.tickCoreApp();
                 if (!self.running and self.windows.items.len == 0) break;
                 continue;
             }
@@ -3443,7 +3641,7 @@ pub const App = struct {
             // standard Win32 accessibility semantics.
             if (self.settings_window.hwnd) |settings_hwnd| {
                 if (sys.IsDialogMessageW(settings_hwnd, &msg) != 0) {
-                    try self.core_app.tick(self);
+                    try self.tickCoreApp();
                     continue;
                 }
             }
@@ -3458,7 +3656,7 @@ pub const App = struct {
                 };
             }
 
-            try self.core_app.tick(self);
+            try self.tickCoreApp();
 
             if (!self.running and self.windows.items.len == 0) break;
         }
@@ -3897,6 +4095,38 @@ pub const App = struct {
         log.warn("win32 session restore: quarantined unreadable state path={s} parse_err={}", .{ destination, parse_error });
     }
 
+    fn tickCoreApp(self: *App) !void {
+        try self.core_app.tick(self);
+        if (self.recovery_first_tick_completed) return;
+        // A launch is unresolved until the outer Win32 message loop completes
+        // its first core-app tick. Renderer and PTY work that continues on
+        // other threads after this boundary is outside recovery accounting.
+        self.recovery_first_tick_completed = true;
+        self.markRecoveryReady();
+    }
+
+    fn markRecoveryWindowCreated(self: *App) void {
+        if (self.recovery_startup.count == 0) return;
+        const current = self.recovery_startup.attempts[0..self.recovery_startup.count];
+        const latest = &current[current.len - 1];
+        if (latest.ready_at_unix_ms != null or latest.phase != .init) return;
+        const path = localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json") orelse return;
+        defer self.core_app.alloc.free(path);
+
+        var persisted: [win32_recovery.max_attempts]win32_recovery.StartupAttempt = undefined;
+        @memcpy(persisted[0..current.len], current);
+        persisted[current.len - 1].phase = .window_created;
+        persistRecoveryRecordAtPath(
+            self.core_app.alloc,
+            path,
+            persisted[0..current.len],
+        ) catch |err| {
+            log.warn("win32 recovery: window-created marker persist failed err={}", .{err});
+            return;
+        };
+        @memcpy(current, persisted[0..current.len]);
+    }
+
     fn markRecoveryReady(self: *App) void {
         if (self.recovery_startup.count == 0) return;
         const memory_attempts = self.recovery_startup.attempts[0..self.recovery_startup.count];
@@ -3937,11 +4167,13 @@ pub const App = struct {
             log.warn("win32 recovery: ready marker merge failed err={}", .{err});
             return;
         };
-        @memcpy(self.recovery_startup.attempts[0..merged.attempts.len], merged.attempts);
-        self.recovery_startup.count = merged.attempts.len;
-        persistRecoveryRecord(
+        const path = localAppDataPathAlloc(self.core_app.alloc, "startup-attempts.json") orelse return;
+        defer self.core_app.alloc.free(path);
+        persistMergedRecoveryReadyAtPath(
             self.core_app.alloc,
-            self.recovery_startup.attempts[0..self.recovery_startup.count],
+            path,
+            &self.recovery_startup,
+            merged,
         ) catch |err| log.warn("win32 recovery: ready marker persist failed err={}", .{err});
     }
 
@@ -4899,6 +5131,14 @@ pub const App = struct {
         try showInfoMessage(.app, "noctty", message);
     }
 
+    fn showRecoverySafeModeNotice(_: *App, _: []const u8) void {
+        var thread = std.Thread.spawn(.{}, recoverySafeModeNoticeThread, .{}) catch |err| {
+            log.warn("win32 recovery: safe-mode notice thread failed err={}", .{err});
+            return;
+        };
+        thread.detach();
+    }
+
     /// True when any user-facing top-level UI window is still alive —
     /// either a terminal Host or the settings window. The quit timer
     /// and message-loop exit check both use this so the app doesn't
@@ -5291,14 +5531,15 @@ pub const App = struct {
             },
 
             .reload_config => {
-                if (target != .app) return false;
                 if (value.soft) {
-                    try self.core_app.updateConfig(self, &self.config);
-                    if (self.config.@"app-notifications".@"config-reload") {
-                        try self.showDesktopNotification(.app, "noctty", "Configuration reloaded");
+                    switch (target) {
+                        .app => try self.core_app.updateConfig(self, &self.config),
+                        .surface => |core_surface| try core_surface.updateConfig(&self.config),
                     }
                     return true;
                 }
+
+                if (target != .app) return false;
 
                 // Same startup-cwd restoration dance as
                 // `settingsSaveAndReload`: `Config.load` calls
@@ -6591,6 +6832,18 @@ pub const App = struct {
                 log.warn("win32 scrollbar refresh failed err={}", .{err});
             };
         }
+    }
+
+    fn syncSystemColorScheme(self: *App) !void {
+        const scheme: apprt.ColorScheme = if (isSystemDarkMode()) .dark else .light;
+
+        // Surface state must change before the app-wide reload because
+        // App.updateConfig applies each surface's own conditional state and
+        // Termio reports mode 2031 only after installing that derived config.
+        for (self.windows.items) |surface| {
+            surface.core().colorSchemeCallback(scheme);
+        }
+        try self.core_app.colorSchemeEvent(self, scheme);
     }
 
     fn reconfigureTheme(self: *App) void {
@@ -11399,7 +11652,7 @@ const Host = struct {
                 .name = theme.name,
                 .display_name = self.storePaletteCatalogLabel(theme.name),
                 .description = switch (theme.location) {
-                    .user => "User theme",
+                    .user, .legacy_user => "User theme",
                     .resources => "Bundled theme",
                 },
                 .enabled = true,
@@ -18603,6 +18856,27 @@ fn isSystemDarkMode() bool {
     return data == 0; // 0 = dark mode, 1 = light mode
 }
 
+const immersive_color_set_w = std.unicode.utf8ToUtf16LeStringLiteral("ImmersiveColorSet");
+
+fn settingChangeIsImmersiveColorSet(lParam: LPARAM) bool {
+    if (lParam == 0) return false;
+    const raw: usize = @bitCast(lParam);
+    const setting_name: [*:0]const u16 = @ptrFromInt(raw);
+    return std.mem.eql(
+        u16,
+        std.mem.span(setting_name),
+        immersive_color_set_w[0..immersive_color_set_w.len],
+    );
+}
+
+test "issue149 Windows setting change filters terminal color sync" {
+    const immersive = std.unicode.utf8ToUtf16LeStringLiteral("ImmersiveColorSet");
+    const unrelated = std.unicode.utf8ToUtf16LeStringLiteral("Environment");
+    try std.testing.expect(settingChangeIsImmersiveColorSet(@bitCast(@intFromPtr(immersive))));
+    try std.testing.expect(!settingChangeIsImmersiveColorSet(@bitCast(@intFromPtr(unrelated))));
+    try std.testing.expect(!settingChangeIsImmersiveColorSet(0));
+}
+
 fn readDynamicScrollbars(default_value: bool) bool {
     const subkey = std.unicode.utf8ToUtf16LeStringLiteral("Control Panel\\Accessibility");
     const value_name = std.unicode.utf8ToUtf16LeStringLiteral("DynamicScrollbars");
@@ -21931,6 +22205,11 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
                 v.app.refreshSystemWheelSettings();
                 v.app.refreshSystemScrollbarPreference();
                 v.app.reconfigureTheme();
+                if (settingChangeIsImmersiveColorSet(lParam)) {
+                    v.app.syncSystemColorScheme() catch |err| {
+                        log.warn("win32 color scheme sync failed err={}", .{err});
+                    };
+                }
             }
             return sys.DefWindowProcW(hwnd, msg, wParam, lParam);
         },
@@ -34496,6 +34775,130 @@ test "win32 safe mode never mutates saved session state" {
 test "win32 layout action result propagates automation failure" {
     try std.testing.expect(try layoutActionResult(true));
     try std.testing.expectError(error.LayoutActionFailed, layoutActionResult(false));
+}
+
+test "win32 recovery failed ready persistence does not commit memory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("startup-attempts.json");
+    const target = try tmp.dir.realpathAlloc(std.testing.allocator, "startup-attempts.json");
+    defer std.testing.allocator.free(target);
+
+    var startup: RecoveryStartup = .{};
+    startup.attempts[0] = .{ .started_at_unix_ms = 100 };
+    startup.count = 1;
+    const merged_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .ready_at_unix_ms = 120 },
+    };
+
+    if (persistMergedRecoveryReadyAtPath(
+        std.testing.allocator,
+        target,
+        &startup,
+        .{ .attempts = &merged_attempts },
+    )) {
+        return error.TestExpectedError;
+    } else |_| {}
+    try std.testing.expectEqual(@as(?u64, null), startup.attempts[0].ready_at_unix_ms);
+}
+
+test "win32 recovery next startup folds retained diagnosis before append" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+    const pending = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".tmp-dead-beef" });
+    defer std.testing.allocator.free(pending);
+
+    const disk_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .phase = .window_created },
+    };
+    const pending_attempts = [_]win32_recovery.StartupAttempt{
+        .{
+            .started_at_unix_ms = 100,
+            .ready_at_unix_ms = 150,
+            .phase = .ready_persist_failed,
+            .last_win32_error = 32,
+        },
+    };
+    const disk_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &disk_attempts });
+    defer std.testing.allocator.free(disk_json);
+    const pending_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &pending_attempts });
+    defer std.testing.allocator.free(pending_json);
+    try win32_session_persistence.writeFileInPlace(target, disk_json);
+    try win32_session_persistence.writeFileInPlace(pending, pending_json);
+
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    try std.testing.expectEqual(win32_recovery.Decision.normal, startup.decision);
+    try std.testing.expectEqual(@as(usize, 2), startup.count);
+    try std.testing.expectEqual(@as(?u64, 150), startup.attempts[0].ready_at_unix_ms);
+    try std.testing.expectEqual(win32_recovery.StartupPhase.ready_persist_failed, startup.attempts[0].phase);
+    try std.testing.expectEqual(@as(?u32, 32), startup.attempts[0].last_win32_error);
+    try std.testing.expectEqual(win32_recovery.StartupPhase.init, startup.attempts[1].phase);
+    try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(pending, .{}));
+}
+
+test "win32 recovery fallback failure is consumed by next startup" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+    const disk_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .phase = .window_created },
+    };
+    const disk_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &disk_attempts });
+    defer std.testing.allocator.free(disk_json);
+    try win32_session_persistence.writeFileInPlace(target, disk_json);
+
+    const target_w = try std.unicode.utf8ToUtf16LeAllocZ(std.testing.allocator, target);
+    defer std.testing.allocator.free(target_w);
+    const held = windows.kernel32.CreateFileW(
+        target_w.ptr,
+        windows.GENERIC_READ,
+        windows.FILE_SHARE_READ,
+        null,
+        windows.OPEN_EXISTING,
+        windows.FILE_ATTRIBUTE_NORMAL,
+        null,
+    );
+    if (held == windows.INVALID_HANDLE_VALUE) return error.TestUnexpectedResult;
+    var ready_attempts = [_]win32_recovery.StartupAttempt{
+        .{
+            .started_at_unix_ms = 100,
+            .ready_at_unix_ms = 150,
+            .phase = .ready,
+        },
+    };
+    if (persistRecoveryRecordAtPath(std.testing.allocator, target, &ready_attempts)) {
+        _ = windows.CloseHandle(held);
+        return error.TestExpectedError;
+    } else |_| {
+        _ = windows.CloseHandle(held);
+    }
+    try std.testing.expectEqual(win32_recovery.StartupPhase.ready_persist_failed, ready_attempts[0].phase);
+    try std.testing.expect(ready_attempts[0].last_win32_error != null);
+
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    try std.testing.expectEqual(win32_recovery.Decision.normal, startup.decision);
+    try std.testing.expectEqual(@as(usize, 2), startup.count);
+    try std.testing.expectEqual(@as(?u64, 150), startup.attempts[0].ready_at_unix_ms);
+    try std.testing.expectEqual(win32_recovery.StartupPhase.ready_persist_failed, startup.attempts[0].phase);
+    try std.testing.expect(startup.attempts[0].last_win32_error != null);
+}
+
+test "win32 recovery safe mode always has a visible notice" {
+    try std.testing.expectEqualStrings(
+        recovery_safe_mode_banner,
+        recoverySafeModeNotice(.safe_mode).?,
+    );
+    try std.testing.expectEqual(@as(?[]const u8, null), recoverySafeModeNotice(.normal));
+    try std.testing.expectEqual(@as(?[]const u8, null), recoverySafeModeNotice(.quarantine_session));
 }
 
 test "win32 explicit startup flows bypass session restore" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2593,6 +2593,38 @@ const recovery_ready_persist_attempts: u8 = 3;
 /// `(recovery_ready_persist_attempts - 1) * this` late.
 const recovery_ready_retry_delay_ms: u32 = 750;
 
+/// May a tick spend a ready-marker attempt yet?
+///
+/// The retry timer only guarantees that an attempt *happens*; it cannot stop
+/// an earlier unrelated tick — PTY output, a keystroke, a resize — from
+/// reaching `resolveRecoveryStartup` first and spending the attempt with no
+/// delay at all. A busy terminal would therefore burn the whole budget in
+/// microseconds, which is the same defect as retrying on a bare wake. The
+/// deadline is what actually makes the spacing real, for every transport.
+fn recoveryRetryDue(not_before_ms: ?u64, now_ms: u64) bool {
+    const deadline = not_before_ms orelse return true;
+    return now_ms >= deadline;
+}
+
+/// What to do after a ready-marker attempt failed.
+const RecoveryFailureAction = enum {
+    /// Budget survives and a spaced retry is armed.
+    retry_scheduled,
+    /// Budget survives but no retry could be armed, so nothing will bring the
+    /// loop back. Retrying immediately instead would spend the remaining
+    /// attempts in microseconds — the busy retry the delay exists to prevent —
+    /// and would still end with the marker unresolved, just with the failure
+    /// counted three times and the log claiming retries that never waited.
+    give_up_unschedulable,
+    /// Budget exhausted, or an error that cannot clear by waiting.
+    give_up_exhausted,
+};
+
+fn recoveryFailurePolicy(budget_exhausted: bool, scheduled: bool) RecoveryFailureAction {
+    if (budget_exhausted) return .give_up_exhausted;
+    return if (scheduled) .retry_scheduled else .give_up_unschedulable;
+}
+
 /// Retry budget for the ready marker, spent across message-loop ticks.
 ///
 /// The ready marker is the only thing that breaks a failure streak, so a
@@ -3175,6 +3207,10 @@ pub const App = struct {
     terminal_handoff_server: ?*win32_terminal_handoff.Server = null,
     undo_prune_timer_id: ?UINT_PTR = null,
     recovery_retry_timer_id: ?UINT_PTR = null,
+    /// Monotonic `GetTickCount64` deadline before which no tick may spend a
+    /// ready-marker attempt. Cleared by the retry timer, which is the tick
+    /// the deadline was waiting for.
+    recovery_retry_not_before_ms: ?u64 = null,
     next_undo_sequence: u64 = 1,
     running: bool = false,
     /// A normal last-host close destroys the native/session model before
@@ -3703,8 +3739,7 @@ pub const App = struct {
             if (msg.message == c.WM_TIMER) {
                 if (self.recovery_retry_timer_id) |timer_id| {
                     if (msg.wParam == timer_id) {
-                        self.stopRecoveryRetryTimer();
-                        self.resolveRecoveryStartup();
+                        self.onRecoveryRetryTimer();
                         continue;
                     }
                 }
@@ -4254,23 +4289,39 @@ pub const App = struct {
     /// which is exactly the crash-loop evidence that selects safe mode.
     fn resolveRecoveryStartup(self: *App) void {
         if (!self.recovery_ready_resolved) {
+            // An unrelated tick that beat the retry timer must not spend an
+            // attempt; the armed timer will bring the loop back on time.
+            if (!recoveryRetryDue(self.recovery_retry_not_before_ms, sys.GetTickCount64())) return;
+
             if (self.markRecoveryReady()) {
                 self.recovery_ready_resolved = true;
                 self.stopRecoveryRetryTimer();
+                self.recovery_retry_not_before_ms = null;
             } else |err| {
-                if (self.recovery_ready_retry.recordFailure(err)) {
-                    log.warn(
-                        "win32 recovery: ready marker unresolved after {d} attempt(s) err={}",
-                        .{ self.recovery_ready_retry.failures, err },
-                    );
-                    self.recovery_ready_resolved = true;
-                    self.stopRecoveryRetryTimer();
-                } else {
-                    log.warn(
+                const exhausted = self.recovery_ready_retry.recordFailure(err);
+                const scheduled = !exhausted and self.scheduleRecoveryRetry();
+                switch (recoveryFailurePolicy(exhausted, scheduled)) {
+                    .retry_scheduled => log.warn(
                         "win32 recovery: ready marker attempt {d} failed err={}; retrying in {d}ms",
                         .{ self.recovery_ready_retry.failures, err, recovery_ready_retry_delay_ms },
-                    );
-                    self.scheduleRecoveryRetry();
+                    ),
+                    .give_up_unschedulable => {
+                        log.warn(
+                            "win32 recovery: ready marker attempt {d} failed err={} and no retry could be scheduled; leaving the launch unresolved",
+                            .{ self.recovery_ready_retry.failures, err },
+                        );
+                        self.recovery_ready_resolved = true;
+                        self.recovery_retry_not_before_ms = null;
+                    },
+                    .give_up_exhausted => {
+                        log.warn(
+                            "win32 recovery: ready marker unresolved after {d} attempt(s) err={}",
+                            .{ self.recovery_ready_retry.failures, err },
+                        );
+                        self.recovery_ready_resolved = true;
+                        self.stopRecoveryRetryTimer();
+                        self.recovery_retry_not_before_ms = null;
+                    },
                 }
             }
         }
@@ -5431,17 +5482,21 @@ pub const App = struct {
     /// Bounded by `RecoveryReadyRetry`: only a failure that has not exhausted
     /// the budget reaches here, so at most
     /// `recovery_ready_persist_attempts - 1` timers are ever armed.
-    fn scheduleRecoveryRetry(self: *App) void {
+    /// Returns false when no retry could be armed. There is deliberately no
+    /// wake fallback: a wake re-ticks immediately, so the remaining attempts
+    /// would run back to back and the delay that lets a handle hold clear
+    /// would be gone exactly when `SetTimer` failing says the session is
+    /// already degraded. The caller stops instead.
+    fn scheduleRecoveryRetry(self: *App) bool {
         self.stopRecoveryRetryTimer();
         const timer_id = sys.SetTimer(null, 0, recovery_ready_retry_delay_ms, null);
         if (timer_id == 0) {
             log.warn("failed to start win32 recovery retry timer err={}", .{windows.kernel32.GetLastError()});
-            // Fall back to an immediate wake: a spaced retry is better, but
-            // an unresolved launch that never retries at all is worse.
-            self.wakeup();
-            return;
+            return false;
         }
         self.recovery_retry_timer_id = timer_id;
+        self.recovery_retry_not_before_ms = sys.GetTickCount64() +| recovery_ready_retry_delay_ms;
+        return true;
     }
 
     fn stopRecoveryRetryTimer(self: *App) void {
@@ -5449,6 +5504,16 @@ pub const App = struct {
             _ = sys.KillTimer(null, timer_id);
             self.recovery_retry_timer_id = null;
         }
+    }
+
+    /// The retry timer fired: this is the tick the deadline was holding out
+    /// for, so clear it rather than re-checking the clock. `SetTimer` may
+    /// deliver marginally early, and refusing its own tick would leave nothing
+    /// armed to come back.
+    fn onRecoveryRetryTimer(self: *App) void {
+        self.stopRecoveryRetryTimer();
+        self.recovery_retry_not_before_ms = null;
+        self.resolveRecoveryStartup();
     }
 
     fn stopUndoPruneTimer(self: *App) void {
@@ -35215,6 +35280,50 @@ test "win32 recovery ready marker schedules a bounded number of retries" {
     // OutOfMemory resolves on the first failure, so it arms no timer at all.
     var oom: RecoveryReadyRetry = .{};
     try std.testing.expect(oom.recordFailure(error.OutOfMemory));
+}
+
+test "win32 recovery ready marker will not spend an attempt before its deadline" {
+    // No retry armed yet: the first attempt runs on the startup tick.
+    try std.testing.expect(recoveryRetryDue(null, 0));
+    try std.testing.expect(recoveryRetryDue(null, std.math.maxInt(u64)));
+
+    // A retry is armed for `now + delay`. Unrelated ticks — PTY output, a
+    // keystroke — reach `resolveRecoveryStartup` first on a busy terminal and
+    // must be refused, or the budget is spent with no spacing at all.
+    const armed_at: u64 = 1_000;
+    const deadline: u64 = armed_at + recovery_ready_retry_delay_ms;
+    try std.testing.expect(!recoveryRetryDue(deadline, armed_at));
+    try std.testing.expect(!recoveryRetryDue(deadline, deadline - 1));
+    try std.testing.expect(recoveryRetryDue(deadline, deadline));
+    try std.testing.expect(recoveryRetryDue(deadline, deadline + 1));
+}
+
+test "win32 recovery gives up rather than busy-retrying when no timer can be armed" {
+    // Budget survives and a spaced retry was armed: keep going.
+    try std.testing.expectEqual(
+        RecoveryFailureAction.retry_scheduled,
+        recoveryFailurePolicy(false, true),
+    );
+
+    // Budget survives but nothing could be armed. Falling back to an
+    // immediate wake would re-tick with no delay and burn every remaining
+    // attempt in microseconds, which is the busy retry the delay exists to
+    // prevent — and it would still end unresolved. Stop instead, so the
+    // safe-mode notice is released once with an honest single failure.
+    try std.testing.expectEqual(
+        RecoveryFailureAction.give_up_unschedulable,
+        recoveryFailurePolicy(false, false),
+    );
+
+    // Exhaustion wins regardless of whether a timer could have been armed.
+    try std.testing.expectEqual(
+        RecoveryFailureAction.give_up_exhausted,
+        recoveryFailurePolicy(true, false),
+    );
+    try std.testing.expectEqual(
+        RecoveryFailureAction.give_up_exhausted,
+        recoveryFailurePolicy(true, true),
+    );
 }
 
 test "win32 safe mode notice waits for the launch to resolve on disk" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2581,6 +2581,55 @@ fn recoverySafeModeNotice(decision: win32_recovery.Decision) ?[]const u8 {
     return if (decision == .safe_mode) recovery_safe_mode_banner else null;
 }
 
+/// How many message-loop ticks may attempt the ready-marker write before the
+/// launch is given up as unresolved.
+const recovery_ready_persist_attempts: u8 = 3;
+
+/// Retry budget for the ready marker, spent across message-loop ticks.
+///
+/// The ready marker is the only thing that breaks a failure streak, so a
+/// transient write failure must not be latched as handled — that leaves the
+/// launch unresolved on disk for the whole session and feeds the automatic
+/// safe mode this branch exists to stop. Retries deliberately ride real
+/// message-loop ticks rather than an in-line sleep loop: an earlier ~20 ms
+/// three-attempt loop was removed because it could not outlast an anti-virus
+/// or backup handle hold, whereas tick-spaced attempts can.
+const RecoveryReadyRetry = struct {
+    failures: u8 = 0,
+
+    /// Records a failed attempt. Returns true when the launch should be
+    /// treated as resolved and no later tick should try again.
+    fn recordFailure(self: *RecoveryReadyRetry, err: anyerror) bool {
+        self.failures +|= 1;
+        // OutOfMemory will not clear by waiting and every retry allocates
+        // again, so stop immediately rather than spending the budget.
+        if (err == error.OutOfMemory) return true;
+        return self.failures >= recovery_ready_persist_attempts;
+    }
+};
+
+/// Sequencing for the safe-mode dialog.
+///
+/// The notice is armed at the initial-window boundary but released only once
+/// the launch is resolved on disk, so a process terminated while the modal is
+/// up has already broken the failure streak.
+const RecoverySafeModeNotice = struct {
+    armed: bool = false,
+    released: bool = false,
+
+    fn arm(self: *RecoverySafeModeNotice, decision: win32_recovery.Decision) void {
+        if (recoverySafeModeNotice(decision) != null) self.armed = true;
+    }
+
+    /// Returns true at most once, and only after the ledger write for this
+    /// launch has succeeded or exhausted its retries.
+    fn release(self: *RecoverySafeModeNotice, launch_resolved: bool) bool {
+        if (!self.armed or self.released or !launch_resolved) return false;
+        self.released = true;
+        return true;
+    }
+};
+
 /// Ownerless by design; do not "fix" this to take the primary Host HWND.
 ///
 /// The notice runs on a detached thread that nothing joins, so it can outlive
@@ -3217,7 +3266,11 @@ pub const App = struct {
     /// never forwarded through the serialized single-instance IPC channel.
     embedding_mode: bool = false,
     recovery_startup: RecoveryStartup = .{},
-    recovery_first_tick_completed: bool = false,
+    /// True once this launch is recorded on disk as resolved — either the
+    /// ready marker landed or its bounded retries were exhausted.
+    recovery_ready_resolved: bool = false,
+    recovery_ready_retry: RecoveryReadyRetry = .{},
+    recovery_safe_mode_notice: RecoverySafeModeNotice = .{},
     /// Top-level shell composition only. Terminal child HWNDs retain their
     /// existing WGL/SwapBuffers ownership regardless of this backend state.
     shell_compositor_driver: win32_compositor_native.NativeDriver = undefined,
@@ -3432,7 +3485,11 @@ pub const App = struct {
             // Forwarding is a successful startup outcome for this process.
             // Mark it ready so repeated new-window launches cannot accumulate
             // false crash-loop evidence and trigger automatic safe mode.
-            self.markRecoveryReady();
+            // This process exits immediately, so there is no later tick to
+            // retry on; the failure is logged and the attempt stays unresolved.
+            self.markRecoveryReady() catch |err| {
+                log.warn("win32 recovery: forwarded launch ready marker failed err={}", .{err});
+            };
             return;
         }
 
@@ -3508,9 +3565,12 @@ pub const App = struct {
 
         if (self.windows.items.len > 0) self.markRecoveryWindowCreated();
 
-        if (recoverySafeModeNotice(self.recovery_startup.decision)) |notice| {
-            self.showRecoverySafeModeNotice(notice);
-        }
+        // Armed here, released by `resolveRecoveryStartup` once the ready
+        // marker is on disk. Spawning it here would let thread scheduling put
+        // the modal on screen while the ledger still holds an unresolved
+        // attempt, so killing the process at the dialog would preserve the
+        // failure streak.
+        self.recovery_safe_mode_notice.arm(self.recovery_startup.decision);
 
         if (!self.embedding_mode) self.initializeJumpList();
         if (!self.embedding_mode) self.scheduleGlobalHotkeySync();
@@ -3521,6 +3581,12 @@ pub const App = struct {
             };
         }
         if (!self.embedding_mode and self.windows.items.len == 0) self.startQuitTimer();
+
+        // Guarantee the loop reaches at least one tick. Resolving this launch
+        // in the ledger and releasing the safe-mode notice both hang off
+        // `tickCoreApp`, so neither may depend on some other subsystem
+        // happening to post a wake first.
+        self.wakeup();
 
         var msg: MSG = undefined;
         while (true) {
@@ -4155,12 +4221,44 @@ pub const App = struct {
 
     fn tickCoreApp(self: *App) !void {
         try self.core_app.tick(self);
-        if (self.recovery_first_tick_completed) return;
-        // A launch is unresolved until the outer Win32 message loop completes
-        // its first core-app tick. Renderer and PTY work that continues on
-        // other threads after this boundary is outside recovery accounting.
-        self.recovery_first_tick_completed = true;
-        self.markRecoveryReady();
+        self.resolveRecoveryStartup();
+    }
+
+    /// Record this launch as resolved in the startup ledger.
+    ///
+    /// A launch is unresolved until the outer Win32 message loop completes its
+    /// first core-app tick. Renderer and PTY work that continues on other
+    /// threads after this boundary is outside recovery accounting.
+    ///
+    /// The write is attempted again on later ticks while the retry budget
+    /// lasts: latching "handled" on the first attempt would let one transient
+    /// sharing violation leave the launch unresolved for the whole session,
+    /// which is exactly the crash-loop evidence that selects safe mode.
+    fn resolveRecoveryStartup(self: *App) void {
+        if (!self.recovery_ready_resolved) {
+            if (self.markRecoveryReady()) {
+                self.recovery_ready_resolved = true;
+            } else |err| {
+                if (self.recovery_ready_retry.recordFailure(err)) {
+                    log.warn(
+                        "win32 recovery: ready marker unresolved after {d} attempt(s) err={}",
+                        .{ self.recovery_ready_retry.failures, err },
+                    );
+                    self.recovery_ready_resolved = true;
+                } else {
+                    log.warn(
+                        "win32 recovery: ready marker attempt {d} failed err={}; retrying next tick",
+                        .{ self.recovery_ready_retry.failures, err },
+                    );
+                }
+            }
+        }
+
+        // Only now may the safe-mode dialog appear: killing the process while
+        // that modal is up must not preserve the failure streak.
+        if (self.recovery_safe_mode_notice.release(self.recovery_ready_resolved)) {
+            self.showRecoverySafeModeNotice(recovery_safe_mode_banner);
+        }
     }
 
     fn markRecoveryWindowCreated(self: *App) void {
@@ -4185,7 +4283,10 @@ pub const App = struct {
         @memcpy(current, persisted[0..current.len]);
     }
 
-    fn markRecoveryReady(self: *App) void {
+    /// Errors are the retryable ones only: everything deterministic (no
+    /// ledger, nothing to mark, an unmergeable record) returns normally so a
+    /// caller's retry budget is not spent on a failure that cannot clear.
+    fn markRecoveryReady(self: *App) !void {
         if (self.recovery_startup.count == 0) return;
         const memory_attempts = self.recovery_startup.attempts[0..self.recovery_startup.count];
         const target_started_at = memory_attempts[memory_attempts.len - 1].started_at_unix_ms;
@@ -4232,7 +4333,10 @@ pub const App = struct {
             path,
             &self.recovery_startup,
             merged,
-        ) catch |err| log.warn("win32 recovery: ready marker persist failed err={}", .{err});
+        ) catch |err| {
+            log.warn("win32 recovery: ready marker persist failed err={}", .{err});
+            return err;
+        };
     }
 
     fn restoreSessionWindow(
@@ -35017,6 +35121,43 @@ test "win32 recovery fallback failure is consumed by next startup" {
         try std.testing.expect(!std.mem.startsWith(u8, entry.name, "startup-attempts.json.tmp-"));
         try std.testing.expect(!std.mem.startsWith(u8, entry.name, "startup-attempts.json.pending-"));
     }
+}
+
+test "win32 recovery ready marker keeps retrying transient write failures" {
+    // A failed attempt must not resolve the launch: latching on the first
+    // failure is what leaves an unresolved attempt on disk for the whole
+    // session and feeds a false safe-mode streak.
+    var transient: RecoveryReadyRetry = .{};
+    try std.testing.expect(!transient.recordFailure(error.AccessDenied));
+    try std.testing.expect(!transient.recordFailure(error.Unexpected));
+    try std.testing.expectEqual(@as(u8, 2), transient.failures);
+
+    // The budget is bounded: the third failure gives up.
+    try std.testing.expect(transient.recordFailure(error.AccessDenied));
+    try std.testing.expectEqual(recovery_ready_persist_attempts, transient.failures);
+
+    // OutOfMemory stops immediately without spending the budget.
+    var oom: RecoveryReadyRetry = .{};
+    try std.testing.expect(oom.recordFailure(error.OutOfMemory));
+    try std.testing.expectEqual(@as(u8, 1), oom.failures);
+}
+
+test "win32 safe mode notice waits for the launch to resolve on disk" {
+    // Never armed outside safe mode.
+    var normal: RecoverySafeModeNotice = .{};
+    normal.arm(.normal);
+    normal.arm(.quarantine_session);
+    try std.testing.expect(!normal.release(true));
+
+    var safe: RecoverySafeModeNotice = .{};
+    safe.arm(.safe_mode);
+    // Held back while the ledger still holds an unresolved attempt, so a
+    // process killed at the dialog has already broken the failure streak.
+    try std.testing.expect(!safe.release(false));
+    try std.testing.expect(!safe.released);
+    try std.testing.expect(safe.release(true));
+    // Every later tick calls this; the dialog must spawn exactly once.
+    try std.testing.expect(!safe.release(true));
 }
 
 test "win32 recovery safe mode always has a visible notice" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2571,10 +2571,37 @@ const recovery_safe_mode_banner_w = blk: {
 };
 const recovery_safe_mode_caption_w = std.unicode.utf8ToUtf16LeStringLiteral("noctty safe mode");
 
+/// Filename infix for a startup-ledger record whose write already failed and
+/// whose diagnosis is waiting to be folded into the next startup's append.
+/// Deliberately disjoint from the `.tmp-` infix used for live atomic-replace
+/// sources so cross-instance cleanup can never delete an in-flight write.
+const recovery_pending_suffix = ".pending-";
+
 fn recoverySafeModeNotice(decision: win32_recovery.Decision) ?[]const u8 {
     return if (decision == .safe_mode) recovery_safe_mode_banner else null;
 }
 
+/// Ownerless by design; do not "fix" this to take the primary Host HWND.
+///
+/// The notice runs on a detached thread that nothing joins, so it can outlive
+/// any terminal window: the user may close the terminal, or safe mode's quit
+/// timer may fire, while the dialog is still up. Destroying an owner destroys
+/// its owned windows, which would pull this box's HWND out from under a modal
+/// loop running on a different thread.
+///
+/// An owner would also be cross-thread. `MB_APPLMODAL` disables the owner,
+/// and `EnableWindow`/foreground activation against a window belonging to the
+/// UI thread sends messages that thread must pump. `App.run` starts this
+/// notice at the `showRecoverySafeModeNotice` call site *before* it enters its
+/// `GetMessageW` loop, so there is a window where the UI thread is not
+/// pumping. (Calling `MessageBoxW` on the UI thread itself is worse still: its
+/// nested modal loop dispatches `WM_WINHOSTTY_WAKE` to a wndproc that returns
+/// 0 without ticking, stalling the app mailbox.)
+///
+/// Finally, `initial-window = false` means there is no host HWND at all, so an
+/// ownerless path has to exist regardless. Safe mode is a usable session; the
+/// notice is informational and must not hold the terminal hostage.
+/// `MB_SETFOREGROUND` plus the box's own taskbar button carry the visibility.
 fn recoverySafeModeNoticeThread() void {
     _ = sys.MessageBoxW(
         null,
@@ -2725,19 +2752,29 @@ fn beginRecoveryStartupAtPath(
             break :retained;
         };
         defer dir.close();
-        const temporary_prefix = std.fmt.allocPrint(
+        // Only `.pending-` records are folded and deleted here. They are
+        // written exclusively by `retainRecoveryPersistDiagnosis`, i.e. after
+        // a ledger write has already definitively failed, and are never used
+        // as the source of an atomic replacement. The `.tmp-` files that
+        // `persistRecoveryRecordAtPath` creates are live replacement sources
+        // for whichever process owns them; a concurrently starting instance
+        // that deleted one would make that process's ReplaceFileW fail and
+        // send it down the in-place fallback, clobbering the record this
+        // process just merged. Keeping the two namespaces disjoint removes
+        // that race without an interprocess lock.
+        const retained_prefix = std.fmt.allocPrint(
             alloc,
-            "{s}.tmp-",
+            "{s}" ++ recovery_pending_suffix,
             .{std.fs.path.basename(path)},
         ) catch break :retained;
-        defer alloc.free(temporary_prefix);
+        defer alloc.free(retained_prefix);
         var entries = dir.iterate();
         while (true) {
             const entry = entries.next() catch |err| {
                 log.warn("win32 recovery: retained history enumeration failed err={}", .{err});
                 break;
             } orelse break;
-            if (!std.mem.startsWith(u8, entry.name, temporary_prefix)) continue;
+            if (!std.mem.startsWith(u8, entry.name, retained_prefix)) continue;
             const retained_path = std.fs.path.join(alloc, &.{ dir_path, entry.name }) catch continue;
             const retained_file = std.fs.openFileAbsolute(retained_path, .{}) catch {
                 alloc.free(retained_path);
@@ -2807,12 +2844,22 @@ fn persistRecoveryRecordAtPath(
     const encoded = try win32_recovery.encodeAlloc(alloc, .{ .attempts = attempts });
     defer alloc.free(encoded);
     const nonce = unixMillis();
+    // `.tmp-` is this process's private replacement source and is never read
+    // or deleted by another instance. `.pending-` is the post-failure
+    // diagnosis another instance folds in and cleans up. See the namespace
+    // note in `beginRecoveryStartupAtPath`.
     const temporary_path = try std.fmt.allocPrint(
         alloc,
         "{s}.tmp-{x}-{x}",
         .{ path, sys.GetCurrentProcessId(), nonce },
     );
     defer alloc.free(temporary_path);
+    const pending_path = try std.fmt.allocPrint(
+        alloc,
+        "{s}" ++ recovery_pending_suffix ++ "{x}-{x}",
+        .{ path, sys.GetCurrentProcessId(), nonce },
+    );
+    defer alloc.free(pending_path);
     var atomic_failure: ?win32_session_persistence.AtomicReplaceFailure = null;
     const disposition = win32_session_persistence.writeFileAtomicOrInPlace(
         path,
@@ -2825,6 +2872,7 @@ fn persistRecoveryRecordAtPath(
             retainRecoveryPersistDiagnosis(
                 alloc,
                 temporary_path,
+                pending_path,
                 attempts,
             );
         }
@@ -2841,6 +2889,7 @@ fn persistRecoveryRecordAtPath(
                 retainRecoveryPersistDiagnosis(
                     alloc,
                     temporary_path,
+                    pending_path,
                     attempts,
                 );
             };
@@ -2861,12 +2910,21 @@ fn recordRecoveryPersistFailure(
 fn retainRecoveryPersistDiagnosis(
     alloc: Allocator,
     temporary_path: []const u8,
+    pending_path: []const u8,
     attempts: []const win32_recovery.StartupAttempt,
 ) void {
     const diagnosed = win32_recovery.encodeAlloc(alloc, .{ .attempts = attempts }) catch return;
     defer alloc.free(diagnosed);
-    win32_session_persistence.writeFileInPlace(temporary_path, diagnosed) catch |err| {
+    // Publish under `.pending-`, not the replacement source. The write has
+    // already failed, so this record is inert: no process will ever hand it
+    // to ReplaceFileW, which makes it safe for a concurrent startup to fold
+    // and delete. Then drop the now-dead `.tmp-` source so it does not leak.
+    win32_session_persistence.writeFileInPlace(pending_path, diagnosed) catch |err| {
         log.warn("win32 recovery: retained diagnosis persist failed err={}", .{err});
+        return;
+    };
+    win32_session_persistence.deleteFileIfPresent(temporary_path) catch |err| {
+        log.warn("win32 recovery: dead replacement source cleanup failed err={}", .{err});
     };
 }
 
@@ -34809,7 +34867,7 @@ test "win32 recovery next startup folds retained diagnosis before append" {
     defer std.testing.allocator.free(root);
     const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
     defer std.testing.allocator.free(target);
-    const pending = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".tmp-dead-beef" });
+    const pending = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".pending-dead-beef" });
     defer std.testing.allocator.free(pending);
 
     const disk_attempts = [_]win32_recovery.StartupAttempt{
@@ -34838,6 +34896,65 @@ test "win32 recovery next startup folds retained diagnosis before append" {
     try std.testing.expectEqual(@as(?u32, 32), startup.attempts[0].last_win32_error);
     try std.testing.expectEqual(win32_recovery.StartupPhase.init, startup.attempts[1].phase);
     try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(pending, .{}));
+}
+
+test "win32 recovery startup leaves another instance's in-flight write temp alone" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const target = try std.fs.path.join(std.testing.allocator, &.{ root, "startup-attempts.json" });
+    defer std.testing.allocator.free(target);
+
+    // A concurrent instance has created and synced its atomic-replace source
+    // but has not called ReplaceFileW yet. Deleting it would fail that
+    // replacement and send the other writer down the in-place fallback, which
+    // would then clobber the record this startup is about to persist.
+    const in_flight = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".tmp-c0ffee-1" });
+    defer std.testing.allocator.free(in_flight);
+    const pending = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".pending-c0ffee-1" });
+    defer std.testing.allocator.free(pending);
+
+    const disk_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .phase = .window_created },
+    };
+    const in_flight_attempts = [_]win32_recovery.StartupAttempt{
+        .{ .started_at_unix_ms = 100, .ready_at_unix_ms = 150, .phase = .ready },
+    };
+    const pending_attempts = [_]win32_recovery.StartupAttempt{
+        .{
+            .started_at_unix_ms = 100,
+            .phase = .ready_persist_failed,
+            .last_win32_error = 32,
+        },
+    };
+    const disk_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &disk_attempts });
+    defer std.testing.allocator.free(disk_json);
+    const in_flight_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &in_flight_attempts });
+    defer std.testing.allocator.free(in_flight_json);
+    const pending_json = try win32_recovery.encodeAlloc(std.testing.allocator, .{ .attempts = &pending_attempts });
+    defer std.testing.allocator.free(pending_json);
+    try win32_session_persistence.writeFileInPlace(target, disk_json);
+    try win32_session_persistence.writeFileInPlace(in_flight, in_flight_json);
+    try win32_session_persistence.writeFileInPlace(pending, pending_json);
+
+    const startup = beginRecoveryStartupAtPath(std.testing.allocator, target, 200);
+    try std.testing.expectEqual(@as(usize, 2), startup.count);
+
+    // The `.pending-` diagnosis is folded and cleaned up.
+    try std.testing.expectEqual(
+        win32_recovery.StartupPhase.ready_persist_failed,
+        startup.attempts[0].phase,
+    );
+    try std.testing.expectEqual(@as(?u32, 32), startup.attempts[0].last_win32_error);
+    try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(pending, .{}));
+
+    // The other instance's replacement source survives untouched and its
+    // uncommitted ready marker was not folded in.
+    try std.testing.expectEqual(@as(?u64, null), startup.attempts[0].ready_at_unix_ms);
+    const survivor = try std.fs.cwd().readFileAlloc(std.testing.allocator, in_flight, 64 * 1024);
+    defer std.testing.allocator.free(survivor);
+    try std.testing.expectEqualStrings(in_flight_json, survivor);
 }
 
 test "win32 recovery fallback failure is consumed by next startup" {
@@ -34890,6 +35007,16 @@ test "win32 recovery fallback failure is consumed by next startup" {
     try std.testing.expectEqual(@as(?u64, 150), startup.attempts[0].ready_at_unix_ms);
     try std.testing.expectEqual(win32_recovery.StartupPhase.ready_persist_failed, startup.attempts[0].phase);
     try std.testing.expect(startup.attempts[0].last_win32_error != null);
+
+    // The dead replacement source is dropped by the writer, and the folded
+    // `.pending-` diagnosis is dropped by the next startup: no leftovers.
+    var root_dir = try std.fs.openDirAbsolute(root, .{ .iterate = true });
+    defer root_dir.close();
+    var entries = root_dir.iterate();
+    while (try entries.next()) |entry| {
+        try std.testing.expect(!std.mem.startsWith(u8, entry.name, "startup-attempts.json.tmp-"));
+        try std.testing.expect(!std.mem.startsWith(u8, entry.name, "startup-attempts.json.pending-"));
+    }
 }
 
 test "win32 recovery safe mode always has a visible notice" {

--- a/src/apprt/win32_recovery.zig
+++ b/src/apprt/win32_recovery.zig
@@ -28,9 +28,18 @@ pub const Decision = enum {
     quarantine_session,
 };
 
+pub const StartupPhase = enum {
+    init,
+    window_created,
+    ready,
+    ready_persist_failed,
+};
+
 pub const StartupAttempt = struct {
     started_at_unix_ms: u64,
     ready_at_unix_ms: ?u64 = null,
+    phase: StartupPhase = .init,
+    last_win32_error: ?u32 = null,
 };
 
 pub const StartupAttemptRecord = struct {
@@ -206,6 +215,68 @@ pub fn markLatestReady(
         return error.ReadyBeforeStart;
     }
     latest.ready_at_unix_ms = ready_at_unix_ms;
+    latest.phase = .ready;
+    latest.last_win32_error = null;
+}
+
+/// Merge two independently observed histories. Duplicate start markers name
+/// the same attempt; retain the furthest lifecycle phase, any ready marker,
+/// and the raw persistence diagnosis. The newest bounded history is returned.
+pub fn mergeRecords(
+    first: StartupAttemptRecord,
+    second: StartupAttemptRecord,
+    out: []StartupAttempt,
+) (ValidationError || MergeReadyError)!StartupAttemptRecord {
+    try validate(first);
+    try validate(second);
+    if (out.len < max_attempts) return error.OutputBufferTooSmall;
+
+    var merged: [max_attempts * 2]StartupAttempt = undefined;
+    var count: usize = 0;
+    var first_i: usize = 0;
+    var second_i: usize = 0;
+    while (first_i < first.attempts.len or second_i < second.attempts.len) {
+        const next = if (second_i >= second.attempts.len or
+            (first_i < first.attempts.len and
+                first.attempts[first_i].started_at_unix_ms <= second.attempts[second_i].started_at_unix_ms))
+        blk: {
+            const value = first.attempts[first_i];
+            first_i += 1;
+            break :blk value;
+        } else blk: {
+            const value = second.attempts[second_i];
+            second_i += 1;
+            break :blk value;
+        };
+
+        if (count > 0 and merged[count - 1].started_at_unix_ms == next.started_at_unix_ms) {
+            const current = &merged[count - 1];
+            if (next.ready_at_unix_ms) |next_ready| {
+                if (current.ready_at_unix_ms == null or next_ready > current.ready_at_unix_ms.?) {
+                    current.ready_at_unix_ms = next_ready;
+                }
+            }
+            const phase_order = std.math.order(
+                @intFromEnum(next.phase),
+                @intFromEnum(current.phase),
+            );
+            if (phase_order == .gt) {
+                current.phase = next.phase;
+                current.last_win32_error = next.last_win32_error;
+            } else if (phase_order == .eq and current.last_win32_error == null) {
+                current.last_win32_error = next.last_win32_error;
+            }
+            continue;
+        }
+        merged[count] = next;
+        count += 1;
+    }
+
+    const retained_count = @min(count, max_attempts);
+    @memcpy(out[0..retained_count], merged[count - retained_count .. count]);
+    const result: StartupAttemptRecord = .{ .attempts = out[0..retained_count] };
+    try validate(result);
+    return result;
 }
 
 /// Merge the startup snapshot retained by this process with a freshly-read
@@ -220,51 +291,21 @@ pub fn mergeMarkReady(
     ready_at_unix_ms: u64,
     out: []StartupAttempt,
 ) (ValidationError || MergeReadyError)!StartupAttemptRecord {
-    try validate(disk);
-    try validate(memory);
-    if (out.len < max_attempts) return error.OutputBufferTooSmall;
-
-    var merged: [max_attempts * 2]StartupAttempt = undefined;
-    var count: usize = 0;
-    var disk_i: usize = 0;
-    var memory_i: usize = 0;
-    while (disk_i < disk.attempts.len or memory_i < memory.attempts.len) {
-        const next = if (memory_i >= memory.attempts.len or
-            (disk_i < disk.attempts.len and
-                disk.attempts[disk_i].started_at_unix_ms <= memory.attempts[memory_i].started_at_unix_ms))
-        blk: {
-            const value = disk.attempts[disk_i];
-            disk_i += 1;
-            break :blk value;
-        } else blk: {
-            const value = memory.attempts[memory_i];
-            memory_i += 1;
-            break :blk value;
-        };
-
-        if (count > 0 and merged[count - 1].started_at_unix_ms == next.started_at_unix_ms) {
-            if (merged[count - 1].ready_at_unix_ms == null and next.ready_at_unix_ms != null) {
-                merged[count - 1].ready_at_unix_ms = next.ready_at_unix_ms;
-            }
-            continue;
-        }
-        merged[count] = next;
-        count += 1;
-    }
+    const merged = try mergeRecords(disk, memory, out);
 
     var found = false;
-    for (merged[0..count]) |*attempt| {
+    for (out[0..merged.attempts.len]) |*attempt| {
         if (attempt.started_at_unix_ms != target_started_at_unix_ms) continue;
         if (ready_at_unix_ms < attempt.started_at_unix_ms) return error.ReadyBeforeStart;
         attempt.ready_at_unix_ms = ready_at_unix_ms;
+        attempt.phase = .ready;
+        attempt.last_win32_error = null;
         found = true;
         break;
     }
     if (!found) return error.TargetAttemptMissing;
 
-    const retained_count = @min(count, max_attempts);
-    @memcpy(out[0..retained_count], merged[count - retained_count .. count]);
-    const result: StartupAttemptRecord = .{ .attempts = out[0..retained_count] };
+    const result: StartupAttemptRecord = .{ .attempts = out[0..merged.attempts.len] };
     try validate(result);
     return result;
 }
@@ -359,14 +400,18 @@ pub fn quarantinePlanAlloc(
 test "win32 recovery record round trips strict schema v1" {
     const attempts = [_]StartupAttempt{
         .{ .started_at_unix_ms = 100, .ready_at_unix_ms = 120 },
-        .{ .started_at_unix_ms = 200 },
+        .{
+            .started_at_unix_ms = 200,
+            .phase = .ready_persist_failed,
+            .last_win32_error = 32,
+        },
     };
     const record: StartupAttemptRecord = .{ .attempts = &attempts };
 
     const encoded = try encodeAlloc(std.testing.allocator, record);
     defer std.testing.allocator.free(encoded);
     try std.testing.expectEqualStrings(
-        "{\"schema_version\":1,\"attempts\":[{\"started_at_unix_ms\":100,\"ready_at_unix_ms\":120},{\"started_at_unix_ms\":200}]}",
+        "{\"schema_version\":1,\"attempts\":[{\"started_at_unix_ms\":100,\"ready_at_unix_ms\":120,\"phase\":\"init\"},{\"started_at_unix_ms\":200,\"phase\":\"ready_persist_failed\",\"last_win32_error\":32}]}",
         encoded,
     );
 
@@ -375,6 +420,21 @@ test "win32 recovery record round trips strict schema v1" {
     try std.testing.expectEqual(@as(usize, 2), parsed.value.attempts.len);
     try std.testing.expectEqual(@as(?u64, 120), parsed.value.attempts[0].ready_at_unix_ms);
     try std.testing.expectEqual(@as(?u64, null), parsed.value.attempts[1].ready_at_unix_ms);
+    try std.testing.expectEqual(StartupPhase.ready_persist_failed, parsed.value.attempts[1].phase);
+    try std.testing.expectEqual(@as(?u32, 32), parsed.value.attempts[1].last_win32_error);
+}
+
+test "win32 recovery schema v1 defaults diagnosis for legacy attempts" {
+    var parsed = try parseAlloc(
+        std.testing.allocator,
+        "{\"schema_version\":1,\"attempts\":[{\"started_at_unix_ms\":100},{\"started_at_unix_ms\":200,\"ready_at_unix_ms\":220}]}",
+    );
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(StartupPhase.init, parsed.value.attempts[0].phase);
+    try std.testing.expectEqual(@as(?u32, null), parsed.value.attempts[0].last_win32_error);
+    try std.testing.expectEqual(StartupPhase.init, parsed.value.attempts[1].phase);
+    try std.testing.expectEqual(@as(?u32, null), parsed.value.attempts[1].last_win32_error);
 }
 
 test "win32 recovery ready merge preserves a concurrent attempt" {
@@ -400,6 +460,62 @@ test "win32 recovery ready merge preserves a concurrent attempt" {
     try std.testing.expectEqual(@as(?u64, 250), merged.attempts[1].ready_at_unix_ms);
     try std.testing.expectEqual(@as(u64, 300), merged.attempts[2].started_at_unix_ms);
     try std.testing.expectEqual(@as(?u64, null), merged.attempts[2].ready_at_unix_ms);
+}
+
+test "win32 recovery merge carries failed persistence diagnosis into next startup" {
+    const disk_attempts = [_]StartupAttempt{
+        .{ .started_at_unix_ms = 100, .phase = .window_created },
+        .{ .started_at_unix_ms = 200, .phase = .window_created },
+    };
+    const pending_attempts = [_]StartupAttempt{
+        .{
+            .started_at_unix_ms = 200,
+            .ready_at_unix_ms = 240,
+            .phase = .ready_persist_failed,
+            .last_win32_error = 32,
+        },
+    };
+    var out: [max_attempts]StartupAttempt = undefined;
+    const merged = try mergeRecords(
+        .{ .attempts = &disk_attempts },
+        .{ .attempts = &pending_attempts },
+        &out,
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), merged.attempts.len);
+    try std.testing.expectEqual(@as(?u64, 240), merged.attempts[1].ready_at_unix_ms);
+    try std.testing.expectEqual(StartupPhase.ready_persist_failed, merged.attempts[1].phase);
+    try std.testing.expectEqual(@as(?u32, 32), merged.attempts[1].last_win32_error);
+}
+
+test "win32 recovery merge keeps error coupled to furthest phase" {
+    const window_created = StartupAttempt{
+        .started_at_unix_ms = 200,
+        .phase = .window_created,
+        .last_win32_error = 5,
+    };
+    const ready_failed = StartupAttempt{
+        .started_at_unix_ms = 200,
+        .ready_at_unix_ms = 240,
+        .phase = .ready_persist_failed,
+        .last_win32_error = 32,
+    };
+    var out: [max_attempts]StartupAttempt = undefined;
+    const forward = try mergeRecords(
+        .{ .attempts = &.{window_created} },
+        .{ .attempts = &.{ready_failed} },
+        &out,
+    );
+    try std.testing.expectEqual(StartupPhase.ready_persist_failed, forward.attempts[0].phase);
+    try std.testing.expectEqual(@as(?u32, 32), forward.attempts[0].last_win32_error);
+
+    const reverse = try mergeRecords(
+        .{ .attempts = &.{ready_failed} },
+        .{ .attempts = &.{window_created} },
+        &out,
+    );
+    try std.testing.expectEqual(StartupPhase.ready_persist_failed, reverse.attempts[0].phase);
+    try std.testing.expectEqual(@as(?u32, 32), reverse.attempts[0].last_win32_error);
 }
 
 test "win32 recovery parser rejects unsupported and unknown schema" {

--- a/src/apprt/win32_session_persistence.zig
+++ b/src/apprt/win32_session_persistence.zig
@@ -103,8 +103,70 @@ pub fn writeFileAtomic(absolute_path: []const u8, temporary_path: []const u8, by
         try file.sync();
     }
 
-    try replaceFileAtomic(absolute_path, temporary_path);
+    if (try replaceFileAtomic(absolute_path, temporary_path)) |failure| {
+        std.log.warn(
+            "win32 atomic replace failed replace_win32_error={d} move_win32_error={d}",
+            .{ failure.replace_error, failure.move_error },
+        );
+        return std.os.windows.unexpectedError(@enumFromInt(failure.move_error));
+    }
     temporary_created = false;
+}
+
+pub const AtomicReplaceFailure = struct {
+    replace_error: u32,
+    move_error: u32,
+};
+
+pub const WriteDisposition = union(enum) {
+    atomic,
+    in_place: AtomicReplaceFailure,
+};
+
+/// Recovery-ledger persistence is allowed to trade atomicity for progress.
+/// Saved-session callers continue to use `writeFileAtomic` and fail closed.
+pub fn writeFileAtomicOrInPlace(
+    absolute_path: []const u8,
+    temporary_path: []const u8,
+    bytes: []const u8,
+    atomic_failure: *?AtomicReplaceFailure,
+) !WriteDisposition {
+    atomic_failure.* = null;
+    var temporary_created = false;
+    // Once replacement fails, retain the unique temporary record if the
+    // in-place fallback also fails. Recovery folds it into the next append.
+    errdefer if (temporary_created and atomic_failure.* == null) {
+        deleteFileIfPresent(temporary_path) catch {};
+    };
+
+    {
+        var file = try std.fs.createFileAbsolute(temporary_path, .{ .truncate = true });
+        temporary_created = true;
+        defer file.close();
+        try file.writeAll(bytes);
+        try file.sync();
+    }
+
+    const failure = (try replaceFileAtomic(absolute_path, temporary_path)) orelse {
+        temporary_created = false;
+        return .atomic;
+    };
+    atomic_failure.* = failure;
+    std.log.warn(
+        "win32 recovery atomic replace failed replace_win32_error={d} move_win32_error={d}; falling back to in-place write",
+        .{ failure.replace_error, failure.move_error },
+    );
+    try writeFileInPlace(absolute_path, bytes);
+    try deleteFileIfPresent(temporary_path);
+    temporary_created = false;
+    return .{ .in_place = failure };
+}
+
+pub fn writeFileInPlace(absolute_path: []const u8, bytes: []const u8) !void {
+    var file = try std.fs.createFileAbsolute(absolute_path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(bytes);
+    try file.sync();
 }
 
 pub fn readFileBoundedAlloc(alloc: Allocator, absolute_path: []const u8, max_bytes: usize) ![]u8 {
@@ -115,25 +177,34 @@ pub fn readFileBoundedAlloc(alloc: Allocator, absolute_path: []const u8, max_byt
     return try file.readToEndAlloc(alloc, max_bytes);
 }
 
-fn replaceFileAtomic(absolute_path: []const u8, temporary_path: []const u8) !void {
+fn replaceFileAtomic(absolute_path: []const u8, temporary_path: []const u8) !?AtomicReplaceFailure {
     if (@import("builtin").os.tag == .windows) return replaceFileAtomicWindows(absolute_path, temporary_path);
-    return std.fs.renameAbsolute(temporary_path, absolute_path);
+    try std.fs.renameAbsolute(temporary_path, absolute_path);
+    return null;
 }
 
-fn replaceFileAtomicWindows(absolute_path: []const u8, temporary_path: []const u8) !void {
-    const windows = std.os.windows;
+fn replaceFileAtomicWindows(absolute_path: []const u8, temporary_path: []const u8) !?AtomicReplaceFailure {
     const target_w = try std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, absolute_path);
     defer std.heap.page_allocator.free(target_w);
     const temporary_w = try std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, temporary_path);
     defer std.heap.page_allocator.free(temporary_w);
 
-    if (sys.ReplaceFileW(target_w.ptr, temporary_w.ptr, null, 0, null, null) == 0 and
-        sys.MoveFileExW(temporary_w.ptr, target_w.ptr, MOVEFILE_REPLACE_EXISTING) == 0)
-    {
-        return windows.unexpectedError(windows.kernel32.GetLastError());
-    }
+    if (sys.ReplaceFileW(target_w.ptr, temporary_w.ptr, null, 0, null, null) != 0) return null;
+    const replace_error: u32 = @intFromEnum(std.os.windows.kernel32.GetLastError());
+    if (sys.MoveFileExW(temporary_w.ptr, target_w.ptr, MOVEFILE_REPLACE_EXISTING) != 0) return null;
+    const move_error: u32 = @intFromEnum(std.os.windows.kernel32.GetLastError());
+    return .{
+        .replace_error = replace_error,
+        .move_error = move_error,
+    };
 }
 
+const GENERIC_READ: u32 = 0x80000000;
+const FILE_SHARE_READ: u32 = 0x00000001;
+const FILE_SHARE_WRITE: u32 = 0x00000002;
+const OPEN_EXISTING: u32 = 3;
+const FILE_ATTRIBUTE_NORMAL: u32 = 0x00000080;
+const ERROR_SHARING_VIOLATION: u32 = 32;
 const MOVEFILE_REPLACE_EXISTING: u32 = 0x00000001;
 test "win32 session persistence load distinguishes missing corrupt oversized and transient reads" {
     var tmp = std.testing.tmpDir(.{});
@@ -197,6 +268,71 @@ test "win32 session persistence atomic write replaces existing file and delete i
     try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(temporary, .{}));
     try deleteFileIfPresent(path);
     try deleteFileIfPresent(path);
+}
+
+test "win32 recovery persistence falls back in place when delete sharing blocks replace" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        var file = try tmp.dir.createFile("startup-attempts.json", .{});
+        defer file.close();
+        try file.writeAll("old");
+    }
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "startup-attempts.json");
+    defer std.testing.allocator.free(path);
+    const temporary = try std.mem.concat(std.testing.allocator, u8, &.{ path, ".tmp" });
+    defer std.testing.allocator.free(temporary);
+    const path_w = try std.unicode.utf8ToUtf16LeAllocZ(std.testing.allocator, path);
+    defer std.testing.allocator.free(path_w);
+
+    const held = std.os.windows.kernel32.CreateFileW(
+        path_w.ptr,
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        null,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        null,
+    );
+    if (held == std.os.windows.INVALID_HANDLE_VALUE) return error.TestUnexpectedResult;
+    defer _ = std.os.windows.CloseHandle(held);
+
+    var atomic_failure: ?AtomicReplaceFailure = null;
+    const disposition = try writeFileAtomicOrInPlace(path, temporary, "new", &atomic_failure);
+    switch (disposition) {
+        .atomic => return error.TestExpectedFallback,
+        .in_place => |failure| {
+            try std.testing.expectEqual(@as(u32, ERROR_SHARING_VIOLATION), failure.replace_error);
+            try std.testing.expectEqual(@as(u32, 5), failure.move_error);
+        },
+    }
+    const contents = try std.fs.cwd().readFileAlloc(std.testing.allocator, path, 16);
+    defer std.testing.allocator.free(contents);
+    try std.testing.expectEqualStrings("new", contents);
+    try std.testing.expectError(error.FileNotFound, std.fs.openFileAbsolute(temporary, .{}));
+}
+
+test "win32 recovery persistence retains temp evidence when fallback also fails" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("startup-attempts.json");
+    const target = try tmp.dir.realpathAlloc(std.testing.allocator, "startup-attempts.json");
+    defer std.testing.allocator.free(target);
+    const temporary = try std.mem.concat(std.testing.allocator, u8, &.{ target, ".tmp" });
+    defer std.testing.allocator.free(temporary);
+
+    var atomic_failure: ?AtomicReplaceFailure = null;
+    if (writeFileAtomicOrInPlace(target, temporary, "diagnosis", &atomic_failure)) |_| {
+        return error.TestExpectedError;
+    } else |_| {}
+    try std.testing.expect(atomic_failure != null);
+    const contents = try std.fs.cwd().readFileAlloc(std.testing.allocator, temporary, 32);
+    defer std.testing.allocator.free(contents);
+    try std.testing.expectEqualStrings("diagnosis", contents);
 }
 
 test "win32 session persistence quarantine preserves existing collision" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2866,12 +2866,14 @@ keybind: Keybinds = .{},
 @"command-palette-entry": RepeatableCommand = .{},
 
 /// Sets the reporting format for OSC sequences that request color information.
-/// Ghostty currently supports OSC 10 (foreground), OSC 11 (background), and
-/// OSC 4 (256 color palette) queries, and by default the reported values
-/// are scaled-up RGB values, where each component are 16 bits. This is how
-/// most terminals report these values. However, some legacy applications may
-/// require 8-bit, unscaled, components. We also support turning off reporting
-/// altogether. The components are lowercase hex values.
+/// The terminal core supports OSC 10 (foreground), OSC 11 (background), and
+/// OSC 4 (256 color palette) queries. On Windows, ConPTY may intercept OSC 10
+/// and OSC 11 queries before noctty receives them, so applications may receive
+/// no reply for those queries. By default, reported values are scaled-up RGB
+/// values, where each component is 16 bits. This is how most terminals report
+/// these values. However, some legacy applications may require 8-bit, unscaled,
+/// components. We also support turning off reporting altogether. The components
+/// are lowercase hex values.
 ///
 /// Allowable values are:
 ///

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
+const build_config = @import("../build_config.zig");
 const global_state = &@import("../global.zig").state;
 const internal_os = @import("../os/main.zig");
 const cli_diags = @import("../cli/diagnostics.zig");
@@ -9,6 +10,7 @@ const cli_diags = @import("../cli/diagnostics.zig");
 /// defines the priority of theme search (from top to bottom).
 pub const Location = enum {
     user, // XDG config dir
+    legacy_user, // Legacy Ghostty XDG config dir
     resources, // Ghostty resources dir
 
     /// Returns the directory for the given theme based on this location type.
@@ -25,9 +27,10 @@ pub const Location = enum {
         arena_alloc: Allocator,
     ) error{OutOfMemory}!?[]const u8 {
         return switch (self) {
-            .user => user: {
+            .user, .legacy_user => user: {
                 const subdir = std.fs.path.join(arena_alloc, &.{
-                    "ghostty", "themes",
+                    if (self == .user) build_config.data_dir_name else "ghostty",
+                    "themes",
                 }) catch return error.OutOfMemory;
 
                 break :user internal_os.xdg.config(
@@ -124,8 +127,8 @@ pub fn list(alloc: Allocator, arena_alloc: Allocator) ![]Entry {
 }
 
 /// Enumerate installed theme files with the same directory priority as
-/// `open`: user themes first, bundled resources second. Duplicate names keep
-/// the first location so user themes shadow bundled themes deterministically.
+/// `open`: current user themes first, legacy user themes second, and bundled
+/// resources last. Duplicate names keep the first location deterministically.
 pub fn listFromDirectories(alloc: Allocator, dirs: []const Directory) ![]Entry {
     var themes: std.ArrayList(Entry) = .empty;
     errdefer {
@@ -370,9 +373,18 @@ test "theme list keeps first duplicate by directory priority" {
     defer tmp.cleanup();
 
     try tmp.dir.makePath("user");
+    try tmp.dir.makePath("legacy-user");
     try tmp.dir.makePath("resources");
     {
         var file = try tmp.dir.createFile("user/Dupe", .{});
+        file.close();
+    }
+    {
+        var file = try tmp.dir.createFile("legacy-user/Dupe", .{});
+        file.close();
+    }
+    {
+        var file = try tmp.dir.createFile("legacy-user/LegacyWins", .{});
         file.close();
     }
     {
@@ -380,26 +392,57 @@ test "theme list keeps first duplicate by directory priority" {
         file.close();
     }
     {
-        var file = try tmp.dir.createFile("resources/Other", .{});
+        var file = try tmp.dir.createFile("resources/LegacyWins", .{});
         file.close();
     }
 
     var user_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var legacy_user_buf: [std.fs.max_path_bytes]u8 = undefined;
     var resources_buf: [std.fs.max_path_bytes]u8 = undefined;
     const user_dir = try tmp.dir.realpath("user", &user_buf);
+    const legacy_user_dir = try tmp.dir.realpath("legacy-user", &legacy_user_buf);
     const resources_dir = try tmp.dir.realpath("resources", &resources_buf);
     const entries = try listFromDirectories(std.testing.allocator, &.{
         .{ .location = .user, .dir = user_dir },
+        .{ .location = .legacy_user, .dir = legacy_user_dir },
         .{ .location = .resources, .dir = resources_dir },
     });
     defer freeList(std.testing.allocator, entries);
 
     try std.testing.expectEqual(@as(usize, 2), entries.len);
+    var found_user = false;
+    var found_legacy_user = false;
     for (entries) |entry| {
         if (std.mem.eql(u8, entry.name, "Dupe")) {
             try std.testing.expectEqual(Location.user, entry.location);
-            return;
+            found_user = true;
+        } else if (std.mem.eql(u8, entry.name, "LegacyWins")) {
+            try std.testing.expectEqual(Location.legacy_user, entry.location);
+            found_legacy_user = true;
         }
     }
-    return error.TestExpectedEqual;
+    try std.testing.expect(found_user);
+    try std.testing.expect(found_legacy_user);
+}
+
+test "issue149 user theme locations prefer noctty before legacy ghostty" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var it: LocationIterator = .{ .arena_alloc = arena.allocator() };
+    const user = (try it.next()).?;
+    try std.testing.expectEqual(Location.user, user.location);
+    try std.testing.expectEqualStrings("themes", std.fs.path.basename(user.dir));
+    try std.testing.expectEqualStrings(
+        build_config.data_dir_name,
+        std.fs.path.basename(std.fs.path.dirname(user.dir).?),
+    );
+
+    const legacy_user = (try it.next()).?;
+    try std.testing.expectEqual(Location.legacy_user, legacy_user.location);
+    try std.testing.expectEqualStrings("themes", std.fs.path.basename(legacy_user.dir));
+    try std.testing.expectEqualStrings(
+        "ghostty",
+        std.fs.path.basename(std.fs.path.dirname(legacy_user.dir).?),
+    );
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -723,11 +723,14 @@ pub fn changeConfig(self: *Termio, td: *ThreadData, config: *DerivedConfig) !voi
 
     // Deinit our old config. We do this in the lock because the
     // stream handler may be referencing the old config (i.e. enquiry resp)
-    const color_scheme_report = installDerivedConfigForColorSchemeReport(
-        &self.config,
-        config,
-        self.terminal.modes.get(.report_color_scheme),
-    );
+    //
+    // This must happen before `StreamHandler.changeConfig` below: that queues
+    // the mode 2031 report, and the queued message is drained against
+    // `self.config`. Installing after it would answer with the outgoing
+    // scheme. There is deliberately no direct write here — the queued report
+    // is the single source of these bytes, so an OS scheme flip produces
+    // exactly one report.
+    installDerivedConfig(&self.config, config);
 
     // Update our stream handler. The stream handler uses the same
     // renderer mutex so this is safe to do despite being executed
@@ -763,21 +766,14 @@ pub fn changeConfig(self: *Termio, td: *ThreadData, config: *DerivedConfig) !voi
             config.image_storage_limit,
         );
     }
-
-    if (color_scheme_report) |report| {
-        try self.queueWrite(td, report, false);
-    }
 }
 
-fn installDerivedConfigForColorSchemeReport(
-    current: *DerivedConfig,
-    replacement: *DerivedConfig,
-    report_enabled: bool,
-) ?[]const u8 {
+/// Replace the live derived config. Split out so the ordering contract with
+/// the queued mode 2031 report is testable: whatever is installed here is what
+/// `colorSchemeReportLocked` will report.
+fn installDerivedConfig(current: *DerivedConfig, replacement: *DerivedConfig) void {
     current.deinit();
     current.* = replacement.*;
-    if (!report_enabled) return null;
-    return colorSchemeReportBytes(current.conditional_state.theme);
 }
 
 /// Resize the terminal.
@@ -1389,13 +1385,14 @@ test "issue149 OS scheme flip reports only the newly installed scheme" {
     defer installed.deinit();
     var replacement = try DerivedConfig.init(testing.allocator, &config, .{ .theme = .dark });
 
-    const report = installDerivedConfigForColorSchemeReport(
-        &installed,
-        &replacement,
-        true,
-    ) orelse return error.TestExpectedEqual;
+    // `changeConfig` installs before `StreamHandler.changeConfig` queues the
+    // mode 2031 report, and that queued message is drained against the live
+    // config. So whatever this leaves installed is exactly what gets reported:
+    // the incoming scheme, never the outgoing one.
+    installDerivedConfig(&installed, &replacement);
 
     try testing.expectEqual(configpkg.ConditionalState.Theme.dark, installed.conditional_state.theme);
+    const report = colorSchemeReportBytes(installed.conditional_state.theme);
     try testing.expectEqualStrings(colorSchemeReportBytes(.dark), report);
     try testing.expect(!std.mem.eql(u8, colorSchemeReportBytes(.light), report));
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -449,6 +449,7 @@ pub const DerivedConfig = struct {
     pub fn init(
         alloc_gpa: Allocator,
         config: *const configpkg.Config,
+        conditional_state: configpkg.ConditionalState,
     ) !DerivedConfig {
         var arena = ArenaAllocator.init(alloc_gpa);
         errdefer arena.deinit();
@@ -480,7 +481,10 @@ pub const DerivedConfig = struct {
             .osc_color_report_format = config.@"osc-color-report-format",
             .clipboard_write = config.@"clipboard-write",
             .enquiry_response = try alloc.dupe(u8, config.@"enquiry-response"),
-            .conditional_state = config._conditional_state,
+            // Config.changeConditionalState intentionally skips replay when no
+            // config field uses the changed condition. The terminal still
+            // needs the live state for color-scheme reports in that case.
+            .conditional_state = conditional_state,
 
             // This has to be last so that we copy AFTER the arena allocations
             // above happen (Zig assigns in order).
@@ -719,8 +723,11 @@ pub fn changeConfig(self: *Termio, td: *ThreadData, config: *DerivedConfig) !voi
 
     // Deinit our old config. We do this in the lock because the
     // stream handler may be referencing the old config (i.e. enquiry resp)
-    self.config.deinit();
-    self.config = config.*;
+    const color_scheme_report = installDerivedConfigForColorSchemeReport(
+        &self.config,
+        config,
+        self.terminal.modes.get(.report_color_scheme),
+    );
 
     // Update our stream handler. The stream handler uses the same
     // renderer mutex so this is safe to do despite being executed
@@ -756,6 +763,21 @@ pub fn changeConfig(self: *Termio, td: *ThreadData, config: *DerivedConfig) !voi
             config.image_storage_limit,
         );
     }
+
+    if (color_scheme_report) |report| {
+        try self.queueWrite(td, report, false);
+    }
+}
+
+fn installDerivedConfigForColorSchemeReport(
+    current: *DerivedConfig,
+    replacement: *DerivedConfig,
+    report_enabled: bool,
+) ?[]const u8 {
+    current.deinit();
+    current.* = replacement.*;
+    if (!report_enabled) return null;
+    return colorSchemeReportBytes(current.conditional_state.theme);
 }
 
 /// Resize the terminal.
@@ -1174,11 +1196,18 @@ pub fn colorSchemeReportLocked(self: *Termio, td: *ThreadData, force: bool) !voi
     if (!force and !self.renderer_state.terminal.modes.get(.report_color_scheme)) {
         return;
     }
-    const output = switch (self.config.conditional_state.theme) {
+    try self.queueWrite(
+        td,
+        colorSchemeReportBytes(self.config.conditional_state.theme),
+        false,
+    );
+}
+
+fn colorSchemeReportBytes(theme: configpkg.ConditionalState.Theme) []const u8 {
+    return switch (theme) {
         .light => "\x1B[?997;2n",
         .dark => "\x1B[?997;1n",
     };
-    try self.queueWrite(td, output, false);
 }
 
 /// ThreadData is the data created and stored in the termio thread
@@ -1290,4 +1319,83 @@ test "shouldWakeRendererAfterOutput wakes when synchronized output ends with pen
         false,
         false,
     ));
+}
+
+test "issue149 explicit config colors reach derived config and terminal colors" {
+    const testing = std.testing;
+
+    var config = try configpkg.Config.default(testing.allocator);
+    defer config.deinit();
+    config.background = .{ .r = 0x13, .g = 0x27, .b = 0x38 };
+    config.foreground = .{ .r = 0xFE, .g = 0xDC, .b = 0xBA };
+    try config.palette.parseCLI("5=#123456");
+
+    const conditional_state: configpkg.ConditionalState = .{ .theme = .dark };
+    var derived = try DerivedConfig.init(testing.allocator, &config, conditional_state);
+    defer derived.deinit();
+    try testing.expectEqual(config.background, derived.background);
+    try testing.expectEqual(config.foreground, derived.foreground);
+    try testing.expectEqual(config.palette.value[5], derived.palette[5]);
+    try testing.expectEqual(conditional_state, derived.conditional_state);
+
+    var terminal = try terminalpkg.Terminal.init(testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .colors = .{
+            .background = .init(derived.background.toTerminalRGB()),
+            .foreground = .init(derived.foreground.toTerminalRGB()),
+            .cursor = .unset,
+            .palette = .init(derived.palette),
+        },
+    });
+    defer terminal.deinit(testing.allocator);
+    try testing.expectEqual(config.background.toTerminalRGB(), terminal.colors.background.get().?);
+    try testing.expectEqual(config.foreground.toTerminalRGB(), terminal.colors.foreground.get().?);
+    try testing.expectEqual(config.palette.value[5], terminal.colors.palette.current[5]);
+
+    // The renderer consumes terminal.RenderState rather than Config directly.
+    // Keep the final public handoff in this regression so a future break
+    // between terminal color defaults and the retained renderer state is
+    // detected before a GUI-only failure ships.
+    var render_state = terminalpkg.RenderState.empty;
+    defer render_state.deinit(testing.allocator);
+    try render_state.update(testing.allocator, &terminal);
+    try testing.expectEqual(
+        terminalpkg.color.RGB{ .r = 0x13, .g = 0x27, .b = 0x38 },
+        render_state.colors.background,
+    );
+    try testing.expectEqual(
+        terminalpkg.color.RGB{ .r = 0xFE, .g = 0xDC, .b = 0xBA },
+        render_state.colors.foreground,
+    );
+    try testing.expectEqual(
+        terminalpkg.color.RGB{ .r = 0x12, .g = 0x34, .b = 0x56 },
+        render_state.colors.palette[5],
+    );
+}
+
+test "issue149 color scheme report bytes distinguish dark and light" {
+    try std.testing.expectEqualStrings("\x1B[?997;1n", colorSchemeReportBytes(.dark));
+    try std.testing.expectEqualStrings("\x1B[?997;2n", colorSchemeReportBytes(.light));
+}
+
+test "issue149 OS scheme flip reports only the newly installed scheme" {
+    const testing = std.testing;
+
+    var config = try configpkg.Config.default(testing.allocator);
+    defer config.deinit();
+
+    var installed = try DerivedConfig.init(testing.allocator, &config, .{ .theme = .light });
+    defer installed.deinit();
+    var replacement = try DerivedConfig.init(testing.allocator, &config, .{ .theme = .dark });
+
+    const report = installDerivedConfigForColorSchemeReport(
+        &installed,
+        &replacement,
+        true,
+    ) orelse return error.TestExpectedEqual;
+
+    try testing.expectEqual(configpkg.ConditionalState.Theme.dark, installed.conditional_state.theme);
+    try testing.expectEqualStrings(colorSchemeReportBytes(.dark), report);
+    try testing.expect(!std.mem.eql(u8, colorSchemeReportBytes(.light), report));
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1749,6 +1749,94 @@ fn expectIssue149Write(mailbox: *termio.Mailbox, expected: []const u8) !void {
     }
 }
 
+fn countIssue149ColorSchemeReports(mailbox: *termio.Mailbox) usize {
+    var count: usize = 0;
+    switch (mailbox.*) {
+        .spsc => |*value| while (value.queue.pop()) |message| {
+            if (message == .color_scheme_report) count += 1;
+        },
+    }
+    return count;
+}
+
+test "issue149 config change queues exactly one color scheme report" {
+    // `Termio.changeConfig` installs the new derived config and then calls
+    // this, which queues the mode 2031 report. That queued message is the
+    // single source of the report bytes: a second direct write here would
+    // deliver every OS scheme flip twice.
+    var term = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .colors = .{
+            .foreground = .init(.{ .r = 0x12, .g = 0x34, .b = 0x56 }),
+            .background = .init(.{ .r = 0xAB, .g = 0xCD, .b = 0xEF }),
+            .cursor = .unset,
+            .palette = .default,
+        },
+    });
+    defer term.deinit(std.testing.allocator);
+
+    var termio_mailbox = try termio.Mailbox.initSPSC(std.testing.allocator);
+    defer termio_mailbox.deinit(std.testing.allocator);
+    var renderer_mutex: std.Thread.Mutex = .{};
+    var renderer_state: renderer.State = undefined;
+    renderer_state.mutex = &renderer_mutex;
+    renderer_state.terminal = &term;
+    var rt_app: apprt.App = undefined;
+    rt_app.windows = .empty;
+    rt_app.ui_thread_id = 0;
+    const AppMailbox = @TypeOf(@as(apprt.surface.Mailbox, undefined).app);
+    const app_queue = try AppMailbox.Queue.create(std.testing.allocator);
+    defer app_queue.destroy(std.testing.allocator);
+    const surface_mailbox: apprt.surface.Mailbox = .{
+        .surface = undefined,
+        .app = .{
+            .rt_app = &rt_app,
+            .mailbox = app_queue,
+        },
+    };
+
+    var stream = StreamHandler.Stream.initAlloc(std.testing.allocator, .{
+        .alloc = std.testing.allocator,
+        .size = undefined,
+        .terminal = &term,
+        .termio_mailbox = &termio_mailbox,
+        .surface_mailbox = surface_mailbox,
+        .renderer_state = &renderer_state,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .default_cursor_style = .block,
+        .default_cursor_blink = true,
+        .enquiry_response = "",
+        .osc_color_report_format = .@"16-bit",
+        .clipboard_write = .allow,
+    });
+    defer stream.deinit();
+    _ = countIssue149ColorSchemeReports(&termio_mailbox);
+
+    var config = try configpkg.Config.default(std.testing.allocator);
+    defer config.deinit();
+    var dark = try termio.DerivedConfig.init(std.testing.allocator, &config, .{ .theme = .dark });
+    defer dark.deinit();
+
+    stream.handler.changeConfig(&dark);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countIssue149ColorSchemeReports(&termio_mailbox),
+    );
+
+    // An unrelated reload still reports once, not zero and not twice. This is
+    // deliberate and predates issue #149: any config change can move the
+    // palette, so mode 2031 subscribers are re-notified. See `changeConfig`.
+    var light = try termio.DerivedConfig.init(std.testing.allocator, &config, .{ .theme = .light });
+    defer light.deinit();
+    stream.handler.changeConfig(&light);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countIssue149ColorSchemeReports(&termio_mailbox),
+    );
+}
+
 test "issue149 OSC 10 and 11 queries format replies and preserve terminators" {
     var term = try terminal.Terminal.init(std.testing.allocator, .{
         .cols = 80,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1732,6 +1732,81 @@ test "semantic output capture follows real stream handler parser" {
     try std.testing.expectEqual(@as(usize, 0), combining_noop.len);
 }
 
+fn expectIssue149Write(mailbox: *termio.Mailbox, expected: []const u8) !void {
+    const message = switch (mailbox.*) {
+        .spsc => |*value| value.queue.pop() orelse return error.TestExpectedEqual,
+    };
+    switch (message) {
+        .write_small => |value| try std.testing.expectEqualStrings(
+            expected,
+            value.data[0..value.len],
+        ),
+        .write_alloc => |value| {
+            defer value.alloc.free(value.data);
+            try std.testing.expectEqualStrings(expected, value.data);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "issue149 OSC 10 and 11 queries format replies and preserve terminators" {
+    var term = try terminal.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .colors = .{
+            .foreground = .init(.{ .r = 0x12, .g = 0x34, .b = 0x56 }),
+            .background = .init(.{ .r = 0xAB, .g = 0xCD, .b = 0xEF }),
+            .cursor = .unset,
+            .palette = .default,
+        },
+    });
+    defer term.deinit(std.testing.allocator);
+
+    var termio_mailbox = try termio.Mailbox.initSPSC(std.testing.allocator);
+    defer termio_mailbox.deinit(std.testing.allocator);
+    var renderer_mutex: std.Thread.Mutex = .{};
+    var renderer_state: renderer.State = undefined;
+    renderer_state.mutex = &renderer_mutex;
+    renderer_state.terminal = &term;
+    var rt_app: apprt.App = undefined;
+    rt_app.windows = .empty;
+    rt_app.ui_thread_id = 0;
+    const AppMailbox = @TypeOf(@as(apprt.surface.Mailbox, undefined).app);
+    const app_queue = try AppMailbox.Queue.create(std.testing.allocator);
+    defer app_queue.destroy(std.testing.allocator);
+    const surface_mailbox: apprt.surface.Mailbox = .{
+        .surface = undefined,
+        .app = .{
+            .rt_app = &rt_app,
+            .mailbox = app_queue,
+        },
+    };
+
+    var stream = StreamHandler.Stream.initAlloc(std.testing.allocator, .{
+        .alloc = std.testing.allocator,
+        .size = undefined,
+        .terminal = &term,
+        .termio_mailbox = &termio_mailbox,
+        .surface_mailbox = surface_mailbox,
+        .renderer_state = &renderer_state,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .default_cursor_style = .block,
+        .default_cursor_blink = true,
+        .enquiry_response = "",
+        .osc_color_report_format = .@"16-bit",
+        .clipboard_write = .allow,
+    });
+    defer stream.deinit();
+
+    stream.nextSlice("\x1b]10;?\x07");
+    try expectIssue149Write(&termio_mailbox, "\x1b]10;rgb:1212/3434/5656\x07");
+
+    stream.handler.osc_color_report_format = .@"8-bit";
+    stream.nextSlice("\x1b]11;?\x1b\\");
+    try expectIssue149Write(&termio_mailbox, "\x1b]11;rgb:ab/cd/ef\x1b\\");
+}
+
 test "decodeOsc7PathForPwd handles Windows file URI with a single fallback allocator" {
     const uri = try internal_os.uri.parse("file://localhost/C:/Users/test/project", .{
         .mac_address = false,

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -315,6 +315,27 @@ Run with:
 powershell.exe -ExecutionPolicy Bypass -File .\interactive-win11-palette-theme.ps1 -ResetState
 ```
 
+## interactive-win11-issue149-colors.ps1
+
+Validates issue #149 through the real default config discovery path and the
+retained WGL presentation path. It first verifies foreground, background, and
+palette index 1 through the public `+show-config --changes-only=false` API. It
+then uses `PrintWindow` client-framebuffer readback rather than desktop
+screenshots, and verifies default colors, bundled `Cobalt2`, explicit overrides
+after the theme, live config reload, new-tab and new-split inheritance. The
+configured payload paints independent bands for the default foreground and
+palette index 1. `-MinimumDpi 144` makes a high-DPI run mandatory when that
+desktop is available.
+
+Run with:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\interactive-win11-issue149-colors.ps1 -ResetState -MinimumDpi 144
+```
+
+The harness is intentionally red-capable: supplying a wrong literal such as
+`-ExpectedThemeBackground 010203` must fail on the Cobalt2 framebuffer phase.
+
 ## interactive-win11-session-restore.ps1
 
 Validates a three-tab session save/restart restore with the second tab selected,

--- a/test/windows/interactive-win11-issue149-colors.ps1
+++ b/test/windows/interactive-win11-issue149-colors.ps1
@@ -1,0 +1,389 @@
+[CmdletBinding()]
+param(
+    [switch]$Rebuild,
+    [switch]$ResetState,
+    [ValidatePattern('^[0-9A-Fa-f]{6}$')] [string]$ExpectedThemeBackground = '132738',
+    [ValidateRange(96, 480)] [int]$MinimumDpi = 96,
+    [ValidateRange(10, 300)] [int]$TimeoutSeconds = 60
+)
+
+$ErrorActionPreference = 'Stop'
+$launcher = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
+if (-not $env:NOCTTY_INTERACTIVE_WIN11_ISSUE149_COLORS_BOOTSTRAPPED) {
+    $args = @(
+        '-TimeoutSeconds', $TimeoutSeconds.ToString(),
+        '-ExpectedThemeBackground', $ExpectedThemeBackground,
+        '-MinimumDpi', $MinimumDpi.ToString()
+    )
+    if ($Rebuild) { $args += '-Rebuild' }
+    if ($ResetState) { $args += '-ResetState' }
+    $code = 0
+    Invoke-InteractiveWin11Bootstrap `
+        -RepoRoot $repoRoot `
+        -LauncherPath $launcher `
+        -EnvironmentVariable 'NOCTTY_INTERACTIVE_WIN11_ISSUE149_COLORS_BOOTSTRAPPED' `
+        -ArgumentList $args `
+        -ExitCode ([ref]$code)
+    exit $code
+}
+
+. (Join-Path $PSScriptRoot 'interactive-win11-stateful-lib.ps1')
+Add-Type -AssemblyName System.Drawing
+if (-not ('NocttyIssue149Framebuffer' -as [type])) {
+    Add-Type -ReferencedAssemblies System.Drawing -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+public static class NocttyIssue149Framebuffer {
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int left, top, right, bottom; }
+
+    [DllImport("user32.dll", SetLastError=true)]
+    private static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
+    [DllImport("user32.dll", SetLastError=true)]
+    private static extern IntPtr GetDC(IntPtr hwnd);
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+    [DllImport("user32.dll", SetLastError=true)]
+    private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdc, uint flags);
+    [DllImport("user32.dll")]
+    public static extern uint GetDpiForWindow(IntPtr hwnd);
+    [DllImport("gdi32.dll", SetLastError=true)]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+    [DllImport("gdi32.dll", SetLastError=true)]
+    private static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int width, int height);
+    [DllImport("gdi32.dll", SetLastError=true)]
+    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr value);
+    [DllImport("gdi32.dll", SetLastError=true)]
+    private static extern bool DeleteObject(IntPtr value);
+    [DllImport("gdi32.dll", SetLastError=true)]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    public static Bitmap CaptureClient(IntPtr hwnd) {
+        RECT rect;
+        if (!GetClientRect(hwnd, out rect)) throw new Win32Exception();
+        int width = rect.right - rect.left;
+        int height = rect.bottom - rect.top;
+        if (width <= 0 || height <= 0) throw new InvalidOperationException("Surface client area is empty.");
+
+        IntPtr source = GetDC(hwnd);
+        if (source == IntPtr.Zero) throw new Win32Exception();
+        IntPtr target = IntPtr.Zero;
+        IntPtr bitmap = IntPtr.Zero;
+        IntPtr previous = IntPtr.Zero;
+        try {
+            target = CreateCompatibleDC(source);
+            if (target == IntPtr.Zero) throw new Win32Exception();
+            bitmap = CreateCompatibleBitmap(source, width, height);
+            if (bitmap == IntPtr.Zero) throw new Win32Exception();
+            previous = SelectObject(target, bitmap);
+            if (previous == IntPtr.Zero || previous == new IntPtr(-1)) throw new Win32Exception();
+
+            // PW_CLIENTONLY | PW_RENDERFULLCONTENT reads the window-owned
+            // presented client framebuffer without desktop/screen capture.
+            if (!PrintWindow(hwnd, target, 0x00000003)) throw new Win32Exception();
+            using (Image image = Image.FromHbitmap(bitmap)) {
+                return new Bitmap(image);
+            }
+        }
+        finally {
+            if (target != IntPtr.Zero && previous != IntPtr.Zero) SelectObject(target, previous);
+            if (bitmap != IntPtr.Zero) DeleteObject(bitmap);
+            if (target != IntPtr.Zero) DeleteDC(target);
+            ReleaseDC(hwnd, source);
+        }
+    }
+
+    public static Task<Bitmap> CaptureClientAsync(IntPtr hwnd) {
+        return Task.Run(() => CaptureClient(hwnd));
+    }
+}
+'@
+}
+
+function Convert-Issue149Rgb([string]$Hex) {
+    return [Convert]::ToInt32($Hex, 16)
+}
+
+function Write-Issue149Config(
+    [string]$Path,
+    [string]$PayloadPath,
+    [string]$MarkerDirectory,
+    [ValidateSet('default', 'theme', 'explicit')] [string]$Case
+) {
+    $lines = [Collections.Generic.List[string]]::new()
+    $lines.Add("command = direct:pwsh.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $PayloadPath -MarkerDirectory $MarkerDirectory")
+    $lines.Add('shell-integration = none')
+    $lines.Add('window-save-state = never')
+    $lines.Add('confirm-close-surface = false')
+    $lines.Add('font-size = 12')
+    $lines.Add('window-width = 90')
+    $lines.Add('window-height = 24')
+    $lines.Add('background-opacity = 1')
+    if ($Case -ne 'default') { $lines.Add('theme = Cobalt2') }
+    if ($Case -eq 'explicit') {
+        # These follow the theme on purpose: explicit values must win.
+        $lines.Add('background = #102030')
+        $lines.Add('foreground = #405060')
+        $lines.Add('palette = 1=#708090')
+    }
+    [IO.File]::WriteAllText(
+        $Path,
+        (($lines -join "`r`n") + "`r`n"),
+        [Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Get-Issue149VisibleSurfaces([IntPtr]$HostHwnd) {
+    return @(Get-StatefulChildren $HostHwnd | Where-Object Class -eq 'noctty.win32')
+}
+
+function Assert-Issue149PublicConfig(
+    [string]$CliPath,
+    [string]$Phase,
+    [string]$Background,
+    [string]$Foreground,
+    [string]$Palette1,
+    [string]$RepoRoot
+) {
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $CliPath
+    $start.Arguments = '+show-config --changes-only=false --no-pager'
+    $start.WorkingDirectory = $RepoRoot
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    if (-not $process.Start()) { throw "$Phase +show-config failed to start." }
+    try {
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit(10000)) {
+            $process.Kill()
+            $process.WaitForExit()
+            throw "$Phase +show-config timed out."
+        }
+        if ($process.ExitCode -ne 0) {
+            throw "$Phase +show-config exited $($process.ExitCode): $($stderr.Result)"
+        }
+        $text = $stdout.Result
+    }
+    finally {
+        $process.Dispose()
+    }
+
+    foreach ($entry in ([ordered]@{
+            background = "background = #$Background"
+            foreground = "foreground = #$Foreground"
+            palette1 = "palette = 1=#$Palette1"
+        }).GetEnumerator()) {
+        if ($text -notmatch "(?m)^$([regex]::Escape($entry.Value))`r?$") {
+            throw "$Phase public config did not contain $($entry.Key) '$($entry.Value)'."
+        }
+    }
+    Write-Host "$Phase public config: background=$Background foreground=$Foreground palette1=$Palette1"
+}
+
+function Invoke-Issue149PaletteAction(
+    [IntPtr]$HostHwnd,
+    [string]$Action,
+    [DateTime]$Deadline,
+    [Parameter(Mandatory)] [Diagnostics.Process]$Process
+) {
+    Invoke-StatefulPostedCommand $HostHwnd 1901 $Deadline $Process
+    $script:Issue149Host = $HostHwnd
+    Wait-InteractiveWin11Until -Deadline $Deadline -Description "palette edit for $Action" -Process $Process -Condition {
+        @(Get-StatefulChildren $script:Issue149Host | Where-Object Id -eq 2002).Count -eq 1
+    }
+    $edit = Get-StatefulChildren $HostHwnd | Where-Object Id -eq 2002 | Select-Object -First 1
+    Set-StatefulEditText $HostHwnd $edit.Hwnd $Action $Deadline $Process
+    Wait-InteractiveWin11Until -Deadline $Deadline -Description "palette result for $Action" -Process $Process -Condition {
+        @(Get-StatefulChildren $script:Issue149Host | Where-Object Id -eq 2006).Count -eq 1
+    }
+    Invoke-StatefulPaletteFirstRow $HostHwnd $Deadline $Process
+    Wait-InteractiveWin11Until -Deadline $Deadline -Description "palette dismissal for $Action" -Process $Process -Condition {
+        @(Get-StatefulChildren $script:Issue149Host | Where-Object { $_.Id -ge 2001 -and $_.Id -le 2006 }).Count -eq 0
+    }
+}
+
+function Assert-Issue149FrameColors(
+    [IntPtr]$SurfaceHwnd,
+    [string]$Name,
+    [string]$Background,
+    [string]$Foreground,
+    [string]$Palette1,
+    [string]$EvidenceDirectory
+) {
+    $capture = [NocttyIssue149Framebuffer]::CaptureClientAsync($SurfaceHwnd)
+    if (-not $capture.Wait(10000)) { throw "$Name client-frame readback timed out." }
+    $bitmap = $capture.GetAwaiter().GetResult()
+    try {
+        $evidencePath = Join-Path $EvidenceDirectory "$Name.png"
+        $bitmap.Save($evidencePath, [Drawing.Imaging.ImageFormat]::Png)
+        $expected = [ordered]@{
+            background = Convert-Issue149Rgb $Background
+            foreground = Convert-Issue149Rgb $Foreground
+            palette1 = Convert-Issue149Rgb $Palette1
+        }
+        $counts = [ordered]@{ background = 0; foreground = 0; palette1 = 0 }
+        $sampleCount = 0
+        for ($y = 2; $y -lt ($bitmap.Height - 2); $y += 2) {
+            for ($x = 2; $x -lt ($bitmap.Width - 2); $x += 2) {
+                $sampleCount++
+                $rgb = $bitmap.GetPixel($x, $y).ToArgb() -band 0xFFFFFF
+                foreach ($key in $expected.Keys) {
+                    if ($rgb -eq $expected[$key]) { $counts[$key]++ }
+                }
+            }
+        }
+        $minimum = [Math]::Max(16, [int]($sampleCount * 0.01))
+        foreach ($key in $expected.Keys) {
+            if ($counts[$key] -lt $minimum) {
+                throw ('{0} framebuffer did not contain configured {1} #{2}: count={3}, minimum={4}, samples={5}' -f `
+                    $Name, $key, $expected[$key].ToString('x6'), $counts[$key], $minimum, $sampleCount)
+            }
+        }
+        $dpi = [NocttyIssue149Framebuffer]::GetDpiForWindow($SurfaceHwnd)
+        if ($dpi -lt $MinimumDpi) { throw "$Name rendered at $dpi DPI; required at least $MinimumDpi DPI." }
+        Write-Host ('{0}: dpi={1} client={2}x{3} samples={4} background={5} foreground={6} palette1={7}' -f `
+            $Name, $dpi, $bitmap.Width, $bitmap.Height, $sampleCount,
+            $counts.background, $counts.foreground, $counts.palette1)
+    }
+    finally {
+        $bitmap.Dispose()
+    }
+}
+
+function Assert-Issue149VisibleSurfaceColors(
+    [IntPtr]$HostHwnd,
+    [string]$Phase,
+    [string]$Background,
+    [string]$Foreground,
+    [string]$Palette1,
+    [string]$EvidenceDirectory
+) {
+    $surfaces = @(Get-Issue149VisibleSurfaces $HostHwnd)
+    if ($surfaces.Count -eq 0) { throw "$Phase has no visible terminal surface." }
+    for ($index = 0; $index -lt $surfaces.Count; $index++) {
+        Assert-Issue149FrameColors `
+            -SurfaceHwnd $surfaces[$index].Hwnd `
+            -Name "$Phase-surface-$index" `
+            -Background $Background `
+            -Foreground $Foreground `
+            -Palette1 $Palette1 `
+            -EvidenceDirectory $EvidenceDirectory
+    }
+}
+
+$harness = Initialize-InteractiveWin11Sandbox `
+    -RepoRoot $repoRoot `
+    -SandboxName 'issue149-colors' `
+    -ResetState:$ResetState `
+    -IncludeResourcesDir
+$layout = $harness.Layout
+$exe = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
+$cli = Join-Path (Split-Path -Parent $exe) 'noctty.com'
+if ((Get-InteractiveWin11LaunchAction `
+        -ExePath $exe `
+        -Rebuild:$Rebuild `
+        -BuildInputs (Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot)) -eq 'build') {
+    Invoke-InteractiveWin11Build -RepoRoot $repoRoot
+}
+Assert-InteractiveWin11ExeExists -ExePath $exe
+if (-not [IO.File]::Exists($cli)) { throw "Missing noctty.com at $cli" }
+
+$configDirectory = Join-Path $layout.LocalAppData 'noctty'
+$markerDirectory = Join-Path $layout.SandboxRoot 'issue149-markers'
+$evidenceDirectory = Join-Path $layout.Logs 'issue149-framebuffers'
+[IO.Directory]::CreateDirectory($configDirectory) | Out-Null
+[IO.Directory]::CreateDirectory($markerDirectory) | Out-Null
+[IO.Directory]::CreateDirectory($evidenceDirectory) | Out-Null
+$configPath = Join-Path $configDirectory 'config.ghostty'
+$payloadPath = Join-Path $PSScriptRoot 'issue149-color-payload.ps1'
+Write-Issue149Config $configPath $payloadPath $markerDirectory 'default'
+Assert-Issue149PublicConfig $cli 'default' '282c34' 'ffffff' 'cc6666' $repoRoot
+
+$run = $null
+$primaryError = $null
+try {
+    $run = Start-StatefulApp $layout $exe $repoRoot 'issue149-colors'
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $hostHwnd = Wait-StatefulHost $run $deadline
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'initial issue149 payload marker' -Process $run.Process -Condition {
+        @(Get-ChildItem -LiteralPath $markerDirectory -Filter '*.ready' -File -ErrorAction SilentlyContinue).Count -eq 1
+    }
+    $surface = Wait-StatefulSurface $hostHwnd $run $deadline
+    $null = Invoke-InteractiveWin11Message -Hwnd $surface.Hwnd -Message 0 -Deadline $deadline -Description 'initial issue149 presentation barrier' -Process $run.Process
+    Assert-Issue149VisibleSurfaceColors $hostHwnd 'default' '282c34' 'ffffff' 'cc6666' $evidenceDirectory
+
+    Write-Issue149Config $configPath $payloadPath $markerDirectory 'theme'
+    Assert-Issue149PublicConfig $cli 'theme' '132738' 'ffffff' 'ff0000' $repoRoot
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Invoke-Issue149PaletteAction $hostHwnd 'reload_config' $deadline $run.Process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'Cobalt2 framebuffer reload' -Process $run.Process -Condition {
+        try {
+            Assert-Issue149VisibleSurfaceColors $hostHwnd 'theme-probe' $ExpectedThemeBackground 'ffffff' 'ff0000' $evidenceDirectory
+            return $true
+        }
+        catch { return $false }
+    }
+    Assert-Issue149VisibleSurfaceColors $hostHwnd 'theme' $ExpectedThemeBackground 'ffffff' 'ff0000' $evidenceDirectory
+
+    Write-Issue149Config $configPath $payloadPath $markerDirectory 'explicit'
+    Assert-Issue149PublicConfig $cli 'explicit' '102030' '405060' '708090' $repoRoot
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Invoke-Issue149PaletteAction $hostHwnd 'reload_config' $deadline $run.Process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'explicit color framebuffer reload' -Process $run.Process -Condition {
+        try {
+            Assert-Issue149VisibleSurfaceColors $hostHwnd 'explicit-probe' '102030' '405060' '708090' $evidenceDirectory
+            return $true
+        }
+        catch { return $false }
+    }
+    Assert-Issue149VisibleSurfaceColors $hostHwnd 'explicit' '102030' '405060' '708090' $evidenceDirectory
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Invoke-StatefulPostedCommand $hostHwnd 1904 $deadline $run.Process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'second tab payload marker' -Process $run.Process -Condition {
+        (Get-StatefulTabCount $hostHwnd) -eq 2 -and
+        @(Get-ChildItem -LiteralPath $markerDirectory -Filter '*.ready' -File -ErrorAction SilentlyContinue).Count -eq 2
+    }
+    Assert-Issue149VisibleSurfaceColors $hostHwnd 'new-tab' '102030' '405060' '708090' $evidenceDirectory
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Invoke-Issue149PaletteAction $hostHwnd 'new_split:right' $deadline $run.Process
+    Wait-InteractiveWin11Until -Deadline $deadline -Description 'split payload markers and surfaces' -Process $run.Process -Condition {
+        @(Get-Issue149VisibleSurfaces $hostHwnd).Count -eq 2 -and
+        @(Get-ChildItem -LiteralPath $markerDirectory -Filter '*.ready' -File -ErrorAction SilentlyContinue).Count -eq 3
+    }
+    Assert-Issue149VisibleSurfaceColors $hostHwnd 'new-split' '102030' '405060' '708090' $evidenceDirectory
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    Close-StatefulHost $hostHwnd $run $deadline
+}
+catch {
+    $primaryError = $_
+}
+finally {
+    if ($null -ne $run) {
+        $run.Process.Refresh()
+        if (-not $run.Process.HasExited) {
+            try { Stop-InteractiveWin11Process -Process $run.Process -Contained }
+            catch {
+                if ($null -eq $primaryError) { $primaryError = $_ }
+                else { Write-Warning "Exact-PID cleanup also failed: $($_.Exception.Message)" }
+            }
+        }
+    }
+}
+
+if ($null -ne $primaryError) { throw $primaryError }
+Write-Host 'PASS: issue #149 default/theme/explicit colors reached the presented WGL framebuffer across reload, new tab, and new split.'

--- a/test/windows/issue149-color-payload.ps1
+++ b/test/windows/issue149-color-payload.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param([Parameter(Mandatory)] [string]$MarkerDirectory)
+
+$ErrorActionPreference = 'Stop'
+[IO.Directory]::CreateDirectory($MarkerDirectory) | Out-Null
+
+$surfaceId = if ([string]::IsNullOrWhiteSpace($env:GHOSTTY_SURFACE_ID)) {
+    'unknown-surface'
+}
+else {
+    $env:GHOSTTY_SURFACE_ID
+}
+$markerPath = Join-Path $MarkerDirectory "$surfaceId.ready"
+[IO.File]::WriteAllText($markerPath, $surfaceId, [Text.UTF8Encoding]::new($false))
+
+$esc = [char]27
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+[Console]::Write("$esc[2J$esc[H$esc[?25l$esc[?7l")
+
+# Rows 5-7 use reverse video with default colors, so their cell backgrounds
+# are the configured foreground. Rows 12-14 use palette index 1 as their cell
+# background. Autowrap is disabled so every row becomes one stable color band
+# regardless of the current column count.
+foreach ($row in 5..7) {
+    [Console]::Write("$esc[$row;1H$esc[0;7m" + (' ' * 512))
+}
+foreach ($row in 12..14) {
+    [Console]::Write("$esc[$row;1H$esc[0;41m" + (' ' * 512))
+}
+[Console]::Write("$esc[0m$esc[H")
+
+while ($true) {
+    Start-Sleep -Seconds 1
+}


### PR DESCRIPTION
## Summary

Three defects, all reproduced or proven with captured evidence on the reporter's own machine.

**1. The reported symptom — "config is resolved but never applied" — is recovery safe mode.** `win32_recovery.decide` selects safe mode after three startup attempts within seven days that never reached the ready marker, and `App.init` then runs the entire GUI on `Config.default()`. `+show-config` never enters `App.init`, so it keeps echoing the user's real values. That is exactly the split the reporter described. This machine's real ledger (`%LOCALAPPDATA%\winghostty\startup-attempts.json`) holds 16 attempts and **zero** `ready_at_unix_ms`; replaying those exact bytes through `decide` returns `.safe_mode`. An **exact v1.3.123 build launched with a copy of that ledger reproduces the report** — theme, background and palette ignored and the configured `command` not run — while the same build with a clean ledger honours all of them. Nothing told the user any of this: safe mode only emitted a log warning.

**2. Windows dark/light mode was never propagated into the core conditional configuration.** `App.colorSchemeEvent` and `Surface.colorSchemeCallback` had zero callers anywhere under `src/apprt/`, so `theme = light:X,dark:Y` stayed pinned to the light branch and the terminal answered DSR 997 / mode 2031 with "light" in dark mode — the reporter's tmux `#{client_theme}` observation.

**3. Per-user themes were still looked up under the pre-rebrand `ghostty/themes` directory.**

Fixes #149

## Changes

### Recovery safe mode
- Show a native information dialog when safe mode is entered, on a detached ownerless worker thread, explaining that built-in defaults are active and that restarting retries normal startup. The first implementation used the in-window banner; a real-app capture proved the banner paints inside the terminal child's lane and is never visible, so it is a modal dialog instead.
- Persist the ready marker *before* showing that dialog, so a process terminated while the modal is up still breaks the failure streak. The notice is armed at the initial-window boundary and released by `resolveRecoveryStartup` once the launch is resolved on disk, never from `run` ahead of the first tick.
- Copy the ready state into memory only after the disk write succeeds. The old order marked the attempt ready first, so a single failed write made every later call in that process take the "already ready" early return and skip any retry.
- Retry a failed ready-marker write up to three times (never for `OutOfMemory`), spread across message-loop ticks rather than an in-line sleep loop, and gated on a monotonic deadline so an unrelated tick on a busy terminal cannot spend an attempt early. Latching the first tick as handled left one transient sharing violation unresolved on disk for the whole session, which is itself crash-loop evidence.
- The retry is deliberate, not accumulated: a ledger write fails in two shapes and only one is self-healing. If the atomic replacement fails **and** the in-place fallback also fails, the diagnosis is retained as a `.pending-` record and folded into the next startup's append. If the write fails *before* the replacement is attempted — the temp file could not be created, written or synced — nothing is retained and the ready marker is lost outright, which is #149's own reported failure mode (16 attempts, zero ready markers). The second shape has no cross-launch recovery, so the in-session retry is its only mitigation. `win32 recovery ready-write failure before atomic replace leaves nothing for the pending fold` pins that boundary so the retry is not removed on the assumption that the `.pending-` fold already covers a failed write.
- Serialise every ledger transaction across instances. Two instances launched at once each read the ledger, appended their own attempt and replaced the file; atomic replacement kept it well-formed but the later writer dropped the earlier writer's record. `RecoveryLedgerLock` takes an exclusive byte-range lock on a sibling `startup-attempts.json.lock` around the read-fold-append-replace-cleanup in `beginRecoveryStartupAtPath`, the window-created hint, and the ready-marker merge. The kernel releases it when the holder exits by any means. Acquisition is bounded (2 s) and fail-open: a launch that cannot take the lock still decides safe mode from the ledger but records nothing, and a busy lock in the ready path spends a retry like a handle hold does. `std.fs.File.tryLock` does not compile on Windows in Zig 0.15.2, so the NT lock call is made directly.

### Color scheme
- Seed the core color scheme from `AppsUseLightTheme` before the first surface is created, and refresh it on `WM_SETTINGCHANGE`. Surfaces are updated before the app-wide reload so their conditional branches are current.
- Accept surface-targeted soft config reloads, previously rejected by a `target != .app` guard placed before the `soft` check. Internal conditional-state reloads no longer raise a "Configuration reloaded" desktop notification; `soft = true` is emitted only by the internal callbacks, so user-initiated reloads still notify.
- Pass the authoritative App/Surface conditional state into `Termio.DerivedConfig`. `Config.changeConditionalState` deliberately skips replay when no config field uses the changed condition, which left `Termio` reporting the stale default.

### Themes and docs
- Resolve per-user themes from `<config>/noctty/themes`, keeping the legacy `<config>/ghostty/themes` as a lower-priority fallback so existing custom themes still resolve after the rebrand. Bundled `share/ghostty/themes` and `GHOSTTY_RESOURCES_DIR` are untouched.
- Correct the `osc-color-report-format` doc comment: Windows ConPTY intercepts OSC 10/11 queries before they reach the terminal parser.

New tests: ready-marker persistence ordering (a failed write leaves the attempt unresolved and retryable); the bounded retry policy; safe mode always carrying a user-visible notice; explicit background/foreground/palette propagation into `Termio.DerivedConfig` and `Terminal.colors`; exact DSR 997 reply bytes per scheme; dark-mode to `ColorScheme` mapping; user-theme directory precedence; and OSC 10/11 reply formatting across 8-bit/16-bit and BEL/ST, which had no coverage at all.

## Validation

Gates on head `126ea55e8`, rebased onto `main` at `e3a38268e` (post docs debloat #206):

- `zig build -Demit-exe=true` — exit 0.
- `zig build test -Demit-test-exe=true` — **4098 passed, 70 skipped, 0 failed** (4168 tests). The invariant is zero failures; pass counts are not comparable across PRs because every branch adds its own tests.
- `zig build test -Dtest-filter=recovery` — 99 passed, 1 skipped.
- `zig build test -Dtest-filter=issue149` — 75 passed, 1 skipped.
- `zig build test -Dtest-filter=theme` — 98 passed, 1 skipped.
- `scripts/check-zig-format.ps1` — passed (693 tracked sources).
- `scripts/check-source-format.ps1` — passed.
- `test/windows/flagship/Test-VerificationContracts.ps1` — PASS (2 scenarios).
- `test/windows/issue149-color-payload.ps1` — runs non-interactively and writes its `<surface>.ready` marker; the interactive harness `interactive-win11-issue149-colors.ps1` was not run in this round and is left for the serialized interactive phase.

An earlier revision of this body claimed "1 failure, the known pre-existing `Command: custom env vars`". **That is retracted.** `b1739a731` on `main` fixed that test and is an ancestor of this head; there is no baseline failure to attribute anything to.

The two new recovery contracts were confirmed red before the fix: the ordering test found the prematurely assigned ready timestamp, and the retry test saw a transient error escape without a retry.

### A/B reproduction

Isolated config and `LOCALAPPDATA` roots throughout; the real ledger was copied, never modified (SHA-256 `A0C1B295…`, 625 bytes, mtime unchanged before and after). WSL launch was denied `E_ACCESSDENIED` in the sandbox, so the payload was PowerShell printing truecolor markers on row 0, row 1 and the last row.

| Arm | Ledger | Safe mode | Configured command ran |
|---|---|---|---|
| Installed 1.3.118 | clean | no | yes |
| Installed 1.3.118 | copy of real | **yes** | **no — default `cmd`** |
| Exact v1.3.123 | clean | no | yes |
| Exact v1.3.123 | copy of real | **yes** | **no — default `cmd`** |
| This branch | clean | no | yes |
| This branch | copy of real | **yes** | **no**, and the safe-mode dialog is now shown |

Self-healing, from the poisoned ledger: run 1 gave `.safe_mode` with the configured command skipped and the ready marker written after 661 ms; run 2 in the same root was `.normal` and executed the configured command. The streak cannot survive a successful ready write.

Safe-mode notice, final implementation: the modal HWND was verified owned by the launched PID, UI Automation matched the exact caption and full notice text and exposed the OK control, and the ready marker was already on disk while the modal was still visible. Screenshot captured at original resolution.

Earlier probes (run before the ledger was understood) also showed that with a **clean** ledger the color pipeline is healthy: default-discovery launches with no `--config-file`, including the reporter's exact `%LOCALAPPDATA%\winghostty\config.ghostty` path, painted `#132738` for `theme = Cobalt2`, `theme = light:Cobalt2,dark:Cobalt2`, and explicit background/foreground plus a 16-entry palette. DSR `CSI ?996n` now answers `ESC[?997;1n` (dark); before the Termio fix the same probe returned `ESC[?997;2n`.

OSC 10/11: a ConPTY probe with positive controls showed the query bytes never reach the parser — baseline 9 input bytes gave 109 bytes read; OSC 10 (+8 bytes) gave 109; OSC 11 (+7) gave 109; OSC 133 (+9) gave 118. Only OSC 133 survives, localizing the loss to in-box ConPTY. No workaround was added.

Evidence artifacts (168 files) are under `C:\Users\amant\.t3\worktrees\winghostty\evidence\149\`.

### Adversarial-review follow-ups (third commit)

- **Ledger diagnosis.** Both real ledgers on the reporter's machine hold 16 attempts with zero ready markers and an mtime equal to the last `started_at_unix_ms`, so the ready write has never landed there — yet a current build self-heals a *fresh copy* of that directory. The v1 schema records nothing about why a write failed, so the historical cause is unrecoverable from it. Added backward-compatible `phase` (`init`, `window_created`, `ready`, `ready_persist_failed`) and `last_win32_error` fields capturing raw `ReplaceFileW`/`MoveFileExW` errors before `unexpectedError` converts them. A failing write cannot record its own failure, so the diagnosis is retained in the temp record and folded into the next startup's append.
- **Fallback write.** Atomic replacement now falls back to truncate-and-write; losing atomicity for this one file beats never recording readiness. Verified against a controlled delete-sharing hold that reproduces `ReplaceFileW=32` / `MoveFileExW=5`. Saved-session persistence stays atomic and fail-closed. The three-attempt ~20 ms *in-line* retry is gone — it could not ride out a handle hold and burned attempts on `AccessDenied`. The bounded retry that remains is tick-spaced, so it spans real wall time and can outlast such a hold, and `AccessDenied` on `ReplaceFileW` no longer aborts now that the in-place fallback exists.
- **"Unresolved" tightened.** Ready now means the outer message loop completed its first `core_app.tick`, so a crash during the first tick counts as a failed startup; `window_created` is persisted before entering the loop.
- **Modal no longer stalls the mailbox.** The notice runs on a detached worker thread with no owner window. As an owned modal before the message loop, its nested loop dispatched `WM_WINHOSTTY_WAKE` to a wndproc that returns 0, stalling every app-mailbox message while the dialog was up.
- `error.IPCFailed` during startup forwarding now continues as a local instance instead of returning early and manufacturing another incomplete startup.
- **`WM_SETTINGCHANGE` filtered** on lParam `L"ImmersiveColorSet"`; it previously ran N surfaces x 2 reload passes for any setting change at all.
- **Mode 2031 regression caught and fixed.** Batching the reload across surfaces had removed live scheme reporting entirely. `Termio.changeConfig` now emits the report after the new derived config is installed, and a test pins that a flip reports the new scheme and never the old one.
- Test seams trimmed: the eagerly-evaluated error-union seam is replaced with path-based helpers, and the tautological `systemColorSchemeForDarkMode` is gone.
- Adds `test/windows/interactive-win11-issue149-colors.ps1` and its payload — an interactive harness driving default config discovery with `PrintWindow` framebuffer readback, covering default colors, bundled Cobalt2, explicit overrides after a theme, live reload, and new-tab/new-split inheritance.

Gate numbers for the current head are in the Validation section above; earlier per-commit figures were removed because they no longer describe this head.

## Residuals / user steps

- **Why the reporter's ledger got poisoned is still not explained.** A current build self-heals a fresh copy of the real directory, so the failure is specific to that directory's historical handle/ACL environment, which cannot be reconstructed. The new `phase` and `last_win32_error` fields exist precisely so the next occurrence names its own cause.
- **Original note:** Safe mode self-heals in one successful launch, so seeing defaults on three consecutive restarts means their launches were either dying before the ready marker or failing to persist it every time. The ledger records no error phase and the historical warnings were ephemeral, so the original filesystem error is not recoverable. This PR makes the failure visible, retryable and non-sticky; if it recurs, the dialog plus the `win32 recovery:` log lines will name the failing step.
- OSC 10/11 remain unanswered on Windows because in-box ConPTY swallows the queries. That needs the bundled `conpty.dll` work tracked separately (#129 / the ConPTY roadmap item); this PR only makes the documentation honest.
- A live dark to light to dark OS theme transition was not executed: the sandbox was denied write access to `HKCU\...\Personalize\AppsUseLightTheme`. The `WM_SETTINGCHANGE` path is wired and unit-tested in both directions, and initial dark reporting is proven on the real app.
- Not addressed (pre-existing upstream core behaviour, out of scope): `App.colorSchemeEvent` and `Surface.colorSchemeCallback` commit the new scheme before their fallible reload, so a failed reload cannot be retried by a repeat `WM_SETTINGCHANGE`.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Make Windows recovery safe mode visible and self-healing while propagating the operating-system color scheme and resolving user themes through the current configuration path.

New Features:
- Add a visible safe-mode notice explaining that built-in defaults are active and normal startup will be retried after restart.
- Report and synchronize the Windows light/dark color scheme throughout conditional configuration and terminal mode responses.
- Support current per-user theme storage under the rebranded configuration directory while retaining the legacy location as a fallback.

Bug Fixes:
- Prevent recovery safe mode from silently ignoring user configuration by making startup readiness persistence ordered, retryable, diagnosable, and resilient to concurrent launches and transient Windows file-sharing failures.
- Ensure explicit colors, conditional themes, and live color-scheme reports reach terminal and renderer state correctly.
- Correct Windows OSC color-report documentation to reflect ConPTY interception of OSC 10/11 queries.

Enhancements:
- Serialize startup-ledger transactions and preserve failed persistence diagnostics for subsequent startup recovery.
- Filter Windows setting-change handling to relevant color-scheme notifications and support surface-targeted soft configuration reloads.

Documentation:
- Document the Windows ConPTY limitation affecting OSC 10/11 color queries.

Tests:
- Add recovery, color propagation, color-scheme reporting, theme precedence, persistence fallback, concurrency, and OSC formatting coverage.
- Add an interactive Windows framebuffer harness covering default, themed, explicit, reload, new-tab, and split color behavior.
