### PR TITLE
feat(windows): cmd.exe shell integration via PROMPT and optional Clink (#125)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -40,9 +40,10 @@ noctty is based on post-`v1.3.1` upstream main (`1.3.2-dev`, `ba398dfff`,
 - Kitty graphics protocol and inline image display.
 - Kitty keyboard protocol with press, repeat, and release events, Caps Lock
   and Num Lock state, and left/right modifier identity.
-- Shell integration for bash, zsh, fish, elvish, nushell, and PowerShell
-  (PowerShell through `shell-integration = detect`). `cmd.exe` is a plain
-  fallback without prompt/cwd/command-finish integration.
+- Shell integration for bash, zsh, fish, elvish, nushell, PowerShell, and
+  `cmd.exe` through automatic detection. Command Prompt gets prompt/cwd marks
+  from `PROMPT`; an active Clink adds command-finish marks and exit codes when
+  it loads the shipped script.
 - Live config reload via keybind (`Ctrl+Shift+,`).
 - `libghostty-vt` retained for Zig and C consumers.
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -38,7 +38,7 @@ Last reviewed: 2026-09-02.
 
 | Ghostty docs surface                                                                         | noctty note                                                                                                                                                                                                                                                                                        |
 | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Shell integration](https://ghostty.org/docs/features/shell-integration)                     | Upstream shell docs apply; PowerShell injection is added on Windows, `cmd.exe` stays a plain fallback. See [shell integration notes](#shell-integration).                                                                                                                                          |
+| [Shell integration](https://ghostty.org/docs/features/shell-integration)                     | Upstream shell docs apply; Windows adds PowerShell injection and `cmd.exe` prompt/cwd marks. Clink is required for cmd command-finish marks and exit codes. See [shell integration notes](#shell-integration).                                                                                     |
 | [Action reference](https://ghostty.org/docs/config/keybind/reference)                        | Shared action grammar is intact, but upstream mixes in macOS/Linux behavior. For Windows truth, prefer `+show-config --default --docs` plus `+list-keybinds`.                                                                                                                                      |
 | [Action reference: `toggle_secure_input`](https://ghostty.org/docs/config/keybind/reference) | A local sensitive-input indicator only; no Windows equivalent of macOS Secure Keyboard Entry, and system-wide keyboard hooks are not blocked.                                                                                                                                                      |
 | [Configuration: `auto-update`](https://ghostty.org/docs/config/reference)                    | Stable-release checking and prompts backed by GitHub Releases. `download` stages only installer releases that pass SHA-256 plus Authenticode verification; apply is user-initiated (UAC may prompt), and portable ZIP apply is not implemented. See [windows.md](windows.md#updates).              |
@@ -101,7 +101,12 @@ that:
 - PowerShell wraps `ssh` for `ssh-env` and cache-aware `ssh-terminfo`, but
   does not auto-install remote terminfo; uncached hosts use
   `xterm-256color`.
-- `cmd.exe` remains a plain fallback shell without automatic integration.
+- Automatic `cmd.exe` integration wraps the existing `PROMPT` (or cmd's
+  `$P$G` default) to emit OSC 133 A/B prompt marks and OSC 9;9 cwd reports.
+  When Clink is detected, noctty appends its shipped Lua directory to
+  `CLINK_PATH` so Clink also emits OSC 133 C/D command marks and exit codes.
+  Without Clink, prompt/cwd marks still work but command-finish marks and exit
+  codes are unavailable.
 
 ### Keyboard input
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -103,10 +103,11 @@ that:
   `xterm-256color`.
 - Automatic `cmd.exe` integration wraps the existing `PROMPT` (or cmd's
   `$P$G` default) to emit OSC 133 A/B prompt marks and OSC 9;9 cwd reports.
-  When Clink is detected, noctty appends its shipped Lua directory to
-  `CLINK_PATH` so Clink also emits OSC 133 C/D command marks and exit codes.
-  Without Clink, prompt/cwd marks still work but command-finish marks and exit
-  codes are unavailable.
+  When Clink is detected, noctty prepends its shipped Lua directory to
+  `CLINK_PATH`; an already-active Clink can then load it and emit OSC 133 C/D
+  command marks and exit codes. Noctty does not activate Clink. Without the
+  loaded Clink script, prompt/cwd marks still work but command-finish marks and
+  exit codes are unavailable.
 
 ### Keyboard input
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -71,8 +71,30 @@ The profile picker detects:
 Shell integration is automatic for PowerShell and for directly launched
 Unix-like shells such as Git Bash. WSL sessions manage their own
 integration inside the distribution. PowerShell integration emits OSC 7
-working-directory updates and OSC 133 prompt markers. `cmd.exe` is a plain
-fallback shell with no automatic prompt, cwd, or command-finish integration.
+working-directory updates and OSC 133 prompt markers.
+
+For `cmd.exe`, noctty wraps the inherited `PROMPT` (or cmd's `$P$G` default)
+so the shell emits OSC 133 A/B prompt marks and an OSC 9;9 working-directory
+report; a `PROMPT` set through `env = PROMPT=...` is applied afterward and
+replaces the wrapper. If `clink.bat` or `clink_x64.exe` is found under
+`%LOCALAPPDATA%\clink` or on a local, mounted, drive-qualified `PATH` entry
+(remote, UNC, and relative entries are skipped so a dead network path cannot
+stall a new tab), noctty prepends its shipped Lua directory to `CLINK_PATH`.
+That only makes the script discoverable once Clink is already active through
+autorun, `clink inject`, or an explicit Clink launch; noctty never injects or
+launches Clink. When loaded, the script adds OSC 133 C/D command marks and the
+exit code before the next prompt, truthful only while Clink's
+`cmd.get_errorlevel` setting is enabled (its default). Without it, prompt
+navigation and cwd reporting still work, but there are no command-finish marks
+or exit codes.
+
+Caveats: on a UNC working directory `$P` yields `\\server\share\dir`, which
+noctty reports unchanged, but cmd.exe itself cannot use a UNC cwd (it warns and
+falls back), so a new cmd tab or split will generally not land on the share. A
+`PROMPT` ending in an odd number of `$` gets a `$S` (one space) inserted before
+the closing mark so cmd does not pair the dangling `$` with the mark's `$E`.
+`PROMPT` is session-wide, so `echo on` batch runs and `cmd /c` children can
+echo the wrapped value and emit spurious OSC 133 marks.
 
 `utf8-console` (`auto`, `always`, `never`) controls UTF-8 setup for bare
 interactive `cmd.exe` launches and for Windows PowerShell 5.1 and PowerShell 7

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -2853,10 +2853,10 @@ test "win32 buildProfileDetailText appends shell integration guidance when prese
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     const profile: windows_shell.Profile = .{
-        .kind = .cmd,
-        .key = "cmd.exe",
-        .label = "Command Prompt",
-        .command = .{ .direct = &.{"cmd.exe"} },
+        .kind = .wsl_default,
+        .key = "wsl.exe",
+        .label = "WSL",
+        .command = .{ .direct = &.{"wsl.exe"} },
     };
 
     const detail = try buildProfileDetailText(
@@ -2873,12 +2873,12 @@ test "win32 buildProfileDetailText appends shell integration guidance when prese
     try std.testing.expect(std.mem.indexOf(
         u8,
         detail,
-        "New hosts inherit this Command Prompt profile; shell integration unavailable.",
+        "New hosts inherit this WSL default profile; shell integration depends on the Linux shell.",
     ) != null);
     try std.testing.expect(std.mem.indexOf(
         u8,
         detail,
-        "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+        "Enable shell integration inside the selected WSL shell startup.",
     ) != null);
     try std.testing.expect(std.mem.indexOf(u8, detail, "+ opens a new tab") != null);
 }
@@ -3140,13 +3140,10 @@ test "win32 profileKindDetail exposes shell integration posture" {
 
     const cmd = profileKindDetail(.cmd);
     try std.testing.expectEqualStrings(
-        "Command Prompt profile; shell integration unavailable",
+        "Command Prompt profile with PROMPT-based shell integration; Clink adds command-start/finish and exit-code marks",
         cmd.summary,
     );
-    try std.testing.expectEqualStrings(
-        "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
-        cmd.next_step.?,
-    );
+    try std.testing.expectEqual(@as(?[]const u8, null), cmd.next_step);
 }
 
 test "win32 buildSearchOverlayLabel reflects match counts" {

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -218,9 +218,8 @@ pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic 
             .summary = "Git Bash profile with automatic shell integration",
         },
         .cmd => .{
-            .support = .unavailable,
-            .summary = "Command Prompt profile; shell integration unavailable",
-            .next_step = "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+            .support = .automatic,
+            .summary = "Command Prompt profile with PROMPT-based shell integration; Clink adds command-start/finish and exit-code marks",
         },
         .ssh => .{
             .support = .unavailable,
@@ -2091,12 +2090,12 @@ test "shellIntegrationDiagnostic differentiates WSL Git Bash and cmd support" {
     try testing.expectEqual(@as(?[]const u8, null), git_bash.next_step);
 
     const cmd = shellIntegrationDiagnostic(.cmd);
-    try testing.expectEqual(ShellIntegrationSupport.unavailable, cmd.support);
+    try testing.expectEqual(ShellIntegrationSupport.automatic, cmd.support);
     try testing.expectEqualStrings(
-        "Command Prompt profile; shell integration unavailable",
+        "Command Prompt profile with PROMPT-based shell integration; Clink adds command-start/finish and exit-code marks",
         cmd.summary,
     );
-    try testing.expect(cmd.next_step != null);
+    try testing.expectEqual(@as(?[]const u8, null), cmd.next_step);
 }
 
 test "utf8-console decision covers modes and guarded code pages" {

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -533,6 +533,14 @@ pub fn isWslPath(path: []const u8) bool {
 /// WSL paths stay WSL-style so they can be inherited into later WSL shells.
 pub fn osc7PathToLocal(alloc: Allocator, path: []const u8) ![]const u8 {
     if (isWindowsUriPath(path)) return try uriPathToWindows(alloc, path);
+    // A UNC path carried in a URI keeps the URI's leading `/`. Strip it before
+    // the WSL check below, which would otherwise treat the whole string as a
+    // POSIX path and hand back an unusable `/\\server\share` cwd.
+    if (isUncUriPath(path)) {
+        const unc = path[1..];
+        if (isWslPath(unc)) return try normalizeWslPath(alloc, unc);
+        return try alloc.dupe(u8, unc);
+    }
     if (isWslPath(path)) return try normalizeWslPath(alloc, path);
     return try alloc.dupe(u8, path);
 }
@@ -542,6 +550,7 @@ pub fn osc7PathToLocal(alloc: Allocator, path: []const u8) ![]const u8 {
 pub fn pathToWsl(alloc: Allocator, path: []const u8) !?[]const u8 {
     if (path.len == 0) return null;
     if (isWindowsUriPath(path)) return try pathToWsl(alloc, path[1..]);
+    if (isUncUriPath(path)) return try pathToWsl(alloc, path[1..]);
     if (isWslPath(path)) return try normalizeWslPath(alloc, path);
 
     if (!isDriveAbsolutePath(path)) return null;
@@ -1292,6 +1301,17 @@ fn isWindowsUriPath(path: []const u8) bool {
         isSeparator(path[3]);
 }
 
+/// True for a UNC path that still carries the leading `/` of the URI it came
+/// from, e.g. `/\\server\share\dir`. cmd's `$P` expands to a raw UNC path, so
+/// `kitty-shell-cwd://localhost/$P` yields exactly this shape.
+fn isUncUriPath(path: []const u8) bool {
+    return path.len >= 4 and
+        path[0] == '/' and
+        path[1] == '\\' and
+        path[2] == '\\' and
+        !isSeparator(path[3]);
+}
+
 pub fn isDriveAbsolutePath(path: []const u8) bool {
     return path.len >= 3 and
         std.ascii.isAlphabetic(path[0]) and
@@ -1804,6 +1824,53 @@ test "osc7PathToLocal converts windows file uri path" {
     defer alloc.free(result);
 
     try testing.expectEqualStrings("C:\\Users\\aman\\src", result);
+}
+
+test "osc7PathToLocal strips the uri slash from a unc path" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const share = try osc7PathToLocal(alloc, "/\\\\server\\share\\dir");
+    defer alloc.free(share);
+    try testing.expectEqualStrings("\\\\server\\share\\dir", share);
+
+    const root = try osc7PathToLocal(alloc, "/\\\\server\\share");
+    defer alloc.free(root);
+    try testing.expectEqualStrings("\\\\server\\share", root);
+
+    // A UNC path pointing back into WSL is still normalized to a WSL path.
+    const wsl = try osc7PathToLocal(alloc, "/\\\\wsl.localhost\\Ubuntu\\home\\aman");
+    defer alloc.free(wsl);
+    try testing.expectEqualStrings("/home/aman", wsl);
+
+    // Real POSIX paths must not be mistaken for UNC.
+    const posix = try osc7PathToLocal(alloc, "/home/aman/src");
+    defer alloc.free(posix);
+    try testing.expectEqualStrings("/home/aman/src", posix);
+}
+
+test "isUncUriPath only matches uri-carried unc paths" {
+    const testing = std.testing;
+
+    try testing.expect(isUncUriPath("/\\\\server\\share"));
+    try testing.expect(isUncUriPath("/\\\\s\\a"));
+    try testing.expect(!isUncUriPath("/home/aman"));
+    try testing.expect(!isUncUriPath("//server/share"));
+    try testing.expect(!isUncUriPath("\\\\server\\share"));
+    try testing.expect(!isUncUriPath("/\\\\"));
+    try testing.expect(!isUncUriPath("/\\\\\\share"));
+    try testing.expect(!isUncUriPath("/C:/Users"));
+}
+
+test "pathToWsl rejects a uri-carried unc path" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    try testing.expect(try pathToWsl(alloc, "/\\\\server\\share\\dir") == null);
+
+    const wsl = (try pathToWsl(alloc, "/\\\\wsl.localhost\\Ubuntu\\home\\aman")).?;
+    defer alloc.free(wsl);
+    try testing.expectEqualStrings("/home/aman", wsl);
 }
 
 test "shellPwd drops invalid non-wsl cwd roots" {

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -1317,7 +1317,17 @@ fn isUncUriPath(path: []const u8) bool {
     if (path.len < 4) return false;
     if (path[0] != '/' or path[1] != '\\' or path[2] != '\\') return false;
     if (isSeparator(path[3])) return false;
-    return std.mem.indexOfScalar(u8, path[3..], '/') == null;
+
+    // Must be backslash-separated throughout: a forward slash proves this is a
+    // POSIX path that merely begins with backslashes, not the form cmd's `$P`
+    // produces.
+    if (std.mem.indexOfScalar(u8, path[3..], '/') != null) return false;
+
+    // A UNC path needs both a host and a non-empty share (`\\server\share`).
+    // `/\\server` alone is a legal POSIX filename, never a usable UNC path.
+    const host = path[3..];
+    const sep = std.mem.indexOfScalar(u8, host, '\\') orelse return false;
+    return sep + 1 < host.len;
 }
 
 pub fn isDriveAbsolutePath(path: []const u8) bool {
@@ -1862,6 +1872,13 @@ test "osc7PathToLocal strips the uri slash from a unc path" {
     const posix_backslashes = try osc7PathToLocal(alloc, "/\\\\server/share");
     defer alloc.free(posix_backslashes);
     try testing.expectEqualStrings("/\\\\server/share", posix_backslashes);
+
+    // A host with no share is not a usable UNC path, so it is a POSIX name.
+    for ([_][]const u8{ "/\\\\server", "/\\\\server\\" }) |path| {
+        const kept = try osc7PathToLocal(alloc, path);
+        defer alloc.free(kept);
+        try testing.expectEqualStrings(path, kept);
+    }
 }
 
 test "isUncUriPath only matches uri-carried unc paths" {

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -1304,12 +1304,20 @@ fn isWindowsUriPath(path: []const u8) bool {
 /// True for a UNC path that still carries the leading `/` of the URI it came
 /// from, e.g. `/\\server\share\dir`. cmd's `$P` expands to a raw UNC path, so
 /// `kitty-shell-cwd://localhost/$P` yields exactly this shape.
+/// A `kitty-shell-cwd` path whose body is a Windows UNC path, i.e. the URI
+/// separator followed by `\\server\share...`.
+///
+/// The remainder must be backslash-separated. Backslashes are legal in POSIX
+/// filenames, so a WSL or POSIX shell could in principle report a directory
+/// such as `/\\server/share`; requiring that no forward slash appears after
+/// the URI separator keeps that case on the WSL path where it belongs, while
+/// still matching everything cmd's `$P` can produce (cmd always emits
+/// backslashes).
 fn isUncUriPath(path: []const u8) bool {
-    return path.len >= 4 and
-        path[0] == '/' and
-        path[1] == '\\' and
-        path[2] == '\\' and
-        !isSeparator(path[3]);
+    if (path.len < 4) return false;
+    if (path[0] != '/' or path[1] != '\\' or path[2] != '\\') return false;
+    if (isSeparator(path[3])) return false;
+    return std.mem.indexOfScalar(u8, path[3..], '/') == null;
 }
 
 pub fn isDriveAbsolutePath(path: []const u8) bool {
@@ -1847,6 +1855,13 @@ test "osc7PathToLocal strips the uri slash from a unc path" {
     const posix = try osc7PathToLocal(alloc, "/home/aman/src");
     defer alloc.free(posix);
     try testing.expectEqualStrings("/home/aman/src", posix);
+
+    // Backslashes are legal in POSIX filenames, so a POSIX cwd can start with
+    // two of them. A forward slash later in the path proves it is not the
+    // backslash-separated UNC form cmd's `$P` produces, so it stays POSIX.
+    const posix_backslashes = try osc7PathToLocal(alloc, "/\\\\server/share");
+    defer alloc.free(posix_backslashes);
+    try testing.expectEqualStrings("/\\\\server/share", posix_backslashes);
 }
 
 test "isUncUriPath only matches uri-carried unc paths" {

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const windows = std.os.windows;
 
 // Export any constants or functions we need from the Windows API so
@@ -36,6 +37,32 @@ pub const FOLDERID_LocalAppData = windows.FOLDERID_LocalAppData;
 
 pub extern "kernel32" fn GetACP() callconv(.winapi) windows.UINT;
 pub extern "kernel32" fn GetOEMCP() callconv(.winapi) windows.UINT;
+pub extern "kernel32" fn GetDriveTypeW(
+    lpRootPathName: ?windows.LPCWSTR,
+) callconv(.winapi) windows.UINT;
+
+/// `GetDriveTypeW` return values, as documented at
+/// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew
+pub const DRIVE_UNKNOWN: windows.UINT = 0;
+pub const DRIVE_NO_ROOT_DIR: windows.UINT = 1;
+pub const DRIVE_REMOVABLE: windows.UINT = 2;
+pub const DRIVE_FIXED: windows.UINT = 3;
+pub const DRIVE_REMOTE: windows.UINT = 4;
+pub const DRIVE_CDROM: windows.UINT = 5;
+pub const DRIVE_RAMDISK: windows.UINT = 6;
+
+/// Classify the drive named by an ASCII drive letter such as 'C'. This only
+/// reads the local drive/mount table, so it does not touch the network even
+/// for a disconnected mapped drive. Returns `DRIVE_UNKNOWN` for anything that
+/// is not a drive letter.
+pub fn driveTypeForLetter(letter: u8) windows.UINT {
+    if (builtin.os.tag != .windows) return DRIVE_UNKNOWN;
+    if (!std.ascii.isAlphabetic(letter)) return DRIVE_UNKNOWN;
+
+    // GetDriveTypeW requires the trailing backslash.
+    const root: [3:0]u16 = .{ letter, ':', '\\' };
+    return GetDriveTypeW(&root);
+}
 
 pub const KnownFolderPathError = error{
     BufferTooSmall,

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -20,7 +20,7 @@ README or the public noctty repository documentation
 | Nushell | Yes, via `XDG_DATA_DIRS` vendor autoload plus `use ghostty *` | Shell-native where available | Yes | Installs remote `xterm-ghostty` terminfo with local `infocmp`, remote `tic`, and `noctty +ssh-cache` |
 | Elvish | Available as distributed module | Shell-native where available | Yes | Installs remote `xterm-ghostty` terminfo with local `infocmp`, remote `tic`, and `noctty +ssh-cache` |
 | PowerShell | Yes on Windows for interactive `powershell.exe` / `pwsh.exe` | OSC 7 + OSC 133 | Yes | Cache-aware only: uses `xterm-ghostty` for hosts already present in `noctty +ssh-cache`, otherwise falls back to `xterm-256color` |
-| cmd.exe | No | No | No | No |
+| cmd.exe | Yes on Windows for interactive launches via `PROMPT`; `CLINK_PATH` exposes the optional script to active Clink | OSC 9;9 + OSC 133 A/B; active Clink adds OSC 133 C/D | No | No |
 
 ### Bash
 
@@ -165,10 +165,13 @@ connection. On Windows PowerShell that path is not portable enough to run
 silently, so uncached hosts remain on `xterm-256color` until the terminfo is
 installed by another shell integration path or manually added to the SSH cache.
 
-`cmd.exe` is intentionally not auto-integrated. Command Prompt has no reliable
-prompt/pre-exec hook equivalent, so the Windows profile picker surfaces it as a
-plain fallback shell without OSC 7 cwd tracking, prompt marks, or command-finish
-notifications.
+Interactive `cmd.exe` launches are auto-integrated by wrapping the inherited
+`PROMPT` (or cmd's `$P$G` default) with OSC 133 A/B prompt marks and OSC 9;9 cwd
+reports. When Clink is detected, noctty prepends the shipped cmd Lua directory
+to `CLINK_PATH`, but does not activate Clink. An already-active Clink discovers
+the script and adds OSC 133 C/D command boundaries; without it, prompt/cwd marks
+remain available. See [windows.md](../../docs/windows.md#shells) for configured
+`PROMPT` precedence and Clink exit-code details.
 
 ### SSH terminfo cache
 

--- a/src/shell-integration/cmd/clink.lua
+++ b/src/shell-integration/cmd/clink.lua
@@ -1,0 +1,30 @@
+-- Noctty cmd.exe shell integration for Clink.
+-- PROMPT supplies OSC 133 A/B and OSC 9;9; this adds C/D with exit status.
+
+local ESC = string.char(27)
+local BEL = string.char(7)
+local command_pending = false
+
+local function emit(body)
+    clink.print(ESC .. "]" .. body .. BEL, NONL)
+end
+
+if clink.onfilterinput and clink.onbeginedit and clink.print and
+    os.geterrorlevel and NONL then
+    clink.onfilterinput(function(line)
+        if line and line:match("%S") then
+            command_pending = true
+            emit("133;C")
+        end
+    end)
+
+    clink.onbeginedit(function()
+        if not command_pending then
+            return
+        end
+
+        local exit_code = os.geterrorlevel()
+        command_pending = false
+        emit("133;D;" .. tostring(exit_code))
+    end)
+end

--- a/src/shell-integration/cmd/clink.lua
+++ b/src/shell-integration/cmd/clink.lua
@@ -3,28 +3,38 @@
 
 local ESC = string.char(27)
 local BEL = string.char(7)
-local command_pending = false
+local state_key = "__noctty_cmd_shell_integration"
+local state = rawget(_G, state_key)
+
+if not state then
+    state = { command_pending = false, registered = false }
+    rawset(_G, state_key, state)
+end
 
 local function emit(body)
     clink.print(ESC .. "]" .. body .. BEL, NONL)
 end
 
 if clink.onfilterinput and clink.onbeginedit and clink.print and
-    os.geterrorlevel and NONL then
+    os.geterrorlevel and NONL and not state.registered then
     clink.onfilterinput(function(line)
         if line and line:match("%S") then
-            command_pending = true
+            state.command_pending = true
             emit("133;C")
         end
     end)
 
+    -- Every prompt closes the previous command boundary: `D;<code>` when a
+    -- command ran, bare `D` for the first prompt, an empty line, or Ctrl-C.
     clink.onbeginedit(function()
-        if not command_pending then
-            return
+        if state.command_pending then
+            emit("133;D;" .. tostring(os.geterrorlevel()))
+        else
+            emit("133;D")
         end
 
-        local exit_code = os.geterrorlevel()
-        command_pending = false
-        emit("133;D;" .. tostring(exit_code))
+        state.command_pending = false
     end)
+
+    state.registered = true
 end

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -576,6 +576,23 @@ const CmdClinkDetectionCache = struct {
 };
 var cmd_clink_detection_cache: CmdClinkDetectionCache = .{};
 
+/// cmd's PROMPT parser consumes `$` plus the character that follows it as a
+/// single code, and `$$` is a literal `$`. A user prompt ending in an odd
+/// number of `$` therefore pairs its dangling `$` with the `$E` that opens our
+/// suffix: `E]133;B` would print as visible text and the prompt region would
+/// never be closed. `$S` expands to one space, so it absorbs the dangling `$`
+/// without dropping any of the user's prompt.
+/// https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/prompt
+const cmd_prompt_dollar_separator = "S";
+
+fn cmdPromptEndsInDanglingDollar(prompt: []const u8) bool {
+    var trailing: usize = 0;
+    while (trailing < prompt.len and
+        prompt[prompt.len - 1 - trailing] == '$') : (trailing += 1)
+    {}
+    return trailing % 2 == 1;
+}
+
 /// Build a cmd PROMPT value that preserves the user's prompt while adding
 /// prompt boundaries and the current working directory. `$E` is ESC in cmd's
 /// PROMPT syntax; ESC followed by `\\` terminates each OSC sequence.
@@ -586,10 +603,16 @@ fn buildCmdPrompt(alloc: Allocator, existing: ?[]const u8) ![]u8 {
         }
     }
 
+    const body = existing orelse cmd_default_prompt;
+    const separator: []const u8 = if (cmdPromptEndsInDanglingDollar(body))
+        cmd_prompt_dollar_separator
+    else
+        "";
+
     return try std.fmt.allocPrint(
         alloc,
-        "{s}{s}{s}",
-        .{ cmd_prompt_prefix, existing orelse cmd_default_prompt, cmd_prompt_suffix },
+        "{s}{s}{s}{s}",
+        .{ cmd_prompt_prefix, body, separator, cmd_prompt_suffix },
     );
 }
 
@@ -745,14 +768,15 @@ fn clinkInstalledUncached(
             &.{ local_app_data, "clink" },
         );
         defer alloc.free(local_clink_dir);
-        if (try directoryContainsClink(alloc, local_clink_dir)) return true;
+        if (cmdDirProbeAllowed(local_clink_dir) and
+            try directoryContainsClink(alloc, local_clink_dir)) return true;
     }
 
     if (path.len > 0) {
         var dirs = std.mem.splitScalar(u8, path, ';');
         while (dirs.next()) |raw_dir| {
             const dir = std.mem.trim(u8, raw_dir, " \t\"");
-            if (cmdPathEntrySafeToProbe(dir) and
+            if (cmdDirProbeAllowed(dir) and
                 try directoryContainsClink(alloc, dir)) return true;
         }
     }
@@ -760,11 +784,31 @@ fn clinkInstalledUncached(
     return false;
 }
 
+/// Whether we are willing to hit the filesystem for `dir` while starting a
+/// shell. This runs under the detection cache mutex, so any probe that blocks
+/// stalls every concurrently starting cmd session.
+fn cmdDirProbeAllowed(dir: []const u8) bool {
+    if (!cmdPathEntrySafeToProbe(dir)) return false;
+    return cmdDriveTypeSafeToProbe(
+        internal_os.windows.driveTypeForLetter(dir[0]),
+    );
+}
+
 fn cmdPathEntrySafeToProbe(dir: []const u8) bool {
     return dir.len >= 3 and
         std.ascii.isAlphabetic(dir[0]) and
         dir[1] == ':' and
         (dir[2] == '\\' or dir[2] == '/');
+}
+
+/// Drive-letter syntax alone does not prove a path is local: a mapped network
+/// drive such as `Z:\tools` looks identical to `C:\tools`, and probing one
+/// whose server is unreachable can block for the SMB timeout. Skip remote
+/// drives and drive letters with nothing mounted; anything else (including
+/// `DRIVE_UNKNOWN`, which some virtual disk stacks report) stays probeable.
+fn cmdDriveTypeSafeToProbe(drive_type: u32) bool {
+    return drive_type != internal_os.windows.DRIVE_REMOTE and
+        drive_type != internal_os.windows.DRIVE_NO_ROOT_DIR;
 }
 
 fn directoryContainsClink(alloc: Allocator, dir: []const u8) !bool {
@@ -803,6 +847,41 @@ test "cmd prompt construction preserves user prompt" {
         "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\[$T] $P$_$$ $E]133;B$E\\",
         prompt,
     );
+}
+
+test "cmd prompt construction separates a dangling trailing dollar" {
+    const testing = std.testing;
+
+    try testing.expect(cmdPromptEndsInDanglingDollar("$P$G$"));
+    try testing.expect(cmdPromptEndsInDanglingDollar("$"));
+    try testing.expect(cmdPromptEndsInDanglingDollar("$P$$$"));
+    try testing.expect(!cmdPromptEndsInDanglingDollar("$P$G"));
+    try testing.expect(!cmdPromptEndsInDanglingDollar("$P$$"));
+    try testing.expect(!cmdPromptEndsInDanglingDollar("$P$$$$"));
+    try testing.expect(!cmdPromptEndsInDanglingDollar("$P$G "));
+    try testing.expect(!cmdPromptEndsInDanglingDollar(""));
+
+    // Without the separator this would emit `$$E]133;B`, which cmd renders as
+    // a literal `$` followed by the visible text `E]133;B`.
+    const dangling = try buildCmdPrompt(testing.allocator, "$P$G$");
+    defer testing.allocator.free(dangling);
+    try testing.expectEqualStrings(
+        "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\$P$G$S$E]133;B$E\\",
+        dangling,
+    );
+
+    // An even trailing run is already self-escaping and is left alone.
+    const balanced = try buildCmdPrompt(testing.allocator, "$P$G$$");
+    defer testing.allocator.free(balanced);
+    try testing.expectEqualStrings(
+        "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\$P$G$$$E]133;B$E\\",
+        balanced,
+    );
+
+    // Re-wrapping the separated prompt must still be a no-op.
+    const repeated = try buildCmdPrompt(testing.allocator, dangling);
+    defer testing.allocator.free(repeated);
+    try testing.expectEqualStrings(dangling, repeated);
 }
 
 test "cmd prompt construction is idempotent" {
@@ -913,6 +992,24 @@ test "cmd Clink detection covers PATH and LocalAppData" {
     try testing.expect(!cmdPathEntrySafeToProbe("\\\\server\\share\\clink"));
     try testing.expect(!cmdPathEntrySafeToProbe("//server/share/clink"));
     try testing.expect(cmdPathEntrySafeToProbe("D:/absolute/clink"));
+}
+
+test "cmd Clink probe skips remote and unmounted drive letters" {
+    const testing = std.testing;
+
+    // Documented GetDriveTypeW results:
+    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew
+    try testing.expect(!cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_REMOTE));
+    try testing.expect(!cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_NO_ROOT_DIR));
+    try testing.expect(cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_FIXED));
+    try testing.expect(cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_REMOVABLE));
+    try testing.expect(cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_CDROM));
+    try testing.expect(cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_RAMDISK));
+    try testing.expect(cmdDriveTypeSafeToProbe(internal_os.windows.DRIVE_UNKNOWN));
+
+    // Syntax rejection still short-circuits before any drive query.
+    try testing.expect(!cmdDirProbeAllowed("\\\\server\\share\\clink"));
+    try testing.expect(!cmdDirProbeAllowed("relative\\clink"));
 }
 
 test "cmd Clink setup fails closed for semicolon integration path" {

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -23,6 +23,9 @@ pub const Shell = enum {
     /// points are left untouched so exit behavior and payload semantics
     /// are preserved.
     powershell,
+    /// Windows Command Prompt. `PROMPT` supplies prompt/cwd marks, and an
+    /// optional Clink script supplies command-start/command-finish marks.
+    cmd,
 };
 
 /// The result of setting up a shell integration.
@@ -94,6 +97,13 @@ pub fn setup(
             resource_dir,
             utf8_console,
         ),
+
+        .cmd => try setupCmd(
+            alloc_arena,
+            command,
+            resource_dir,
+            env,
+        ),
     } orelse return null;
 
     return .{
@@ -120,6 +130,7 @@ test "force shell" {
 
         const command: config.Command = switch (shell) {
             .powershell => .{ .direct = &.{"pwsh.exe"} },
+            .cmd => .{ .direct = &.{"cmd.exe"} },
             else => .{ .shell = "sh" },
         };
 
@@ -131,7 +142,9 @@ test "force shell" {
             shell,
             false,
         );
-        if (shell == .powershell and builtin.os.tag != .windows) {
+        if ((shell == .powershell or shell == .cmd) and
+            builtin.os.tag != .windows)
+        {
             try testing.expect(result == null);
         } else {
             try testing.expectEqual(shell, result.?.shell);
@@ -202,6 +215,12 @@ fn detectShell(alloc: Allocator, command: config.Command) !?Shell {
         return .powershell;
     }
 
+    if (std.ascii.eqlIgnoreCase(exe, "cmd") or
+        std.ascii.eqlIgnoreCase(exe, "cmd.exe"))
+    {
+        return .cmd;
+    }
+
     return null;
 }
 
@@ -229,6 +248,11 @@ test detectShell {
     try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "powershell" }));
     try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "PowerShell.EXE" }));
     try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoProfile" }));
+    try testing.expectEqual(.cmd, try detectShell(alloc, .{ .shell = "cmd" }));
+    try testing.expectEqual(.cmd, try detectShell(alloc, .{ .shell = "cmd.exe" }));
+    try testing.expectEqual(.cmd, try detectShell(alloc, .{
+        .direct = &.{"C:\\Windows\\System32\\cmd.exe"},
+    }));
 
     if (comptime builtin.target.os.tag.isDarwin()) {
         try testing.expect(try detectShell(alloc, .{ .shell = "/bin/bash" }) == null);
@@ -527,6 +551,238 @@ fn setupPowerShell(
     )) orelse return null;
 
     return .{ .direct = injected };
+}
+
+const cmd_default_prompt = "$P$G";
+// OSC 9;9 feeds the same cwd handler as OSC 7, so use its accepted URI form.
+// The kitty scheme keeps cmd's unescaped `$P` Windows path intact.
+const cmd_prompt_prefix = "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\";
+const cmd_prompt_suffix = "$E]133;B$E\\";
+const cmd_clink_executables = [_][]const u8{
+    "clink.bat",
+    "clink_x64.exe",
+};
+
+/// Build a cmd PROMPT value that preserves the user's prompt while adding
+/// prompt boundaries and the current working directory. `$E` is ESC in cmd's
+/// PROMPT syntax; ESC followed by `\\` terminates each OSC sequence.
+fn buildCmdPrompt(alloc: Allocator, existing: ?[]const u8) ![]u8 {
+    return try std.fmt.allocPrint(
+        alloc,
+        "{s}{s}{s}",
+        .{ cmd_prompt_prefix, existing orelse cmd_default_prompt, cmd_prompt_suffix },
+    );
+}
+
+fn composeCmdClinkPath(
+    alloc: Allocator,
+    existing: ?[]const u8,
+    integration_dir: []const u8,
+) ![]u8 {
+    const current = existing orelse "";
+    if (current.len == 0) return try alloc.dupe(u8, integration_dir);
+    return try std.fmt.allocPrint(alloc, "{s};{s}", .{ current, integration_dir });
+}
+
+fn setupCmd(
+    alloc: Allocator,
+    command: config.Command,
+    resource_dir: []const u8,
+    env: *EnvMap,
+) !?config.Command {
+    if (builtin.os.tag != .windows) return null;
+    if (!isInteractiveCmd(alloc, command)) return null;
+
+    const prompt = try buildCmdPrompt(alloc, env.get("PROMPT"));
+    defer alloc.free(prompt);
+    try env.put("PROMPT", prompt);
+
+    if (try clinkInstalled(alloc, env)) {
+        const integration_dir = try std.fs.path.join(alloc, &.{
+            resource_dir,
+            "shell-integration",
+            "cmd",
+        });
+        defer alloc.free(integration_dir);
+
+        const script_path = try std.fs.path.join(alloc, &.{
+            integration_dir,
+            "clink.lua",
+        });
+        defer alloc.free(script_path);
+
+        if (fileExistsAbsolute(script_path)) {
+            const clink_path = try composeCmdClinkPath(
+                alloc,
+                env.get("CLINK_PATH"),
+                integration_dir,
+            );
+            defer alloc.free(clink_path);
+            try env.put("CLINK_PATH", clink_path);
+        } else {
+            log.warn("cmd Clink integration script is unavailable path={s}", .{script_path});
+        }
+    }
+
+    return try command.clone(alloc);
+}
+
+fn isInteractiveCmd(alloc: Allocator, command: config.Command) bool {
+    var arg_iter = command.argIterator(alloc) catch return false;
+    defer arg_iter.deinit();
+
+    _ = arg_iter.next() orelse return false;
+    while (arg_iter.next()) |arg| {
+        if (cmdMode(arg)) |keep_open| return keep_open;
+    }
+    return true;
+}
+
+fn cmdMode(arg: []const u8) ?bool {
+    if (arg.len < 2 or (arg[0] != '/' and arg[0] != '-')) return null;
+    return switch (std.ascii.toLower(arg[1])) {
+        'c' => false,
+        'k' => true,
+        else => null,
+    };
+}
+
+fn clinkInstalled(alloc: Allocator, env: *const EnvMap) !bool {
+    if (builtin.os.tag != .windows) return false;
+
+    if (env.get("PATH")) |path| {
+        var dirs = std.mem.splitScalar(u8, path, ';');
+        while (dirs.next()) |raw_dir| {
+            const dir = std.mem.trim(u8, raw_dir, " \t\"");
+            if (dir.len > 0 and try directoryContainsClink(alloc, dir)) return true;
+        }
+    }
+
+    const local_app_data = env.get("LOCALAPPDATA") orelse return false;
+    const local_clink_dir = try std.fs.path.resolve(
+        alloc,
+        &.{ local_app_data, "clink" },
+    );
+    defer alloc.free(local_clink_dir);
+    return try directoryContainsClink(alloc, local_clink_dir);
+}
+
+fn directoryContainsClink(alloc: Allocator, dir: []const u8) !bool {
+    for (cmd_clink_executables) |exe| {
+        const candidate = try std.fs.path.resolve(alloc, &.{ dir, exe });
+        defer alloc.free(candidate);
+        if (fileExistsAbsolute(candidate)) return true;
+    }
+    return false;
+}
+
+fn fileExistsAbsolute(path: []const u8) bool {
+    std.fs.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+test "cmd prompt construction defaults and preserves escapes" {
+    const testing = std.testing;
+
+    const prompt = try buildCmdPrompt(testing.allocator, null);
+    defer testing.allocator.free(prompt);
+
+    try testing.expectEqualStrings(
+        "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\$P$G$E]133;B$E\\",
+        prompt,
+    );
+}
+
+test "cmd prompt construction preserves user prompt" {
+    const testing = std.testing;
+
+    const prompt = try buildCmdPrompt(testing.allocator, "[$T] $P$_$$ ");
+    defer testing.allocator.free(prompt);
+
+    try testing.expectEqualStrings(
+        "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\[$T] $P$_$$ $E]133;B$E\\",
+        prompt,
+    );
+}
+
+test "cmd Clink path composition appends integration directory" {
+    const testing = std.testing;
+
+    const empty = try composeCmdClinkPath(testing.allocator, "", "C:\\noctty\\cmd");
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings("C:\\noctty\\cmd", empty);
+
+    const existing = try composeCmdClinkPath(
+        testing.allocator,
+        "C:\\user\\clink;D:\\shared\\clink",
+        "C:\\noctty\\cmd",
+    );
+    defer testing.allocator.free(existing);
+    try testing.expectEqualStrings(
+        "C:\\user\\clink;D:\\shared\\clink;C:\\noctty\\cmd",
+        existing,
+    );
+}
+
+test "cmd Clink detection covers PATH and LocalAppData" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makePath("path-bat");
+    try tmp_dir.dir.makePath("path-x64");
+    try tmp_dir.dir.makePath("local/clink");
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "path-bat/clink.bat",
+        .data = "",
+    });
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "path-x64/clink_x64.exe",
+        .data = "",
+    });
+
+    const root = try tmp_dir.dir.realpathAlloc(alloc, ".");
+    const path_bat = try std.fs.path.join(alloc, &.{ root, "path-bat" });
+    const path_x64 = try std.fs.path.join(alloc, &.{ root, "path-x64" });
+    const local_app_data = try std.fs.path.join(alloc, &.{ root, "local" });
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    try env.put("PATH", path_bat);
+    try testing.expect(try clinkInstalled(alloc, &env));
+
+    try env.put("PATH", path_x64);
+    try testing.expect(try clinkInstalled(alloc, &env));
+
+    env.remove("PATH");
+    try env.put("LOCALAPPDATA", local_app_data);
+    try testing.expect(!try clinkInstalled(alloc, &env));
+
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "local/clink/clink_x64.exe",
+        .data = "",
+    });
+    try testing.expect(try clinkInstalled(alloc, &env));
+}
+
+test "cmd integration skips execute-and-exit but accepts UTF-8 preamble" {
+    const testing = std.testing;
+
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/C", "echo hi" },
+    }));
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/cecho hi" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/K", "chcp 65001 >nul" },
+    }));
 }
 
 /// Set up the shell integration features environment variable.
