### PR TITLE
feat(windows): UTF-8 console preamble with CJK code-page guard (#124)

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -71,6 +71,19 @@ integration inside the distribution. PowerShell integration emits OSC 7
 working-directory updates and OSC 133 prompt markers. `cmd.exe` is a plain
 fallback shell with no automatic prompt, cwd, or command-finish integration.
 
+`utf8-console` (`auto`, `always`, `never`) controls UTF-8 setup for bare
+interactive `cmd.exe` launches and for Windows PowerShell 5.1 and PowerShell 7
+sessions. `auto` (the default) enables UTF-8 unless the machine ANSI or OEM
+code page is a legacy CJK page (932, 936, 949, 950, or 1361); `always` ignores
+that guard; `never` leaves the encoding alone. The cmd preamble applies only to
+an interactive launch with no `/c`, `/r`, or `/k` payload: option switches such
+as `/d`, `/q`, and `/v:on` are kept in order ahead of it, and it is a no-op
+when the console already uses code page 65001. The PowerShell half runs inside
+the injected shell-integration script, so it does nothing with
+`shell-integration = none` or a command line that injection declines
+(`-Command`, `-File`, `-EncodedCommand`, `-NonInteractive`). WSL and Git Bash
+are unaffected.
+
 WSL appears in the picker but never becomes the default shell implicitly,
 because `wsl.exe --status` can report a healthy installation even when
 launching a session would fail. To make it the default:

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -860,6 +860,7 @@ pub fn init(
             .env_override = config.env,
             .shell_integration = config.@"shell-integration",
             .shell_integration_features = config.@"shell-integration-features",
+            .utf8_console = config.@"utf8-console",
             .cursor_blink = config.@"cursor-style-blink",
             .working_directory = if (config.@"working-directory") |wd| wd.value() else null,
             .working_directory_home = if (config.@"working-directory") |wd| wd == .home else false,

--- a/src/apprt/win32_powershell_install.zig
+++ b/src/apprt/win32_powershell_install.zig
@@ -7,8 +7,10 @@
 //!      `integration_script_sha256`. Writes atomically (temp + rename) only
 //!      when the hash differs or the file is missing.
 //!   3. `buildInjectedArgv` wraps interactive PowerShell launches with
-//!      `-NoExit -Command "& { . '<path>' }"` while preserving existing
-//!      prefix flags and skipping explicit command / script entry points.
+//!      `-NoExit -Command "& { $__ghostty_utf8_console = $true|$false; . '<path>' }"`
+//!      while preserving existing prefix flags and skipping explicit command /
+//!      script entry points. The sentinel is always bound, both ways, so it
+//!      shadows any same-named variable a profile may have defined.
 //!
 //! Testing: `@embedFile("../...")` needs the `src/` package root.
 //!   echo 'test { _ = @import("apprt/win32_powershell_install.zig"); }' > src/_t.zig
@@ -395,14 +397,17 @@ fn isValueTakingInteractiveFlag(arg: []const u8) bool {
 pub const utf8_console_variable = "__ghostty_utf8_console";
 
 fn buildCommandValue(alloc: Allocator, escaped: []const u8, utf8_console: bool) ![]u8 {
-    if (!utf8_console) {
-        return std.fmt.allocPrint(alloc, "& {{ . '{s}' }}", .{escaped});
-    }
-
+    // Always bind the sentinel, including the `false` case. `integration.ps1`
+    // resolves it with an unscoped `Get-Variable`, which walks the scope chain
+    // up to global — so if we emitted nothing when the decision is "no", a
+    // profile that happens to define `$global:__ghostty_utf8_console = $true`
+    // would be found instead and force UTF-8 against `utf8-console = never`
+    // or against the CJK guard. A local binding shadows any such outer
+    // variable, so the decision we computed is the one that applies.
     return std.fmt.allocPrint(
         alloc,
-        "& {{ ${s} = $true; . '{s}' }}",
-        .{ utf8_console_variable, escaped },
+        "& {{ ${s} = ${s}; . '{s}' }}",
+        .{ utf8_console_variable, if (utf8_console) "true" else "false", escaped },
     );
 }
 
@@ -479,7 +484,7 @@ test "buildInjectedArgv: interactive shell injects without changing banner seman
     try std.testing.expectEqualStrings("pwsh.exe", r[0]);
     try std.testing.expectEqualStrings("-NoExit", r[1]);
     try std.testing.expectEqualStrings("-Command", r[2]);
-    try std.testing.expectEqualStrings("& { . 'C:\\Users\\test\\integration.ps1' }", r[3]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\Users\\test\\integration.ps1' }", r[3]);
 }
 
 test "buildInjectedArgv: utf8 console travels in the command payload" {
@@ -501,6 +506,24 @@ test "buildInjectedArgv: utf8 console travels in the command payload" {
     try std.testing.expect(std.mem.indexOf(u8, r[3], "env:") == null);
 }
 
+test "buildInjectedArgv: a negative utf8 decision is bound explicitly" {
+    // `integration.ps1` resolves the sentinel with an unscoped `Get-Variable`,
+    // which walks the scope chain up to global. Emitting nothing for the
+    // "no" case would let a profile's `$global:__ghostty_utf8_console = $true`
+    // be found instead and override `utf8-console = never` or the CJK guard.
+    // The explicit `$false` binding shadows any such outer variable.
+    const argv = [_][]const u8{"pwsh.exe"};
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
+    defer {
+        for (r) |s| std.testing.allocator.free(s);
+        std.testing.allocator.free(r);
+    }
+    try std.testing.expectEqualStrings(
+        "& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }",
+        r[3],
+    );
+}
+
 test "buildInjectedArgv: preserves existing prefix flags" {
     const argv = [_][]const u8{ "pwsh.exe", "-ExecutionPolicy", "Bypass", "-NoProfile" };
     const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
@@ -515,7 +538,7 @@ test "buildInjectedArgv: preserves existing prefix flags" {
     try std.testing.expectEqualStrings("-NoProfile", r[3]);
     try std.testing.expectEqualStrings("-NoExit", r[4]);
     try std.testing.expectEqualStrings("-Command", r[5]);
-    try std.testing.expectEqualStrings("& { . 'C:\\int.ps1' }", r[6]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }", r[6]);
 }
 
 test "buildInjectedArgv: preserves slash-prefixed interactive flags" {
@@ -530,7 +553,7 @@ test "buildInjectedArgv: preserves slash-prefixed interactive flags" {
     try std.testing.expectEqualStrings("/NoProfile", r[1]);
     try std.testing.expectEqualStrings("-NoExit", r[2]);
     try std.testing.expectEqualStrings("-Command", r[3]);
-    try std.testing.expectEqualStrings("& { . 'C:\\int.ps1' }", r[4]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }", r[4]);
 }
 
 test "buildInjectedArgv: existing noexit is not duplicated for powershell.exe" {
@@ -545,7 +568,7 @@ test "buildInjectedArgv: existing noexit is not duplicated for powershell.exe" {
     try std.testing.expectEqualStrings("-NoExit", r[1]);
     try std.testing.expectEqualStrings("-NoProfile", r[2]);
     try std.testing.expectEqualStrings("-Command", r[3]);
-    try std.testing.expectEqualStrings("& { . 'C:\\int.ps1' }", r[4]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }", r[4]);
 }
 
 test "buildInjectedArgv: existing slash noexit is not duplicated" {
@@ -560,7 +583,7 @@ test "buildInjectedArgv: existing slash noexit is not duplicated" {
     try std.testing.expectEqualStrings("/NoExit", r[1]);
     try std.testing.expectEqualStrings("/NoProfile", r[2]);
     try std.testing.expectEqualStrings("-Command", r[3]);
-    try std.testing.expectEqualStrings("& { . 'C:\\int.ps1' }", r[4]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }", r[4]);
 }
 
 test "buildInjectedArgv: path with single quote" {
@@ -570,7 +593,7 @@ test "buildInjectedArgv: path with single quote" {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
     }
-    try std.testing.expectEqualStrings("& { . 'C:\\don''t\\integration.ps1' }", r[3]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\don''t\\integration.ps1' }", r[3]);
 }
 
 test "buildInjectedArgv: skips explicit command mode" {
@@ -625,7 +648,7 @@ test "buildInjectedArgv: existing noexit prefix is not duplicated" {
     try std.testing.expectEqualStrings("-NoEx", r[1]);
     try std.testing.expectEqualStrings("-NoProfile", r[2]);
     try std.testing.expectEqualStrings("-Command", r[3]);
-    try std.testing.expectEqualStrings("& { . 'C:\\int.ps1' }", r[4]);
+    try std.testing.expectEqualStrings("& { $__ghostty_utf8_console = $false; . 'C:\\int.ps1' }", r[4]);
 }
 
 test "buildInjectedArgv: skips ambiguous no prefix" {

--- a/src/apprt/win32_powershell_install.zig
+++ b/src/apprt/win32_powershell_install.zig
@@ -398,12 +398,14 @@ pub const utf8_console_variable = "__ghostty_utf8_console";
 
 fn buildCommandValue(alloc: Allocator, escaped: []const u8, utf8_console: bool) ![]u8 {
     // Always bind the sentinel, including the `false` case. `integration.ps1`
-    // resolves it with an unscoped `Get-Variable`, which walks the scope chain
-    // up to global — so if we emitted nothing when the decision is "no", a
-    // profile that happens to define `$global:__ghostty_utf8_console = $true`
-    // would be found instead and force UTF-8 against `utf8-console = never`
-    // or against the CJK guard. A local binding shadows any such outer
-    // variable, so the decision we computed is the one that applies.
+    // reads it with `Get-Variable -Scope Local`, which sees only the scope
+    // this script block creates (the dot-sourced script shares it) and never
+    // walks up to a profile-defined `$global:__ghostty_utf8_console`. That
+    // scope pin is what enforces `utf8-console = never` and the CJK guard
+    // against a hostile profile; the explicit `$false` exists so the "no"
+    // decision is a deliberate value rather than an absent variable, and so
+    // the local binding shadows any same-named outer variable if the lookup
+    // is ever loosened again.
     return std.fmt.allocPrint(
         alloc,
         "& {{ ${s} = ${s}; . '{s}' }}",
@@ -507,11 +509,11 @@ test "buildInjectedArgv: utf8 console travels in the command payload" {
 }
 
 test "buildInjectedArgv: a negative utf8 decision is bound explicitly" {
-    // `integration.ps1` resolves the sentinel with an unscoped `Get-Variable`,
-    // which walks the scope chain up to global. Emitting nothing for the
-    // "no" case would let a profile's `$global:__ghostty_utf8_console = $true`
-    // be found instead and override `utf8-console = never` or the CJK guard.
-    // The explicit `$false` binding shadows any such outer variable.
+    // `integration.ps1` reads the sentinel with `Get-Variable -Scope Local`,
+    // so a profile's `$global:__ghostty_utf8_console = $true` is never
+    // consulted. The "no" decision must still be an explicit `$false` binding
+    // in that local scope rather than an absent variable: it keeps the shape
+    // uniform for both outcomes and shadows any same-named outer variable.
     const argv = [_][]const u8{"pwsh.exe"};
     const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {

--- a/src/apprt/win32_powershell_install.zig
+++ b/src/apprt/win32_powershell_install.zig
@@ -153,10 +153,17 @@ pub const InjectError = error{ OutOfMemory, EmptyCommand };
 /// explicit command launch modes (`-Command`, `-File`, etc.) because
 /// appending our own `-Command` would change exit behavior or drop user
 /// payload.
+///
+/// `utf8_console` asks `integration.ps1` to switch the console encodings to
+/// UTF-8. It travels inside the `-Command` payload as a PowerShell variable
+/// rather than as a child environment variable: profiles run before our
+/// `-Command` does, so an environment variable would already have been
+/// inherited by anything a profile spawned.
 pub fn buildInjectedArgv(
     alloc: Allocator,
     pwsh_argv: []const []const u8,
     integration_path: []const u8,
+    utf8_console: bool,
 ) InjectError!?[]const [:0]const u8 {
     if (pwsh_argv.len == 0) return InjectError.EmptyCommand;
 
@@ -166,7 +173,7 @@ pub fn buildInjectedArgv(
         return InjectError.OutOfMemory;
     defer alloc.free(escaped);
 
-    const cmd_val = buildCommandValue(alloc, escaped) catch
+    const cmd_val = buildCommandValue(alloc, escaped, utf8_console) catch
         return InjectError.OutOfMemory;
     defer alloc.free(cmd_val);
 
@@ -381,8 +388,22 @@ fn isValueTakingInteractiveFlag(arg: []const u8) bool {
         isExactFlag(arg, "WorkingDirectory", &.{ "wd", "wo" });
 }
 
-fn buildCommandValue(alloc: Allocator, escaped: []const u8) ![]u8 {
-    return std.fmt.allocPrint(alloc, "& {{ . '{s}' }}", .{escaped});
+/// The variable `integration.ps1` reads to decide whether to force UTF-8
+/// console encodings. It only ever exists in the script block scope that
+/// dot-sources the integration script, so it is gone by the time the
+/// interactive session starts and no child process can inherit it.
+pub const utf8_console_variable = "__ghostty_utf8_console";
+
+fn buildCommandValue(alloc: Allocator, escaped: []const u8, utf8_console: bool) ![]u8 {
+    if (!utf8_console) {
+        return std.fmt.allocPrint(alloc, "& {{ . '{s}' }}", .{escaped});
+    }
+
+    return std.fmt.allocPrint(
+        alloc,
+        "& {{ ${s} = $true; . '{s}' }}",
+        .{ utf8_console_variable, escaped },
+    );
 }
 
 /// Escape a path for a PowerShell single-quoted string (`'` -> `''`).
@@ -449,7 +470,7 @@ test "escapeForPwshSingleQuote: consecutive quotes" {
 
 test "buildInjectedArgv: interactive shell injects without changing banner semantics" {
     const argv = [_][]const u8{"pwsh.exe"};
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\Users\\test\\integration.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\Users\\test\\integration.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -461,9 +482,28 @@ test "buildInjectedArgv: interactive shell injects without changing banner seman
     try std.testing.expectEqualStrings("& { . 'C:\\Users\\test\\integration.ps1' }", r[3]);
 }
 
+test "buildInjectedArgv: utf8 console travels in the command payload" {
+    const argv = [_][]const u8{"pwsh.exe"};
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", true)).?;
+    defer {
+        for (r) |s| std.testing.allocator.free(s);
+        std.testing.allocator.free(r);
+    }
+    try std.testing.expectEqual(@as(usize, 4), r.len);
+    try std.testing.expectEqualStrings("-Command", r[2]);
+    try std.testing.expectEqualStrings(
+        "& { $__ghostty_utf8_console = $true; . 'C:\\int.ps1' }",
+        r[3],
+    );
+
+    // The decision must never become part of the child environment, or a
+    // profile that runs before our -Command would leak it to its own children.
+    try std.testing.expect(std.mem.indexOf(u8, r[3], "env:") == null);
+}
+
 test "buildInjectedArgv: preserves existing prefix flags" {
     const argv = [_][]const u8{ "pwsh.exe", "-ExecutionPolicy", "Bypass", "-NoProfile" };
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -480,7 +520,7 @@ test "buildInjectedArgv: preserves existing prefix flags" {
 
 test "buildInjectedArgv: preserves slash-prefixed interactive flags" {
     const argv = [_][]const u8{ "pwsh.exe", "/NoProfile" };
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -495,7 +535,7 @@ test "buildInjectedArgv: preserves slash-prefixed interactive flags" {
 
 test "buildInjectedArgv: existing noexit is not duplicated for powershell.exe" {
     const argv = [_][]const u8{ "powershell.exe", "-NoExit", "-NoProfile" };
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -510,7 +550,7 @@ test "buildInjectedArgv: existing noexit is not duplicated for powershell.exe" {
 
 test "buildInjectedArgv: existing slash noexit is not duplicated" {
     const argv = [_][]const u8{ "powershell.exe", "/NoExit", "/NoProfile" };
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -525,7 +565,7 @@ test "buildInjectedArgv: existing slash noexit is not duplicated" {
 
 test "buildInjectedArgv: path with single quote" {
     const argv = [_][]const u8{"pwsh.exe"};
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\don't\\integration.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\don't\\integration.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -535,47 +575,47 @@ test "buildInjectedArgv: path with single quote" {
 
 test "buildInjectedArgv: skips explicit command mode" {
     const argv = [_][]const u8{ "pwsh.exe", "-Command", "Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips short command alias" {
     const argv = [_][]const u8{ "pwsh.exe", "-c", "Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips long command prefix" {
     const argv = [_][]const u8{ "pwsh.exe", "-Com", "Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips attached command form" {
     const argv = [_][]const u8{ "pwsh.exe", "-Command:Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips attached file form" {
     const argv = [_][]const u8{ "pwsh.exe", "-File:.\\script.ps1" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips attached encoded command form" {
     const argv = [_][]const u8{ "pwsh.exe", "-EncodedCommand:QQA=" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips slash version form" {
     const argv = [_][]const u8{ "pwsh.exe", "/Version" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips slash noninteractive form" {
     const argv = [_][]const u8{ "pwsh.exe", "/NonInteractive" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: existing noexit prefix is not duplicated" {
     const argv = [_][]const u8{ "pwsh.exe", "-NoEx", "-NoProfile" };
-    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")).?;
+    const r = (try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)).?;
     defer {
         for (r) |s| std.testing.allocator.free(s);
         std.testing.allocator.free(r);
@@ -590,42 +630,42 @@ test "buildInjectedArgv: existing noexit prefix is not duplicated" {
 
 test "buildInjectedArgv: skips ambiguous no prefix" {
     const argv = [_][]const u8{ "pwsh.exe", "-No" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips empty flag names" {
     const argv = [_][]const u8{ "pwsh.exe", "-:Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips empty slash flag names" {
     const argv = [_][]const u8{ "pwsh.exe", "/:Get-Date" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips positional script path after prefix flags" {
     const argv = [_][]const u8{ "pwsh.exe", "-NoProfile", ".\\script.ps1" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips encoded arguments mode" {
     const argv = [_][]const u8{ "powershell.exe", "-EncodedArguments", "QQA=" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips help mode" {
     const argv = [_][]const u8{ "pwsh.exe", "-?" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: skips version mode" {
     const argv = [_][]const u8{ "powershell.exe", "-Version", "5.1" };
-    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1")) == null);
+    try std.testing.expect((try buildInjectedArgv(std.testing.allocator, &argv, "C:\\int.ps1", false)) == null);
 }
 
 test "buildInjectedArgv: empty argv" {
     const argv = [_][]const u8{};
-    try std.testing.expectError(InjectError.EmptyCommand, buildInjectedArgv(std.testing.allocator, &argv, "p"));
+    try std.testing.expectError(InjectError.EmptyCommand, buildInjectedArgv(std.testing.allocator, &argv, "p", false));
 }
 
 test "installIfStale: first install writes" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -41,6 +41,7 @@ pub const RepeatableStringMap = @import("config/RepeatableStringMap.zig");
 pub const RepeatablePath = Config.RepeatablePath;
 pub const Path = Config.Path;
 pub const ShellIntegrationFeatures = Config.ShellIntegrationFeatures;
+pub const Utf8Console = Config.Utf8Console;
 pub const WindowDecoration = Config.WindowDecoration;
 pub const WindowPaddingColor = Config.WindowPaddingColor;
 pub const BackgroundImagePosition = Config.BackgroundImagePosition;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3176,6 +3176,26 @@ keybind: Keybinds = .{},
 /// hard-fail attachment to make descendant cleanup deterministic.
 @"windows-job-object-kill-on-close": bool = false,
 
+/// Controls the Windows console UTF-8 preamble for interactive Command Prompt
+/// and PowerShell sessions. This has no effect on WSL or Git Bash sessions.
+///
+/// The available modes are:
+///
+///   * `auto` (default) - Enable UTF-8 unless either the machine ANSI or OEM
+///     code page is a legacy CJK page: 932 (Shift-JIS), 936 (GBK), 949
+///     (EUC-KR), or 950 (Big5). Those code pages are left unchanged to avoid
+///     breaking programs that depend on them.
+///   * `always` - Enable UTF-8 even when a legacy CJK code page is active.
+///   * `never` - Do not set an environment signal, change Command Prompt
+///     arguments, or alter PowerShell console encodings.
+///
+/// Both `auto` and `always` skip the preamble when either code page is already
+/// 65001. For a bare interactive `cmd.exe`, the preamble runs `chcp 65001`
+/// silently before the prompt. For interactive Windows PowerShell 5.1 and
+/// PowerShell 7 (`pwsh`), the existing shell integration sets both
+/// `[Console]::InputEncoding` and `[Console]::OutputEncoding` to UTF-8.
+@"utf8-console": Utf8Console = .auto,
+
 /// Retained compatibility settings from the removed GTK runtime.
 ///
 /// These keys continue to parse so existing configs remain loadable, but they
@@ -8903,6 +8923,9 @@ pub const ShellIntegration = enum {
     nushell,
     zsh,
 };
+
+/// See utf8-console.
+pub const Utf8Console = windows_shell.Utf8Console;
 
 /// Shell integration features
 pub const ShellIntegrationFeatures = packed struct {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3184,8 +3184,8 @@ keybind: Keybinds = .{},
 ///
 ///   * `auto` (default) - Enable UTF-8 unless either the machine ANSI or OEM
 ///     code page is a legacy CJK page: 932 (Shift-JIS), 936 (GBK), 949
-///     (Unified Hangul Code), or 950 (Big5). Those code pages are left
-///     unchanged to avoid breaking programs that depend on them.
+///     (Unified Hangul Code), 950 (Big5), or 1361 (Johab). Those code pages
+///     are left unchanged to avoid breaking programs that depend on them.
 ///   * `always` - Enable UTF-8 even when a legacy CJK code page is active.
 ///   * `never` - Do not set an environment signal, change Command Prompt
 ///     arguments, or alter PowerShell console encodings.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3192,10 +3192,16 @@ keybind: Keybinds = .{},
 ///
 /// For a bare interactive `cmd.exe`, the preamble runs `chcp 65001` silently
 /// before the prompt and is a no-op when the live console is already UTF-8;
-/// cmd launches with any command tail are left unchanged. For interactive
-/// Windows PowerShell 5.1 and PowerShell 7 (`pwsh`), the existing shell
-/// integration sets both `[Console]::InputEncoding` and
-/// `[Console]::OutputEncoding` to UTF-8 only when their live code pages differ.
+/// cmd launches with any command tail are left unchanged.
+///
+/// The PowerShell half is performed by the injected shell-integration script,
+/// not by noctty itself: it sets `[Console]::InputEncoding` and
+/// `[Console]::OutputEncoding` only when their live code pages differ. It
+/// therefore requires automatic shell-integration injection to have happened.
+/// With `shell-integration = none`, or with a PowerShell command line that
+/// injection declines (`-Command`, `-File`, `-EncodedCommand`,
+/// `-NonInteractive`), `utf8-console` has no effect on PowerShell at all. The
+/// `cmd.exe` half does not depend on shell integration.
 @"utf8-console": Utf8Console = .auto,
 
 /// Retained compatibility settings from the removed GTK runtime.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3176,8 +3176,9 @@ keybind: Keybinds = .{},
 /// hard-fail attachment to make descendant cleanup deterministic.
 @"windows-job-object-kill-on-close": bool = false,
 
-/// Controls the Windows console UTF-8 preamble for interactive Command Prompt
-/// and PowerShell sessions. This has no effect on WSL or Git Bash sessions.
+/// Controls Windows console UTF-8 setup for bare interactive Command Prompt
+/// launches and interactive PowerShell sessions. This has no effect on WSL or
+/// Git Bash sessions.
 ///
 /// The available modes are:
 ///
@@ -3189,11 +3190,12 @@ keybind: Keybinds = .{},
 ///   * `never` - Do not set an environment signal, change Command Prompt
 ///     arguments, or alter PowerShell console encodings.
 ///
-/// Both `auto` and `always` skip the preamble when either code page is already
-/// 65001. For a bare interactive `cmd.exe`, the preamble runs `chcp 65001`
-/// silently before the prompt. For interactive Windows PowerShell 5.1 and
-/// PowerShell 7 (`pwsh`), the existing shell integration sets both
-/// `[Console]::InputEncoding` and `[Console]::OutputEncoding` to UTF-8.
+/// For a bare interactive `cmd.exe`, the preamble runs `chcp 65001` silently
+/// before the prompt and is a no-op when the live console is already UTF-8;
+/// cmd launches with any command tail are left unchanged. For interactive
+/// Windows PowerShell 5.1 and PowerShell 7 (`pwsh`), the existing shell
+/// integration sets both `[Console]::InputEncoding` and
+/// `[Console]::OutputEncoding` to UTF-8 only when their live code pages differ.
 @"utf8-console": Utf8Console = .auto,
 
 /// Retained compatibility settings from the removed GTK runtime.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3184,8 +3184,8 @@ keybind: Keybinds = .{},
 ///
 ///   * `auto` (default) - Enable UTF-8 unless either the machine ANSI or OEM
 ///     code page is a legacy CJK page: 932 (Shift-JIS), 936 (GBK), 949
-///     (EUC-KR), or 950 (Big5). Those code pages are left unchanged to avoid
-///     breaking programs that depend on them.
+///     (Unified Hangul Code), or 950 (Big5). Those code pages are left
+///     unchanged to avoid breaking programs that depend on them.
 ///   * `always` - Enable UTF-8 even when a legacy CJK code page is active.
 ///   * `never` - Do not set an environment signal, change Command Prompt
 ///     arguments, or alter PowerShell console encodings.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3190,9 +3190,11 @@ keybind: Keybinds = .{},
 ///   * `never` - Do not set an environment signal, change Command Prompt
 ///     arguments, or alter PowerShell console encodings.
 ///
-/// For a bare interactive `cmd.exe`, the preamble runs `chcp 65001` silently
-/// before the prompt and is a no-op when the live console is already UTF-8;
-/// cmd launches with any command tail are left unchanged.
+/// For an interactive `cmd.exe` with no command payload of its own, the
+/// preamble runs `chcp 65001` silently before the prompt and is a no-op when
+/// the live console is already UTF-8. Non-payload switches (`/d`, `/q`,
+/// `/v:on`, ...) are preserved in order and the preamble is appended after
+/// them; a `/c`, `/r`, or `/k` payload is left byte-for-byte unchanged.
 ///
 /// The PowerShell half is performed by the injected shell-integration script,
 /// not by noctty itself: it sets `[Console]::InputEncoding` and

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -229,8 +229,8 @@ pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic 
 }
 
 /// Prepare a command for Windows spawning. This applies the guarded UTF-8
-/// preamble to bare cmd launches and translates WSL working directories into
-/// `wsl.exe --cd ...` without paying a shell trampoline cost.
+/// preamble to payload-free cmd launches and translates WSL working
+/// directories into `wsl.exe --cd ...` without paying a shell trampoline cost.
 pub fn prepareCommand(
     alloc: Allocator,
     command: Command,
@@ -381,8 +381,8 @@ fn prepareCommandWithLookup(
     utf8_console: bool,
     lookup: anytype,
 ) !Command {
-    if (utf8_console and try isBareCmdCommand(alloc, command)) {
-        return try prepareBareCmdUtf8(alloc, command);
+    if (utf8_console) {
+        if (try prepareCmdUtf8(alloc, command)) |prepared| return prepared;
     }
 
     if (!isWslCommand(command)) return try command.clone(alloc);
@@ -403,37 +403,109 @@ fn prepareCommandWithLookup(
     };
 }
 
-fn isBareCmdCommand(alloc: Allocator, command: Command) !bool {
-    return switch (command) {
-        .direct => |argv| argv.len == 1 and
-            (isExecutableName(argv[0], "cmd") or
-                isExecutableName(argv[0], "cmd.exe")),
-        .shell => {
-            var arg_iter = try command.argIterator(alloc);
-            defer arg_iter.deinit();
+/// The silent code-page switch we run before an interactive Command Prompt
+/// draws its first prompt. `chcp` is idempotent, so this is a no-op when the
+/// console already uses code page 65001.
+const cmd_utf8_preamble = "chcp 65001 >nul";
 
-            const argv0 = arg_iter.next() orelse return false;
-            if (!isExecutableName(argv0, "cmd") and
-                !isExecutableName(argv0, "cmd.exe")) return false;
-            return arg_iter.next() == null;
-        },
-    };
+/// Build the UTF-8 preamble form of a `cmd.exe` launch, or `null` when the
+/// launch must be left byte-for-byte unchanged.
+///
+/// Only an interactive Command Prompt that carries no command payload of its
+/// own is rewritten. Non-payload switches (`/d`, `/q`, `/v:on`, ...) are kept
+/// in their original order and `/K "chcp 65001 >nul"` is appended after them.
+fn prepareCmdUtf8(alloc: Allocator, command: Command) !?Command {
+    var arg_iter = try command.argIterator(alloc);
+    defer arg_iter.deinit();
+
+    var args: std.ArrayList([]const u8) = .empty;
+    defer args.deinit(alloc);
+
+    const argv0 = arg_iter.next() orelse return null;
+    if (!isExecutableName(argv0, "cmd") and
+        !isExecutableName(argv0, "cmd.exe")) return null;
+    try args.append(alloc, argv0);
+
+    while (arg_iter.next()) |arg| {
+        if (classifyCmdArg(arg) == .unsupported) return null;
+        try args.append(alloc, arg);
+    }
+
+    try args.append(alloc, "/K");
+    try args.append(alloc, cmd_utf8_preamble);
+    return try directCommand(alloc, args.items);
 }
 
-fn prepareBareCmdUtf8(alloc: Allocator, command: Command) !Command {
-    return switch (command) {
-        .direct => |argv| try prepareBareCmdUtf8Argv0(alloc, argv[0]),
-        .shell => shell: {
-            var arg_iter = try command.argIterator(alloc);
-            defer arg_iter.deinit();
-            const argv0 = arg_iter.next() orelse unreachable;
-            break :shell try prepareBareCmdUtf8Argv0(alloc, argv0);
-        },
-    };
-}
+const CmdArg = enum {
+    /// A switch run carrying only non-payload options. Safe to preserve and
+    /// to append our own `/K` after.
+    option,
 
-fn prepareBareCmdUtf8Argv0(alloc: Allocator, argv0: []const u8) !Command {
-    return try directCommand(alloc, &.{ argv0, "/K", "chcp 65001 >nul" });
+    /// A command payload switch or a token we don't recognize. The launch is
+    /// left untouched.
+    unsupported,
+};
+
+/// Classify one `cmd.exe` argument.
+///
+/// `cmd.exe` only treats `/` as a switch prefix (`-c` is a positional), and it
+/// accepts fused switch runs such as `/d/q/c` and `/v:on/c`, so a run has to be
+/// walked to the end before it can be called payload-free.
+fn classifyCmdArg(arg: []const u8) CmdArg {
+    if (arg.len < 2 or arg[0] != '/') return .unsupported;
+
+    var i: usize = 0;
+    while (i < arg.len) {
+        // A fused run repeats the `/` separator: `/d/q/v:on`.
+        if (arg[i] == '/') {
+            i += 1;
+            if (i >= arg.len) return .unsupported;
+        }
+
+        switch (std.ascii.toLower(arg[i])) {
+            // `/c` and `/r` run a command and terminate; `/k` runs a command
+            // and stays interactive. All three carry the user's own payload,
+            // which we never touch.
+            'c', 'r', 'k' => return .unsupported,
+
+            // Valueless options: ANSI/Unicode piped output, quiet echo,
+            // AutoRun suppression, and quoting mode.
+            'a', 'u', 'q', 'd', 's' => i += 1,
+
+            // `/e:on`, `/f:off`, `/v:on`.
+            'e', 'f', 'v' => {
+                i += 1;
+                if (i >= arg.len or arg[i] != ':') return .unsupported;
+                i += 1;
+                if (asciiStartsWithIgnoreCase(arg[i..], "off")) {
+                    i += "off".len;
+                } else if (asciiStartsWithIgnoreCase(arg[i..], "on")) {
+                    i += "on".len;
+                } else return .unsupported;
+            },
+
+            // `/t:fg` takes one or two hex color digits.
+            't' => {
+                i += 1;
+                if (i >= arg.len or arg[i] != ':') return .unsupported;
+                i += 1;
+                var digits: usize = 0;
+                while (digits < 2 and i < arg.len and std.ascii.isHex(arg[i])) {
+                    i += 1;
+                    digits += 1;
+                }
+                if (digits == 0) return .unsupported;
+            },
+
+            else => return .unsupported,
+        }
+
+        // A run either ends here or continues with another `/`. Anything else
+        // is a fused payload such as `/cecho hi`.
+        if (i < arg.len and arg[i] != '/') return .unsupported;
+    }
+
+    return .option;
 }
 
 pub fn isWslCommand(command: Command) bool {
@@ -2057,7 +2129,7 @@ test "utf8-console decision covers modes and guarded code pages" {
     try testing.expect(!shouldApplyUtf8Console(.never, 1252, 65001));
 }
 
-test "utf8-console cmd preamble only changes bare cmd" {
+test "utf8-console cmd preamble leaves payload launches unchanged" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -2117,4 +2189,97 @@ test "utf8-console cmd preamble only changes bare cmd" {
 
     try testing.expect(prepared_trampoline == .shell);
     try testing.expectEqualStrings("cmd.exe /c echo ok", prepared_trampoline.shell);
+}
+
+test "classifyCmdArg separates option-only switches from payload switches" {
+    const testing = std.testing;
+
+    for ([_][]const u8{
+        "/d",      "/Q",     "/a",    "/u",      "/s",
+        "/d/q",    "/D/Q/A", "/e:on", "/E:OFF",  "/f:off",
+        "/v:on",   "/t:0A",  "/t:f",  "/d/v:on", "/v:on/q",
+        "/t:0a/q", "/s/d",
+    }) |arg| {
+        try testing.expectEqual(CmdArg.option, classifyCmdArg(arg));
+    }
+
+    for ([_][]const u8{
+        // Payload switches, separate and fused.
+        "/c",       "/K",         "/r",     "/d/q/c", "/v:on/c",
+        "/e:on/k",  "/cecho",     "/Kchcp", "/s/c",
+        // Not a switch at all: cmd has no `-` prefix.
+          "-c",
+        "-d",       "script.bat",
+        // Malformed or unknown switch runs.
+        "/",      "/z",     "/e",
+        "/e:maybe", "/t",         "/t:",    "/t:zz",  "/d/",
+        "/v:onx",
+    }) |arg| {
+        try testing.expectEqual(CmdArg.unsupported, classifyCmdArg(arg));
+    }
+}
+
+test "utf8-console cmd preamble preserves option-only switches" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const lookup = struct {
+        fn lookup(_: Allocator, _: []const u8) !?[]u8 {
+            return null;
+        }
+    }.lookup;
+
+    // Separate switches keep their order and gain the preamble.
+    const separate = try directCommand(alloc, &.{ "cmd.exe", "/d", "/q" });
+    defer separate.deinit(alloc);
+    const prepared_separate = try prepareCommandWithLookup(alloc, separate, null, false, true, lookup);
+    defer prepared_separate.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 5), prepared_separate.direct.len);
+    try testing.expectEqualStrings("cmd.exe", prepared_separate.direct[0]);
+    try testing.expectEqualStrings("/d", prepared_separate.direct[1]);
+    try testing.expectEqualStrings("/q", prepared_separate.direct[2]);
+    try testing.expectEqualStrings("/K", prepared_separate.direct[3]);
+    try testing.expectEqualStrings("chcp 65001 >nul", prepared_separate.direct[4]);
+
+    // Combined switch runs are preserved verbatim.
+    const combined = try directCommand(alloc, &.{ "cmd.exe", "/d/q", "/v:on" });
+    defer combined.deinit(alloc);
+    const prepared_combined = try prepareCommandWithLookup(alloc, combined, null, false, true, lookup);
+    defer prepared_combined.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 5), prepared_combined.direct.len);
+    try testing.expectEqualStrings("/d/q", prepared_combined.direct[1]);
+    try testing.expectEqualStrings("/v:on", prepared_combined.direct[2]);
+    try testing.expectEqualStrings("/K", prepared_combined.direct[3]);
+    try testing.expectEqualStrings("chcp 65001 >nul", prepared_combined.direct[4]);
+
+    // A shell-form option-only launch normalizes into direct argv.
+    const shell_options: Command = .{ .shell = "\"C:\\Windows\\System32\\cmd.exe\" /d /q" };
+    const prepared_shell = try prepareCommandWithLookup(alloc, shell_options, null, false, true, lookup);
+    defer prepared_shell.deinit(alloc);
+
+    try testing.expect(prepared_shell == .direct);
+    try testing.expectEqual(@as(usize, 5), prepared_shell.direct.len);
+    try testing.expectEqualStrings("C:\\Windows\\System32\\cmd.exe", prepared_shell.direct[0]);
+    try testing.expectEqualStrings("/K", prepared_shell.direct[3]);
+
+    // A fused payload switch after options is still left untouched.
+    for ([_][]const []const u8{
+        &.{ "cmd.exe", "/d", "/q", "/c", "echo ok" },
+        &.{ "cmd.exe", "/d/q/c", "echo ok" },
+        &.{ "cmd.exe", "/v:on/c", "echo ok" },
+        &.{ "cmd.exe", "/k", "echo ok" },
+        &.{ "cmd.exe", "/cecho ok" },
+    }) |argv| {
+        const original = try directCommand(alloc, argv);
+        defer original.deinit(alloc);
+        const prepared = try prepareCommandWithLookup(alloc, original, null, false, true, lookup);
+        defer prepared.deinit(alloc);
+
+        try testing.expectEqual(original.direct.len, prepared.direct.len);
+        for (original.direct, prepared.direct) |expected, actual| {
+            try testing.expectEqualStrings(expected, actual);
+        }
+    }
 }

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const internal_os = @import("../os/main.zig");
+const win32 = @import("../os/windows.zig");
 const Command = @import("command.zig").Command;
 const windows_shell_types = @import("windows_shell_types.zig");
 const windows_ssh_hosts = @import("windows_ssh_hosts.zig");
@@ -26,6 +27,39 @@ pub const DefaultShell = enum {
 };
 
 pub const ProfileKind = windows_shell_types.ProfileKind;
+pub const Utf8Console = windows_shell_types.Utf8Console;
+
+const utf8_code_page: u32 = 65001;
+const legacy_cjk_code_pages = [_]u32{ 932, 936, 949, 950 };
+
+pub fn shouldApplyUtf8Console(
+    mode: Utf8Console,
+    ansi_code_page: u32,
+    oem_code_page: u32,
+) bool {
+    if (ansi_code_page == utf8_code_page or oem_code_page == utf8_code_page) {
+        return false;
+    }
+
+    return switch (mode) {
+        .never => false,
+        .always => true,
+        .auto => !isLegacyCjkCodePage(ansi_code_page) and
+            !isLegacyCjkCodePage(oem_code_page),
+    };
+}
+
+pub fn shouldApplyUtf8ConsoleForCurrentSystem(mode: Utf8Console) bool {
+    if (comptime builtin.os.tag != .windows) return false;
+    return shouldApplyUtf8Console(mode, win32.GetACP(), win32.GetOEMCP());
+}
+
+fn isLegacyCjkCodePage(code_page: u32) bool {
+    for (legacy_cjk_code_pages) |legacy| {
+        if (code_page == legacy) return true;
+    }
+    return false;
+}
 
 pub const ShellIntegrationSupport = enum {
     automatic,
@@ -199,20 +233,22 @@ pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic 
     };
 }
 
-/// Prepare a command for Windows spawning. Today this only special-cases WSL
-/// so that inherited or explicit working directories become `wsl.exe --cd ...`
-/// launches without paying a shell trampoline cost.
+/// Prepare a command for Windows spawning. This applies the guarded UTF-8
+/// preamble to bare cmd launches and translates WSL working directories into
+/// `wsl.exe --cd ...` without paying a shell trampoline cost.
 pub fn prepareCommand(
     alloc: Allocator,
     command: Command,
     cwd: ?[]const u8,
     working_directory_home: bool,
+    utf8_console: bool,
 ) !Command {
     return try prepareCommandWithLookup(
         alloc,
         command,
         cwd,
         working_directory_home,
+        utf8_console,
         lookupExecutable,
     );
 }
@@ -347,8 +383,13 @@ fn prepareCommandWithLookup(
     command: Command,
     cwd: ?[]const u8,
     working_directory_home: bool,
+    utf8_console: bool,
     lookup: anytype,
 ) !Command {
+    if (utf8_console and try isBareCmdCommand(alloc, command)) {
+        return try prepareBareCmdUtf8(alloc, command);
+    }
+
     if (!isWslCommand(command)) return try command.clone(alloc);
 
     const target_cwd: ?[]const u8 = cwd_: {
@@ -364,6 +405,38 @@ fn prepareCommandWithLookup(
         // We only auto-rewrite WSL direct launches. A shell command is assumed
         // to be user-authored and remains untouched.
         .shell => try command.clone(alloc),
+    };
+}
+
+fn isBareCmdCommand(alloc: Allocator, command: Command) !bool {
+    return switch (command) {
+        .direct => |argv| argv.len == 1 and
+            (isExecutableName(argv[0], "cmd") or
+                isExecutableName(argv[0], "cmd.exe")),
+        .shell => {
+            var arg_iter = try command.argIterator(alloc);
+            defer arg_iter.deinit();
+
+            const argv0 = arg_iter.next() orelse return false;
+            if (!isExecutableName(argv0, "cmd") and
+                !isExecutableName(argv0, "cmd.exe")) return false;
+            return arg_iter.next() == null;
+        },
+    };
+}
+
+fn prepareBareCmdUtf8(alloc: Allocator, command: Command) !Command {
+    return switch (command) {
+        .direct => |argv| try directCommand(
+            alloc,
+            &.{ argv[0], "/K", "chcp 65001 >nul" },
+        ),
+        .shell => |value| .{ .shell = try std.fmt.allocPrintSentinel(
+            alloc,
+            "chcp 65001 >nul & {s}",
+            .{value},
+            0,
+        ) },
     };
 }
 
@@ -1769,7 +1842,7 @@ test "prepareCommand injects translated cwd for wsl direct command" {
 
     const command = try directCommand(alloc, &.{"wsl.exe"});
     defer command.deinit(alloc);
-    const prepared = try prepareCommandWithLookup(alloc, command, "D:\\work\\noctty", false, struct {
+    const prepared = try prepareCommandWithLookup(alloc, command, "D:\\work\\noctty", false, false, struct {
         fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
             if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
             return null;
@@ -1790,7 +1863,7 @@ test "prepareCommand replaces default wsl home sentinel with explicit cwd" {
 
     const command = try directCommand(alloc, &.{ "wsl.exe", "~" });
     defer command.deinit(alloc);
-    const prepared = try prepareCommandWithLookup(alloc, command, "D:\\work\\noctty", false, struct {
+    const prepared = try prepareCommandWithLookup(alloc, command, "D:\\work\\noctty", false, false, struct {
         fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
             if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
             return null;
@@ -1811,7 +1884,7 @@ test "prepareCommand rewrites wsl home sentinel to explicit --cd" {
 
     const command = try directCommand(alloc, &.{ "wsl.exe", "~" });
     defer command.deinit(alloc);
-    const prepared = try prepareCommandWithLookup(alloc, command, null, true, struct {
+    const prepared = try prepareCommandWithLookup(alloc, command, null, true, false, struct {
         fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
             if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
             return null;
@@ -1832,7 +1905,7 @@ test "prepareCommand replaces existing wsl --cd" {
 
     const command = try directCommand(alloc, &.{ "wsl.exe", "--cd", "~", "--", "bash" });
     defer command.deinit(alloc);
-    const prepared = try prepareCommandWithLookup(alloc, command, "/home/aman/src", false, struct {
+    const prepared = try prepareCommandWithLookup(alloc, command, "/home/aman/src", false, false, struct {
         fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
             if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
             return null;
@@ -1952,4 +2025,78 @@ test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd support" {
         cmd.summary,
     );
     try testing.expect(cmd.next_step != null);
+}
+
+test "utf8-console decision covers modes and guarded code pages" {
+    const testing = std.testing;
+
+    const cases = [_]struct {
+        mode: Utf8Console,
+        western: bool,
+        cjk: bool,
+        utf8: bool,
+    }{
+        .{ .mode = .auto, .western = true, .cjk = false, .utf8 = false },
+        .{ .mode = .always, .western = true, .cjk = true, .utf8 = false },
+        .{ .mode = .never, .western = false, .cjk = false, .utf8 = false },
+    };
+
+    for (cases) |case| {
+        try testing.expectEqual(case.western, shouldApplyUtf8Console(case.mode, 1252, 437));
+        try testing.expectEqual(case.cjk, shouldApplyUtf8Console(case.mode, 932, 932));
+        try testing.expectEqual(case.utf8, shouldApplyUtf8Console(case.mode, 65001, 65001));
+    }
+
+    for ([_]u32{ 932, 936, 949, 950 }) |code_page| {
+        try testing.expect(!shouldApplyUtf8Console(.auto, code_page, 437));
+        try testing.expect(!shouldApplyUtf8Console(.auto, 1252, code_page));
+    }
+
+    try testing.expect(!shouldApplyUtf8Console(.always, 65001, 437));
+    try testing.expect(!shouldApplyUtf8Console(.always, 1252, 65001));
+}
+
+test "utf8-console cmd preamble only changes bare cmd" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const lookup = struct {
+        fn lookup(_: Allocator, _: []const u8) !?[]u8 {
+            return null;
+        }
+    }.lookup;
+
+    const bare = try directCommand(alloc, &.{"cmd.exe"});
+    defer bare.deinit(alloc);
+    const prepared_bare = try prepareCommandWithLookup(alloc, bare, null, false, true, lookup);
+    defer prepared_bare.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 3), prepared_bare.direct.len);
+    try testing.expectEqualStrings("cmd.exe", prepared_bare.direct[0]);
+    try testing.expectEqualStrings("/K", prepared_bare.direct[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul", prepared_bare.direct[2]);
+
+    const with_tail = try directCommand(alloc, &.{ "cmd.exe", "/c", "echo ok" });
+    defer with_tail.deinit(alloc);
+    const prepared_tail = try prepareCommandWithLookup(alloc, with_tail, null, false, true, lookup);
+    defer prepared_tail.deinit(alloc);
+
+    try testing.expectEqual(with_tail.direct.len, prepared_tail.direct.len);
+    for (with_tail.direct, prepared_tail.direct) |expected, actual| {
+        try testing.expectEqualStrings(expected, actual);
+    }
+
+    const shell_bare: Command = .{ .shell = "cmd.exe" };
+    const prepared_shell_bare = try prepareCommandWithLookup(alloc, shell_bare, null, false, true, lookup);
+    defer prepared_shell_bare.deinit(alloc);
+
+    try testing.expect(prepared_shell_bare == .shell);
+    try testing.expectEqualStrings("chcp 65001 >nul & cmd.exe", prepared_shell_bare.shell);
+
+    const trampoline: Command = .{ .shell = "cmd.exe /c echo ok" };
+    const prepared_trampoline = try prepareCommandWithLookup(alloc, trampoline, null, false, true, lookup);
+    defer prepared_trampoline.deinit(alloc);
+
+    try testing.expect(prepared_trampoline == .shell);
+    try testing.expectEqualStrings("cmd.exe /c echo ok", prepared_trampoline.shell);
 }

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -29,7 +29,9 @@ pub const DefaultShell = enum {
 pub const ProfileKind = windows_shell_types.ProfileKind;
 pub const Utf8Console = windows_shell_types.Utf8Console;
 
-const legacy_cjk_code_pages = [_]u32{ 932, 936, 949, 950 };
+/// ANSI/OEM code pages where forcing 65001 would mojibake legacy programs.
+/// 932 Shift-JIS, 936 GBK, 949 Unified Hangul Code, 950 Big5, 1361 Johab.
+const legacy_cjk_code_pages = [_]u32{ 932, 936, 949, 950, 1361 };
 
 pub fn shouldApplyUtf8Console(
     mode: Utf8Console,
@@ -469,8 +471,10 @@ fn classifyCmdArg(arg: []const u8) CmdArg {
             'c', 'r', 'k' => return .unsupported,
 
             // Valueless options: ANSI/Unicode piped output, quiet echo,
-            // AutoRun suppression, and quoting mode.
-            'a', 'u', 'q', 'd', 's' => i += 1,
+            // AutoRun suppression, and quoting mode. `/x` and `/y` are the
+            // OS/2-compatibility spellings of `/e:on` and `/e:off`, which
+            // `cmd /?` documents and which take no value.
+            'a', 'u', 'q', 'd', 's', 'x', 'y' => i += 1,
 
             // `/e:on`, `/f:off`, `/v:on`.
             'e', 'f', 'v' => {
@@ -2115,7 +2119,7 @@ test "utf8-console decision covers modes and guarded code pages" {
         try testing.expectEqual(case.utf8, shouldApplyUtf8Console(case.mode, 65001, 65001));
     }
 
-    for ([_]u32{ 932, 936, 949, 950 }) |code_page| {
+    for ([_]u32{ 932, 936, 949, 950, 1361 }) |code_page| {
         try testing.expect(!shouldApplyUtf8Console(.auto, code_page, 437));
         try testing.expect(!shouldApplyUtf8Console(.auto, 1252, code_page));
     }
@@ -2195,10 +2199,14 @@ test "classifyCmdArg separates option-only switches from payload switches" {
     const testing = std.testing;
 
     for ([_][]const u8{
-        "/d",      "/Q",     "/a",    "/u",      "/s",
-        "/d/q",    "/D/Q/A", "/e:on", "/E:OFF",  "/f:off",
-        "/v:on",   "/t:0A",  "/t:f",  "/d/v:on", "/v:on/q",
+        "/d",      "/Q",      "/a",    "/u",      "/s",
+        "/d/q",    "/D/Q/A",  "/e:on", "/E:OFF",  "/f:off",
+        "/v:on",   "/t:0A",   "/t:f",  "/d/v:on", "/v:on/q",
         "/t:0a/q", "/s/d",
+        // `cmd /?`: "for compatibility reasons, /X is the same as /E:ON,
+        // /Y is the same as /E:OFF". Both are valueless.
+           "/x",    "/Y",      "/x/q",
+        "/d/y",    "/x/v:on",
     }) |arg| {
         try testing.expectEqual(CmdArg.option, classifyCmdArg(arg));
     }

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -29,7 +29,6 @@ pub const DefaultShell = enum {
 pub const ProfileKind = windows_shell_types.ProfileKind;
 pub const Utf8Console = windows_shell_types.Utf8Console;
 
-const utf8_code_page: u32 = 65001;
 const legacy_cjk_code_pages = [_]u32{ 932, 936, 949, 950 };
 
 pub fn shouldApplyUtf8Console(
@@ -37,10 +36,6 @@ pub fn shouldApplyUtf8Console(
     ansi_code_page: u32,
     oem_code_page: u32,
 ) bool {
-    if (ansi_code_page == utf8_code_page or oem_code_page == utf8_code_page) {
-        return false;
-    }
-
     return switch (mode) {
         .never => false,
         .always => true,
@@ -427,17 +422,18 @@ fn isBareCmdCommand(alloc: Allocator, command: Command) !bool {
 
 fn prepareBareCmdUtf8(alloc: Allocator, command: Command) !Command {
     return switch (command) {
-        .direct => |argv| try directCommand(
-            alloc,
-            &.{ argv[0], "/K", "chcp 65001 >nul" },
-        ),
-        .shell => |value| .{ .shell = try std.fmt.allocPrintSentinel(
-            alloc,
-            "chcp 65001 >nul & {s}",
-            .{value},
-            0,
-        ) },
+        .direct => |argv| try prepareBareCmdUtf8Argv0(alloc, argv[0]),
+        .shell => shell: {
+            var arg_iter = try command.argIterator(alloc);
+            defer arg_iter.deinit();
+            const argv0 = arg_iter.next() orelse unreachable;
+            break :shell try prepareBareCmdUtf8Argv0(alloc, argv0);
+        },
     };
+}
+
+fn prepareBareCmdUtf8Argv0(alloc: Allocator, argv0: []const u8) !Command {
+    return try directCommand(alloc, &.{ argv0, "/K", "chcp 65001 >nul" });
 }
 
 pub fn isWslCommand(command: Command) bool {
@@ -2036,8 +2032,8 @@ test "utf8-console decision covers modes and guarded code pages" {
         cjk: bool,
         utf8: bool,
     }{
-        .{ .mode = .auto, .western = true, .cjk = false, .utf8 = false },
-        .{ .mode = .always, .western = true, .cjk = true, .utf8 = false },
+        .{ .mode = .auto, .western = true, .cjk = false, .utf8 = true },
+        .{ .mode = .always, .western = true, .cjk = true, .utf8 = true },
         .{ .mode = .never, .western = false, .cjk = false, .utf8 = false },
     };
 
@@ -2052,8 +2048,13 @@ test "utf8-console decision covers modes and guarded code pages" {
         try testing.expect(!shouldApplyUtf8Console(.auto, 1252, code_page));
     }
 
-    try testing.expect(!shouldApplyUtf8Console(.always, 65001, 437));
-    try testing.expect(!shouldApplyUtf8Console(.always, 1252, 65001));
+    for ([_]Utf8Console{ .auto, .always }) |mode| {
+        try testing.expect(shouldApplyUtf8Console(mode, 65001, 437));
+        try testing.expect(shouldApplyUtf8Console(mode, 1252, 65001));
+    }
+
+    try testing.expect(!shouldApplyUtf8Console(.never, 65001, 437));
+    try testing.expect(!shouldApplyUtf8Console(.never, 1252, 65001));
 }
 
 test "utf8-console cmd preamble only changes bare cmd" {
@@ -2076,6 +2077,20 @@ test "utf8-console cmd preamble only changes bare cmd" {
     try testing.expectEqualStrings("/K", prepared_bare.direct[1]);
     try testing.expectEqualStrings("chcp 65001 >nul", prepared_bare.direct[2]);
 
+    const prepared_never = try prepareCommandWithLookup(
+        alloc,
+        bare,
+        null,
+        false,
+        shouldApplyUtf8Console(.never, 1252, 437),
+        lookup,
+    );
+    defer prepared_never.deinit(alloc);
+
+    try testing.expect(prepared_never == .direct);
+    try testing.expectEqual(@as(usize, 1), prepared_never.direct.len);
+    try testing.expectEqualStrings("cmd.exe", prepared_never.direct[0]);
+
     const with_tail = try directCommand(alloc, &.{ "cmd.exe", "/c", "echo ok" });
     defer with_tail.deinit(alloc);
     const prepared_tail = try prepareCommandWithLookup(alloc, with_tail, null, false, true, lookup);
@@ -2086,12 +2101,15 @@ test "utf8-console cmd preamble only changes bare cmd" {
         try testing.expectEqualStrings(expected, actual);
     }
 
-    const shell_bare: Command = .{ .shell = "cmd.exe" };
+    const shell_bare: Command = .{ .shell = "\"C:\\Windows\\System32\\cmd.exe\"" };
     const prepared_shell_bare = try prepareCommandWithLookup(alloc, shell_bare, null, false, true, lookup);
     defer prepared_shell_bare.deinit(alloc);
 
-    try testing.expect(prepared_shell_bare == .shell);
-    try testing.expectEqualStrings("chcp 65001 >nul & cmd.exe", prepared_shell_bare.shell);
+    try testing.expect(prepared_shell_bare == .direct);
+    try testing.expectEqual(@as(usize, 3), prepared_shell_bare.direct.len);
+    try testing.expectEqualStrings("C:\\Windows\\System32\\cmd.exe", prepared_shell_bare.direct[0]);
+    try testing.expectEqualStrings("/K", prepared_shell_bare.direct[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul", prepared_shell_bare.direct[2]);
 
     const trampoline: Command = .{ .shell = "cmd.exe /c echo ok" };
     const prepared_trampoline = try prepareCommandWithLookup(alloc, trampoline, null, false, true, lookup);

--- a/src/config/windows_shell_types.zig
+++ b/src/config/windows_shell_types.zig
@@ -12,3 +12,9 @@ pub const ProfileKind = enum {
     cmd,
     ssh,
 };
+
+pub const Utf8Console = enum {
+    auto,
+    always,
+    never,
+};

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -33,6 +33,9 @@ pub const TRUE = windows.TRUE;
 pub const FOLDERID_Profile = windows.GUID.parse("{5E6C858F-0E22-4760-9AFE-EA3317B67173}");
 pub const FOLDERID_LocalAppData = windows.FOLDERID_LocalAppData;
 
+pub extern "kernel32" fn GetACP() callconv(.winapi) windows.UINT;
+pub extern "kernel32" fn GetOEMCP() callconv(.winapi) windows.UINT;
+
 pub const KnownFolderPathError = error{
     BufferTooSmall,
 };

--- a/src/shell-integration/powershell/integration.ps1
+++ b/src/shell-integration/powershell/integration.ps1
@@ -1,7 +1,10 @@
 # Noctty shell integration for PowerShell 5.1+ / pwsh 7+
 # Emits OSC 133 (command marking) and OSC 7 (current working directory) sequences.
 
-if ($env:GHOSTTY_UTF8_CONSOLE -eq '1') {
+$ghosttyUtf8Console = $env:GHOSTTY_UTF8_CONSOLE
+Remove-Item Env:GHOSTTY_UTF8_CONSOLE -ErrorAction SilentlyContinue
+
+if ($ghosttyUtf8Console -eq '1') {
     try {
         if (([Console]::InputEncoding.CodePage -ne 65001) -or
             ([Console]::OutputEncoding.CodePage -ne 65001)) {

--- a/src/shell-integration/powershell/integration.ps1
+++ b/src/shell-integration/powershell/integration.ps1
@@ -1,6 +1,20 @@
 # Noctty shell integration for PowerShell 5.1+ / pwsh 7+
 # Emits OSC 133 (command marking) and OSC 7 (current working directory) sequences.
 
+if ($env:GHOSTTY_UTF8_CONSOLE -eq '1') {
+    try {
+        if (([Console]::InputEncoding.CodePage -ne 65001) -or
+            ([Console]::OutputEncoding.CodePage -ne 65001)) {
+            $utf8 = [System.Text.UTF8Encoding]::new($false)
+            [Console]::InputEncoding = $utf8
+            [Console]::OutputEncoding = $utf8
+        }
+    } catch {
+        # Keep the rest of shell integration available if the host does not
+        # expose mutable console encodings.
+    }
+}
+
 $ESC = [char]27
 $BEL = [char]7
 

--- a/src/shell-integration/powershell/integration.ps1
+++ b/src/shell-integration/powershell/integration.ps1
@@ -5,8 +5,11 @@
 # scope that dot-sources this script, never in the environment: profiles run
 # before our -Command does, so an environment variable would already have been
 # inherited by anything a profile spawned. Get-Variable keeps this safe under
-# Set-StrictMode when the variable is absent (manual dot-sourcing).
-$ghosttyUtf8Console = Get-Variable -Name '__ghostty_utf8_console' -ValueOnly -ErrorAction SilentlyContinue
+# Set-StrictMode when the variable is absent (manual dot-sourcing). -Scope Local
+# is explicit so a profile's $PSDefaultParameterValues['Get-Variable:Scope']
+# cannot redirect the lookup to a global of the same name: an explicitly passed
+# parameter always wins over a default-parameter value.
+$ghosttyUtf8Console = Get-Variable -Name '__ghostty_utf8_console' -Scope Local -ValueOnly -ErrorAction SilentlyContinue
 
 if ($ghosttyUtf8Console) {
     try {

--- a/src/shell-integration/powershell/integration.ps1
+++ b/src/shell-integration/powershell/integration.ps1
@@ -1,10 +1,14 @@
 # Noctty shell integration for PowerShell 5.1+ / pwsh 7+
 # Emits OSC 133 (command marking) and OSC 7 (current working directory) sequences.
 
-$ghosttyUtf8Console = $env:GHOSTTY_UTF8_CONSOLE
-Remove-Item Env:GHOSTTY_UTF8_CONSOLE -ErrorAction SilentlyContinue
+# Per-launch UTF-8 console request. noctty sets $__ghostty_utf8_console in the
+# scope that dot-sources this script, never in the environment: profiles run
+# before our -Command does, so an environment variable would already have been
+# inherited by anything a profile spawned. Get-Variable keeps this safe under
+# Set-StrictMode when the variable is absent (manual dot-sourcing).
+$ghosttyUtf8Console = Get-Variable -Name '__ghostty_utf8_console' -ValueOnly -ErrorAction SilentlyContinue
 
-if ($ghosttyUtf8Console -eq '1') {
+if ($ghosttyUtf8Console) {
     try {
         if (([Console]::InputEncoding.CodePage -ne 65001) -or
             ([Console]::OutputEncoding.CodePage -ne 65001)) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -676,6 +676,7 @@ pub const Config = struct {
     env_override: configpkg.RepeatableStringMap = .{},
     shell_integration: configpkg.Config.ShellIntegration = .detect,
     shell_integration_features: configpkg.Config.ShellIntegrationFeatures = .{},
+    utf8_console: configpkg.Utf8Console = .auto,
     cursor_blink: ?bool = null,
     working_directory: ?[]const u8 = null,
     working_directory_home: bool = false,
@@ -873,7 +874,13 @@ const Subprocess = struct {
         // This is not apprt-specific, so we do it here.
         env.remove("VTE_VERSION");
 
+        const utf8_console = if (builtin.os.tag == .windows)
+            windows_shell.shouldApplyUtf8ConsoleForCurrentSystem(cfg.utf8_console)
+        else
+            false;
+
         // Setup our shell integration, if we can.
+        var powershell_utf8_console = false;
         const shell_command: configpkg.Command = shell: {
             const default_shell_command: configpkg.Command =
                 cfg.command orelse switch (builtin.os.tag) {
@@ -927,6 +934,10 @@ const Subprocess = struct {
                 .{integration.shell},
             );
 
+            if (utf8_console and integration.shell == .powershell) {
+                powershell_utf8_console = true;
+            }
+
             break :shell integration.command;
         };
 
@@ -936,6 +947,7 @@ const Subprocess = struct {
                 shell_command,
                 cfg.working_directory,
                 cfg.working_directory_home,
+                utf8_console,
             )
         else
             shell_command;
@@ -947,6 +959,13 @@ const Subprocess = struct {
                 entry.key_ptr.*,
                 entry.value_ptr.*,
             );
+        }
+
+        // This is an internal, per-launch signal. Do not inherit or allow an
+        // env override to replay a decision from a differently configured shell.
+        env.remove("GHOSTTY_UTF8_CONSOLE");
+        if (powershell_utf8_console) {
+            try env.put("GHOSTTY_UTF8_CONSOLE", "1");
         }
 
         // Build our args list

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -880,7 +880,6 @@ const Subprocess = struct {
             false;
 
         // Setup our shell integration, if we can.
-        var powershell_utf8_console = false;
         const shell_command: configpkg.Command = shell: {
             const default_shell_command: configpkg.Command =
                 cfg.command orelse switch (builtin.os.tag) {
@@ -924,6 +923,7 @@ const Subprocess = struct {
                 default_shell_command,
                 &env,
                 force,
+                utf8_console,
             ) orelse {
                 log.info("automatic shell integration not injected", .{});
                 break :shell default_shell_command;
@@ -933,10 +933,6 @@ const Subprocess = struct {
                 "shell integration automatically injected shell={}",
                 .{integration.shell},
             );
-
-            if (utf8_console and integration.shell == .powershell) {
-                powershell_utf8_console = true;
-            }
 
             break :shell integration.command;
         };
@@ -959,13 +955,6 @@ const Subprocess = struct {
                 entry.key_ptr.*,
                 entry.value_ptr.*,
             );
-        }
-
-        // This is an internal, per-launch signal. Do not inherit or allow an
-        // env override to replay a decision from a differently configured shell.
-        env.remove("GHOSTTY_UTF8_CONSOLE");
-        if (powershell_utf8_console) {
-            try env.put("GHOSTTY_UTF8_CONSOLE", "1");
         }
 
         // Build our args list

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -46,12 +46,16 @@ pub const ShellIntegration = struct {
 /// The allocator is used for temporary values and to allocate values
 /// in the ShellIntegration result. It is expected to be an arena to
 /// simplify cleanup.
+///
+/// `utf8_console` is Windows-only and only reaches PowerShell: it asks the
+/// injected integration script to force UTF-8 console encodings.
 pub fn setup(
     alloc_arena: Allocator,
     resource_dir: []const u8,
     command: config.Command,
     env: *EnvMap,
     force_shell: ?Shell,
+    utf8_console: bool,
 ) !?ShellIntegration {
     const shell: Shell = force_shell orelse
         try detectShell(alloc_arena, command) orelse
@@ -84,7 +88,12 @@ pub fn setup(
             break :xdg try command.clone(alloc_arena);
         },
 
-        .powershell => try setupPowerShell(alloc_arena, command, resource_dir),
+        .powershell => try setupPowerShell(
+            alloc_arena,
+            command,
+            resource_dir,
+            utf8_console,
+        ),
     } orelse return null;
 
     return .{
@@ -120,6 +129,7 @@ test "force shell" {
             command,
             &env,
             shell,
+            false,
         );
         if (shell == .powershell and builtin.os.tag != .windows) {
             try testing.expect(result == null);
@@ -145,6 +155,7 @@ test "shell integration failure" {
         .{ .shell = "sh" },
         &env,
         null,
+        false,
     );
 
     try testing.expect(result == null);
@@ -243,7 +254,7 @@ test "setup powershell: interactive direct command auto injects" {
     defer res.deinit();
 
     const command: config.Command = .{ .direct = &.{ "pwsh.exe", "-NoProfile" } };
-    const result = (try setup(alloc, res.path, command, &env, .powershell)).?;
+    const result = (try setup(alloc, res.path, command, &env, .powershell, false)).?;
 
     const expected_path = try std.fs.path.join(alloc, &.{ res.path, "shell-integration", "powershell", "integration.ps1" });
     defer alloc.free(expected_path);
@@ -280,7 +291,7 @@ test "setup powershell: interactive shell command auto injects" {
     defer res.deinit();
 
     const command: config.Command = .{ .shell = "powershell.exe -NoProfile" };
-    const result = (try setup(alloc, res.path, command, &env, .powershell)).?;
+    const result = (try setup(alloc, res.path, command, &env, .powershell, false)).?;
 
     const expected_path = try std.fs.path.join(alloc, &.{ res.path, "shell-integration", "powershell", "integration.ps1" });
     defer alloc.free(expected_path);
@@ -317,7 +328,7 @@ test "setup powershell: interactive shell command with quoted exe path auto inje
     defer res.deinit();
 
     const command: config.Command = .{ .shell = "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoProfile" };
-    const result = (try setup(alloc, res.path, command, &env, .powershell)).?;
+    const result = (try setup(alloc, res.path, command, &env, .powershell, false)).?;
 
     const expected_path = try std.fs.path.join(alloc, &.{ res.path, "shell-integration", "powershell", "integration.ps1" });
     defer alloc.free(expected_path);
@@ -359,6 +370,7 @@ test "setup powershell: explicit command launch is not wrapped" {
         .{ .direct = &.{ "pwsh.exe", "-Command", "Get-Date" } },
         &env,
         .powershell,
+        false,
     );
 
     try testing.expect(result == null);
@@ -385,6 +397,7 @@ test "setup powershell: explicit short command launch is not wrapped" {
         .{ .shell = "pwsh.exe -c Get-Date" },
         &env,
         .powershell,
+        false,
     );
 
     try testing.expect(result == null);
@@ -411,6 +424,7 @@ test "setup powershell: explicit command prefix launch is not wrapped" {
         .{ .shell = "powershell.exe -Com Get-Date" },
         &env,
         .powershell,
+        false,
     );
 
     try testing.expect(result == null);
@@ -432,7 +446,7 @@ test "setup powershell: slash-prefixed interactive launch auto injects" {
     defer res.deinit();
 
     const command: config.Command = .{ .shell = "pwsh.exe /NoProfile" };
-    const result = (try setup(alloc, res.path, command, &env, .powershell)).?;
+    const result = (try setup(alloc, res.path, command, &env, .powershell, false)).?;
 
     const expected_path = try std.fs.path.join(alloc, &.{ res.path, "shell-integration", "powershell", "integration.ps1" });
     defer alloc.free(expected_path);
@@ -474,6 +488,7 @@ test "setup powershell: slash version launch is not wrapped" {
         .{ .shell = "powershell.exe /Version" },
         &env,
         .powershell,
+        false,
     );
 
     try testing.expect(result == null);
@@ -483,6 +498,7 @@ fn setupPowerShell(
     alloc: Allocator,
     command: config.Command,
     resource_dir: []const u8,
+    utf8_console: bool,
 ) !?config.Command {
     if (builtin.os.tag != .windows) return null;
 
@@ -507,6 +523,7 @@ fn setupPowerShell(
         alloc,
         argv.items,
         integration_path,
+        utf8_console,
     )) orelse return null;
 
     return .{ .direct = injected };

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -260,7 +260,7 @@ test "setup powershell: interactive direct command auto injects" {
     defer alloc.free(expected_path);
     const expected_command = try std.fmt.allocPrint(
         alloc,
-        "& {{ . '{s}' }}",
+        "& {{ $__ghostty_utf8_console = $false; . '{s}' }}",
         .{expected_path},
     );
     defer alloc.free(expected_command);
@@ -297,7 +297,7 @@ test "setup powershell: interactive shell command auto injects" {
     defer alloc.free(expected_path);
     const expected_command = try std.fmt.allocPrint(
         alloc,
-        "& {{ . '{s}' }}",
+        "& {{ $__ghostty_utf8_console = $false; . '{s}' }}",
         .{expected_path},
     );
     defer alloc.free(expected_command);
@@ -334,7 +334,7 @@ test "setup powershell: interactive shell command with quoted exe path auto inje
     defer alloc.free(expected_path);
     const expected_command = try std.fmt.allocPrint(
         alloc,
-        "& {{ . '{s}' }}",
+        "& {{ $__ghostty_utf8_console = $false; . '{s}' }}",
         .{expected_path},
     );
     defer alloc.free(expected_command);
@@ -452,7 +452,7 @@ test "setup powershell: slash-prefixed interactive launch auto injects" {
     defer alloc.free(expected_path);
     const expected_command = try std.fmt.allocPrint(
         alloc,
-        "& {{ . '{s}' }}",
+        "& {{ $__ghostty_utf8_console = $false; . '{s}' }}",
         .{expected_path},
     );
     defer alloc.free(expected_command);

--- a/test/windows/powershell-shell-integration.ps1
+++ b/test/windows/powershell-shell-integration.ps1
@@ -17,7 +17,7 @@ function Assert-True {
 $script:OriginalPrompt = $function:global:prompt
 $script:OriginalOut = [Console]::Out
 $script:OriginalFeatures = $env:GHOSTTY_SHELL_FEATURES
-$script:OriginalUtf8Console = $env:GHOSTTY_UTF8_CONSOLE
+$script:IntegrationPath = Join-Path $RepoRoot 'src\shell-integration\powershell\integration.ps1'
 $script:TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("noctty-ps-si-" + [guid]::NewGuid().ToString('n'))
 
 try {
@@ -28,9 +28,18 @@ try {
 
     function global:prompt { 'PS> ' }
 
-    $env:GHOSTTY_UTF8_CONSOLE = '1'
-    . (Join-Path $RepoRoot 'src\shell-integration\powershell\integration.ps1')
-    Assert-True (-not (Test-Path Env:GHOSTTY_UTF8_CONSOLE)) "UTF-8 console launch signal leaked into the interactive environment"
+    # The UTF-8 console decision must never travel in the child environment.
+    # A PowerShell profile runs before noctty's injected -Command, so an
+    # environment variable would already have leaked to anything the profile
+    # spawned by the time this script could clear it.
+    $integrationSource = Get-Content -LiteralPath $script:IntegrationPath -Raw
+    Assert-True (-not ($integrationSource -match 'env:GHOSTTY_UTF8_CONSOLE')) "UTF-8 console decision must not travel through a child environment variable"
+    Assert-True ($integrationSource -match '__ghostty_utf8_console') "UTF-8 console decision must be read from the injected launch variable"
+
+    # Dot-sourcing without the launch variable set is the manual-integration
+    # path: Get-Variable must resolve to nothing instead of erroring.
+    . $script:IntegrationPath
+    Assert-True ($null -eq (Get-Variable -Name '__ghostty_utf8_console' -ValueOnly -ErrorAction SilentlyContinue)) "Manual dot-sourcing must not define the launch variable"
 
     $cwdUri = __ghostty_encode_cwd_uri
     Assert-True ($cwdUri.StartsWith('file://')) "OSC 7 cwd URI must include file:// scheme"
@@ -133,11 +142,6 @@ try {
         Remove-Item Env:GHOSTTY_SHELL_FEATURES -ErrorAction SilentlyContinue
     } else {
         $env:GHOSTTY_SHELL_FEATURES = $script:OriginalFeatures
-    }
-    if ($null -eq $script:OriginalUtf8Console) {
-        Remove-Item Env:GHOSTTY_UTF8_CONSOLE -ErrorAction SilentlyContinue
-    } else {
-        $env:GHOSTTY_UTF8_CONSOLE = $script:OriginalUtf8Console
     }
     Remove-Item -LiteralPath $script:TempDir -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/test/windows/powershell-shell-integration.ps1
+++ b/test/windows/powershell-shell-integration.ps1
@@ -17,6 +17,7 @@ function Assert-True {
 $script:OriginalPrompt = $function:global:prompt
 $script:OriginalOut = [Console]::Out
 $script:OriginalFeatures = $env:GHOSTTY_SHELL_FEATURES
+$script:OriginalUtf8Console = $env:GHOSTTY_UTF8_CONSOLE
 $script:TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("noctty-ps-si-" + [guid]::NewGuid().ToString('n'))
 
 try {
@@ -27,7 +28,9 @@ try {
 
     function global:prompt { 'PS> ' }
 
+    $env:GHOSTTY_UTF8_CONSOLE = '1'
     . (Join-Path $RepoRoot 'src\shell-integration\powershell\integration.ps1')
+    Assert-True (-not (Test-Path Env:GHOSTTY_UTF8_CONSOLE)) "UTF-8 console launch signal leaked into the interactive environment"
 
     $cwdUri = __ghostty_encode_cwd_uri
     Assert-True ($cwdUri.StartsWith('file://')) "OSC 7 cwd URI must include file:// scheme"
@@ -130,6 +133,11 @@ try {
         Remove-Item Env:GHOSTTY_SHELL_FEATURES -ErrorAction SilentlyContinue
     } else {
         $env:GHOSTTY_SHELL_FEATURES = $script:OriginalFeatures
+    }
+    if ($null -eq $script:OriginalUtf8Console) {
+        Remove-Item Env:GHOSTTY_UTF8_CONSOLE -ErrorAction SilentlyContinue
+    } else {
+        $env:GHOSTTY_UTF8_CONSOLE = $script:OriginalUtf8Console
     }
     Remove-Item -LiteralPath $script:TempDir -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Summary

Adds `utf8-console = auto|always|never` (default `auto`) so Nerd Font / oh-my-posh
glyphs render instead of mojibake in the shells Windows users actually start with.
A bare interactive `cmd.exe` launch gets a silent `chcp 65001` preamble; PowerShell
5.1 and pwsh 7 set `[Console]::InputEncoding`/`OutputEncoding` to UTF-8 through the
existing shell-integration injection. `auto` refuses to force UTF-8 when the machine
ANSI or OEM code page is a legacy CJK page (932/936/949/950/1361).

Fixes #124

## Changes

- `utf8-console` config option; its doc comment in `src/config/Config.zig` is the
  reference-doc source of truth.
- `shouldApplyUtf8Console` decision function in `src/config/windows_shell.zig`
  (pure, unit-tested across every mode x code-page combination), with `GetACP`/
  `GetOEMCP` bindings added to `src/os/windows.zig`.
- Bare cmd launches (direct argv or shell form, quoted path included) normalize to
  `{<cmd path>, "/K", "chcp 65001 >nul"}`. `cmd.exe /c ...`, `/k <payload>`, and any
  other command tail are left byte-for-byte unchanged.
- For automatically injected PowerShell sessions the decision travels as a
  scriptblock-local variable inside the injected `-Command`
  (`& { $__ghostty_utf8_console = $true|$false; . '<path>' }`), never in the
  child environment. `integration.ps1` reads it with `Get-Variable -Scope Local`
  (so a profile-defined global cannot override it) and only assigns encodings
  when the live code pages differ.
- `docs/windows.md` shells section documents the three modes and the CJK guard,
  in the compressed style `main` adopted in #206.

## Validation (head `e77679ed4`, rebased onto `main` @ `13e07ba35`)

| Gate                                                                                        | Result                              |
| ------------------------------------------------------------------------------------------- | ----------------------------------- |
| `zig build -Demit-exe=true`                                                                 | exit 0                              |
| `zig build test -Demit-test-exe=true`                                                       | 4177 passed / 71 skipped / 0 failed |
| `scripts/check-zig-format.ps1`                                                              | PASS (696 sources)                  |
| `scripts/check-source-format.ps1`                                                           | PASS                                |
| `test/windows/flagship/Test-VerificationContracts.ps1`                                      | PASS (2 scenarios)                  |
| `npx prettier@3 --check docs/windows.md`                                                    | PASS                                |
| `-Dtest-filter=` `utf8` / `windows_shell` / `shell_integration` | exit 0 each (see note)              |

Note on `-Dtest-filter`: a filtered `zig build test` run does apply the filter, but `--summary all` only prints the pass count on a cache miss; on a cached repeat it prints `run test ghostty-test success` with no count, which made an earlier round read the filtered rows as vacuous. Verified on `main` with a cleared cache: a bogus filter runs the 68 unnamed always-on test blocks, and a real filter runs those plus its matches. Filtered rows therefore prove only that the matched tests passed; the zero-failure full suite remains the real signal.

Earlier rounds additionally ran `test/windows/powershell-shell-integration.ps1`
(PASS on Windows PowerShell 5.1 and pwsh 7), checked
`+show-config --default --docs` renders the three-mode doc comment, and did a
live GUI run (`always` -> `chcp` 65001, `never` -> 437, `/c` tail untouched);
none of the code those exercised changed in this round.

## Residuals / user steps

- The validation machine is western-code-page (ANSI 1252 / OEM 437). The legacy-CJK
  refusal is covered by the decision-table unit tests, not by changing the host locale.
- No user action required.

---

## Adversarial-review delta (a0a8bb72f)

- **[medium] doc nit — fixed.** `docs/windows.md` and the `utf8-console` doc comment in
  `src/config/Config.zig` now state that the PowerShell half lives in the injected
  `integration.ps1`, so with `shell-integration = none` — or a PowerShell command line
  that injection declines (`-Command`, `-File`, `-EncodedCommand`, `-NonInteractive`) —
  `utf8-console` does nothing for PowerShell. The cmd.exe half is independent of shell
  integration. Verified rendered via `+show-config --default --docs`.

## Summary by Sourcery

Add configurable, code-page-aware UTF-8 console initialization for interactive Windows shells.

New Features:
- Add the `utf8-console` setting with `auto`, `always`, and `never` modes for Windows console encoding setup.
- Enable guarded UTF-8 initialization for interactive Command Prompt and automatically injected PowerShell sessions while leaving WSL and Git Bash unaffected.

Bug Fixes:
- Prevent UTF-8 setup from altering Command Prompt launches that include command payloads such as `/c`, `/r`, or `/k`.
- Avoid leaking the PowerShell UTF-8 decision through the child environment and protect it from profile-defined variables.

Enhancements:
- Guard automatic UTF-8 setup on legacy CJK ANSI and OEM code pages, while preserving compatible Command Prompt switches and existing console encodings when already UTF-8.

Documentation:
- Document the Windows UTF-8 console modes, CJK code-page guard, and shell-integration limitations.

Tests:
- Add coverage for UTF-8 mode decisions, Command Prompt argument classification and rewriting, and PowerShell launch-variable handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows UTF-8 console support for Command Prompt and PowerShell.
  * Added `utf8-console` settings with `auto`, `always`, and `never` modes.
  * Automatically preserves legacy CJK code pages in `auto` mode.
  * Applies UTF-8 encoding to interactive PowerShell sessions when shell integration is enabled.
  * Configures bare Command Prompt sessions for UTF-8 when appropriate.

* **Documentation**
  * Documented Windows UTF-8 console behavior, supported shells, modes, and exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Bot-review round (2026-08-30) - 2 findings, both real, both fixed

Rebased onto current `main` first, so the suite is a true zero-failure result.

- **[P2, Codex] `GHOSTTY_UTF8_CONSOLE` leaked to processes started by PowerShell
  profiles - fixed by removing the environment transport.** The injection appends
  `-NoExit -Command "& { . '<path>' }"` after the user's argv and never adds
  `-NoProfile`, so profiles run *before* `integration.ps1` gets a chance to
  `Remove-Item Env:GHOSTTY_UTF8_CONSOLE`. Anything a profile spawns (starship
  init, fnm env, git-prompt helpers) inherited the variable, which made the PR's
  "not inherited by descendants" claim false as written. Nothing but
  `integration.ps1` consumes the variable, so impact was hygiene rather than
  misbehaviour - but we fixed the transport rather than softening the claim.
  `buildInjectedArgv` now emits `& { $__ghostty_utf8_console = $true; . '<path>' }`,
  so the flag lives only in the scriptblock scope that dot-sources the script and
  is gone before the interactive session starts. `integration.ps1` reads it with
  `Get-Variable -ErrorAction SilentlyContinue` (strict-mode safe, no-op for manual
  dot-sourcing); `Exec.zig` no longer touches `env` for this.
- **[Major, CodeRabbit] Option-only `cmd.exe` launches missed the preamble - fixed.**
  The gate really was `argv.len == 1`, so `cmd.exe /d`, `/q`, `/v:on` and friends
  got no UTF-8 preamble despite being interactive. We did **not** implement the
  suggested parser shape verbatim: checking cmd.exe's actual behaviour rather than
  its help text turned up a trap - **`cmd /v:on/c "echo X"` runs the payload**,
  because cmd keeps parsing switches after a colon value. A parser that consumed
  the rest of a token after `:` would have missed that `/c` and appended `/K` to a
  *non-interactive* launch, which is worse than the original gap. The new
  `classifyCmdArg` walks the whole fused run: it accepts valueless `/a /u /q /d /s`,
  `/e:`/`/f:`/`/v:` with `on|off`, and `/t:` with 1-2 hex digits; it declines on
  `/c`, `/r` or `/k` anywhere in a run, on any non-`/` token, and on anything
  unrecognised. Switches are preserved in order with the preamble appended after
  them; otherwise the command (including `.shell` form) is left byte-for-byte.
  Confirmed empirically on this machine for fused `/d/q/c`, attached `/cecho hi`,
  `-c` (not a switch), `/t:0A`, `/v:on /f:off`, and `/u`.

**Validation (this round, all personally observed):**
`scripts/check-zig-format.ps1` PASS (670 sources) - `zig build -Demit-exe=true`
PASS - full suite **3776 passed, 70 skipped, 0 failed** -
`scripts/check-source-format.ps1` PASS -
`test/windows/powershell-shell-integration.ps1` PASS.

---

## Bot-review round (2026-09-02) - 1 finding, real, fixed (comments only)

Rebased onto current `main` (`e3a38268e`, the docs debloat). The only conflict
was `docs/windows.md`; the `utf8-console` paragraph is re-expressed in the
shorter style rather than restoring the deleted text.

- **[P3, Codex] Stale sentinel rationale - fixed.** `integration.ps1:12` reads
  the sentinel with `Get-Variable -Scope Local`, so the lookup never walks to a
  profile's `$global:__ghostty_utf8_console`. The comment in
  `buildCommandValue` and its regression test still described the older model
  in which the always-bound `$false` was the defence. Both now describe the
  scope pin as the defence and the explicit `$false` as the uniform-shape /
  shadowing second layer. This PR description was equally stale about an
  environment-variable transport and is corrected above. No behaviour change.

## Rebase round (2026-09-03) - rebase only, no code change

Rebased onto `main` @ `13e07ba35` (#159, #170, #161, #163, #207 and #208 landed
since the last round). This branch rebased with no conflicts. All 8 review
threads were already answered and resolved in earlier rounds; nothing was
unresolved at the start of this round and no new code was written, so the only
change is the new base and the gate numbers above.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above
was verified against the code and the gate output.