### PR TITLE
fix(win32): place terminal content below the integrated titlebar band (#150)

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -10618,7 +10618,7 @@ const Host = struct {
         // widths survive, while the integrated-caption policy
         // (caption row inside client + maximized invisible-margin
         // compensation) stays centralized in `win32_nc_layout`.
-        const metrics = win32_nc_layout.metricsDefault(self.current_dpi);
+        const metrics = self.ncMetrics();
         const state: win32_nc_layout.WindowState = if (sys.IsZoomed(hwnd) != 0) .maximized else .normal;
         const adjusted = win32_nc_layout.calcNcClientRect(.{
             .left = params.rgrc[0].left,
@@ -10649,7 +10649,7 @@ const Host = struct {
             .bottom = win_rect.bottom,
         };
         const cursor: win32_nc_layout.Point = .{ .x = cx, .y = cy };
-        const metrics = win32_nc_layout.metricsDefault(self.current_dpi);
+        const metrics = self.ncMetrics();
         const state: win32_nc_layout.WindowState =
             if (sys.IsZoomed(hwnd) != 0) .maximized else .normal;
         const ht = win32_nc_layout.hitTest(window_rect, cursor, metrics, state);
@@ -10781,7 +10781,12 @@ const Host = struct {
         const hwnd = self.hwnd orelse return 0;
         var rect: RECT = undefined;
         if (sys.GetClientRect(hwnd, &rect) == 0) return 0;
-        const list_top = self.tabBarHeight() + self.scaled(host_overlay_height);
+        const bands = self.contentBands(
+            self.tabBarHeight(),
+            self.scaled(host_overlay_height),
+            0,
+        );
+        const list_top = bands.inspector_top;
         return paletteVisibleRowCapacity(
             rect.bottom - list_top - self.scaled(8),
             self.scaled(palette_row_height),
@@ -14757,7 +14762,13 @@ const Host = struct {
         focused: bool,
         hovered: bool,
     ) void {
-        const theme = &self.app.resolved_theme;
+        const titlebar_theme = clientTitlebarTheme(
+            &self.app.resolved_theme,
+            &self.app.config,
+            self.usingIntegratedTitlebar(),
+            isHighContrastActive(),
+        );
+        const theme = &titlebar_theme;
         const parent_bg = theme.chrome_bg;
         const is_hc = isHighContrastActive();
         fillSolidRect(draw.hDC, draw.rcItem, parent_bg);
@@ -14813,7 +14824,13 @@ const Host = struct {
         const tab_button = self.isTabButton(draw.hwndItem);
         const search_role = self.searchBarButtonRole(draw.hwndItem);
         const icon = self.searchBarButtonIcon(draw.hwndItem);
-        const theme = &self.app.resolved_theme;
+        const titlebar_theme = clientTitlebarTheme(
+            &self.app.resolved_theme,
+            &self.app.config,
+            tab_button and self.usingIntegratedTitlebar(),
+            isHighContrastActive(),
+        );
+        const theme = &titlebar_theme;
         if (search_role) |role| {
             self.drawSearchBarButton(
                 draw,
@@ -15371,6 +15388,31 @@ const Host = struct {
         return self.scaled(base);
     }
 
+    fn contentBands(
+        self: *const Host,
+        tab_bottom: i32,
+        overlay_height: i32,
+        inspector_height: i32,
+    ) win32_nc_layout.ContentBands {
+        const caption_bottom = if (self.usingIntegratedTitlebar())
+            self.ncMetrics().caption_button_h
+        else
+            0;
+        return win32_nc_layout.contentBands(
+            tab_bottom,
+            caption_bottom,
+            overlay_height,
+            inspector_height,
+        );
+    }
+
+    fn ncMetrics(self: *const Host) win32_nc_layout.Metrics {
+        return win32_nc_layout.metricsDefault(
+            self.current_dpi,
+            host_caption_button_h,
+        );
+    }
+
     fn rightButtonsWidth(self: *const Host) i32 {
         if (self.usingIntegratedTitlebar()) {
             return self.scaled(host_titlebar_action_button_size) * 2 + self.scaled(12);
@@ -15439,21 +15481,26 @@ const Host = struct {
         return x;
     }
 
+    fn contentRectFromClient(self: *Host, rect: RECT) RECT {
+        const tab_offset: i32 = self.tabBarHeight();
+        const overlay_offset: i32 = if (self.overlay_mode == .none) 0 else self.scaled(host_overlay_height);
+        const inspector_offset: i32 = if (self.inspectorPanelVisible()) self.scaled(host_inspector_panel_height) else 0;
+        const bands = self.contentBands(tab_offset, overlay_offset, inspector_offset);
+        return .{
+            .left = 0,
+            .top = bands.content_top,
+            .right = rect.right,
+            .bottom = @max(bands.content_top + 1, rect.bottom - statusBarHeight()),
+        };
+    }
+
     fn contentRect(self: *Host) !RECT {
         const hwnd = self.hwnd orelse return error.InvalidHost;
         var rect: RECT = undefined;
         if (sys.GetClientRect(hwnd, &rect) == 0) {
             return lastError();
         }
-        const tab_offset: i32 = self.tabBarHeight();
-        const overlay_offset: i32 = if (self.overlay_mode == .none) 0 else self.scaled(host_overlay_height);
-        const inspector_offset: i32 = if (self.inspectorPanelVisible()) self.scaled(host_inspector_panel_height) else 0;
-        return .{
-            .left = 0,
-            .top = tab_offset + overlay_offset + inspector_offset,
-            .right = rect.right,
-            .bottom = @max(tab_offset + 1, rect.bottom - statusBarHeight()),
-        };
+        return self.contentRectFromClient(rect);
     }
 
     fn close(self: *Host) void {
@@ -16183,7 +16230,12 @@ const Host = struct {
             const edit_hwnd = self.overlay_edit_hwnd orelse return false;
             const accept_hwnd = self.overlay_accept_hwnd orelse return false;
             const cancel_hwnd = self.overlay_cancel_hwnd orelse return false;
-            const overlay_y = self.tabBarHeight();
+            const bands = self.contentBands(
+                self.tabBarHeight(),
+                self.scaled(host_overlay_height),
+                0,
+            );
+            const overlay_y = bands.overlay_top;
             const padding = self.scaled(host_overlay_padding);
             const label_w = self.scaled(host_overlay_label_width);
             const accept_button_w = self.scaled(host_overlay_accept_width);
@@ -16571,7 +16623,7 @@ const Host = struct {
         theme: *const win32_theme.ThemeColors,
     ) void {
         const cb_w = self.scaled(host_caption_button_w);
-        const cb_h = self.scaled(host_caption_button_h);
+        const cb_h = self.ncMetrics().caption_button_h;
         if (cb_w <= 0 or cb_h <= 0) return;
 
         const maximized = if (self.hwnd) |h| sys.IsZoomed(h) != 0 else false;
@@ -16619,6 +16671,18 @@ const Host = struct {
         paint_top: bool,
         theme: *const ThemeColors,
     ) void {
+        // The client-drawn band is what the user actually sees while the
+        // integrated titlebar is active, so `window-titlebar-background` /
+        // `-foreground` have to reach it here rather than only the DWM
+        // caption. Unconfigured, this is byte-identical to `theme`.
+        const titlebar_theme_value = clientTitlebarTheme(
+            theme,
+            &self.app.config,
+            self.usingIntegratedTitlebar(),
+            isHighContrastActive(),
+        );
+        const titlebar_theme = &titlebar_theme_value;
+
         // Tab bar (only when visible)
         if (paint_top and tab_h > 0) {
             const tab_rect = RECT{
@@ -16627,7 +16691,7 @@ const Host = struct {
                 .right = client_rect.right,
                 .bottom = tab_h,
             };
-            fillSolidRect(hdc, tab_rect, theme.chrome_bg);
+            fillSolidRect(hdc, tab_rect, titlebar_theme.chrome_bg);
 
             // Focused-tab accent underline. Lives in the 2 px gap
             // between the tab button's bottom edge (button_height = tab_h
@@ -16661,7 +16725,7 @@ const Host = struct {
                     .right = client_rect.right,
                     .bottom = @max(1, self.scaled(2)),
                 },
-                themeSurface(theme, .tab_accent),
+                themeSurface(titlebar_theme, .tab_accent),
             );
             if (!self.usingIntegratedTitlebar()) {
                 const cluster_left = @max(self.scaled(8), client_rect.right - self.rightButtonsWidth() - self.scaled(4));
@@ -16675,8 +16739,8 @@ const Host = struct {
                     drawRoundedRect(
                         hdc,
                         cluster_rect,
-                        themeSurface(theme, .caption_cluster_bg),
-                        themeSurface(theme, .caption_cluster_border),
+                        themeSurface(titlebar_theme, .caption_cluster_bg),
+                        themeSurface(titlebar_theme, .caption_cluster_border),
                         self.scaled(6),
                     );
                     if (cluster_left > self.scaled(14)) {
@@ -16695,7 +16759,7 @@ const Host = struct {
             // from our NC mouse handlers so Snap Layout hover remains
             // intact while the visuals stay app-owned.
             if (self.usingIntegratedTitlebar()) {
-                self.paintCaptionButtons(hdc, client_rect, theme);
+                self.paintCaptionButtons(hdc, client_rect, titlebar_theme);
             }
 
             fillSolidRect(
@@ -16706,7 +16770,7 @@ const Host = struct {
                     .right = client_rect.right,
                     .bottom = tab_h,
                 },
-                theme.chrome_border,
+                titlebar_theme.chrome_border,
             );
         } // end tab bar painting
     }
@@ -16717,15 +16781,16 @@ const Host = struct {
         alloc: Allocator,
         client_rect: RECT,
         tab_h: i32,
+        bands: win32_nc_layout.ContentBands,
         paint_top: bool,
         theme: *const ThemeColors,
     ) bool {
         if (paint_top and self.overlay_mode != .none) {
             const overlay_rect = RECT{
                 .left = 0,
-                .top = tab_h,
+                .top = bands.overlay_top,
                 .right = client_rect.right,
-                .bottom = tab_h + self.scaled(host_overlay_height),
+                .bottom = bands.inspector_top,
             };
             fillSolidRect(hdc, overlay_rect, theme.overlay_bg);
             const overlay_panel = RECT{
@@ -17082,8 +17147,7 @@ const Host = struct {
         hdc: HDC,
         alloc: Allocator,
         client_rect: RECT,
-        tab_h: i32,
-        overlay_offset: i32,
+        bands: win32_nc_layout.ContentBands,
         inspector_panel_visible: bool,
         paint_top: bool,
         theme: *const ThemeColors,
@@ -17091,9 +17155,9 @@ const Host = struct {
         if (paint_top and inspector_panel_visible) {
             const panel_rect = RECT{
                 .left = 0,
-                .top = tab_h + overlay_offset,
+                .top = bands.inspector_top,
                 .right = client_rect.right,
-                .bottom = tab_h + overlay_offset + self.scaled(host_inspector_panel_height),
+                .bottom = bands.content_top,
             };
             fillSolidRect(hdc, panel_rect, theme.inspector_bg);
             fillSolidRect(
@@ -17696,11 +17760,12 @@ const Host = struct {
         const inspector_panel_visible = self.inspectorPanelVisible();
         const inspector_offset: i32 = if (inspector_panel_visible) self.scaled(host_inspector_panel_height) else 0;
         const status_h = statusBarHeight();
+        const bands = self.contentBands(tab_h, overlay_offset, inspector_offset);
         const content_rect = RECT{
             .left = 0,
-            .top = tab_h + overlay_offset + inspector_offset,
+            .top = bands.content_top,
             .right = client_rect.right,
-            .bottom = @max(tab_h + 1, client_rect.bottom - status_h),
+            .bottom = @max(bands.content_top + 1, client_rect.bottom - status_h),
         };
         const top_rect = RECT{
             .left = client_rect.left,
@@ -17717,17 +17782,16 @@ const Host = struct {
         const paint_top = paintRectVisible(hdc, ps.rcPaint, top_rect);
         const paint_content = paintRectVisible(hdc, ps.rcPaint, content_rect);
         const paint_status = paintRectVisible(hdc, ps.rcPaint, status_rect);
-        const banner_y: i32 = tab_h + overlay_offset + inspector_offset + self.scaled(2);
+        const banner_y: i32 = bands.content_top + self.scaled(2);
 
         self.paintChromeTabBar(hdc, client_rect, tab_h, paint_top, theme);
-        if (!self.paintChromeOverlay(hdc, alloc, client_rect, tab_h, paint_top, theme)) return;
+        if (!self.paintChromeOverlay(hdc, alloc, client_rect, tab_h, bands, paint_top, theme)) return;
         self.paintChromeContentLane(hdc, content_rect, paint_content, theme);
         self.paintChromeInspectorPanel(
             hdc,
             alloc,
             client_rect,
-            tab_h,
-            overlay_offset,
+            bands,
             inspector_panel_visible,
             paint_top,
             theme,
@@ -18700,6 +18764,37 @@ fn titlebarTextColor(theme: *const ThemeColors, config: *const configpkg.Config)
     }
 
     return theme.text_primary;
+}
+
+fn clientTitlebarTheme(
+    theme: *const ThemeColors,
+    config: *const configpkg.Config,
+    integrated: bool,
+    high_contrast: bool,
+) ThemeColors {
+    var result = theme.*;
+    if (!integrated or high_contrast or config.@"window-theme" != .ghostty) return result;
+
+    if (config.@"window-titlebar-background" != null) {
+        result.chrome_bg = titlebarCaptionColor(theme, config);
+        if (config.@"window-titlebar-foreground" == null) {
+            const background = config.@"window-titlebar-background".?;
+            result.is_dark = (terminal.color.RGB{
+                .r = background.r,
+                .g = background.g,
+                .b = background.b,
+            }).perceivedLuminance() < 0.5;
+            const derived_theme = if (result.is_dark) darkTheme() else lightTheme();
+            result.text_primary = derived_theme.text_primary;
+            result.button_chrome_fg = derived_theme.text_primary;
+        }
+    }
+    if (config.@"window-titlebar-foreground" != null) {
+        const foreground = titlebarTextColor(theme, config);
+        result.text_primary = foreground;
+        result.button_chrome_fg = foreground;
+    }
+    return result;
 }
 
 fn applyDwmThemeWithBuild(hwnd: HWND, theme: *const ThemeColors, config: *const configpkg.Config, os_build: u32) void {
@@ -23911,12 +24006,12 @@ pub const Surface = struct {
             self.drop_target_registered = false;
         };
 
-        const content_rect: RECT = host.contentRect() catch .{
+        const content_rect = host.contentRect() catch host.contentRectFromClient(.{
             .left = 0,
-            .top = host_tab_height,
+            .top = 0,
             .right = 1280,
-            .bottom = 800 - host_status_height,
-        };
+            .bottom = 800,
+        });
         _ = applyChildRect(hwnd, &self.placement, content_rect);
         self.placement.visible = false;
         self.placement.visible_known = true;
@@ -31638,11 +31733,41 @@ test "win32 titlebar colors honor ghostty overrides" {
     try std.testing.expectEqual(theme.text_primary, titlebarTextColor(&theme, &config));
 
     config.@"window-theme" = .ghostty;
-    config.@"window-titlebar-background" = .{ .r = 1, .g = 2, .b = 3 };
+    // Nothing configured: the client band must be byte-identical to the
+    // base theme, or every integrated titlebar changes appearance.
+    try std.testing.expectEqualDeep(theme, clientTitlebarTheme(&theme, &config, true, false));
+
+    // Background only: derive readable glyphs from its luminance instead of
+    // keeping the dark palette's light text on a light band.
+    config.@"window-titlebar-background" = .{ .r = 240, .g = 241, .b = 242 };
+    const background_only = clientTitlebarTheme(&theme, &config, true, false);
+    try std.testing.expectEqual(rgb(240, 241, 242), background_only.chrome_bg);
+    try std.testing.expect(!background_only.is_dark);
+    try std.testing.expectEqual(lightTheme().text_primary, background_only.text_primary);
+    try std.testing.expectEqual(lightTheme().text_primary, background_only.button_chrome_fg);
+
+    // Foreground only: keep the theme background and its darkness.
+    config.@"window-titlebar-background" = null;
     config.@"window-titlebar-foreground" = .{ .r = 4, .g = 5, .b = 6 };
+    const foreground_only = clientTitlebarTheme(&theme, &config, true, false);
+    try std.testing.expectEqual(theme.chrome_bg, foreground_only.chrome_bg);
+    try std.testing.expectEqual(theme.is_dark, foreground_only.is_dark);
+    try std.testing.expectEqual(rgb(4, 5, 6), foreground_only.text_primary);
+    try std.testing.expectEqual(rgb(4, 5, 6), foreground_only.button_chrome_fg);
+
+    config.@"window-titlebar-background" = .{ .r = 1, .g = 2, .b = 3 };
 
     try std.testing.expectEqual(rgb(1, 2, 3), titlebarCaptionColor(&theme, &config));
     try std.testing.expectEqual(rgb(4, 5, 6), titlebarTextColor(&theme, &config));
+
+    const client_theme = clientTitlebarTheme(&theme, &config, true, false);
+    try std.testing.expectEqual(rgb(1, 2, 3), client_theme.chrome_bg);
+    try std.testing.expectEqual(rgb(4, 5, 6), client_theme.text_primary);
+    try std.testing.expectEqual(rgb(4, 5, 6), client_theme.button_chrome_fg);
+
+    // Non-integrated and high contrast both bypass the overrides.
+    try std.testing.expectEqualDeep(theme, clientTitlebarTheme(&theme, &config, false, false));
+    try std.testing.expectEqualDeep(theme, clientTitlebarTheme(&theme, &config, true, true));
 }
 
 test "win32 cursorPosFromLParam decodes signed coordinates" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -18775,19 +18775,32 @@ fn clientTitlebarTheme(
     var result = theme.*;
     if (!integrated or high_contrast or config.@"window-theme" != .ghostty) return result;
 
-    if (config.@"window-titlebar-background" != null) {
+    if (config.@"window-titlebar-background") |background| {
         result.chrome_bg = titlebarCaptionColor(theme, config);
-        if (config.@"window-titlebar-foreground" == null) {
-            const background = config.@"window-titlebar-background".?;
-            result.is_dark = (terminal.color.RGB{
-                .r = background.r,
-                .g = background.g,
-                .b = background.b,
-            }).perceivedLuminance() < 0.5;
-            const derived_theme = if (result.is_dark) darkTheme() else lightTheme();
-            result.text_primary = derived_theme.text_primary;
-            result.button_chrome_fg = derived_theme.text_primary;
-        }
+
+        // The band's polarity is whatever the configured background says it
+        // is, not whatever the base theme was. Every polarity-dependent token
+        // the client-drawn band consumes has to move with it: leaving them
+        // behind is what puts dark borders, dark disabled glyphs and a dark
+        // focus ring on a light band. `chrome_bg` stays the explicit value,
+        // and `accent` stays the theme's own — `themeSurface` already adapts
+        // the accent through `is_dark`.
+        result.is_dark = (terminal.color.RGB{
+            .r = background.r,
+            .g = background.g,
+            .b = background.b,
+        }).perceivedLuminance() < 0.5;
+        const derived_theme = if (result.is_dark) darkTheme() else lightTheme();
+        result.text_primary = derived_theme.text_primary;
+        result.text_secondary = derived_theme.text_secondary;
+        result.text_disabled = derived_theme.text_disabled;
+        result.chrome_border = derived_theme.chrome_border;
+        result.button_chrome_fg = derived_theme.text_primary;
+        result.button_focus_ring = derived_theme.button_focus_ring;
+        result.button_active_focus_ring = derived_theme.button_active_focus_ring;
+        result.button_disabled_bg = derived_theme.button_disabled_bg;
+        result.button_disabled_border = derived_theme.button_disabled_border;
+        result.button_disabled_fg = derived_theme.button_disabled_fg;
     }
     if (config.@"window-titlebar-foreground" != null) {
         const foreground = titlebarTextColor(theme, config);
@@ -31745,6 +31758,20 @@ test "win32 titlebar colors honor ghostty overrides" {
     try std.testing.expect(!background_only.is_dark);
     try std.testing.expectEqual(lightTheme().text_primary, background_only.text_primary);
     try std.testing.expectEqual(lightTheme().text_primary, background_only.button_chrome_fg);
+    // Every other polarity-dependent token the band paints has to follow the
+    // derived polarity too, or a light band keeps dark borders, dark disabled
+    // glyphs and a dark focus ring.
+    try std.testing.expectEqual(lightTheme().chrome_border, background_only.chrome_border);
+    try std.testing.expectEqual(lightTheme().text_secondary, background_only.text_secondary);
+    try std.testing.expectEqual(lightTheme().text_disabled, background_only.text_disabled);
+    try std.testing.expectEqual(lightTheme().button_focus_ring, background_only.button_focus_ring);
+    try std.testing.expectEqual(lightTheme().button_active_focus_ring, background_only.button_active_focus_ring);
+    try std.testing.expectEqual(lightTheme().button_disabled_bg, background_only.button_disabled_bg);
+    try std.testing.expectEqual(lightTheme().button_disabled_border, background_only.button_disabled_border);
+    try std.testing.expectEqual(lightTheme().button_disabled_fg, background_only.button_disabled_fg);
+    // The accent is theme identity, not polarity: `themeSurface` adapts it
+    // through `is_dark`, so it must survive the override untouched.
+    try std.testing.expectEqual(theme.accent, background_only.accent);
 
     // Foreground only: keep the theme background and its darkness.
     config.@"window-titlebar-background" = null;
@@ -31764,6 +31791,19 @@ test "win32 titlebar colors honor ghostty overrides" {
     try std.testing.expectEqual(rgb(1, 2, 3), client_theme.chrome_bg);
     try std.testing.expectEqual(rgb(4, 5, 6), client_theme.text_primary);
     try std.testing.expectEqual(rgb(4, 5, 6), client_theme.button_chrome_fg);
+
+    // Both configured, with a light background under a dark base theme. The
+    // explicit foreground wins for text, but the band is still light, so the
+    // rest of the chrome must be light too rather than staying on the base
+    // theme's dark polarity.
+    config.@"window-titlebar-background" = .{ .r = 240, .g = 241, .b = 242 };
+    const both_configured = clientTitlebarTheme(&theme, &config, true, false);
+    try std.testing.expect(!both_configured.is_dark);
+    try std.testing.expectEqual(rgb(240, 241, 242), both_configured.chrome_bg);
+    try std.testing.expectEqual(rgb(4, 5, 6), both_configured.text_primary);
+    try std.testing.expectEqual(lightTheme().chrome_border, both_configured.chrome_border);
+    try std.testing.expectEqual(lightTheme().button_focus_ring, both_configured.button_focus_ring);
+    config.@"window-titlebar-background" = .{ .r = 1, .g = 2, .b = 3 };
 
     // Non-integrated and high contrast both bypass the overrides.
     try std.testing.expectEqualDeep(theme, clientTitlebarTheme(&theme, &config, false, false));

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -16668,6 +16668,7 @@ const Host = struct {
         hdc: HDC,
         client_rect: RECT,
         tab_h: i32,
+        band_bottom: i32,
         paint_top: bool,
         theme: *const ThemeColors,
     ) void {
@@ -16685,11 +16686,17 @@ const Host = struct {
 
         // Tab bar (only when visible)
         if (paint_top and tab_h > 0) {
+            // Fill the whole chrome band, not just the tab row. The tab
+            // metric and the caption metric are scaled independently and can
+            // land a pixel apart at DPIs that are not a multiple of 24 (110
+            // dpi: 45 px vs 46 px), and everything below stacks from the
+            // greater of the two. Filling only `tab_h` would leave that pixel
+            // row stale between the tab strip and the terminal.
             const tab_rect = RECT{
                 .left = 0,
                 .top = 0,
                 .right = client_rect.right,
-                .bottom = tab_h,
+                .bottom = @max(tab_h, band_bottom),
             };
             fillSolidRect(hdc, tab_rect, titlebar_theme.chrome_bg);
 
@@ -16762,13 +16769,17 @@ const Host = struct {
                 self.paintCaptionButtons(hdc, client_rect, titlebar_theme);
             }
 
+            // The separator belongs on the band boundary the terminal
+            // actually starts at, so it tracks `contentBands` rather than the
+            // tab metric alone.
+            const separator_bottom = @max(tab_h, band_bottom);
             fillSolidRect(
                 hdc,
                 .{
                     .left = 0,
-                    .top = tab_h - 1,
+                    .top = separator_bottom - 1,
                     .right = client_rect.right,
-                    .bottom = tab_h,
+                    .bottom = separator_bottom,
                 },
                 titlebar_theme.chrome_border,
             );
@@ -17784,7 +17795,7 @@ const Host = struct {
         const paint_status = paintRectVisible(hdc, ps.rcPaint, status_rect);
         const banner_y: i32 = bands.content_top + self.scaled(2);
 
-        self.paintChromeTabBar(hdc, client_rect, tab_h, paint_top, theme);
+        self.paintChromeTabBar(hdc, client_rect, tab_h, bands.overlay_top, paint_top, theme);
         if (!self.paintChromeOverlay(hdc, alloc, client_rect, tab_h, bands, paint_top, theme)) return;
         self.paintChromeContentLane(hdc, content_rect, paint_content, theme);
         self.paintChromeInspectorPanel(
@@ -18766,6 +18777,31 @@ fn titlebarTextColor(theme: *const ThemeColors, config: *const configpkg.Config)
     return theme.text_primary;
 }
 
+/// Unpack a Win32 COLORREF (0x00BBGGRR) into an RGB triple.
+fn rgbFromColorRef(color: u32) terminal.color.RGB {
+    return .{
+        .r = @truncate(color & 0xFF),
+        .g = @truncate((color >> 8) & 0xFF),
+        .b = @truncate((color >> 16) & 0xFF),
+    };
+}
+
+/// Which palette a configured titlebar background should be painted with.
+///
+/// The point of deriving a polarity at all is readability, so decide it by
+/// the readability itself rather than by a fixed luminance cutoff. A cutoff
+/// misclassifies saturated midtones: `#00C800` sits at ~0.46 perceived
+/// luminance, so `< 0.5` calls it dark and puts the dark palette's near-white
+/// glyphs on bright green at roughly 1.7:1, where the light palette's dark
+/// glyphs reach about 7.6:1. Comparing the two candidates' actual WCAG
+/// contrast against the configured background picks the readable side and
+/// still agrees with the cutoff on ordinary near-black and near-white values.
+fn titlebarBandIsDark(background: terminal.color.RGB) bool {
+    const dark_text = rgbFromColorRef(darkTheme().text_primary);
+    const light_text = rgbFromColorRef(lightTheme().text_primary);
+    return background.contrast(dark_text) >= background.contrast(light_text);
+}
+
 fn clientTitlebarTheme(
     theme: *const ThemeColors,
     config: *const configpkg.Config,
@@ -18785,11 +18821,11 @@ fn clientTitlebarTheme(
         // focus ring on a light band. `chrome_bg` stays the explicit value,
         // and `accent` stays the theme's own — `themeSurface` already adapts
         // the accent through `is_dark`.
-        result.is_dark = (terminal.color.RGB{
+        result.is_dark = titlebarBandIsDark(.{
             .r = background.r,
             .g = background.g,
             .b = background.b,
-        }).perceivedLuminance() < 0.5;
+        });
         const derived_theme = if (result.is_dark) darkTheme() else lightTheme();
         result.text_primary = derived_theme.text_primary;
         result.text_secondary = derived_theme.text_secondary;
@@ -31734,6 +31770,68 @@ test "win32 configuredHostWindowPosition requires both coordinates" {
     const position = configuredHostWindowPosition(&config).?;
     try std.testing.expectEqual(@as(i32, 120), position.x);
     try std.testing.expectEqual(@as(i32, -40), position.y);
+}
+
+// The `win32_nc_layout` tests model the tab bottom with `scaleDim`, the same
+// round-to-nearest the caption metric uses, so by construction they cannot see
+// the divergence. Production scales the tab metric through
+// `win32_chrome_state.scaled`, which truncates. Pin the gap here, where both
+// real functions are reachable.
+test "Issue150 chrome band spans both scaling policies at fractional DPI" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // 40 DIP at 110 dpi is 45.83 px: truncated 45, rounded 46.
+    const dpi: u32 = 110;
+    const tab_bottom = win32_chrome_state.scaled(host_tab_height_integrated, dpi);
+    const caption_bottom = win32_nc_layout.metricsDefault(
+        dpi,
+        host_caption_button_h,
+    ).caption_button_h;
+    try std.testing.expectEqual(@as(i32, 45), tab_bottom);
+    try std.testing.expectEqual(@as(i32, 46), caption_bottom);
+
+    // Everything below the chrome stacks from the greater of the two, so the
+    // painted band has to reach it as well. `paintChromeTabBar` fills and
+    // draws its separator through this value rather than through `tab_h`,
+    // otherwise row 45 is left stale between the tab strip and the terminal.
+    const bands = win32_nc_layout.contentBands(tab_bottom, caption_bottom, 0, 0);
+    try std.testing.expectEqual(caption_bottom, bands.overlay_top);
+    try std.testing.expectEqual(caption_bottom, bands.content_top);
+    try std.testing.expect(bands.overlay_top > tab_bottom);
+
+    // The shipped 96 dpi path is unaffected: both policies agree.
+    try std.testing.expectEqual(
+        win32_chrome_state.scaled(host_tab_height_integrated, 96),
+        win32_nc_layout.metricsDefault(96, host_caption_button_h).caption_button_h,
+    );
+}
+
+test "win32 titlebar band polarity follows readability, not a luminance cutoff" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // Ordinary near-black / near-white agree with the old cutoff.
+    try std.testing.expect(titlebarBandIsDark(.{ .r = 0, .g = 0, .b = 0 }));
+    try std.testing.expect(!titlebarBandIsDark(.{ .r = 255, .g = 255, .b = 255 }));
+    try std.testing.expect(titlebarBandIsDark(.{ .r = 19, .g = 39, .b = 56 }));
+    try std.testing.expect(!titlebarBandIsDark(.{ .r = 240, .g = 241, .b = 242 }));
+
+    // Saturated midtone: perceived luminance is 0.46, so a `< 0.5` cutoff
+    // called this dark and picked near-white glyphs. Dark glyphs read far
+    // better, so the band must be treated as light.
+    const green: terminal.color.RGB = .{ .r = 0, .g = 200, .b = 0 };
+    try std.testing.expect(green.perceivedLuminance() < 0.5);
+    try std.testing.expect(!titlebarBandIsDark(green));
+    try std.testing.expect(
+        green.contrast(rgbFromColorRef(lightTheme().text_primary)) >
+            green.contrast(rgbFromColorRef(darkTheme().text_primary)),
+    );
+
+    // COLORREF packing is 0x00BBGGRR; a wrong unpack would silently invert
+    // every decision above.
+    const unpacked = rgbFromColorRef(rgb(1, 2, 3));
+    try std.testing.expectEqual(@as(u8, 1), unpacked.r);
+    try std.testing.expectEqual(@as(u8, 2), unpacked.g);
+    try std.testing.expectEqual(@as(u8, 3), unpacked.b);
 }
 
 test "win32 titlebar colors honor ghostty overrides" {

--- a/src/apprt/win32_nc_layout.zig
+++ b/src/apprt/win32_nc_layout.zig
@@ -71,14 +71,14 @@ pub const Metrics = struct {
 };
 
 /// Return default metrics scaled linearly from 96 dpi base values.
-pub fn metricsDefault(dpi: u32) Metrics {
+pub fn metricsDefault(dpi: u32, caption_button_height: i32) Metrics {
     const scale = @as(i32, @intCast(dpi));
     return .{
         .size_frame_y = scaleDim(4, scale),
         .size_frame_x = scaleDim(4, scale),
         .padded_border = scaleDim(4, scale),
         .caption_button_w = scaleDim(46, scale),
-        .caption_button_h = scaleDim(40, scale),
+        .caption_button_h = scaleDim(caption_button_height, scale),
         .edge_resize_width = scaleDim(8, scale),
     };
 }
@@ -236,6 +236,28 @@ fn scaleDim(base: i32, dpi: i32) i32 {
     return @divTrunc(base * dpi + 48, 96);
 }
 
+pub const ContentBands = struct {
+    overlay_top: i32,
+    inspector_top: i32,
+    content_top: i32,
+};
+
+/// Boundaries for panels stacked between the tab/caption band and terminal.
+pub fn contentBands(
+    tab_bottom: i32,
+    caption_bottom: i32,
+    overlay_height: i32,
+    inspector_height: i32,
+) ContentBands {
+    const chrome_bottom = @max(tab_bottom, caption_bottom);
+    const inspector_top = chrome_bottom + overlay_height;
+    return .{
+        .overlay_top = chrome_bottom,
+        .inspector_top = inspector_top,
+        .content_top = inspector_top + inspector_height,
+    };
+}
+
 fn edgeHitTest(window: Rect, cursor: Point, ew: i32) ?HitTest {
     const in_left = cursor.x < window.left + ew;
     const in_right = cursor.x >= window.right - ew;
@@ -258,7 +280,7 @@ fn edgeHitTest(window: Rect, cursor: Point, ew: i32) ?HitTest {
 // ---------------------------------------------------------------------------
 
 test "metricsDefault: 96 dpi produces base values" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     try std.testing.expectEqual(@as(i32, 4), m.size_frame_x);
     try std.testing.expectEqual(@as(i32, 4), m.size_frame_y);
     try std.testing.expectEqual(@as(i32, 4), m.padded_border);
@@ -268,14 +290,14 @@ test "metricsDefault: 96 dpi produces base values" {
 }
 
 test "metricsDefault: 144 dpi (150%)" {
-    const m = metricsDefault(144);
+    const m = metricsDefault(144, 40);
     try std.testing.expectEqual(@as(i32, 6), m.size_frame_x);
     try std.testing.expectEqual(@as(i32, 69), m.caption_button_w);
     try std.testing.expectEqual(@as(i32, 60), m.caption_button_h);
 }
 
 test "metricsDefault: 192 dpi (200%)" {
-    const m = metricsDefault(192);
+    const m = metricsDefault(192, 40);
     try std.testing.expectEqual(@as(i32, 8), m.size_frame_x);
     try std.testing.expectEqual(@as(i32, 92), m.caption_button_w);
     try std.testing.expectEqual(@as(i32, 80), m.caption_button_h);
@@ -284,7 +306,7 @@ test "metricsDefault: 192 dpi (200%)" {
 // -- calcNcClientRect -------------------------------------------------------
 
 test "normal: zero top, keep side borders" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const proposed = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const r = calcNcClientRect(proposed, m, .normal);
     try std.testing.expectEqual(@as(i32, 4), r.left);
@@ -294,7 +316,7 @@ test "normal: zero top, keep side borders" {
 }
 
 test "maximized: additional top inset" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const proposed = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const r = calcNcClientRect(proposed, m, .maximized);
     // top = size_frame_y + padded_border = 4 + 4 = 8
@@ -302,7 +324,7 @@ test "maximized: additional top inset" {
 }
 
 test "sides preserved in both states" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const proposed = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
     const rn = calcNcClientRect(proposed, m, .normal);
     const rm = calcNcClientRect(proposed, m, .maximized);
@@ -317,21 +339,21 @@ test "sides preserved in both states" {
 // -- hitTest ----------------------------------------------------------------
 
 test "top-left corner: resize wins over sysmenu in outer frame" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     try std.testing.expectEqual(HitTest.topleft, hitTest(win, .{ .x = 0, .y = 0 }, m, .normal));
     try std.testing.expectEqual(HitTest.sysmenu, hitTest(win, .{ .x = 20, .y = 20 }, m, .normal));
 }
 
 test "topleft resize at bottom-left corner" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // Bottom-left corner is unambiguously bottomleft resize.
     try std.testing.expectEqual(HitTest.bottomleft, hitTest(win, .{ .x = 0, .y = 799 }, m, .normal));
 }
 
 test "top-right corner: resize wins over close in outer frame" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     try std.testing.expectEqual(HitTest.topright, hitTest(win, .{ .x = 1279, .y = 0 }, m, .normal));
     try std.testing.expectEqual(HitTest.close, hitTest(win, .{ .x = 1257, .y = 20 }, m, .normal));
@@ -339,7 +361,7 @@ test "top-right corner: resize wins over close in outer frame" {
 }
 
 test "over close button" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     const cx = @divTrunc(btns.close.left + btns.close.right, 2);
@@ -348,7 +370,7 @@ test "over close button" {
 }
 
 test "over max button" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     const cx = @divTrunc(btns.max.left + btns.max.right, 2);
@@ -357,7 +379,7 @@ test "over max button" {
 }
 
 test "over min button" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     const cx = @divTrunc(btns.min.left + btns.min.right, 2);
@@ -366,7 +388,7 @@ test "over min button" {
 }
 
 test "caption area between sysmenu and buttons" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // Pick a point in the caption row, past sysmenu, before buttons.
     // Sysmenu occupies [0, 40) horizontally; buttons start at 1280 - 3*46 = 1142.
@@ -375,21 +397,21 @@ test "caption area between sysmenu and buttons" {
 }
 
 test "client area below caption" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // y = 200 is well below the caption row (40 px).
     try std.testing.expectEqual(HitTest.client, hitTest(win, .{ .x = 640, .y = 200 }, m, .normal));
 }
 
 test "bottom edge strip" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // y = 799 (last row), x in the middle — avoids corner zones.
     try std.testing.expectEqual(HitTest.bottom, hitTest(win, .{ .x = 640, .y = 799 }, m, .normal));
 }
 
 test "maximized edge resize -> client not bottom" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // Same position as "bottom edge strip" but maximized — edge resize
     // strips are suppressed.
@@ -397,7 +419,7 @@ test "maximized edge resize -> client not bottom" {
 }
 
 test "sysmenu icon rect (leftmost 40px of caption row)" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     // Centre of the sysmenu rect: x = 20, y = 20.
     try std.testing.expectEqual(HitTest.sysmenu, hitTest(win, .{ .x = 20, .y = 20 }, m, .normal));
@@ -406,14 +428,14 @@ test "sysmenu icon rect (leftmost 40px of caption row)" {
 // -- captionButtonsRect -----------------------------------------------------
 
 test "buttons flush right" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     try std.testing.expectEqual(@as(i32, 1280), btns.close.right);
 }
 
 test "buttons ordered right-to-left" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     try std.testing.expect(btns.close.left < win.right);
@@ -422,7 +444,7 @@ test "buttons ordered right-to-left" {
 }
 
 test "button height == metrics.caption_button_h" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 0, .top = 0, .right = 1280, .bottom = 800 };
     const btns = captionButtonsRect(win, m, .normal);
     try std.testing.expectEqual(m.caption_button_h, btns.close.height());
@@ -435,7 +457,7 @@ test "button height == metrics.caption_button_h" {
 }
 
 test "maximized buttons align to visible caption row" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
     const btns = captionButtonsRect(win, m, .maximized);
     const expected_top = win.top + m.size_frame_y + m.padded_border;
@@ -445,7 +467,7 @@ test "maximized buttons align to visible caption row" {
 }
 
 test "maximized hit test follows shifted caption buttons" {
-    const m = metricsDefault(96);
+    const m = metricsDefault(96, 40);
     const win = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
     const btns = captionButtonsRect(win, m, .maximized);
     const max_x = @divTrunc(btns.max.left + btns.max.right, 2);
@@ -457,7 +479,7 @@ test "maximized hit test follows shifted caption buttons" {
 }
 
 test "maximized caption row starts below invisible top margin at 150% dpi" {
-    const m = metricsDefault(144);
+    const m = metricsDefault(144, 40);
     const win = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
     const caption_top = win.top + m.size_frame_y + m.padded_border;
 
@@ -466,11 +488,86 @@ test "maximized caption row starts below invisible top margin at 150% dpi" {
 }
 
 test "max button hit test scales at 150% dpi for snap hover" {
-    const m = metricsDefault(144);
+    const m = metricsDefault(144, 40);
     const win = Rect{ .left = 40, .top = 20, .right = 1480, .bottom = 920 };
     const btns = captionButtonsRect(win, m, .normal);
     const max_x = @divTrunc(btns.max.left + btns.max.right, 2);
     const max_y = @divTrunc(btns.max.top + btns.max.bottom, 2);
 
     try std.testing.expectEqual(HitTest.maxbutton, hitTest(win, .{ .x = max_x, .y = max_y }, m, .normal));
+}
+
+test "Issue150 terminal content clears independently sized integrated caption" {
+    const dpis = [_]u32{ 96, 144, 192 };
+    const states = [_]WindowState{ .normal, .maximized };
+    const window = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
+
+    // Keep the two metrics deliberately different. The production defaults
+    // are both 40 DIP today, but terminal placement must not depend on that
+    // coincidence when the painted caption is independently sized.
+    const tab_height_dip: i32 = 32;
+
+    for (dpis) |dpi| {
+        const metrics = metricsDefault(@intCast(dpi), 40);
+        for (states) |state| {
+            const client = calcNcClientRect(window, metrics, state);
+            const caption = captionButtonsRect(window, metrics, state);
+            const bands = contentBands(
+                scaleDim(tab_height_dip, @intCast(dpi)),
+                metrics.caption_button_h,
+                0,
+                0,
+            );
+            const content_screen_top = client.top + bands.content_top;
+            try std.testing.expect(content_screen_top >= caption.close.bottom);
+        }
+    }
+}
+
+test "Issue150 runtime DPI changes recompute integrated content boundary" {
+    const dpi_sequence = [_]i32{ 96, 144, 192, 144, 96 };
+    const window = Rect{ .left = 100, .top = 50, .right = 1380, .bottom = 850 };
+
+    for (dpi_sequence) |dpi| {
+        const metrics = metricsDefault(@intCast(dpi), 40);
+        const client = calcNcClientRect(window, metrics, .maximized);
+        const caption = captionButtonsRect(window, metrics, .maximized);
+        const bands = contentBands(
+            scaleDim(32, dpi),
+            metrics.caption_button_h,
+            0,
+            0,
+        );
+        const content_screen_top = client.top + bands.content_top;
+        try std.testing.expect(content_screen_top >= caption.close.bottom);
+    }
+}
+
+test "Issue150 non-integrated content keeps tab and panel offsets" {
+    const bands = contentBands(32, 0, 58, 42);
+    try std.testing.expectEqual(@as(i32, 132), bands.content_top);
+}
+
+test "Issue150 panels start below an unequal integrated caption band" {
+    const bands = contentBands(32, 48, 58, 42);
+    try std.testing.expectEqual(@as(i32, 48), bands.overlay_top);
+    try std.testing.expectEqual(@as(i32, 106), bands.inspector_top);
+    try std.testing.expectEqual(@as(i32, 148), bands.content_top);
+}
+
+test "Issue150 shipped integrated bands start content at tab bottom" {
+    const tab_height_dip: i32 = 40;
+    const titlebar_height_dip: i32 = 40;
+    const caption_height_dip: i32 = 40;
+    const dpi: i32 = 96;
+
+    const metrics = metricsDefault(@intCast(dpi), caption_height_dip);
+    const tab_bottom = scaleDim(tab_height_dip, dpi);
+    try std.testing.expectEqual(
+        scaleDim(titlebar_height_dip, dpi),
+        metrics.caption_button_h,
+    );
+
+    const bands = contentBands(tab_bottom, metrics.caption_button_h, 0, 0);
+    try std.testing.expectEqual(tab_bottom, bands.content_top);
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2271,6 +2271,8 @@ keybind: Keybinds = .{},
 
 /// Background color for the window titlebar. This only takes effect if
 /// `window-theme` is set to `ghostty`.
+/// On Windows, a custom value can differ from the tab fill and produce a
+/// two-tone integrated titlebar strip.
 ///
 /// Supported in the Windows-only fork when `window-theme=ghostty`.
 ///


### PR DESCRIPTION
## Summary

`Host.contentRect` derived the terminal's top edge from the tab-strip height alone, while the client-painted caption band is sized from a completely independent metric. Three constants — `height_tab_integrated`, `height_titlebar`, `caption_button_h` — all happen to be 40 DIP today, and that coincidence is the only thing keeping the two bands aligned. `height_titlebar` ("integrated titlebar total") was dead code, referenced nowhere. Because the core derives rows/cols from the child HWND's own client size, any overlap means the obscured row is still advertised to the child process, which is exactly the accounting the reporter observed with tmux `status-position top`.

Refs #150 — deliberately not `Fixes`. See the A/B below: no arm reproduced the reporter's clipping, including the exact version the issue was filed against, so this PR is not proven to be what makes their window correct. Auto-closing the issue on merge would tell the reporter their symptom was fixed when the body itself says it was never reproduced. What this PR does close is a latent invariant and a 1 px scaling divergence, both now guarded by tests. The reporter should re-test after #149 lands, since safe mode was discarding their config

**Scope note:** with the shipped metrics all equal at 40 DIP this does not change the rendered geometry on the current default path, so the reporter's exact overlap is not reproduced here. See Validation for what was reproduced and how.

## Changes

- Add `win32_nc_layout.contentBands`: the chrome band bottom is the greater of the tab-strip and painted-caption bottoms, and the overlay panel, inspector panel and terminal rect all stack from it. `Host.contentRect`, the overlay control placement, the command-palette row capacity, and `paintChrome`'s independently computed rects now all consume it, so placement and painting cannot drift apart.
- Clamp the content bottom against the content top rather than the tab offset. With unequal metrics and a small client area the old `@max(tab_offset + 1, ...)` clamp could produce `bottom < top`.
- Drop the `Surface.init` fallback rect that used the raw unscaled 32 px `host_tab_height`; use the real `contentRect`.
- Propagate `window-titlebar-background` / `window-titlebar-foreground` into the client-drawn band (tab strip, action buttons, caption buttons) when `window-theme = ghostty`. Previously those options only reached the DWM caption, which is not visible while the integrated titlebar is active, so they had no effect. Colors are overridden only when explicitly configured, and a background-only override derives `is_dark` and the glyph color from the configured background's perceived luminance so one-sided overrides stay readable. High contrast still bypasses the overrides entirely.

`window-theme = ghostty` is not load-bearing for the geometry: the integrated-titlebar gate reads only the Windows build number and tab-bar visibility, so every Win11 window was structurally exposed to this. That setting only made the reporter's custom titlebar colors relevant.

New tests: the band/content invariant at 96/144/192 DPI in normal and maximized states with deliberately unequal tab and caption metrics; a 96→144→192→144→96 runtime DPI sequence; overlay/inspector stacking under unequal metrics; the small-client bottom clamp; the non-integrated path; and the unconfigured and one-sided titlebar color cases.

## Validation

Commands run on the current head `68d309da7`, rebased onto `main` at `e3a38268e`, locally on Windows 11:

- `pwsh -NoProfile -File scripts/check-zig-format.ps1` — passed (693 tracked sources).
- `pwsh -NoProfile -File scripts/check-source-format.ps1` — passed.
- `zig build -Demit-exe=true` — exit 0.
- `zig build test -Dtest-filter=Issue150` — 74 passed, 1 skipped, 0 failed.
- `zig build test -Dtest-filter=win32_nc_layout` — 97 passed, 1 skipped, 0 failed.
- `zig build test -Dtest-filter=titlebar` — 74 passed, 1 skipped, 0 failed.
- `zig build test -Dtest-filter=contentBands` — 68 passed, 1 skipped, 0 failed.
- `zig build test -Demit-test-exe=true` (full suite, current head) — **4079 passed, 70 skipped, 0 failed** (4149 tests).

  **Correction to an earlier revision of this body**, stated as a retraction rather than silently overwritten. It previously reported "3772/3843 passed, 70 skipped, 1 failed: the known pre-existing `Command: custom env vars`". That is no longer true and must not be relied on: `b1739a731` on `main` fixed that test by changing its argv from `/C` to `/D /C` to defeat a user `cmd.exe` AutoRun hook, and this branch is based on `e3a38268e`, which contains it. The invariant here is **zero failures**, not a pass count — a body still calling a failure "the known baseline" would lead a merger to wave through a genuinely failing suite.

Real-app measurements (Windows 11, sandboxed `%LOCALAPPDATA%`/`XDG_CONFIG_HOME`, explicit `--config-file` carrying the issue's exact config block; screenshots and geometry JSON captured; every launched PID recorded and stopped by exact PID):

| Scenario | Host client | Painted caption | Child surface | Core = child grid |
|---|---|---|---|---|
| 96 DPI normal | `[3908,531,4892,1223]` | `[3908,531,4892,571]` | `[3908,571,4892,1223]` | 25 × 88 |
| 96 DPI maximized | `[3840,471,5760,1503]` | `[3840,471,5760,511]` | `[3840,511,5760,1503]` | 39 × 173 |
| 144 DPI normal | `[71,60,1549,1099]` | `[71,60,1549,120]` | `[71,120,1549,1099]` | 26 × 86 |
| 144 DPI maximized | `[0,1,3840,2088]` | `[0,1,3840,61]` | `[0,61,3840,2088]` | 54 × 224 |
| runtime 144→96, normal | `[3928,551,4579,1010]` | `[3928,551,4579,591]` | `[3928,591,4579,1010]` | 16 × 58 |

In every case caption bottom equals child surface top, and the core's grid equals the independently computed child-advertised grid. Sampled band pixels are RGB (19,39,56) = `#132738`, confirming the titlebar color fix.

To prove the defect is real rather than theoretical, the tab metric was temporarily set to 32 DIP against the *old* placement algorithm. That reproduced the report exactly: painted caption `[3908,531,4892,571]` vs child surface `[3908,563,4892,1223]` — an 8 px overlap, with 26 rows advertised including the obscured one, and the invariant `surface top >= caption bottom` false. The new tests fail against that old algorithm.

### A/B against the shipped build

After this PR was opened, a controlled A/B was run on the reporter's own machine with the issue's exact config block, isolated config/`LOCALAPPDATA` roots, and matched payloads:

| Arm | Integrated band @96 DPI | Grid | Row 0 present |
|---|---|---|---|
| Installed 1.3.118 | 40 px | 64x19 | build exposes no usable UIA text |
| Exact v1.3.123 | 40 px | 64x19 | yes (row 0, row 1, last row) |
| `issues/149-win32-color-scheme` | 40 px | 64x19 | yes |
| this branch | 40 px | 64x19 | yes; titlebar band captured as `#132738` |

**No arm reproduced the clipping**, including the exact version the issue was filed against. Static history agrees: the band is 40 px at v1.3.118, v1.3.123 and `origin/main`, introduced earlier by `246e429b720322057772e5aacde9f7e5fb467871`, and there is no commit between v1.3.123 and `origin/main` that changes it. So there is no "fixed on main by <sha>" to cite — the latent divergent-height defect this PR removes was simply never activated in any measured configuration.

Note that the reporter's other issue (#149) was traced to recovery safe mode silently replacing their config with defaults. Any observation made while that was active — including the `window-theme = ghostty` titlebar behaviour described here — was made against default settings rather than the config in the issue, which is the most likely explanation for the report.

Evidence artifacts (132 files) are under `C:\Users\amant\.t3\worktrees\winghostty\evidence\150\`.

### Adversarial-review follow-ups (second commit)

- **One source of truth for the caption height.** Hit-testing and `WM_NCCALCSIZE` scaled 40 DIP through `win32_nc_layout.scaleDim` (round-to-nearest) while `contentBands` and `paintCaptionButtons` scaled `ThemeMetrics.caption_button_h` through `Host.scaled` (truncating), so they could disagree by 1 px at DPI values that are not multiples of 24 — which undercut the "cannot drift apart" claim. `metricsDefault` now takes `caption_button_h` and scales it once; every consumer reads the same `Metrics` value.
- **`Surface.init` degrades again instead of failing.** The first commit replaced the fallback rect with `try host.contentRect()`, turning a transient `GetClientRect` failure into a fatal one. The fallback is restored, but its top edge now comes from the current scaled tab/caption bands via the shared `Host.contentRectFromClient` rather than the unscaled 32 px constant that was the original bug.
- **Trimmed.** The four public layout helpers collapse to one `contentBands` plus its result struct; `terminalContentTop`, `captionBandBottom`, `contentBottom` and the resurrected `host_titlebar_height` alias are gone. Net for this commit: 86 insertions, 103 deletions.
- **Default-path coverage added.** `Issue150 shipped integrated bands start content at tab bottom` pins the shipped 40/40/40 configuration and asserts `content_top == tab_bottom`; the previous tests only exercised deliberately unequal metrics.
- Documented that a custom `window-titlebar-background` can read as a two-tone strip against the tab fill.

**This PR does not close the reporter's symptom.** It removes a latent invariant and its 1 px scaling divergence, and guards both with tests. See the A/B above: no arm reproduced the clipping.

## Residuals / user steps

- **The reporter's exact overlap was not reproduced anywhere**, including on exact v1.3.123 (see the A/B above). Because all three metrics are 40 DIP, old and new math agree at every DPI on the default path. This PR removes the undocumented invariant the layout silently depended on and guards it with tests; it is not proven to be the change that makes the reporter's window correct. They should re-test after #149 lands (safe mode was discarding their config) and, if row 0 is still hidden, attach a screenshot plus `tmux display -p '#{client_height} #{window_height}'` so we can measure their actual band.
- No physical 200% display was available. 192 DPI is covered by the pure layout tests in both window states and across a runtime DPI sequence, but there is no 200% screenshot.
- WSL instance creation was denied in the validation sandbox, so the literal `tmux set -g status-position top` case was not run; a native payload printing a marker into row 0 was used instead.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Align the Windows integrated titlebar, chrome painting, and terminal content layout under a shared DPI-aware boundary and propagate titlebar color overrides to the client-painted band.

Bug Fixes:
- Prevent integrated Windows titlebar and terminal content from overlapping when tab and caption heights differ or DPI scaling introduces rounding differences.
- Ensure content, overlay, inspector, and terminal bounds remain valid in very small client areas.

Enhancements:
- Centralize integrated chrome band layout so painting, hit testing, panel placement, and terminal sizing share the same boundaries.
- Apply configured Ghostty titlebar colors to the client-painted integrated titlebar while preserving readable contrast and high-contrast behavior.
- Restore resilient Surface initialization fallback behavior using the current scaled content layout.

Documentation:
- Document that custom Windows titlebar backgrounds may differ from the tab fill and create a two-tone integrated titlebar.

Tests:
- Add Windows layout coverage for unequal chrome metrics, fractional and runtime DPI changes, panel stacking, small clients, non-integrated windows, shipped defaults, and titlebar color overrides.