@@ -1360,6 +1616,10 @@ const TmpResourcesDir = struct {
             }),
             .powershell => try tmp_dir.dir.writeFile(.{
                 .sub_path = "shell-integration/powershell/integration.ps1",
+                .data = "",
+            }),
+            .cmd => try tmp_dir.dir.writeFile(.{
+                .sub_path = "shell-integration/cmd/clink.lua",
                 .data = "",
             }),
             else => {},

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -581,7 +581,7 @@ var cmd_clink_detection_cache: CmdClinkDetectionCache = .{};
 /// PROMPT syntax; ESC followed by `\\` terminates each OSC sequence.
 fn buildCmdPrompt(alloc: Allocator, existing: ?[]const u8) ![]u8 {
     if (existing) |current| {
-        if (std.mem.startsWith(u8, current, cmd_prompt_osc_a)) {
+        if (std.mem.indexOf(u8, current, cmd_prompt_osc_a) != null) {
             return try alloc.dupe(u8, current);
         }
     }
@@ -812,8 +812,20 @@ test "cmd prompt construction is idempotent" {
     defer testing.allocator.free(prompt);
     const repeated = try buildCmdPrompt(testing.allocator, prompt);
     defer testing.allocator.free(repeated);
+    const clink_prefixed = try std.fmt.allocPrint(
+        testing.allocator,
+        "C\x08L\x08I\x08N\x08K\x08 \x08{s}",
+        .{prompt},
+    );
+    defer testing.allocator.free(clink_prefixed);
+    const prefixed_repeated = try buildCmdPrompt(
+        testing.allocator,
+        clink_prefixed,
+    );
+    defer testing.allocator.free(prefixed_repeated);
 
     try testing.expectEqualStrings(prompt, repeated);
+    try testing.expectEqualStrings(clink_prefixed, prefixed_repeated);
 }
 
 test "cmd Clink path composition prepends once and rejects semicolons" {

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -556,17 +556,36 @@ fn setupPowerShell(
 const cmd_default_prompt = "$P$G";
 // OSC 9;9 feeds the same cwd handler as OSC 7, so use its accepted URI form.
 // The kitty scheme keeps cmd's unescaped `$P` Windows path intact.
-const cmd_prompt_prefix = "$E]133;A$E\\$E]9;9;kitty-shell-cwd://localhost/$P$E\\";
+const cmd_prompt_osc_a = "$E]133;A$E\\";
+const cmd_prompt_prefix = cmd_prompt_osc_a ++
+    "$E]9;9;kitty-shell-cwd://localhost/$P$E\\";
 const cmd_prompt_suffix = "$E]133;B$E\\";
 const cmd_clink_executables = [_][]const u8{
     "clink.bat",
     "clink_x64.exe",
 };
+const CmdClinkDetectionCache = struct {
+    mutex: std.Thread.Mutex = .{},
+    snapshot: ?Snapshot = null,
+
+    const Snapshot = struct {
+        path: []u8,
+        local_app_data: []u8,
+        installed: bool,
+    };
+};
+var cmd_clink_detection_cache: CmdClinkDetectionCache = .{};
 
 /// Build a cmd PROMPT value that preserves the user's prompt while adding
 /// prompt boundaries and the current working directory. `$E` is ESC in cmd's
 /// PROMPT syntax; ESC followed by `\\` terminates each OSC sequence.
 fn buildCmdPrompt(alloc: Allocator, existing: ?[]const u8) ![]u8 {
+    if (existing) |current| {
+        if (std.mem.startsWith(u8, current, cmd_prompt_osc_a)) {
+            return try alloc.dupe(u8, current);
+        }
+    }
+
     return try std.fmt.allocPrint(
         alloc,
         "{s}{s}{s}",
@@ -581,7 +600,24 @@ fn composeCmdClinkPath(
 ) ![]u8 {
     const current = existing orelse "";
     if (current.len == 0) return try alloc.dupe(u8, integration_dir);
-    return try std.fmt.allocPrint(alloc, "{s};{s}", .{ current, integration_dir });
+
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(alloc);
+    try result.appendSlice(alloc, integration_dir);
+
+    var dirs = std.mem.splitScalar(u8, current, ';');
+    while (dirs.next()) |raw_dir| {
+        const dir = std.mem.trim(u8, raw_dir, " \t\"");
+        if (std.ascii.eqlIgnoreCase(dir, integration_dir)) continue;
+        try result.append(alloc, ';');
+        try result.appendSlice(alloc, raw_dir);
+    }
+
+    return try result.toOwnedSlice(alloc);
+}
+
+fn cmdClinkIntegrationDirSafe(integration_dir: []const u8) bool {
+    return std.mem.indexOfScalar(u8, integration_dir, ';') == null;
 }
 
 fn setupCmd(
@@ -597,14 +633,22 @@ fn setupCmd(
     defer alloc.free(prompt);
     try env.put("PROMPT", prompt);
 
-    if (try clinkInstalled(alloc, env)) {
-        const integration_dir = try std.fs.path.join(alloc, &.{
-            resource_dir,
-            "shell-integration",
-            "cmd",
-        });
-        defer alloc.free(integration_dir);
+    const integration_dir = try std.fs.path.join(alloc, &.{
+        resource_dir,
+        "shell-integration",
+        "cmd",
+    });
+    defer alloc.free(integration_dir);
 
+    if (!cmdClinkIntegrationDirSafe(integration_dir)) {
+        log.warn(
+            "cmd Clink integration disabled because its path contains a semicolon path={s}",
+            .{integration_dir},
+        );
+        return try command.clone(alloc);
+    }
+
+    if (try clinkInstalled(alloc, env)) {
         const script_path = try std.fs.path.join(alloc, &.{
             integration_dir,
             "clink.lua",
@@ -639,32 +683,88 @@ fn isInteractiveCmd(alloc: Allocator, command: config.Command) bool {
 }
 
 fn cmdMode(arg: []const u8) ?bool {
-    if (arg.len < 2 or (arg[0] != '/' and arg[0] != '-')) return null;
-    return switch (std.ascii.toLower(arg[1])) {
-        'c' => false,
-        'k' => true,
-        else => null,
-    };
+    if (arg.len < 2 or arg[0] != '/') return null;
+
+    var index: usize = 0;
+    while (index + 1 < arg.len) : (index += 1) {
+        if (arg[index] != '/') continue;
+        switch (std.ascii.toLower(arg[index + 1])) {
+            'c', 'r' => return false,
+            'k' => return true,
+            else => {},
+        }
+    }
+
+    return null;
 }
 
 fn clinkInstalled(alloc: Allocator, env: *const EnvMap) !bool {
     if (builtin.os.tag != .windows) return false;
 
-    if (env.get("PATH")) |path| {
-        var dirs = std.mem.splitScalar(u8, path, ';');
-        while (dirs.next()) |raw_dir| {
-            const dir = std.mem.trim(u8, raw_dir, " \t\"");
-            if (dir.len > 0 and try directoryContainsClink(alloc, dir)) return true;
+    const path = env.get("PATH") orelse "";
+    const local_app_data = env.get("LOCALAPPDATA") orelse "";
+
+    cmd_clink_detection_cache.mutex.lock();
+    defer cmd_clink_detection_cache.mutex.unlock();
+
+    if (cmd_clink_detection_cache.snapshot) |snapshot| {
+        if (std.mem.eql(u8, snapshot.path, path) and
+            std.mem.eql(u8, snapshot.local_app_data, local_app_data))
+        {
+            return snapshot.installed;
         }
     }
 
-    const local_app_data = env.get("LOCALAPPDATA") orelse return false;
-    const local_clink_dir = try std.fs.path.resolve(
-        alloc,
-        &.{ local_app_data, "clink" },
-    );
-    defer alloc.free(local_clink_dir);
-    return try directoryContainsClink(alloc, local_clink_dir);
+    const installed = try clinkInstalledUncached(alloc, path, local_app_data);
+    const cache_alloc = std.heap.page_allocator;
+    const path_copy = try cache_alloc.dupe(u8, path);
+    errdefer cache_alloc.free(path_copy);
+    const local_app_data_copy = try cache_alloc.dupe(u8, local_app_data);
+    errdefer cache_alloc.free(local_app_data_copy);
+
+    if (cmd_clink_detection_cache.snapshot) |snapshot| {
+        cache_alloc.free(snapshot.path);
+        cache_alloc.free(snapshot.local_app_data);
+    }
+    cmd_clink_detection_cache.snapshot = .{
+        .path = path_copy,
+        .local_app_data = local_app_data_copy,
+        .installed = installed,
+    };
+    return installed;
+}
+
+fn clinkInstalledUncached(
+    alloc: Allocator,
+    path: []const u8,
+    local_app_data: []const u8,
+) !bool {
+    if (local_app_data.len > 0) {
+        const local_clink_dir = try std.fs.path.resolve(
+            alloc,
+            &.{ local_app_data, "clink" },
+        );
+        defer alloc.free(local_clink_dir);
+        if (try directoryContainsClink(alloc, local_clink_dir)) return true;
+    }
+
+    if (path.len > 0) {
+        var dirs = std.mem.splitScalar(u8, path, ';');
+        while (dirs.next()) |raw_dir| {
+            const dir = std.mem.trim(u8, raw_dir, " \t\"");
+            if (cmdPathEntrySafeToProbe(dir) and
+                try directoryContainsClink(alloc, dir)) return true;
+        }
+    }
+
+    return false;
+}
+
+fn cmdPathEntrySafeToProbe(dir: []const u8) bool {
+    return dir.len >= 3 and
+        std.ascii.isAlphabetic(dir[0]) and
+        dir[1] == ':' and
+        (dir[2] == '\\' or dir[2] == '/');
 }
 
 fn directoryContainsClink(alloc: Allocator, dir: []const u8) !bool {
@@ -705,7 +805,18 @@ test "cmd prompt construction preserves user prompt" {
     );
 }
 
-test "cmd Clink path composition appends integration directory" {
+test "cmd prompt construction is idempotent" {
+    const testing = std.testing;
+
+    const prompt = try buildCmdPrompt(testing.allocator, "[$T] $P$_$$ ");
+    defer testing.allocator.free(prompt);
+    const repeated = try buildCmdPrompt(testing.allocator, prompt);
+    defer testing.allocator.free(repeated);
+
+    try testing.expectEqualStrings(prompt, repeated);
+}
+
+test "cmd Clink path composition prepends once and rejects semicolons" {
     const testing = std.testing;
 
     const empty = try composeCmdClinkPath(testing.allocator, "", "C:\\noctty\\cmd");
@@ -719,9 +830,31 @@ test "cmd Clink path composition appends integration directory" {
     );
     defer testing.allocator.free(existing);
     try testing.expectEqualStrings(
-        "C:\\user\\clink;D:\\shared\\clink;C:\\noctty\\cmd",
+        "C:\\noctty\\cmd;C:\\user\\clink;D:\\shared\\clink",
         existing,
     );
+
+    const idempotent = try composeCmdClinkPath(
+        testing.allocator,
+        existing,
+        "C:\\noctty\\cmd",
+    );
+    defer testing.allocator.free(idempotent);
+    try testing.expectEqualStrings(existing, idempotent);
+
+    const repeated = try composeCmdClinkPath(
+        testing.allocator,
+        "C:\\user\\clink;C:\\noctty\\cmd;D:\\shared\\clink",
+        "C:\\noctty\\cmd",
+    );
+    defer testing.allocator.free(repeated);
+    try testing.expectEqualStrings(
+        "C:\\noctty\\cmd;C:\\user\\clink;D:\\shared\\clink",
+        repeated,
+    );
+
+    try testing.expect(cmdClinkIntegrationDirSafe("C:\\noctty\\cmd"));
+    try testing.expect(!cmdClinkIntegrationDirSafe("C:\\unsafe;path\\cmd"));
 }
 
 test "cmd Clink detection covers PATH and LocalAppData" {
@@ -751,37 +884,136 @@ test "cmd Clink detection covers PATH and LocalAppData" {
     const path_x64 = try std.fs.path.join(alloc, &.{ root, "path-x64" });
     const local_app_data = try std.fs.path.join(alloc, &.{ root, "local" });
 
-    var env = EnvMap.init(alloc);
-    defer env.deinit();
-
-    try env.put("PATH", path_bat);
-    try testing.expect(try clinkInstalled(alloc, &env));
-
-    try env.put("PATH", path_x64);
-    try testing.expect(try clinkInstalled(alloc, &env));
-
-    env.remove("PATH");
-    try env.put("LOCALAPPDATA", local_app_data);
-    try testing.expect(!try clinkInstalled(alloc, &env));
+    try testing.expect(try clinkInstalledUncached(alloc, path_bat, ""));
+    try testing.expect(try clinkInstalledUncached(alloc, path_x64, ""));
+    try testing.expect(!try clinkInstalledUncached(alloc, "", local_app_data));
 
     try tmp_dir.dir.writeFile(.{
         .sub_path = "local/clink/clink_x64.exe",
         .data = "",
     });
+    try testing.expect(try clinkInstalledUncached(alloc, path_bat, local_app_data));
+
+    try testing.expect(cmdPathEntrySafeToProbe(path_bat));
+    try testing.expect(!cmdPathEntrySafeToProbe("relative\\clink"));
+    try testing.expect(!cmdPathEntrySafeToProbe("C:relative\\clink"));
+    try testing.expect(!cmdPathEntrySafeToProbe("\\rooted\\clink"));
+    try testing.expect(!cmdPathEntrySafeToProbe("\\\\server\\share\\clink"));
+    try testing.expect(!cmdPathEntrySafeToProbe("//server/share/clink"));
+    try testing.expect(cmdPathEntrySafeToProbe("D:/absolute/clink"));
+}
+
+test "cmd Clink setup fails closed for semicolon integration path" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makePath("resources;unsafe/shell-integration/cmd");
+    try tmp_dir.dir.makePath("local/clink");
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "resources;unsafe/shell-integration/cmd/clink.lua",
+        .data = "",
+    });
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "local/clink/clink_x64.exe",
+        .data = "",
+    });
+
+    const root = try tmp_dir.dir.realpathAlloc(alloc, ".");
+    const resource_dir = try std.fs.path.join(alloc, &.{ root, "resources;unsafe" });
+    const local_app_data = try std.fs.path.join(alloc, &.{ root, "local" });
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+    try env.put("LOCALAPPDATA", local_app_data);
+    try env.put("CLINK_PATH", "C:\\trusted\\clink");
+
+    _ = (try setupCmd(
+        alloc,
+        .{ .direct = &.{"cmd.exe"} },
+        resource_dir,
+        &env,
+    )).?;
+    try testing.expectEqualStrings("C:\\trusted\\clink", env.get("CLINK_PATH").?);
+}
+
+test "cmd Clink detection caches one environment snapshot" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makePath("path");
+    try tmp_dir.dir.makePath("local");
+
+    const root = try tmp_dir.dir.realpathAlloc(alloc, ".");
+    const path = try std.fs.path.join(alloc, &.{ root, "path" });
+    const local_app_data = try std.fs.path.join(alloc, &.{ root, "local" });
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+    try env.put("PATH", path);
+    try env.put("LOCALAPPDATA", local_app_data);
+
+    try testing.expect(!try clinkInstalled(alloc, &env));
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "path/clink.bat",
+        .data = "",
+    });
+    try testing.expect(!try clinkInstalled(alloc, &env));
+
+    const changed_path = try std.fmt.allocPrint(alloc, "{s};relative", .{path});
+    try env.put("PATH", changed_path);
     try testing.expect(try clinkInstalled(alloc, &env));
 }
 
-test "cmd integration skips execute-and-exit but accepts UTF-8 preamble" {
+test "cmd integration follows cmd slash switch modes" {
     const testing = std.testing;
 
     try testing.expect(!isInteractiveCmd(testing.allocator, .{
-        .direct = &.{ "cmd.exe", "/C", "echo hi" },
+        .direct = &.{ "cmd.exe", "/C", "payload" },
     }));
     try testing.expect(!isInteractiveCmd(testing.allocator, .{
-        .direct = &.{ "cmd.exe", "/cecho hi" },
+        .direct = &.{ "cmd.exe", "/Cpayload" },
+    }));
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/D", "/Q", "/C", "payload" },
+    }));
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/d/q/c", "payload" },
+    }));
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/R", "payload" },
+    }));
+    try testing.expect(!isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/C/K", "payload" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/K" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/D", "/Q", "/K" },
     }));
     try testing.expect(isInteractiveCmd(testing.allocator, .{
         .direct = &.{ "cmd.exe", "/K", "chcp 65001 >nul" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "/K/C", "payload" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{ "cmd.exe", "-c", "payload" },
+    }));
+    try testing.expect(isInteractiveCmd(testing.allocator, .{
+        .direct = &.{"cmd.exe"},
     }));
 }
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1989,4 +1989,13 @@ test "cmd OSC 9;9 URI updates terminal pwd" {
     var message = app_queue.pop().?;
     message.deinit(alloc);
     try std.testing.expect(app_queue.pop() == null);
+
+    // A UNC cwd must drop the URI's leading slash instead of being reported as
+    // the invalid path `/\\server\share\dir`.
+    stream.nextSlice("\x1b]9;9;kitty-shell-cwd://localhost/\\\\server\\share\\dir\x1b\\");
+    try std.testing.expectEqualStrings("\\\\server\\share\\dir", term.getPwd().?);
+
+    var unc_message = app_queue.pop().?;
+    unc_message.deinit(alloc);
+    try std.testing.expect(app_queue.pop() == null);
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1934,3 +1934,59 @@ test "security regression OSC 7 pwd rejects percent-decoded Windows controls" {
         StreamHandler.decodeOsc7PathForPwd(arena.allocator(), uri),
     );
 }
+
+test "cmd OSC 9;9 URI updates terminal pwd" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+    var term = try terminal.Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var termio_mailbox = try termio.Mailbox.initSPSC(alloc);
+    defer termio_mailbox.deinit(alloc);
+    var renderer_mutex: std.Thread.Mutex = .{};
+    var renderer_state: renderer.State = undefined;
+    renderer_state.mutex = &renderer_mutex;
+    renderer_state.terminal = &term;
+    var rt_app: apprt.App = undefined;
+    rt_app.windows = .empty;
+    rt_app.ui_thread_id = 0;
+    const AppMailbox = @TypeOf(@as(apprt.surface.Mailbox, undefined).app);
+    const app_queue = try AppMailbox.Queue.create(alloc);
+    defer app_queue.destroy(alloc);
+    const surface_mailbox: apprt.surface.Mailbox = .{
+        .surface = undefined,
+        .app = .{
+            .rt_app = &rt_app,
+            .mailbox = app_queue,
+        },
+    };
+
+    var stream = StreamHandler.Stream.initAlloc(alloc, .{
+        .alloc = alloc,
+        .size = undefined,
+        .terminal = &term,
+        .termio_mailbox = &termio_mailbox,
+        .surface_mailbox = surface_mailbox,
+        .renderer_state = &renderer_state,
+        .renderer_mailbox = undefined,
+        .renderer_wakeup = undefined,
+        .default_cursor_style = .block,
+        .default_cursor_blink = true,
+        .enquiry_response = "",
+        .osc_color_report_format = .none,
+        .clipboard_write = .allow,
+    });
+    defer stream.deinit();
+    stream.handler.seen_title = true;
+
+    stream.nextSlice("\x1b]9;9;kitty-shell-cwd://localhost/C:\\Users\\test\\project\x1b\\");
+    try std.testing.expectEqualStrings("C:\\Users\\test\\project", term.getPwd().?);
+
+    var message = app_queue.pop().?;
+    message.deinit(alloc);
+    try std.testing.expect(app_queue.pop() == null);
+}


### PR DESCRIPTION
## Summary

Closes the last unsupported-shell gap: `cmd.exe` is no longer a plain fallback.
Detected cmd sessions wrap the inherited `PROMPT` (or cmd's `$P$G` default) so the
shell emits OSC 133;A/B prompt marks and an OSC 9;9 working-directory report, which
makes cwd-correct new tabs/splits and prompt navigation work in Command Prompt.
When Clink is installed, a small shipped Lua script adds OSC 133;C/D with exit
codes; without it the session degrades to prompt and cwd marks.

Fixes #125

Stacked on #124 (both touch the cmd launch path and `docs/windows.md`).

## Changes

- `Shell.cmd` variant plus `setupCmd` in `src/termio/shell_integration.zig`,
  mirroring how PowerShell is wired. Delivery is entirely via environment
  variables, so it composes with #124's `cmd.exe /K "chcp 65001 >nul"` rewrite.
- `PROMPT` wrapping is idempotent (relaunching noctty from an integrated cmd does
  not double the marks) and preserves a user's existing prompt byte-for-byte.
  OSC 9;9 uses the `kitty-shell-cwd://` URI form, which is what this codebase's
  pwd handler accepts.
- Clink detection checks `%LOCALAPPDATA%\clink` first, then drive-qualified `PATH`
  entries only. UNC and relative entries are skipped, and `GetDriveTypeW` rejects
  remote and unmounted drive letters, so a dead network path cannot stall a new
  tab. One environment snapshot is cached per process.
- `src/shell-integration/cmd/clink.lua` ships under
  `share/ghostty/shell-integration/cmd/` via the existing resource install. It is
  prepended to `CLINK_PATH`, and Clink setup fails closed if the integration path
  contains a `;`. Every prompt closes the previous boundary: `133;D;<code>` after a
  command, bare `133;D` for an empty line or Ctrl-C.
- cmd switch parsing follows cmd.exe: `/C` and `/R` are non-interactive, `/K` is
  interactive, combined (`/d/q/c`) and fused (`/Cpayload`) forms are handled, and
  `-` is not a switch prefix.
- `shellIntegrationDiagnostic(.cmd)` now reports automatic support; `docs/status.md`,
  `docs/windows-capability-matrix.md`, `docs/windows.md`, and
  `src/shell-integration/README.md` updated to match, including the honest caveats
  (see Residuals). The `docs/windows.md` text follows the compressed style `main`
  adopted in #206.

## Validation (head `ee33e007e`, rebased onto #167 @ `e77679ed4`, which sits on `main` @ `13e07ba35`)

| Gate                                                                   | Result                              |
| ---------------------------------------------------------------------- | ----------------------------------- |
| `zig build -Demit-exe=true`                                            | exit 0                              |
| `zig build test -Demit-test-exe=true`                                  | 4191 passed / 71 skipped / 0 failed |
| `scripts/check-zig-format.ps1`                                         | PASS (696 sources)                  |
| `scripts/check-source-format.ps1`                                      | PASS                                |
| `test/windows/flagship/Test-VerificationContracts.ps1`                 | PASS (2 scenarios)                  |
| `-Dtest-filter=` `cmd` / `unc` / `Clink` / `utf8-console`              | exit 0 each (see note)              |

Note on `-Dtest-filter`: a filtered `zig build test` run does apply the filter, but `--summary all` only prints the pass count on a cache miss; on a cached repeat it prints `run test ghostty-test success` with no count, which made an earlier round read the filtered rows as vacuous. Verified on `main` with a cleared cache: a bogus filter runs the 68 unnamed always-on test blocks, and a real filter runs those plus its matches. Filtered rows therefore prove only that the matched tests passed; the zero-failure full suite remains the real signal.

`npx prettier@3 --check` is clean on `docs/windows.md` and `docs/status.md`;
`docs/windows-capability-matrix.md` and `src/shell-integration/README.md` fail
it identically on `main` (pre-existing table padding, not introduced here).

Earlier rounds, unchanged code paths:

- `zig-out/share/ghostty/shell-integration/cmd/clink.lua` present after build
- Raw byte probe: a real cmd session launched with the generated `PROMPT` emitted
  three 133;A marks, three 133;B marks, and both the initial and post-`cd`
  `kitty-shell-cwd` values, with a custom user prompt preserved
- Live noctty probes: new tab and `new_split:right` both inherited the cmd session's
  cwd exactly, with zero OSC cwd URI warnings

## Residuals / user steps

- `CLINK_PATH` only makes the script discoverable once Clink is already active
  (autorun, `clink inject`, or an explicit Clink launch). noctty deliberately does
  not inject or execute Clink. Documented in `docs/windows.md`.
- Clink is not installed on the validation machine, so the live 133;C/D + exit-code
  path was checked against Clink's documented APIs rather than exercised.
- `os.geterrorlevel()` is truthful only while Clink's `cmd.get_errorlevel` setting is
  enabled (its default). Documented.
- A `PROMPT` supplied through `env = PROMPT=...` is applied after shell integration
  and intentionally replaces the wrapper. Documented.

## Stacked on

#167 (issue #124)

---

## Adversarial-review delta (20cc22ee0..7286f8cd4)

- **[medium] live Clink probe — done, no code change needed.** Portable Clink v1.9.31
  (`clink.1.9.31.8c8e92.zip`, SHA-256 `4E5F4F…0232`) was downloaded to a TEMP dir,
  extracted, and injected into a throwaway `cmd.exe` with `clink_x64.exe inject --profile
  <temp> --scripts <repo cmd dir>`. Observed marker order per executed command was
  **`A B C D`** (`ver >nul` → `C D;0`, `cmd /d /c exit 7` → `C D;7`, empty Enter → bare
  `D` with no `C`). `clink.onbeginedit` runs *before* cmd renders the next `PROMPT`, so
  the feared `A … D` inversion does not occur and `clink.lua` is unchanged. TEMP dir and
  all recorded PIDs cleaned up.
- **[low] PROMPT idempotence — fixed.** Clink prefixes `PROMPT` in-process with its own
  tag, so the previous `startsWith` check missed an already-wrapped prompt and double-
  wrapped it. Now uses `std.mem.indexOf`, with a regression test using Clink's exact tag
  (`C\bL\bI\bN\bK\b \b`).
- **[low] UNC cwd — documented.** ~~`$P` on a UNC cwd yields a path the OSC conversion
  keeps with a spurious leading `/`.~~ **Superseded: fixed in the 2026-08-30 bot-review
  round below.** Greptile was right that shipping an invalid path is worse than the
  limitation.
- **[low] session-wide PROMPT — documented.** `echo on` batch runs and `cmd /c` children
  can echo the wrapped prompt and emit spurious OSC 133 marks.

Rebased onto the updated #124 branch.

## Summary by Sourcery

Enable automatic cmd.exe shell integration with prompt and cwd tracking, while adding optional Clink command completion and exit-code markers.

New Features:
- Add automatic shell integration for interactive cmd.exe sessions using PROMPT-based prompt and working-directory markers.
- Support optional Clink integration for command boundaries and exit-code reporting when Clink is already active.

Bug Fixes:
- Handle UNC working-directory reports correctly without misclassifying them as WSL paths.
- Prevent Clink discovery from probing remote or unmounted drive paths and avoid malformed PROMPT values caused by trailing dollar signs.
- Make cmd prompt wrapping idempotent, including prompts modified by Clink.

Enhancements:
- Recognize cmd.exe launch modes and distinguish interactive sessions from /C and /R command execution.
- Expose cmd.exe as automatically supported in shell-integration diagnostics and Windows profile guidance.

Documentation:
- Update Windows capability, status, and shell-integration documentation with cmd.exe support and its Clink and UNC-path caveats.

Tests:
- Add coverage for cmd prompt construction, Clink discovery and path handling, command-mode parsing, UNC path conversion, and OSC 9;9 working-directory updates.

Chores:
- Ship the Clink Lua integration script with the application resources.


---

## Bot-review round (2026-08-30) - 3 findings, all real, all fixed

Rebased onto current `main` and the updated #167. That rebase surfaced a real
integration break on its own: #177 relocated two win32 profile tests into
`src/apprt/win32/labels.zig`, and those relocated copies still asserted the *old*
cmd shell-integration strings this PR changes. Ported them, so the stack no
longer breaks main's tests on landing.

- **[P1, Greptile] UNC cwd reported as an invalid path - fixed.** This PR
  previously carried it as an accepted low-severity limitation; that framing was
  wrong, because reporting an actively invalid path is worse than reporting
  nothing. `osc7PathToLocal` tried `isWindowsUriPath` (fails: `path[1]` is a
  backslash, not a drive letter), then `isWslPath` (returns true for *anything*
  starting with `/`), and `normalizeWslPath` returned the string unchanged - so
  the terminal pwd became `/\\server\share\dir` and was misclassified as WSL.
  A new tight `isUncUriPath` predicate now runs **before** the WSL check in both
  `osc7PathToLocal` and `pathToWsl`. A UNC path pointing back into WSL still
  normalises correctly, and `pathToWsl` on a real share now returns `null` rather
  than a bogus WSL path. Three unit tests plus the requested end-to-end
  assertion through the real stream handler. Honest caveat now in `docs/windows.md`
  instead of glossed over: the reported path is correct, but cmd.exe does not
  support a UNC working directory (it warns and falls back), so inheriting that
  cwd into a new cmd tab or split still will not generally land on the share.
- **[P1, Codex] A mapped network drive on `PATH` could stall Clink discovery - fixed.**
  The PR's stated mitigation ("UNC and relative entries are skipped") was defeated
  by a drive letter: the predicate checked only drive-letter syntax, so a
  disconnected `Z:\tools` passed exactly like `C:\tools`, and `clinkInstalled`
  holds the process-wide cache mutex across every `accessAbsolute`. `GetDriveTypeW`
  is now bound in `src/os/windows.zig` with the seven return values checked against
  Microsoft's fileapi reference, and `cmdDirProbeAllowed` gates both the `PATH` loop
  and the `%LOCALAPPDATA%` probe - cheap syntax check first, then reject
  `DRIVE_REMOTE` and `DRIVE_NO_ROOT_DIR`. `DRIVE_UNKNOWN` stays probeable on
  purpose (some virtual-disk stacks report it). `GetDriveTypeW` reads the local
  mount table, so the classification itself never touches the network.
- **[P2, Codex] A `PROMPT` ending in a lone `$` swallowed the closing mark - fixed.**
  Checked against Microsoft's `prompt` reference: `$$` is a literal `$`, so a
  prompt ending in an odd number of `$` produced `$$E]133;B` and printed
  `E]133;B` as visible text with the boundary never closing.
  `cmdPromptEndsInDanglingDollar` counts the trailing run and `buildCmdPrompt`
  inserts `$S` (a documented single space) to absorb it - chosen over doubling the
  `$` (which would print a character the user never wrote) and over declining to
  wrap (which would silently lose integration). Scope note: we could not confirm
  cmd's rendering empirically because cmd suppresses prompt echo on a non-tty, so
  the fix relies only on documented `$S`/`$$` behaviour, never on undefined
  dangling-`$` behaviour.

**Validation (this round, all personally observed):**
`scripts/check-zig-format.ps1` PASS (670 sources) - `zig build -Demit-exe=true`
PASS - full suite **3790 passed, 70 skipped, 0 failed** -
`scripts/check-source-format.ps1` PASS.



---

## Bot-review round (2026-09-02) - 0 new findings; rebase and thread close-out

Rebased onto the updated #167 (`abea6a5bd`), which now sits on `main`'s docs
debloat (#206). Conflicts were `docs/status.md` and `docs/windows.md` only; the
cmd.exe section is re-expressed in the shorter style (two paragraphs: how it
works, then caveats) with every fact from the previous text kept: `PROMPT`
precedence, `CLINK_PATH` and the no-injection rule, `cmd.get_errorlevel`,
remote/unmounted drive skipping, UNC cwd, dangling `$`, session-wide `PROMPT`.
`main`'s newer `Last updated` date in `docs/status.md` is kept.

All four open threads were fixed in earlier rounds (`91017be04`, `346a48027`,
`b2b43b916`); each fix was confirmed present on this head (`cmdDirProbeAllowed`
/ `cmdDriveTypeSafeToProbe`, `cmdPromptEndsInDanglingDollar`, the
forward-slash and share-component checks in `isUncUriPath`) and the threads
resolved. No code change this round.

## Rebase round (2026-09-03) - rebase only, no code change

Rebased onto the new #167 head `e77679ed4`, which sits on `main` @ `13e07ba35`.
One conflict, both hunks additive:

- `src/termio/stream_handler.zig`: `main` (#163, paste-path audit) and this
  branch each appended a new test at the end of the file. Kept both.
- `src/config/windows_shell.zig`: `main` widened `isDriveAbsolutePath` to `pub`
  for `src/apprt/win32.zig:9094`; this branch adds `isUncUriPath` above it. Kept
  `main`'s `pub` and this branch's new helper.

All 5 review threads were already answered and resolved. No behaviour change
this round.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above
was verified against the code and the gate output.