### PR TITLE
feat(shell-integration): surface prompt-mark navigation verbs (#128)

### DIFF
--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -100,9 +100,11 @@ that:
 - PowerShell emits OSC 7 cwd URIs, OSC 133 prompt marks, command-finish
   status, and PSReadLine command metadata when available.
 - OSC 133 prompt marks back previous/next prompt navigation, copying the last
-  completed command output, and rerunning the last recoverable single-line
-  command from the command palette. Rerun requires OSC 133;B and OSC 133;C;
-  it does not inspect or modify the shell's line editor.
+  completed command output, and inserting the last recoverable single-line
+  command back on the prompt from the command palette. Insert requires
+  OSC 133;B and OSC 133;C; it does not inspect or modify the shell's line
+  editor, and it does not submit the command — OSC 133 marks are forgeable by
+  any program writing to the terminal, so the user reviews and presses Enter.
 - PowerShell wraps `ssh` for `ssh-env` and cache-aware `ssh-terminfo`, but
   does not auto-install remote terminfo; uncached hosts use
   `xterm-256color`.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -99,6 +99,10 @@ that:
   `%LOCALAPPDATA%\noctty\shell-integration\powershell\integration.ps1`.
 - PowerShell emits OSC 7 cwd URIs, OSC 133 prompt marks, command-finish
   status, and PSReadLine command metadata when available.
+- OSC 133 prompt marks back previous/next prompt navigation, copying the last
+  completed command output, and rerunning the last recoverable single-line
+  command from the command palette. Rerun requires OSC 133;B and OSC 133;C;
+  it does not inspect or modify the shell's line editor.
 - PowerShell wraps `ssh` for `ssh-env` and cache-aware `ssh-terminfo`, but
   does not auto-install remote terminfo; uncached hosts use
   `xterm-256color`.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -102,9 +102,10 @@ that:
 - OSC 133 prompt marks back previous/next prompt navigation, copying the last
   completed command output, and inserting the last recoverable single-line
   command back on the prompt from the command palette. Insert requires
-  OSC 133;B and OSC 133;C; it does not inspect or modify the shell's line
-  editor, and it does not submit the command — OSC 133 marks are forgeable by
-  any program writing to the terminal, so the user reviews and presses Enter.
+  OSC 133;B and OSC 133;C and a B mark that noctty has not itself submitted
+  with Enter since; it does not inspect or modify the shell's line editor, and
+  it does not submit the command — OSC 133 marks are forgeable by any program
+  writing to the terminal, so the user reviews and presses Enter.
 - PowerShell wraps `ssh` for `ssh-env` and cache-aware `ssh-terminfo`, but
   does not auto-install remote terminfo; uncached hosts use
   `xterm-256color`.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -106,8 +106,10 @@ With OSC 133 shell integration active, the command palette also offers:
   single-line command back on the prompt without submitting it. Needs OSC
   133;B and OSC 133;C boundaries; noctty never reads or modifies the shell's
   line editor. It refuses on the alternate screen, while a command is running,
-  and when no OSC 133;B input mark is outstanding, and it rejects text that is
-  empty, multi-line, over 4096 bytes, or carries control or invisible
+  and when no OSC 133;B input mark is outstanding (pressing Enter, or pasting
+  a line terminator, consumes the mark until the shell draws the next prompt,
+  which matters for the A/B-only cmd.exe integration), and it rejects text
+  that is empty, multi-line, over 4096 bytes, or carries control or invisible
   formatting characters. It does not press Enter, by design: OSC 133 marks
   carry no provenance, so any program that can print (a file you `type`, a log
   you tail, a host you SSH into) can forge a complete A/B/C/D lifecycle around

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -96,6 +96,29 @@ the closing mark so cmd does not pair the dangling `$` with the mark's `$E`.
 `PROMPT` is session-wide, so `echo on` batch runs and `cmd /c` children can
 echo the wrapped value and emit spurious OSC 133 marks.
 
+With OSC 133 shell integration active, the command palette also offers:
+
+- `jump_to_prompt:-1` / `jump_to_prompt:1` (`Ctrl+Shift+PageUp` /
+  `Ctrl+Shift+PageDown`): previous / next prompt.
+- `copy_last_command_output` (`Ctrl+Shift+Y`): copy the last completed
+  command's output. Needs OSC 133;C and OSC 133;D boundaries.
+- `insert_last_command` (no default keybind): put the last recoverable
+  single-line command back on the prompt without submitting it. Needs OSC
+  133;B and OSC 133;C boundaries; noctty never reads or modifies the shell's
+  line editor. It refuses on the alternate screen, while a command is running,
+  and when no OSC 133;B input mark is outstanding, and it rejects text that is
+  empty, multi-line, over 4096 bytes, or carries control or invisible
+  formatting characters. It does not press Enter, by design: OSC 133 marks
+  carry no provenance, so any program that can print (a file you `type`, a log
+  you tail, a host you SSH into) can forge a complete A/B/C/D lifecycle around
+  text of its choosing and have it retained as "the last command". The text is
+  inserted the way a clipboard paste is (bracketed when the terminal asked for
+  it); you read what landed on the prompt and submit it yourself.
+
+After a resize or repaint, ConPTY can redraw the whole screen and retag
+previously marked cells as output, so a recovered command or output region may
+occasionally be unavailable or truncated afterward.
+
 `utf8-console` (`auto`, `always`, `never`) controls UTF-8 setup for bare
 interactive `cmd.exe` launches and for Windows PowerShell 5.1 and PowerShell 7
 sessions. `auto` (the default) enables UTF-8 unless the machine ANSI or OEM

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1117,7 +1117,55 @@ fn queueIo(
         }
     }
 
+    // Every byte noctty writes to the pty passes through here, so this is
+    // the one place to notice that we just submitted a line.
+    switch (msg) {
+        .write_small => |v| self.noteSubmittedInput(v.data[0..v.len], mutex),
+        .write_stable => |v| self.noteSubmittedInput(v, mutex),
+        .write_alloc => |v| self.noteSubmittedInput(v.data, mutex),
+        else => {},
+    }
+
     self.io.queueMessage(msg, mutex);
+}
+
+/// True if `data`, about to be written to the pty, contains a line
+/// terminator. This is the legacy encoding of Enter, the end of a text
+/// binding or IME commit, and any multi-line paste; the Kitty keyboard
+/// protocol encodes Enter as `CSI 13 u` instead and is handled at the key
+/// level in `keyCallback`.
+fn submissionInBytes(data: []const u8) bool {
+    return std.mem.indexOfAny(u8, data, "\r\n") != null;
+}
+
+/// Consume the OSC 133;B input mark if `data` submits the line. See
+/// `SemanticCommand.consumeInput` for why: the mark is the shell's claim that
+/// it is reading input, and once we have sent the terminator that claim is
+/// stale until the shell renews it. `mutex` follows the `queueIo` contract.
+fn noteSubmittedInput(
+    self: *Surface,
+    data: []const u8,
+    mutex: termio.Termio.MutexState,
+) void {
+    if (!submissionInBytes(data)) return;
+    self.markInputSubmitted(mutex);
+}
+
+fn markInputSubmitted(self: *Surface, mutex: termio.Termio.MutexState) void {
+    if (mutex == .unlocked) self.renderer_state.mutex.lock();
+    defer if (mutex == .unlocked) self.renderer_state.mutex.unlock();
+    self.io.terminal.screens.active.semanticPromptInputSubmitted();
+}
+
+test "Surface: submissionInBytes recognises line terminators" {
+    const testing = std.testing;
+    try testing.expect(submissionInBytes("\r"));
+    try testing.expect(submissionInBytes("\n"));
+    try testing.expect(submissionInBytes("\x1b[200~one\ntwo\x1b[201~"));
+    try testing.expect(!submissionInBytes(""));
+    try testing.expect(!submissionInBytes("ls -la"));
+    try testing.expect(!submissionInBytes("\x1b[A"));
+    try testing.expect(!submissionInBytes("\x1b[<0;10;20M"));
 }
 
 /// Forces the surface to render. This is useful for when the surface
@@ -3366,6 +3414,15 @@ pub fn keyCallback(
             .stable => |v| .{ .write_stable = v },
             .alloc => |v| .{ .write_alloc = v },
         }, .unlocked);
+
+        // Enter submits the line whatever its encoding. The legacy `\r` is
+        // caught by `queueIo`'s byte scan; the Kitty keyboard protocol sends
+        // `CSI 13 u`, which is not, so consume the OSC 133;B mark here too.
+        if (event.action != .release and
+            (event.key == .enter or event.key == .numpad_enter))
+        {
+            self.markInputSubmitted(.unlocked);
+        }
     } else {
         // No valid request means that we didn't encode anything.
         return .ignored;
@@ -6222,7 +6279,11 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 // line of input. "No command is running" is not enough on its
                 // own: a child that emits OSC 133;A without a following B
                 // clears the running flag while still owning the pty, and we
-                // would type into that child instead of a shell prompt.
+                // would type into that child instead of a shell prompt. The
+                // mark is also consumed the moment we write a submission
+                // (`queueIo`), because an A/B-only shell such as the cmd.exe
+                // PROMPT integration emits nothing between Enter and the next
+                // prompt, and a B that survived our own Enter proves nothing.
                 if (!self.io.terminal.screens.active.semanticPromptInputPending()) {
                     log.info(
                         "insert last command ignored: no OSC 133;B input mark is outstanding",

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6195,7 +6195,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             return true;
         },
 
-        .rerun_last_command => {
+        .insert_last_command => {
             const command = command: {
                 self.renderer_state.mutex.lock();
                 defer self.renderer_state.mutex.unlock();
@@ -6205,14 +6205,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 // the bytes would land somewhere the user did not intend.
                 if (self.io.terminal.screens.active_key != .primary) {
                     log.info(
-                        "rerun last command ignored: the alternate screen is active",
+                        "insert last command ignored: the alternate screen is active",
                         .{},
                     );
                     return true;
                 }
                 if (self.io.terminal.screens.active.semanticPromptCommandRunning()) {
                     log.info(
-                        "rerun last command ignored: a command is still running",
+                        "insert last command ignored: a command is still running",
                         .{},
                     );
                     return true;
@@ -6223,35 +6223,40 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 );
             } orelse {
                 log.info(
-                    "rerun last command ignored: no recoverable complete OSC 133 B/C region is available",
+                    "insert last command ignored: no recoverable complete OSC 133 B/C region is available",
                     .{},
                 );
                 return true;
             };
             defer self.alloc.free(command);
 
-            if (!rerunCommandIsSafe(command)) {
+            if (!insertCommandIsSafe(command)) {
                 log.info(
-                    "rerun last command ignored: recovered command is empty, multiline, invalid UTF-8, or contains control characters",
+                    "insert last command ignored: recovered command is empty, multiline, invalid UTF-8, or contains control characters",
                     .{},
                 );
                 return true;
             }
 
-            const write = try self.alloc.alloc(u8, command.len + 1);
-            defer self.alloc.free(write);
-            @memcpy(write[0..command.len], command);
-            write[command.len] = '\r';
-
-            self.queueIo(try termio.Message.writeReq(
-                self.alloc,
-                write,
-            ), .unlocked);
-
-            self.renderer_state.mutex.lock();
-            defer self.renderer_state.mutex.unlock();
-            self.scrollToBottom() catch |err| {
-                log.warn("error scrolling to bottom err={}", .{err});
+            // Deliberately no trailing carriage return. OSC 133 marks carry no
+            // provenance: every byte the terminal sees is written by the child
+            // PTY, so any program that can print can also forge a complete
+            // A/B/C/D lifecycle around text of its choosing and have it
+            // retained as "the last command". Submitting that text on a single
+            // keypress would turn "display untrusted output" into "execute
+            // attacker-chosen command". We hand the text to the shell's line
+            // editor through the same encoder clipboard pastes use — bracketed
+            // when the terminal asked for it — and let the user read it and
+            // press Enter themselves.
+            self.completeClipboardPaste(command, false) catch |err| switch (err) {
+                error.UnsafePaste => {
+                    log.info(
+                        "insert last command ignored: recovered command failed paste protection",
+                        .{},
+                    );
+                    return true;
+                },
+                else => return err,
             };
 
             return true;
@@ -7363,11 +7368,13 @@ fn completeClipboardPaste(
     };
 }
 
-/// Rerun uses the same unsafe-paste detector as clipboard paste, then applies
-/// the stricter contract required for unattended command execution: one
-/// non-empty UTF-8 line with no control or Unicode line-separator characters.
-fn rerunCommandIsSafe(data: []const u8) bool {
-    if (data.len == 0 or data.len > rerun_command_max_len) return false;
+/// Insert uses the same unsafe-paste detector as clipboard paste, then applies
+/// a stricter contract than a normal paste: one non-empty UTF-8 line with no
+/// control or Unicode line-separator characters. The recovered text is never
+/// submitted for the user, but it still has to reach the prompt as exactly the
+/// one line they can see.
+fn insertCommandIsSafe(data: []const u8) bool {
+    if (data.len == 0 or data.len > insert_command_max_len) return false;
     if (!input.paste.isSafe(data)) return false;
 
     const view = std.unicode.Utf8View.init(data) catch return false;
@@ -7392,32 +7399,32 @@ fn rerunCommandIsSafe(data: []const u8) bool {
     return true;
 }
 
-/// Recovered command text longer than this is rejected rather than submitted.
+/// Recovered command text longer than this is rejected rather than inserted.
 /// A recovered line that long is far more likely to be a mis-parse than
 /// something the user actually typed.
-const rerun_command_max_len: usize = 4096;
+const insert_command_max_len: usize = 4096;
 
-test "Surface: last-command rerun safety reuses paste protection and rejects controls" {
+test "Surface: last-command insert safety reuses paste protection and rejects controls" {
     const testing = std.testing;
 
-    try testing.expect(rerunCommandIsSafe("Write-Output 'safe'"));
-    try testing.expect(!rerunCommandIsSafe(""));
-    try testing.expect(!rerunCommandIsSafe("one\ntwo"));
-    try testing.expect(!rerunCommandIsSafe("one\rtwo"));
-    try testing.expect(!rerunCommandIsSafe("one\ttwo"));
-    try testing.expect(!rerunCommandIsSafe("one\x1b[201~two"));
-    try testing.expect(!rerunCommandIsSafe("one\xC2\x85two"));
-    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA8two"));
-    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA9two"));
-    try testing.expect(!rerunCommandIsSafe("one\xC0two"));
-    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xAEtwo"));
-    try testing.expect(!rerunCommandIsSafe("one\xE2\x81\xA6two"));
-    try testing.expect(!rerunCommandIsSafe("one\xEF\xBB\xBFtwo"));
+    try testing.expect(insertCommandIsSafe("Write-Output 'safe'"));
+    try testing.expect(!insertCommandIsSafe(""));
+    try testing.expect(!insertCommandIsSafe("one\ntwo"));
+    try testing.expect(!insertCommandIsSafe("one\rtwo"));
+    try testing.expect(!insertCommandIsSafe("one\ttwo"));
+    try testing.expect(!insertCommandIsSafe("one\x1b[201~two"));
+    try testing.expect(!insertCommandIsSafe("one\xC2\x85two"));
+    try testing.expect(!insertCommandIsSafe("one\xE2\x80\xA8two"));
+    try testing.expect(!insertCommandIsSafe("one\xE2\x80\xA9two"));
+    try testing.expect(!insertCommandIsSafe("one\xC0two"));
+    try testing.expect(!insertCommandIsSafe("one\xE2\x80\xAEtwo"));
+    try testing.expect(!insertCommandIsSafe("one\xE2\x81\xA6two"));
+    try testing.expect(!insertCommandIsSafe("one\xEF\xBB\xBFtwo"));
 
-    const too_long = "e" ** (rerun_command_max_len + 1);
-    try testing.expect(!rerunCommandIsSafe(too_long));
-    const at_limit = "e" ** rerun_command_max_len;
-    try testing.expect(rerunCommandIsSafe(at_limit));
+    const too_long = "e" ** (insert_command_max_len + 1);
+    try testing.expect(!insertCommandIsSafe(too_long));
+    const at_limit = "e" ** insert_command_max_len;
+    try testing.expect(insertCommandIsSafe(at_limit));
 }
 
 fn completeClipboardReadOSC52(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6173,6 +6173,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             };
             defer self.alloc.free(output);
 
+            if (output.len == 0) {
+                log.info(
+                    "copy last command output ignored: the completed command produced no output",
+                    .{},
+                );
+                return true;
+            }
+
             self.rt_surface.setClipboard(.standard, &.{.{
                 .mime = "text/plain",
                 .data = output,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6191,6 +6191,25 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             const command = command: {
                 self.renderer_state.mutex.lock();
                 defer self.renderer_state.mutex.unlock();
+
+                // Never type into an alternate-screen program (a TUI) and
+                // never type while a command is still running: in both cases
+                // the bytes would land somewhere the user did not intend.
+                if (self.io.terminal.screens.active_key != .primary) {
+                    log.info(
+                        "rerun last command ignored: the alternate screen is active",
+                        .{},
+                    );
+                    return true;
+                }
+                if (self.io.terminal.screens.active.semanticPromptCommandRunning()) {
+                    log.info(
+                        "rerun last command ignored: a command is still running",
+                        .{},
+                    );
+                    return true;
+                }
+
                 break :command try self.io.terminal.screens.active.lastCommandString(
                     self.alloc,
                 );
@@ -7340,7 +7359,8 @@ fn completeClipboardPaste(
 /// the stricter contract required for unattended command execution: one
 /// non-empty UTF-8 line with no control or Unicode line-separator characters.
 fn rerunCommandIsSafe(data: []const u8) bool {
-    if (data.len == 0 or !input.paste.isSafe(data)) return false;
+    if (data.len == 0 or data.len > rerun_command_max_len) return false;
+    if (!input.paste.isSafe(data)) return false;
 
     const view = std.unicode.Utf8View.init(data) catch return false;
     var it = view.iterator();
@@ -7348,7 +7368,14 @@ fn rerunCommandIsSafe(data: []const u8) bool {
         if (cp < 0x20 or
             (cp >= 0x7F and cp <= 0x9F) or
             cp == 0x2028 or
-            cp == 0x2029)
+            cp == 0x2029 or
+            // Bidi and other invisible formatting controls: they can make the
+            // command the user sees differ from the command that runs.
+            (cp >= 0x200B and cp <= 0x200F) or
+            (cp >= 0x202A and cp <= 0x202E) or
+            (cp >= 0x2060 and cp <= 0x2064) or
+            (cp >= 0x2066 and cp <= 0x2069) or
+            cp == 0xFEFF)
         {
             return false;
         }
@@ -7356,6 +7383,11 @@ fn rerunCommandIsSafe(data: []const u8) bool {
 
     return true;
 }
+
+/// Recovered command text longer than this is rejected rather than submitted.
+/// A recovered line that long is far more likely to be a mis-parse than
+/// something the user actually typed.
+const rerun_command_max_len: usize = 4096;
 
 test "Surface: last-command rerun safety reuses paste protection and rejects controls" {
     const testing = std.testing;
@@ -7370,6 +7402,14 @@ test "Surface: last-command rerun safety reuses paste protection and rejects con
     try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA8two"));
     try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA9two"));
     try testing.expect(!rerunCommandIsSafe("one\xC0two"));
+    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xAEtwo"));
+    try testing.expect(!rerunCommandIsSafe("one\xE2\x81\xA6two"));
+    try testing.expect(!rerunCommandIsSafe("one\xEF\xBB\xBFtwo"));
+
+    const too_long = "e" ** (rerun_command_max_len + 1);
+    try testing.expect(!rerunCommandIsSafe(too_long));
+    const at_limit = "e" ** rerun_command_max_len;
+    try testing.expect(rerunCommandIsSafe(at_limit));
 }
 
 fn completeClipboardReadOSC52(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6218,6 +6218,19 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                     return true;
                 }
 
+                // Only write into something that has told us it is reading a
+                // line of input. "No command is running" is not enough on its
+                // own: a child that emits OSC 133;A without a following B
+                // clears the running flag while still owning the pty, and we
+                // would type into that child instead of a shell prompt.
+                if (!self.io.terminal.screens.active.semanticPromptInputPending()) {
+                    log.info(
+                        "insert last command ignored: no OSC 133;B input mark is outstanding",
+                        .{},
+                    );
+                    return true;
+                }
+
                 break :command try self.io.terminal.screens.active.lastCommandString(
                     self.alloc,
                 );

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -6158,6 +6158,78 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             return true;
         },
 
+        .copy_last_command_output => {
+            self.renderer_state.mutex.lock();
+            defer self.renderer_state.mutex.unlock();
+
+            const output = try self.io.terminal.screens.active.lastCommandOutputString(
+                self.alloc,
+            ) orelse {
+                log.info(
+                    "copy last command output ignored: no complete OSC 133 C/D region is available",
+                    .{},
+                );
+                return true;
+            };
+            defer self.alloc.free(output);
+
+            self.rt_surface.setClipboard(.standard, &.{.{
+                .mime = "text/plain",
+                .data = output,
+            }}, false) catch |err| {
+                log.err("error copying last command output err={}", .{err});
+                return false;
+            };
+
+            if (self.config.app_notifications.@"clipboard-copy") {
+                try self.showAppNotification("noctty", "Copied last command output to clipboard");
+            }
+            return true;
+        },
+
+        .rerun_last_command => {
+            const command = command: {
+                self.renderer_state.mutex.lock();
+                defer self.renderer_state.mutex.unlock();
+                break :command try self.io.terminal.screens.active.lastCommandString(
+                    self.alloc,
+                );
+            } orelse {
+                log.info(
+                    "rerun last command ignored: no recoverable complete OSC 133 B/C region is available",
+                    .{},
+                );
+                return true;
+            };
+            defer self.alloc.free(command);
+
+            if (!rerunCommandIsSafe(command)) {
+                log.info(
+                    "rerun last command ignored: recovered command is empty, multiline, invalid UTF-8, or contains control characters",
+                    .{},
+                );
+                return true;
+            }
+
+            const write = try self.alloc.alloc(u8, command.len + 1);
+            defer self.alloc.free(write);
+            @memcpy(write[0..command.len], command);
+            write[command.len] = '\r';
+
+            self.queueIo(try termio.Message.writeReq(
+                self.alloc,
+                write,
+            ), .unlocked);
+
+            self.renderer_state.mutex.lock();
+            defer self.renderer_state.mutex.unlock();
+            self.scrollToBottom() catch |err| {
+                log.warn("error scrolling to bottom err={}", .{err});
+            };
+
+            return true;
+        },
+
         .copy_url_to_clipboard => {
             // If the mouse isn't over a link, nothing we can do.
             if (!self.mouse.over_link) return false;
@@ -7262,6 +7334,42 @@ fn completeClipboardPaste(
             vec,
         ), .unlocked);
     };
+}
+
+/// Rerun uses the same unsafe-paste detector as clipboard paste, then applies
+/// the stricter contract required for unattended command execution: one
+/// non-empty UTF-8 line with no control or Unicode line-separator characters.
+fn rerunCommandIsSafe(data: []const u8) bool {
+    if (data.len == 0 or !input.paste.isSafe(data)) return false;
+
+    const view = std.unicode.Utf8View.init(data) catch return false;
+    var it = view.iterator();
+    while (it.nextCodepoint()) |cp| {
+        if (cp < 0x20 or
+            (cp >= 0x7F and cp <= 0x9F) or
+            cp == 0x2028 or
+            cp == 0x2029)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+test "Surface: last-command rerun safety reuses paste protection and rejects controls" {
+    const testing = std.testing;
+
+    try testing.expect(rerunCommandIsSafe("Write-Output 'safe'"));
+    try testing.expect(!rerunCommandIsSafe(""));
+    try testing.expect(!rerunCommandIsSafe("one\ntwo"));
+    try testing.expect(!rerunCommandIsSafe("one\rtwo"));
+    try testing.expect(!rerunCommandIsSafe("one\ttwo"));
+    try testing.expect(!rerunCommandIsSafe("one\x1b[201~two"));
+    try testing.expect(!rerunCommandIsSafe("one\xC2\x85two"));
+    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA8two"));
+    try testing.expect(!rerunCommandIsSafe("one\xE2\x80\xA9two"));
+    try testing.expect(!rerunCommandIsSafe("one\xC0two"));
 }
 
 fn completeClipboardReadOSC52(

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6537,6 +6537,18 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .page_down }, .mods = .{ .shift = true, .ctrl = true } },
                 .{ .jump_to_prompt = 1 },
             );
+            if (comptime builtin.target.os.tag == .windows) {
+                try self.set.put(
+                    alloc,
+                    .{ .key = .{ .unicode = 'y' }, .mods = .{ .shift = true, .ctrl = true } },
+                    .{ .copy_last_command_output = {} },
+                );
+                try self.set.put(
+                    alloc,
+                    .{ .key = .{ .unicode = 'r' }, .mods = .{ .shift = true, .ctrl = true } },
+                    .{ .rerun_last_command = {} },
+                );
+            }
 
             // Search
             try self.set.putFlags(
@@ -7769,6 +7781,45 @@ pub const Keybinds = struct {
                 .mods = .{ .ctrl = true, .alt = true },
                 .key = .{ .physical = case.key },
             }) == null);
+        }
+    }
+
+    test "Windows last-command defaults preserve prompt navigation without conflicts" {
+        if (builtin.target.os.tag != .windows) return error.SkipZigTest;
+
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+
+        var keybinds: Keybinds = .{};
+        try keybinds.init(arena.allocator());
+
+        const cases = [_]struct {
+            trigger: inputpkg.Binding.Trigger,
+            action: inputpkg.Binding.Action,
+        }{
+            .{
+                .trigger = .{ .key = .{ .physical = .page_up }, .mods = .{ .shift = true, .ctrl = true } },
+                .action = .{ .jump_to_prompt = -1 },
+            },
+            .{
+                .trigger = .{ .key = .{ .physical = .page_down }, .mods = .{ .shift = true, .ctrl = true } },
+                .action = .{ .jump_to_prompt = 1 },
+            },
+            .{
+                .trigger = .{ .key = .{ .unicode = 'y' }, .mods = .{ .shift = true, .ctrl = true } },
+                .action = .copy_last_command_output,
+            },
+            .{
+                .trigger = .{ .key = .{ .unicode = 'r' }, .mods = .{ .shift = true, .ctrl = true } },
+                .action = .rerun_last_command,
+            },
+        };
+
+        for (cases) |case| {
+            const entry = keybinds.set.get(case.trigger).?.value_ptr.*;
+            try testing.expect(entry == .leaf);
+            try testing.expectEqual(case.action, entry.leaf.action);
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6537,8 +6537,8 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .page_down }, .mods = .{ .shift = true, .ctrl = true } },
                 .{ .jump_to_prompt = 1 },
             );
-            // `rerun_last_command` deliberately has no default binding: it
-            // submits a command, and `ctrl+shift+r` is the chord our own
+            // `insert_last_command` deliberately has no default binding:
+            // `ctrl+shift+r`, the obvious chord for it, is what our own
             // getting-started guide shows users rebinding to reload_config.
             // It stays available from the command palette and user keybinds.
             if (comptime builtin.target.os.tag == .windows) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6537,16 +6537,15 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .page_down }, .mods = .{ .shift = true, .ctrl = true } },
                 .{ .jump_to_prompt = 1 },
             );
+            // `rerun_last_command` deliberately has no default binding: it
+            // submits a command, and `ctrl+shift+r` is the chord our own
+            // getting-started guide shows users rebinding to reload_config.
+            // It stays available from the command palette and user keybinds.
             if (comptime builtin.target.os.tag == .windows) {
                 try self.set.put(
                     alloc,
                     .{ .key = .{ .unicode = 'y' }, .mods = .{ .shift = true, .ctrl = true } },
                     .{ .copy_last_command_output = {} },
-                );
-                try self.set.put(
-                    alloc,
-                    .{ .key = .{ .unicode = 'r' }, .mods = .{ .shift = true, .ctrl = true } },
-                    .{ .rerun_last_command = {} },
                 );
             }
 
@@ -7810,10 +7809,6 @@ pub const Keybinds = struct {
                 .trigger = .{ .key = .{ .unicode = 'y' }, .mods = .{ .shift = true, .ctrl = true } },
                 .action = .copy_last_command_output,
             },
-            .{
-                .trigger = .{ .key = .{ .unicode = 'r' }, .mods = .{ .shift = true, .ctrl = true } },
-                .action = .rerun_last_command,
-            },
         };
 
         for (cases) |case| {
@@ -7821,6 +7816,12 @@ pub const Keybinds = struct {
             try testing.expect(entry == .leaf);
             try testing.expectEqual(case.action, entry.leaf.action);
         }
+
+        // Rerun is palette-only by default and must not claim ctrl+shift+r.
+        try testing.expect(keybinds.set.get(.{
+            .key = .{ .unicode = 'r' },
+            .mods = .{ .shift = true, .ctrl = true },
+        }) == null);
     }
 
     test "clone with tables" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -349,6 +349,14 @@ pub const Action = union(enum) {
     /// Copy the selected text to the clipboard.
     copy_to_clipboard: CopyToClipboard,
 
+    /// Copy the output of the most recent command completed by shell
+    /// integration to the default clipboard.
+    copy_last_command_output,
+
+    /// Re-run the most recent single-line command recoverable from shell
+    /// integration. This never reads or modifies the shell's line editor.
+    rerun_last_command,
+
     /// Paste the contents of the default clipboard.
     paste_from_clipboard,
 
@@ -1366,6 +1374,8 @@ pub const Action = union(enum) {
             .end_search,
             .reset,
             .copy_to_clipboard,
+            .copy_last_command_output,
+            .rerun_last_command,
             .copy_url_to_clipboard,
             .copy_title_to_clipboard,
             .paste_from_clipboard,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -353,9 +353,14 @@ pub const Action = union(enum) {
     /// integration to the default clipboard.
     copy_last_command_output,
 
-    /// Re-run the most recent single-line command recoverable from shell
-    /// integration. This never reads or modifies the shell's line editor.
-    rerun_last_command,
+    /// Insert the most recent single-line command recoverable from shell
+    /// integration at the shell's prompt, without submitting it. This never
+    /// reads or modifies the shell's line editor, and it deliberately does
+    /// not press Enter for you: OSC 133 marks are emitted by whatever is
+    /// writing to the terminal, so any program that produces output can forge
+    /// a command lifecycle. You review what lands on the prompt and submit it
+    /// yourself.
+    insert_last_command,
 
     /// Paste the contents of the default clipboard.
     paste_from_clipboard,
@@ -1375,7 +1380,7 @@ pub const Action = union(enum) {
             .reset,
             .copy_to_clipboard,
             .copy_last_command_output,
-            .rerun_last_command,
+            .insert_last_command,
             .copy_url_to_clipboard,
             .copy_title_to_clipboard,
             .paste_from_clipboard,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -159,6 +159,18 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Copy the selected text as HTML to the clipboard.",
         } },
 
+        .copy_last_command_output => comptime &.{.{
+            .action = .copy_last_command_output,
+            .title = "Copy Last Command Output",
+            .description = "Copy the output of the most recent completed command to the clipboard. Requires OSC 133 shell integration.",
+        }},
+
+        .rerun_last_command => comptime &.{.{
+            .action = .rerun_last_command,
+            .title = "Rerun Last Command",
+            .description = "Run the most recent recoverable single-line command again. Requires OSC 133 B/C command marks.",
+        }},
+
         .copy_url_to_clipboard => comptime &.{.{
             .action = .copy_url_to_clipboard,
             .title = "Copy URL to Clipboard",
@@ -524,6 +536,19 @@ fn actionCommands(action: Action.Key) []const Command {
             },
         },
 
+        .jump_to_prompt => comptime &.{
+            .{
+                .action = .{ .jump_to_prompt = -1 },
+                .title = "Jump to Previous Prompt",
+                .description = "Jump to the previous shell prompt.",
+            },
+            .{
+                .action = .{ .jump_to_prompt = 1 },
+                .title = "Jump to Next Prompt",
+                .description = "Jump to the next shell prompt.",
+            },
+        },
+
         .goto_window => comptime &.{
             .{
                 .action = .{ .goto_window = .previous },
@@ -729,7 +754,6 @@ fn actionCommands(action: Action.Key) []const Command {
         .scroll_page_fractional,
         .scroll_page_lines,
         .adjust_selection,
-        .jump_to_prompt,
         .write_scrollback_file,
         .goto_tab,
         .resize_split,
@@ -791,4 +815,22 @@ test "command defaults expose exactly one elevated window action" {
         }
     }
     try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+test "command defaults expose last-command and prompt navigation verbs" {
+    const expected = [_]Action{
+        .{ .jump_to_prompt = -1 },
+        .{ .jump_to_prompt = 1 },
+        .copy_last_command_output,
+        .rerun_last_command,
+    };
+    var found = [_]bool{false} ** expected.len;
+
+    for (defaults) |cmd| {
+        for (expected, 0..) |action, i| {
+            if (cmd.action.equal(action)) found[i] = true;
+        }
+    }
+
+    for (found) |value| try std.testing.expect(value);
 }

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -165,10 +165,10 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = "Copy the output of the most recent completed command to the clipboard. Requires OSC 133 shell integration.",
         }},
 
-        .rerun_last_command => comptime &.{.{
-            .action = .rerun_last_command,
-            .title = "Rerun Last Command",
-            .description = "Run the most recent recoverable single-line command again. Requires OSC 133 B/C command marks.",
+        .insert_last_command => comptime &.{.{
+            .action = .insert_last_command,
+            .title = "Insert Last Command",
+            .description = "Put the most recent recoverable single-line command back on the prompt without submitting it. Requires OSC 133 B/C command marks.",
         }},
 
         .copy_url_to_clipboard => comptime &.{.{
@@ -822,7 +822,7 @@ test "command defaults expose last-command and prompt navigation verbs" {
         .{ .jump_to_prompt = -1 },
         .{ .jump_to_prompt = 1 },
         .copy_last_command_output,
-        .rerun_last_command,
+        .insert_last_command,
     };
     var found = [_]bool{false} ** expected.len;
 

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -13,6 +13,7 @@ const tripwire = @import("../tripwire.zig");
 const unicode = @import("../unicode/main.zig");
 const Selection = @import("Selection.zig");
 const PageList = @import("PageList.zig");
+const SemanticCommand = @import("semantic_command.zig");
 const StringMap = @import("StringMap.zig");
 const ScreenFormatter = @import("formatter.zig").ScreenFormatter;
 const osc = @import("osc.zig");
@@ -77,6 +78,9 @@ else
 /// Semantic prompt (OSC133) state.
 semantic_prompt: SemanticPrompt = .disabled,
 
+/// Recoverable completed-command state derived from OSC 133 marks.
+semantic_command: SemanticCommand = .{},
+
 /// Dirty flags for the renderer.
 dirty: Dirty = .{},
 
@@ -105,29 +109,9 @@ pub const SemanticPrompt = struct {
     /// prompt is handling.
     click: SemanticClick,
 
-    /// Prompt whose input has started with OSC 133;B/I but whose output has
-    /// not started yet. This pin is tracked so reflow and scrolling keep it
-    /// valid until the command starts or the region is trimmed.
-    pending_command: ?*Pin,
-
-    /// Prompt whose command has emitted OSC 133;C but not OSC 133;D.
-    active_command: ?*Pin,
-
-    /// Most recent command with a complete OSC 133;B..C..D lifecycle.
-    last_command: ?CompletedCommand,
-
     pub const disabled: SemanticPrompt = .{
         .seen = false,
         .click = .none,
-        .pending_command = null,
-        .active_command = null,
-        .last_command = null,
-    };
-
-    pub const CompletedCommand = struct {
-        prompt: *Pin,
-        /// Inclusive last output cell at OSC 133;D, or null for empty output.
-        output_end: ?*Pin,
     };
 
     pub const SemanticClick = union(enum) {
@@ -342,7 +326,7 @@ pub fn deinit(self: *Screen) void {
     if (comptime build_options.kitty_graphics) {
         self.kitty_images.deinit(self.alloc, self);
     }
-    self.clearSemanticPromptCommandState();
+    self.semantic_command.deinit(&self.pages);
     self.cursor.deinit(self.alloc);
     self.pages.deinit();
 }
@@ -386,7 +370,7 @@ pub fn assertIntegrity(self: *const Screen) void {
 /// - Disables protection mode
 ///
 pub fn reset(self: *Screen) void {
-    self.clearSemanticPromptCommandState();
+    self.semantic_command.deinit(&self.pages);
 
     // Reset our pages
     self.pages.reset();
@@ -417,6 +401,7 @@ pub fn reset(self: *Screen) void {
     self.kitty_keyboard = .{};
     self.protected_mode = .off;
     self.semantic_prompt = .disabled;
+    self.semantic_command = .{};
     self.clearSelection();
 }
 
@@ -816,7 +801,7 @@ pub fn cursorDownScroll(self: *Screen) !void {
 
     // If we have no scrollback, then we shift all our rows instead.
     if (self.no_scrollback) {
-        self.semanticPromptEraseActiveTopRow();
+        self.semantic_command.invalidateActiveTopRow(&self.pages);
 
         // If we have a single-row screen, we have no rows to shift
         // so our cursor is in the correct place we just have to clear
@@ -1332,6 +1317,11 @@ pub inline fn eraseHistory(
     bl: ?point.Point,
 ) void {
     defer self.assertIntegrity();
+    self.semantic_command.invalidateRange(
+        &self.pages,
+        .{ .history = .{} },
+        bl,
+    );
     self.pages.eraseHistory(bl);
     self.cursorReload();
 }
@@ -1341,6 +1331,11 @@ pub inline fn eraseActive(
     y: size.CellCountInt,
 ) void {
     defer self.assertIntegrity();
+    self.semantic_command.invalidateRange(
+        &self.pages,
+        .{ .active = .{} },
+        .{ .active = .{ .y = y } },
+    );
     self.pages.eraseActive(y);
     self.cursorReload();
 }
@@ -1359,7 +1354,7 @@ pub fn clearRows(
 ) void {
     defer self.assertIntegrity();
 
-    self.semanticPromptInvalidateRange(tl, bl);
+    self.semantic_command.invalidateRange(&self.pages, tl, bl);
 
     var it = self.pages.pageIterator(.right_down, tl, bl);
     while (it.next()) |chunk| {
@@ -1790,6 +1785,7 @@ pub inline fn resize(
     // erase our history. This is because PageList always keeps at least
     // a page size of history.
     if (self.no_scrollback) {
+        self.semantic_command.invalidateRange(&self.pages, .{ .history = .{} }, null);
         self.pages.eraseHistory(null);
     }
 
@@ -2421,153 +2417,40 @@ pub fn cursorSetSemanticContent(self: *Screen, t: union(enum) {
 /// prompt instead of scraping the cursor line so later extraction can use the
 /// semantic-content boundaries maintained by PageList.
 pub fn semanticPromptStartInput(self: *Screen) Allocator.Error!void {
-    self.clearPendingCommand();
-    self.clearActiveCommand();
-
-    if (!self.semantic_prompt.seen) return;
-    var it = self.cursor.page_pin.*.promptIterator(.left_up, null);
-    const prompt = it.next() orelse return;
-
-    // A shell that redraws in place can start new input on the very row the
-    // last completed command was recorded against. Retaining that record
-    // would let extraction read the line the user is typing right now.
-    if (self.semantic_prompt.last_command) |command| {
-        if (command.prompt.*.eql(prompt)) self.clearLastCommand();
-    }
-
-    self.semantic_prompt.pending_command = try self.pages.trackPin(prompt);
+    return self.semantic_command.startInput(
+        &self.pages,
+        self.semantic_prompt.seen,
+        self.cursor.page_pin.*,
+    );
 }
 
 /// Record OSC 133;C. Prefer the prompt tracked by OSC 133;B/I, but preserve
 /// C..D output recovery even when the shell omitted the input mark.
 pub fn semanticPromptStartOutput(self: *Screen) Allocator.Error!void {
-    self.clearActiveCommand();
-    if (self.semantic_prompt.pending_command) |prompt| {
-        self.semantic_prompt.active_command = prompt;
-        self.semantic_prompt.pending_command = null;
-        return;
-    }
-
-    if (!self.semantic_prompt.seen) return;
-    var it = self.cursor.page_pin.*.promptIterator(.left_up, null);
-    const prompt = it.next() orelse return;
-    self.semantic_prompt.active_command = try self.pages.trackPin(prompt);
+    return self.semantic_command.startOutput(
+        &self.pages,
+        self.semantic_prompt.seen,
+        self.cursor.page_pin.*,
+    );
 }
 
 /// Record OSC 133;D and freeze the completed command's output endpoint.
 pub fn semanticPromptEndCommand(self: *Screen) Allocator.Error!void {
-    const prompt = self.semantic_prompt.active_command orelse return;
-    if (!semanticPromptPinIsValid(prompt)) {
-        self.clearActiveCommand();
-        return;
-    }
-
-    // `highlightSemanticContent` scans to the next prompt (or the bottom of
-    // the screen), so on its own it can run past the D cursor and pick up
-    // stale rows. Clamp to the last text cell at or before the D cursor.
-    const output_end = if (self.pages.highlightSemanticContent(prompt.*, .output)) |hl| end: {
-        const cursor_pin = self.cursor.page_pin.*;
-        if (!cursor_pin.before(hl.end)) break :end try self.pages.trackPin(hl.end);
-
-        var clamped = hl.start;
-        var cell_it = cursor_pin.cellIterator(.left_up, hl.start);
-        while (cell_it.next()) |p| {
-            clamped = p;
-            if (p.rowAndCell().cell.hasText()) break;
-        }
-        break :end try self.pages.trackPin(clamped);
-    } else null;
-    errdefer if (output_end) |pin| self.pages.untrackPin(pin);
-
-    self.clearLastCommand();
-    self.semantic_prompt.last_command = .{
-        .prompt = prompt,
-        .output_end = output_end,
-    };
-    self.semantic_prompt.active_command = null;
+    return self.semantic_command.endCommand(
+        &self.pages,
+        self.cursor.page_pin.*,
+    );
 }
 
 /// True while a command has emitted OSC 133;C but not yet OSC 133;D, i.e. the
 /// shell is busy running something rather than sitting at an idle prompt.
 pub fn semanticPromptCommandRunning(self: *const Screen) bool {
-    return self.semantic_prompt.active_command != null;
+    return self.semantic_command.commandRunning();
 }
 
 /// Discard B/C state when a new prompt begins without a completing D mark.
 pub fn semanticPromptAbortCommand(self: *Screen) void {
-    self.clearPendingCommand();
-    self.clearActiveCommand();
-}
-
-fn clearPendingCommand(self: *Screen) void {
-    if (self.semantic_prompt.pending_command) |pin| self.pages.untrackPin(pin);
-    self.semantic_prompt.pending_command = null;
-}
-
-fn clearActiveCommand(self: *Screen) void {
-    if (self.semantic_prompt.active_command) |pin| self.pages.untrackPin(pin);
-    self.semantic_prompt.active_command = null;
-}
-
-fn clearLastCommand(self: *Screen) void {
-    if (self.semantic_prompt.last_command) |command| {
-        self.pages.untrackPin(command.prompt);
-        if (command.output_end) |pin| self.pages.untrackPin(pin);
-    }
-    self.semantic_prompt.last_command = null;
-}
-
-/// Drop any retained command whose tracked pins lie inside a region that is
-/// about to be erased. Without this a stale pin silently "revalidates" once a
-/// later prompt reuses the same physical row.
-fn semanticPromptInvalidateRange(
-    self: *Screen,
-    tl: point.Point,
-    bl: ?point.Point,
-) void {
-    if (!self.semantic_prompt.seen) return;
-
-    const top = self.pages.pin(tl) orelse return;
-    const bottom = if (bl) |pt|
-        self.pages.pin(pt) orelse return
-    else
-        self.pages.getBottomRight(tl) orelse return;
-
-    if (self.semantic_prompt.pending_command) |pin| {
-        if (pin.*.isBetween(top, bottom)) self.clearPendingCommand();
-    }
-    if (self.semantic_prompt.active_command) |pin| {
-        if (pin.*.isBetween(top, bottom)) self.clearActiveCommand();
-    }
-    if (self.semantic_prompt.last_command) |command| {
-        const hit = command.prompt.*.isBetween(top, bottom) or
-            if (command.output_end) |pin| pin.*.isBetween(top, bottom) else false;
-        if (hit) self.clearLastCommand();
-    }
-}
-
-fn clearSemanticPromptCommandState(self: *Screen) void {
-    self.clearPendingCommand();
-    self.clearActiveCommand();
-    self.clearLastCommand();
-}
-
-/// With scrollback disabled, PageList shifts active rows in place rather than
-/// pruning a page, so tracked pins are not marked garbage. Clear any command
-/// whose prompt row is about to be erased before the shift can retarget it.
-fn semanticPromptEraseActiveTopRow(self: *Screen) void {
-    if (!self.semantic_prompt.seen) return;
-    const top = self.pages.getTopLeft(.active);
-
-    if (self.semantic_prompt.pending_command) |pin| {
-        if (pin.*.eql(top)) self.clearPendingCommand();
-    }
-    if (self.semantic_prompt.active_command) |pin| {
-        if (pin.*.eql(top)) self.clearActiveCommand();
-    }
-    if (self.semantic_prompt.last_command) |command| {
-        if (command.prompt.*.eql(top)) self.clearLastCommand();
-    }
+    self.semantic_command.abortCommand(&self.pages);
 }
 
 /// Set the selection to the given selection. If this is a tracked selection
@@ -3102,20 +2985,14 @@ pub fn lastCommandOutputString(
     self: *Screen,
     alloc: Allocator,
 ) Allocator.Error!?[:0]const u8 {
-    const command = self.lastCompletedCommand() orelse return null;
-
-    const output_end = command.output_end orelse
-        return try alloc.dupeZ(u8, "");
-    if (output_end.garbage) return null;
-
-    const hl = self.pages.highlightSemanticContent(
-        command.prompt.*,
-        .output,
-    ) orelse return null;
-    if (!output_end.*.isBetween(hl.start, hl.end)) return null;
+    const region = switch (self.semantic_command.outputRegion(&self.pages)) {
+        .unavailable => return null,
+        .empty => return try alloc.dupeZ(u8, ""),
+        .region => |region| region,
+    };
 
     return try self.selectionString(alloc, .{
-        .sel = .init(hl.start, output_end.*, false),
+        .sel = .init(region.start, region.end, false),
         .trim = false,
     });
 }
@@ -3126,35 +3003,13 @@ pub fn lastCommandString(
     self: *Screen,
     alloc: Allocator,
 ) Allocator.Error!?[:0]const u8 {
-    const command = self.lastCompletedCommand() orelse return null;
-
-    const hl = self.pages.highlightSemanticContent(
-        command.prompt.*,
-        .input,
-    ) orelse return null;
+    const region = self.semantic_command.inputRegion(&self.pages) orelse
+        return null;
 
     return try self.selectionString(alloc, .{
-        .sel = .init(hl.start, hl.end, false),
-        .trim = false,
+        .sel = .init(region.start, region.end, false),
+        .trim = true,
     });
-}
-
-fn lastCompletedCommand(self: *const Screen) ?SemanticPrompt.CompletedCommand {
-    const command = self.semantic_prompt.last_command orelse return null;
-    if (!semanticPromptPinIsValid(command.prompt)) return null;
-
-    return command;
-}
-
-fn semanticPromptPinIsValid(pin: *const Pin) bool {
-    if (pin.garbage) return false;
-
-    // PageList callers require a real semantic prompt row before invoking
-    // promptIterator/highlightSemanticContent.
-    return switch (pin.rowAndCell().row.semantic_prompt) {
-        .prompt, .prompt_continuation => true,
-        .none => false,
-    };
 }
 
 pub const LineIterator = struct {
@@ -10620,7 +10475,7 @@ test "Screen: last-command extracts most recent completed semantic regions" {
     try s.testWriteString("PS> ");
     s.cursorSetSemanticContent(.{ .input = .clear_explicit });
     try s.semanticPromptStartInput();
-    try s.testWriteString("Write-Output second");
+    try s.testWriteString("  Write-Output second   ");
     s.cursorSetSemanticContent(.output);
     try s.semanticPromptStartOutput();
     try s.testWriteString("\nsecond output\nsecond line");
@@ -10635,7 +10490,7 @@ test "Screen: last-command extracts most recent completed semantic regions" {
 
     const command = (try s.lastCommandString(alloc)).?;
     defer alloc.free(command);
-    try testing.expectEqualStrings("Write-Output second", command);
+    try testing.expectEqualStrings("  Write-Output second", command);
 }
 
 test "Screen: last-command has no region without shell integration or D" {
@@ -10706,45 +10561,212 @@ test "Screen: last-command copies C/D output without B input" {
     try testing.expect((try s.lastCommandString(alloc)) == null);
 }
 
-test "Screen: last-command is dropped when its rows are erased" {
+fn testExpectLastCommandUnavailable(
+    self: *Screen,
+    alloc: Allocator,
+) !void {
+    const command = try self.lastCommandString(alloc);
+    defer if (command) |value| alloc.free(value);
+    try std.testing.expect(command == null);
+
+    const output = try self.lastCommandOutputString(alloc);
+    defer if (output) |value| alloc.free(value);
+    try std.testing.expect(output == null);
+}
+
+test "Screen: last-command ED2 drops a record whose output endpoint is erased" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    var s = try init(alloc, .{ .cols = 30, .rows = 6, .max_scrollback = 0 });
+    var s = try init(alloc, .{ .cols = 30, .rows = 3, .max_scrollback = 1000 });
     defer s.deinit();
 
     s.cursorSetSemanticContent(.{ .prompt = .initial });
     try s.testWriteString("PS> ");
     s.cursorSetSemanticContent(.{ .input = .clear_explicit });
     try s.semanticPromptStartInput();
-    try s.testWriteString("echo done");
+    try s.testWriteString("echo old");
     s.cursorSetSemanticContent(.output);
     try s.semanticPromptStartOutput();
-    try s.testWriteString("\ndone");
+    try s.testWriteString("\nold");
     try s.semanticPromptEndCommand();
+
+    // Scroll once so the valid prompt/input is in history while the tracked
+    // output endpoint remains in the active display that ED2 will clear.
+    try s.testWriteString("\n\n");
 
     {
         const command = (try s.lastCommandString(alloc)).?;
         defer alloc.free(command);
-        try testing.expectEqualStrings("echo done", command);
+        try testing.expectEqualStrings("echo old", command);
     }
 
-    // ED2 wipes the recorded rows; the record must not survive to be revived
-    // by whatever prompt reuses those rows next.
+    // Query before any new prompt exists so only range invalidation can make
+    // this unavailable; the same-row redraw guard cannot mask a missing hook.
     s.clearRows(.{ .active = .{} }, null, false);
-    try testing.expect((try s.lastCommandString(alloc)) == null);
-    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testExpectLastCommandUnavailable(&s, alloc);
+}
 
-    // A new prompt reusing the same physical rows must not resurrect it.
+test "Screen: last-command middle-row erase drops the completed span" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo lines");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\none\ntwo\nthree");
+    try s.semanticPromptEndCommand();
+
+    // The prompt and output endpoint remain intact, but erasing a row inside
+    // the recovered C..D span must invalidate the whole saved command.
+    s.clearRows(
+        .{ .active = .{ .y = 2 } },
+        .{ .active = .{ .y = 2 } },
+        false,
+    );
+    try testExpectLastCommandUnavailable(&s, alloc);
+}
+
+test "Screen: last-command same-row redraw drops the completed record" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 3, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo old");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.semanticPromptEndCommand();
+
+    // Start new input on the recorded prompt row without erasing anything.
     s.cursorAbsolute(0, 0);
     s.cursorSetSemanticContent(.{ .prompt = .initial });
     try s.testWriteString("PS> ");
     s.cursorSetSemanticContent(.{ .input = .clear_explicit });
     try s.semanticPromptStartInput();
-    try s.testWriteString("secret being typed");
+    try s.testWriteString("rm -rf secret");
 
-    try testing.expect((try s.lastCommandString(alloc)) == null);
-    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testExpectLastCommandUnavailable(&s, alloc);
+}
+
+test "Screen: last-command history erase cannot retarget a completed prompt" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 3, .max_scrollback = 1000 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo old");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nold");
+    try s.semanticPromptEndCommand();
+
+    // Scroll both retained pins into history, then type but do not submit a
+    // new command at active row zero.
+    try s.testWriteString("\n\n\n");
+    s.cursorAbsolute(0, 0);
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("rm -rf secret");
+
+    // PageList relocates erased pins to the top of the surviving page. Screen
+    // must invalidate first so the old record cannot land on current input.
+    s.eraseHistory(null);
+    try testExpectLastCommandUnavailable(&s, alloc);
+}
+
+test "Screen: last-command active erase cannot retarget a completed prompt" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 3, .max_scrollback = 1000 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo old");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nold");
+    try s.semanticPromptEndCommand();
+
+    // Type but do not submit a new command below the completed record.
+    s.cursorAbsolute(0, 2);
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("rm -rf secret");
+
+    // Erasing rows zero and one shifts current input to row zero. The old
+    // prompt pin must be invalidated before PageList can retarget it there.
+    s.eraseActive(1);
+    try testExpectLastCommandUnavailable(&s, alloc);
+}
+
+test "Screen: last-command no-scrollback row shrink cannot retarget a completed prompt" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 3, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // Complete a command across rows zero and one.
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo old");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    s.cursorAbsolute(0, 1);
+    try s.testWriteString("old");
+    try s.semanticPromptEndCommand();
+
+    // Type but do not submit a new command on the row that will survive.
+    s.cursorAbsolute(0, 2);
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("rm -rf secret");
+
+    {
+        const command = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(command);
+        try testing.expectEqualStrings("echo old", command);
+    }
+
+    // Row shrink creates history that the no-scrollback path erases directly.
+    // Invalidate before PageList can retarget the completed pins to current input.
+    try s.resize(.{
+        .cols = 30,
+        .rows = 1,
+        .reflow = false,
+        .prompt_redraw = .false,
+    });
+    try testExpectLastCommandUnavailable(&s, alloc);
 }
 
 test "Screen: last-command output stops at the D cursor" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1359,6 +1359,8 @@ pub fn clearRows(
 ) void {
     defer self.assertIntegrity();
 
+    self.semanticPromptInvalidateRange(tl, bl);
+
     var it = self.pages.pageIterator(.right_down, tl, bl);
     while (it.next()) |chunk| {
         for (chunk.rows()) |*row| {
@@ -2425,6 +2427,14 @@ pub fn semanticPromptStartInput(self: *Screen) Allocator.Error!void {
     if (!self.semantic_prompt.seen) return;
     var it = self.cursor.page_pin.*.promptIterator(.left_up, null);
     const prompt = it.next() orelse return;
+
+    // A shell that redraws in place can start new input on the very row the
+    // last completed command was recorded against. Retaining that record
+    // would let extraction read the line the user is typing right now.
+    if (self.semantic_prompt.last_command) |command| {
+        if (command.prompt.*.eql(prompt)) self.clearLastCommand();
+    }
+
     self.semantic_prompt.pending_command = try self.pages.trackPin(prompt);
 }
 
@@ -2452,10 +2462,21 @@ pub fn semanticPromptEndCommand(self: *Screen) Allocator.Error!void {
         return;
     }
 
-    const output_end = if (self.pages.highlightSemanticContent(prompt.*, .output)) |hl|
-        try self.pages.trackPin(hl.end)
-    else
-        null;
+    // `highlightSemanticContent` scans to the next prompt (or the bottom of
+    // the screen), so on its own it can run past the D cursor and pick up
+    // stale rows. Clamp to the last text cell at or before the D cursor.
+    const output_end = if (self.pages.highlightSemanticContent(prompt.*, .output)) |hl| end: {
+        const cursor_pin = self.cursor.page_pin.*;
+        if (!cursor_pin.before(hl.end)) break :end try self.pages.trackPin(hl.end);
+
+        var clamped = hl.start;
+        var cell_it = cursor_pin.cellIterator(.left_up, hl.start);
+        while (cell_it.next()) |p| {
+            clamped = p;
+            if (p.rowAndCell().cell.hasText()) break;
+        }
+        break :end try self.pages.trackPin(clamped);
+    } else null;
     errdefer if (output_end) |pin| self.pages.untrackPin(pin);
 
     self.clearLastCommand();
@@ -2464,6 +2485,12 @@ pub fn semanticPromptEndCommand(self: *Screen) Allocator.Error!void {
         .output_end = output_end,
     };
     self.semantic_prompt.active_command = null;
+}
+
+/// True while a command has emitted OSC 133;C but not yet OSC 133;D, i.e. the
+/// shell is busy running something rather than sitting at an idle prompt.
+pub fn semanticPromptCommandRunning(self: *const Screen) bool {
+    return self.semantic_prompt.active_command != null;
 }
 
 /// Discard B/C state when a new prompt begins without a completing D mark.
@@ -2488,6 +2515,35 @@ fn clearLastCommand(self: *Screen) void {
         if (command.output_end) |pin| self.pages.untrackPin(pin);
     }
     self.semantic_prompt.last_command = null;
+}
+
+/// Drop any retained command whose tracked pins lie inside a region that is
+/// about to be erased. Without this a stale pin silently "revalidates" once a
+/// later prompt reuses the same physical row.
+fn semanticPromptInvalidateRange(
+    self: *Screen,
+    tl: point.Point,
+    bl: ?point.Point,
+) void {
+    if (!self.semantic_prompt.seen) return;
+
+    const top = self.pages.pin(tl) orelse return;
+    const bottom = if (bl) |pt|
+        self.pages.pin(pt) orelse return
+    else
+        self.pages.getBottomRight(tl) orelse return;
+
+    if (self.semantic_prompt.pending_command) |pin| {
+        if (pin.*.isBetween(top, bottom)) self.clearPendingCommand();
+    }
+    if (self.semantic_prompt.active_command) |pin| {
+        if (pin.*.isBetween(top, bottom)) self.clearActiveCommand();
+    }
+    if (self.semantic_prompt.last_command) |command| {
+        const hit = command.prompt.*.isBetween(top, bottom) or
+            if (command.output_end) |pin| pin.*.isBetween(top, bottom) else false;
+        if (hit) self.clearLastCommand();
+    }
 }
 
 fn clearSemanticPromptCommandState(self: *Screen) void {
@@ -10648,6 +10704,97 @@ test "Screen: last-command copies C/D output without B input" {
     defer alloc.free(output);
     try testing.expectEqualStrings("output without B", output);
     try testing.expect((try s.lastCommandString(alloc)) == null);
+}
+
+test "Screen: last-command is dropped when its rows are erased" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 6, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo done");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\ndone");
+    try s.semanticPromptEndCommand();
+
+    {
+        const command = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(command);
+        try testing.expectEqualStrings("echo done", command);
+    }
+
+    // ED2 wipes the recorded rows; the record must not survive to be revived
+    // by whatever prompt reuses those rows next.
+    s.clearRows(.{ .active = .{} }, null, false);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+
+    // A new prompt reusing the same physical rows must not resurrect it.
+    s.cursorAbsolute(0, 0);
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("secret being typed");
+
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+}
+
+test "Screen: last-command output stops at the D cursor" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 6, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // Stale output text further down the screen that a later command must
+    // never absorb into its own C..D region.
+    s.cursorAbsolute(0, 3);
+    try s.testWriteString("stale text below");
+    s.cursorAbsolute(0, 0);
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo hi");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nhi");
+    try s.semanticPromptEndCommand();
+
+    const output = (try s.lastCommandOutputString(alloc)).?;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("hi", output);
+}
+
+test "Screen: last-command reports whether a command is running" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 6, .max_scrollback = 0 });
+    defer s.deinit();
+
+    try testing.expect(!s.semanticPromptCommandRunning());
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("sleep 10");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try testing.expect(s.semanticPromptCommandRunning());
+
+    try s.semanticPromptEndCommand();
+    try testing.expect(!s.semanticPromptCommandRunning());
 }
 
 test "Screen: last-command rejects a completed region trimmed from scrollback" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2460,6 +2460,13 @@ pub fn semanticPromptCommandRunning(self: *const Screen) bool {
     return self.semantic_command.commandRunning();
 }
 
+/// Whether an OSC 133;B input mark is currently outstanding. See
+/// `SemanticCommand.inputPending` — required before writing recovered bytes
+/// back to the pty, not required for reading history.
+pub fn semanticPromptInputPending(self: *const Screen) bool {
+    return self.semantic_command.inputPending();
+}
+
 /// Discard B/C state when a new prompt begins without a completing D mark.
 pub fn semanticPromptAbortCommand(self: *Screen) void {
     self.semantic_command.abortCommand(&self.pages);
@@ -10526,6 +10533,42 @@ test "Screen: last-command has no region without shell integration or D" {
 
     try testing.expect((try s.lastCommandOutputString(alloc)) == null);
     try testing.expect((try s.lastCommandString(alloc)) == null);
+}
+
+test "Screen: semantic prompt input pending tracks the OSC 133;B mark" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    try testing.expect(!s.semanticPromptInputPending());
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo one");
+    try testing.expect(s.semanticPromptInputPending());
+
+    // Once the command starts the input mark is consumed, and it stays
+    // consumed after the command completes.
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try testing.expect(!s.semanticPromptInputPending());
+    try s.testWriteString(" one");
+    try s.semanticPromptEndCommand();
+    try testing.expect(!s.semanticPromptInputPending());
+
+    // A bare OSC 133;A with no following B — the shape a non-shell child can
+    // produce — must not look like a live prompt to write into, even though no
+    // command is reported as running.
+    try s.testWriteString("\n");
+    s.semanticPromptAbortCommand();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    try testing.expect(!s.semanticPromptCommandRunning());
+    try testing.expect(!s.semanticPromptInputPending());
 }
 
 test "Screen: last-command drops a record shifted onto the active input row" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -2467,6 +2467,12 @@ pub fn semanticPromptInputPending(self: *const Screen) bool {
     return self.semantic_command.inputPending();
 }
 
+/// Consume the outstanding OSC 133;B input mark because a line terminator or
+/// Enter key was just written to the pty. See `SemanticCommand.consumeInput`.
+pub fn semanticPromptInputSubmitted(self: *Screen) void {
+    self.semantic_command.consumeInput(&self.pages);
+}
+
 /// Discard B/C state when a new prompt begins without a completing D mark.
 pub fn semanticPromptAbortCommand(self: *Screen) void {
     self.semantic_command.abortCommand(&self.pages);
@@ -10569,6 +10575,77 @@ test "Screen: semantic prompt input pending tracks the OSC 133;B mark" {
     try s.testWriteString("PS> ");
     try testing.expect(!s.semanticPromptCommandRunning());
     try testing.expect(!s.semanticPromptInputPending());
+}
+
+test "Screen: semantic prompt input mark is consumed when input is submitted" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // An earlier complete command, the kind a Clink-enabled cmd session or a
+    // nested PowerShell leaves behind.
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("C:\\> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("ver");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nMicrosoft Windows");
+    try s.semanticPromptEndCommand();
+
+    // The A/B-only cmd PROMPT integration: a new prompt with a B mark, then
+    // the user presses Enter. cmd emits neither C nor another prompt until the
+    // child command exits, so the terminal sees nothing more for now.
+    try s.testWriteString("\n");
+    s.semanticPromptAbortCommand();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("C:\\> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("some-child.exe");
+    try testing.expect(s.semanticPromptInputPending());
+    {
+        const before = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(before);
+        try testing.expectEqualStrings("ver", before);
+    }
+
+    // Submitting consumes the mark: nothing has told us a line editor is
+    // reading input any more, so an insertion gate must refuse, even though
+    // no command is reported as running and history is still readable.
+    s.semanticPromptInputSubmitted();
+    try testing.expect(!s.semanticPromptInputPending());
+    try testing.expect(!s.semanticPromptCommandRunning());
+    {
+        const history = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(history);
+        try testing.expectEqualStrings("ver", history);
+    }
+
+    // A shell that does emit C/D still completes the record normally: C falls
+    // back to the prompt iterator when no pending pin exists.
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try testing.expect(s.semanticPromptCommandRunning());
+    try s.testWriteString("\nchild output");
+    try s.semanticPromptEndCommand();
+    {
+        const command = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(command);
+        try testing.expectEqualStrings("some-child.exe", command);
+    }
+
+    // A fresh B mark re-arms the gate.
+    try s.testWriteString("\n");
+    s.semanticPromptAbortCommand();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("C:\\> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try testing.expect(s.semanticPromptInputPending());
 }
 
 test "Screen: last-command drops a record shifted onto the active input row" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -105,9 +105,29 @@ pub const SemanticPrompt = struct {
     /// prompt is handling.
     click: SemanticClick,
 
+    /// Prompt whose input has started with OSC 133;B/I but whose output has
+    /// not started yet. This pin is tracked so reflow and scrolling keep it
+    /// valid until the command starts or the region is trimmed.
+    pending_command: ?*Pin,
+
+    /// Prompt whose command has emitted OSC 133;C but not OSC 133;D.
+    active_command: ?*Pin,
+
+    /// Most recent command with a complete OSC 133;B..C..D lifecycle.
+    last_command: ?CompletedCommand,
+
     pub const disabled: SemanticPrompt = .{
         .seen = false,
         .click = .none,
+        .pending_command = null,
+        .active_command = null,
+        .last_command = null,
+    };
+
+    pub const CompletedCommand = struct {
+        prompt: *Pin,
+        /// Inclusive last output cell at OSC 133;D, or null for empty output.
+        output_end: ?*Pin,
     };
 
     pub const SemanticClick = union(enum) {
@@ -322,6 +342,7 @@ pub fn deinit(self: *Screen) void {
     if (comptime build_options.kitty_graphics) {
         self.kitty_images.deinit(self.alloc, self);
     }
+    self.clearSemanticPromptCommandState();
     self.cursor.deinit(self.alloc);
     self.pages.deinit();
 }
@@ -365,6 +386,8 @@ pub fn assertIntegrity(self: *const Screen) void {
 /// - Disables protection mode
 ///
 pub fn reset(self: *Screen) void {
+    self.clearSemanticPromptCommandState();
+
     // Reset our pages
     self.pages.reset();
 
@@ -793,6 +816,8 @@ pub fn cursorDownScroll(self: *Screen) !void {
 
     // If we have no scrollback, then we shift all our rows instead.
     if (self.no_scrollback) {
+        self.semanticPromptEraseActiveTopRow();
+
         // If we have a single-row screen, we have no rows to shift
         // so our cursor is in the correct place we just have to clear
         // the cells.
@@ -2390,6 +2415,105 @@ pub fn cursorSetSemanticContent(self: *Screen, t: union(enum) {
     }
 }
 
+/// Record OSC 133;B/I, which begins recoverable command input. We track the
+/// prompt instead of scraping the cursor line so later extraction can use the
+/// semantic-content boundaries maintained by PageList.
+pub fn semanticPromptStartInput(self: *Screen) Allocator.Error!void {
+    self.clearPendingCommand();
+    self.clearActiveCommand();
+
+    if (!self.semantic_prompt.seen) return;
+    var it = self.cursor.page_pin.*.promptIterator(.left_up, null);
+    const prompt = it.next() orelse return;
+    self.semantic_prompt.pending_command = try self.pages.trackPin(prompt);
+}
+
+/// Record OSC 133;C. Prefer the prompt tracked by OSC 133;B/I, but preserve
+/// C..D output recovery even when the shell omitted the input mark.
+pub fn semanticPromptStartOutput(self: *Screen) Allocator.Error!void {
+    self.clearActiveCommand();
+    if (self.semantic_prompt.pending_command) |prompt| {
+        self.semantic_prompt.active_command = prompt;
+        self.semantic_prompt.pending_command = null;
+        return;
+    }
+
+    if (!self.semantic_prompt.seen) return;
+    var it = self.cursor.page_pin.*.promptIterator(.left_up, null);
+    const prompt = it.next() orelse return;
+    self.semantic_prompt.active_command = try self.pages.trackPin(prompt);
+}
+
+/// Record OSC 133;D and freeze the completed command's output endpoint.
+pub fn semanticPromptEndCommand(self: *Screen) Allocator.Error!void {
+    const prompt = self.semantic_prompt.active_command orelse return;
+    if (!semanticPromptPinIsValid(prompt)) {
+        self.clearActiveCommand();
+        return;
+    }
+
+    const output_end = if (self.pages.highlightSemanticContent(prompt.*, .output)) |hl|
+        try self.pages.trackPin(hl.end)
+    else
+        null;
+    errdefer if (output_end) |pin| self.pages.untrackPin(pin);
+
+    self.clearLastCommand();
+    self.semantic_prompt.last_command = .{
+        .prompt = prompt,
+        .output_end = output_end,
+    };
+    self.semantic_prompt.active_command = null;
+}
+
+/// Discard B/C state when a new prompt begins without a completing D mark.
+pub fn semanticPromptAbortCommand(self: *Screen) void {
+    self.clearPendingCommand();
+    self.clearActiveCommand();
+}
+
+fn clearPendingCommand(self: *Screen) void {
+    if (self.semantic_prompt.pending_command) |pin| self.pages.untrackPin(pin);
+    self.semantic_prompt.pending_command = null;
+}
+
+fn clearActiveCommand(self: *Screen) void {
+    if (self.semantic_prompt.active_command) |pin| self.pages.untrackPin(pin);
+    self.semantic_prompt.active_command = null;
+}
+
+fn clearLastCommand(self: *Screen) void {
+    if (self.semantic_prompt.last_command) |command| {
+        self.pages.untrackPin(command.prompt);
+        if (command.output_end) |pin| self.pages.untrackPin(pin);
+    }
+    self.semantic_prompt.last_command = null;
+}
+
+fn clearSemanticPromptCommandState(self: *Screen) void {
+    self.clearPendingCommand();
+    self.clearActiveCommand();
+    self.clearLastCommand();
+}
+
+/// With scrollback disabled, PageList shifts active rows in place rather than
+/// pruning a page, so tracked pins are not marked garbage. Clear any command
+/// whose prompt row is about to be erased before the shift can retarget it.
+fn semanticPromptEraseActiveTopRow(self: *Screen) void {
+    if (!self.semantic_prompt.seen) return;
+    const top = self.pages.getTopLeft(.active);
+
+    if (self.semantic_prompt.pending_command) |pin| {
+        if (pin.*.eql(top)) self.clearPendingCommand();
+    }
+    if (self.semantic_prompt.active_command) |pin| {
+        if (pin.*.eql(top)) self.clearActiveCommand();
+    }
+    if (self.semantic_prompt.last_command) |command| {
+        if (command.prompt.*.eql(top)) self.clearLastCommand();
+    }
+}
+
 /// Set the selection to the given selection. If this is a tracked selection
 /// then the screen will take ownership of the selection. If this is untracked
 /// then the screen will convert it to tracked internally. This will automatically
@@ -2913,6 +3037,68 @@ pub fn selectOutput(self: *Screen, pin: Pin) ?Selection {
     }
 
     return .init(hl.start, hl.end, false);
+}
+
+/// Return the output text in the most recent complete OSC 133;C..D region.
+/// A completed command with no output returns an allocated empty string;
+/// missing, running, or trimmed command regions return null.
+pub fn lastCommandOutputString(
+    self: *Screen,
+    alloc: Allocator,
+) Allocator.Error!?[:0]const u8 {
+    const command = self.lastCompletedCommand() orelse return null;
+
+    const output_end = command.output_end orelse
+        return try alloc.dupeZ(u8, "");
+    if (output_end.garbage) return null;
+
+    const hl = self.pages.highlightSemanticContent(
+        command.prompt.*,
+        .output,
+    ) orelse return null;
+    if (!output_end.*.isBetween(hl.start, hl.end)) return null;
+
+    return try self.selectionString(alloc, .{
+        .sel = .init(hl.start, output_end.*, false),
+        .trim = false,
+    });
+}
+
+/// Return the command text in the most recent complete OSC 133;B..C region.
+/// The caller decides whether the recovered text is safe to execute.
+pub fn lastCommandString(
+    self: *Screen,
+    alloc: Allocator,
+) Allocator.Error!?[:0]const u8 {
+    const command = self.lastCompletedCommand() orelse return null;
+
+    const hl = self.pages.highlightSemanticContent(
+        command.prompt.*,
+        .input,
+    ) orelse return null;
+
+    return try self.selectionString(alloc, .{
+        .sel = .init(hl.start, hl.end, false),
+        .trim = false,
+    });
+}
+
+fn lastCompletedCommand(self: *const Screen) ?SemanticPrompt.CompletedCommand {
+    const command = self.semantic_prompt.last_command orelse return null;
+    if (!semanticPromptPinIsValid(command.prompt)) return null;
+
+    return command;
+}
+
+fn semanticPromptPinIsValid(pin: *const Pin) bool {
+    if (pin.garbage) return false;
+
+    // PageList callers require a real semantic prompt row before invoking
+    // promptIterator/highlightSemanticContent.
+    return switch (pin.rowAndCell().row.semantic_prompt) {
+        .prompt, .prompt_continuation => true,
+        .none => false,
+    };
 }
 
 pub const LineIterator = struct {
@@ -10351,4 +10537,154 @@ test "Screen: promptClickMove click right of input cursor on last char" {
 
     try testing.expectEqual(@as(usize, 1), result.right);
     try testing.expectEqual(@as(usize, 0), result.left);
+}
+
+test "Screen: last-command extracts most recent completed semantic regions" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // First complete A/B/C/D command lifecycle.
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("Write-Output first");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nfirst output");
+    try s.semanticPromptEndCommand();
+
+    // A later complete command must replace the prior region.
+    try s.testWriteString("\n");
+    s.semanticPromptAbortCommand();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("Write-Output second");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nsecond output\nsecond line");
+    try s.semanticPromptEndCommand();
+
+    // Text after D is outside the completed output region.
+    try s.testWriteString(" ignored after D");
+
+    const output = (try s.lastCommandOutputString(alloc)).?;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("second output\nsecond line", output);
+
+    const command = (try s.lastCommandString(alloc)).?;
+    defer alloc.free(command);
+    try testing.expectEqualStrings("Write-Output second", command);
+}
+
+test "Screen: last-command has no region without shell integration or D" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 6, .max_scrollback = 0 });
+    defer s.deinit();
+
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("Start-Sleep 10");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nstill running");
+
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+}
+
+test "Screen: last-command preserves an empty completed output region" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 4, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("$null");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.semanticPromptEndCommand();
+
+    const output = (try s.lastCommandOutputString(alloc)).?;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("", output);
+
+    const command = (try s.lastCommandString(alloc)).?;
+    defer alloc.free(command);
+    try testing.expectEqualStrings("$null", command);
+}
+
+test "Screen: last-command copies C/D output without B input" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 30, .rows = 4, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\noutput without B");
+    try s.semanticPromptEndCommand();
+
+    const output = (try s.lastCommandOutputString(alloc)).?;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("output without B", output);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+}
+
+test "Screen: last-command rejects a completed region trimmed from scrollback" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 20, .rows = 3, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo old");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString("\nold");
+    try s.semanticPromptEndCommand();
+
+    for (0..6) |_| try s.testWriteString("\ntrim");
+
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+
+    // Trimming while a command is still active must also make a later D a
+    // no-op rather than completing a relocated prompt pin.
+    s.reset();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("long-running");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    for (0..6) |_| try s.testWriteString("\nrunning");
+    try s.semanticPromptEndCommand();
+
+    try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
 }

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1674,6 +1674,18 @@ pub inline fn resize(
         self.kitty_images.dirty = true;
     }
 
+    // A column shrink without reflow (the primary screen takes this path
+    // whenever DEC wraparound is off, and the alternate screen always does)
+    // clears every cell past the new width and clamps tracked pins to it,
+    // rather than moving the text somewhere else. A retained command record
+    // would survive that with its span silently truncated, so the recovered
+    // text would be a *different* command than the one that ran — a truncated
+    // path or a dropped redirect. Drop the record instead of recovering a
+    // half command.
+    if (!opts.reflow and opts.cols < self.pages.cols) {
+        self.semantic_command.reset(&self.pages);
+    }
+
     // Release the cursor style while resizing just
     // in case the cursor ends up on a different page.
     const cursor_style = self.cursor.style;
@@ -10513,6 +10525,109 @@ test "Screen: last-command has no region without shell integration or D" {
     try s.testWriteString("\nstill running");
 
     try testing.expect((try s.lastCommandOutputString(alloc)) == null);
+    try testing.expect((try s.lastCommandString(alloc)) == null);
+}
+
+test "Screen: last-command drops a record shifted onto the active input row" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // A complete command whose whole lifecycle sits on row 0.
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo one");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString(" one");
+    try s.semanticPromptEndCommand();
+
+    // A new prompt on row 1 whose input the user has NOT submitted.
+    try s.testWriteString("\n");
+    s.semanticPromptAbortCommand();
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("rm -rf secret");
+
+    // The scrolling fast path rotates row contents and shifts tracked pins by
+    // hand without marking them garbage, so the completed record's prompt pin
+    // lands on the row now holding the unsubmitted input.
+    try s.pages.eraseRowBounded(.{ .active = .{ .y = 0 } }, 7);
+
+    // The record must not resurrect as the unsubmitted line.
+    const command = try s.lastCommandString(alloc);
+    if (command) |v| {
+        defer alloc.free(v);
+        try testing.expect(std.mem.indexOf(u8, v, "rm -rf secret") == null);
+    }
+}
+
+test "Screen: last-command treats output starting after the D cursor as empty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    // Leave output-tagged rows below where the next command will finish.
+    s.cursorSetSemanticContent(.output);
+    s.cursorAbsolute(0, 2);
+    try s.testWriteString("stale output below");
+
+    // A command on row 0 that produces no output at all, so its OSC 133;D
+    // cursor sits above the stale output rows the highlight will find.
+    s.cursorAbsolute(0, 0);
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("echo silent");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.semanticPromptEndCommand();
+
+    // Must not hand back the stale rows as this command's output.
+    const output = try s.lastCommandOutputString(alloc);
+    if (output) |v| {
+        defer alloc.free(v);
+        try testing.expect(std.mem.indexOf(u8, v, "stale output below") == null);
+    }
+}
+
+test "Screen: last-command drops a record truncated by a non-reflow column shrink" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, .{ .cols = 40, .rows = 8, .max_scrollback = 0 });
+    defer s.deinit();
+
+    s.cursorSetSemanticContent(.{ .prompt = .initial });
+    try s.testWriteString("PS> ");
+    s.cursorSetSemanticContent(.{ .input = .clear_explicit });
+    try s.semanticPromptStartInput();
+    try s.testWriteString("Remove-Item C:\\keep\\this\\path");
+    s.cursorSetSemanticContent(.output);
+    try s.semanticPromptStartOutput();
+    try s.testWriteString(" done");
+    try s.semanticPromptEndCommand();
+
+    {
+        const command = (try s.lastCommandString(alloc)).?;
+        defer alloc.free(command);
+        try testing.expectEqualStrings("Remove-Item C:\\keep\\this\\path", command);
+    }
+
+    // Shrinking columns without reflow clears every cell past the new width
+    // and clamps tracked pins, so the retained span would silently become a
+    // shorter, different command.
+    try s.resize(.{ .cols = 16, .rows = 8, .reflow = false });
+
     try testing.expect((try s.lastCommandString(alloc)) == null);
 }
 

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1175,6 +1175,8 @@ pub fn semanticPrompt(
         .fresh_line => try self.semanticPromptFreshLine(),
 
         .fresh_line_new_prompt => {
+            self.screens.active.semanticPromptAbortCommand();
+
             // "First do a fresh-line."
             try self.semanticPromptFreshLine();
 
@@ -1250,6 +1252,7 @@ pub fn semanticPrompt(
             self.screens.active.cursorSetSemanticContent(.{
                 .input = .clear_explicit,
             });
+            try self.screens.active.semanticPromptStartInput();
         },
 
         .end_prompt_start_input_terminate_eol => {
@@ -1257,11 +1260,13 @@ pub fn semanticPrompt(
             self.screens.active.cursorSetSemanticContent(.{
                 .input = .clear_eol,
             });
+            try self.screens.active.semanticPromptStartInput();
         },
 
         .end_input_start_output => {
             // "End of input, and start of output."
             self.screens.active.cursorSetSemanticContent(.output);
+            try self.screens.active.semanticPromptStartOutput();
 
             // If our current row is marked as a prompt and we're
             // at column zero then we assume we're un-prompting. This
@@ -1280,6 +1285,8 @@ pub fn semanticPrompt(
         },
 
         .end_command => {
+            try self.screens.active.semanticPromptEndCommand();
+
             // From a terminal state perspective, this doesn't really do
             // anything. Other terminals appear to do nothing here. I think
             // its reasonable at this point to reset our semantic content

--- a/src/terminal/semantic_command.zig
+++ b/src/terminal/semantic_command.zig
@@ -1,0 +1,258 @@
+//! Tracks the most recent command delimited by OSC 133 shell integration.
+const SemanticCommand = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const PageList = @import("PageList.zig");
+const point = @import("point.zig");
+const Pin = PageList.Pin;
+
+/// Prompt whose input has started with OSC 133;B/I but whose output has not.
+pending: ?*Pin = null,
+
+/// Prompt whose command has emitted OSC 133;C but not OSC 133;D.
+active: ?*Pin = null,
+
+/// Most recent command with a complete OSC 133;B..C..D lifecycle.
+completed: ?Completed = null,
+
+const Completed = struct {
+    prompt: *Pin,
+    /// Inclusive last output cell at OSC 133;D, or null for empty output.
+    output_end: ?*Pin,
+};
+
+pub const Region = struct {
+    start: Pin,
+    end: Pin,
+};
+
+pub const OutputRegion = union(enum) {
+    unavailable,
+    empty,
+    region: Region,
+};
+
+pub fn deinit(self: *SemanticCommand, pages: *PageList) void {
+    self.clearPending(pages);
+    self.clearActive(pages);
+    self.clearCompleted(pages);
+}
+
+/// Record OSC 133;B/I, which begins recoverable command input.
+pub fn startInput(
+    self: *SemanticCommand,
+    pages: *PageList,
+    semantic_prompt_seen: bool,
+    cursor: Pin,
+) Allocator.Error!void {
+    self.clearPending(pages);
+    self.clearActive(pages);
+
+    if (!semantic_prompt_seen) return;
+    var it = cursor.promptIterator(.left_up, null);
+    const prompt = it.next() orelse return;
+
+    // A shell that redraws in place can start new input on the very row the
+    // last completed command was recorded against. Retaining that record
+    // would let extraction read the line the user is typing right now.
+    if (self.completed) |command| {
+        if (command.prompt.*.eql(prompt)) self.clearCompleted(pages);
+    }
+
+    self.pending = try pages.trackPin(prompt);
+}
+
+/// Record OSC 133;C. Prefer the prompt tracked by OSC 133;B/I, but preserve
+/// C..D output recovery even when the shell omitted the input mark.
+pub fn startOutput(
+    self: *SemanticCommand,
+    pages: *PageList,
+    semantic_prompt_seen: bool,
+    cursor: Pin,
+) Allocator.Error!void {
+    self.clearActive(pages);
+    if (self.pending) |prompt| {
+        self.active = prompt;
+        self.pending = null;
+        return;
+    }
+
+    if (!semantic_prompt_seen) return;
+    var it = cursor.promptIterator(.left_up, null);
+    const prompt = it.next() orelse return;
+    self.active = try pages.trackPin(prompt);
+}
+
+/// Record OSC 133;D and freeze the completed command's output endpoint.
+pub fn endCommand(
+    self: *SemanticCommand,
+    pages: *PageList,
+    cursor: Pin,
+) Allocator.Error!void {
+    const prompt = self.active orelse return;
+    if (!pinIsValid(prompt)) {
+        self.clearActive(pages);
+        return;
+    }
+
+    // highlightSemanticContent scans to the next prompt (or the bottom of
+    // the screen), so on its own it can run past the D cursor and pick up
+    // stale rows. Clamp to the last text cell at or before the D cursor.
+    const output_end = if (pages.highlightSemanticContent(prompt.*, .output)) |hl| end: {
+        if (!cursor.before(hl.end)) break :end try pages.trackPin(hl.end);
+
+        var clamped = hl.start;
+        var cell_it = cursor.cellIterator(.left_up, hl.start);
+        while (cell_it.next()) |p| {
+            clamped = p;
+            if (p.rowAndCell().cell.hasText()) break;
+        }
+        break :end try pages.trackPin(clamped);
+    } else null;
+    errdefer if (output_end) |pin| pages.untrackPin(pin);
+
+    self.clearCompleted(pages);
+    self.completed = .{
+        .prompt = prompt,
+        .output_end = output_end,
+    };
+    self.active = null;
+}
+
+pub fn commandRunning(self: *const SemanticCommand) bool {
+    return self.active != null;
+}
+
+/// Discard B/C state when a new prompt begins without a completing D mark.
+pub fn abortCommand(self: *SemanticCommand, pages: *PageList) void {
+    self.clearPending(pages);
+    self.clearActive(pages);
+}
+
+/// Drop retained state whose recovered span overlaps a range about to be
+/// erased, before PageList can relocate those pins onto unrelated rows.
+pub fn invalidateRange(
+    self: *SemanticCommand,
+    pages: *PageList,
+    tl: point.Point,
+    bl: ?point.Point,
+) void {
+    var top = pages.pin(tl) orelse return;
+    top.x = 0;
+
+    var bottom = if (bl) |pt|
+        pages.pin(pt) orelse return
+    else
+        pages.getBottomRight(tl) orelse return;
+    bottom.x = pages.cols - 1;
+
+    if (self.pending) |pin| {
+        if (pin.*.isBetween(top, bottom)) self.clearPending(pages);
+    }
+    if (self.active) |pin| {
+        if (pin.*.isBetween(top, bottom)) self.clearActive(pages);
+    }
+    if (self.completed) |command| {
+        const command_end = if (command.output_end) |pin|
+            pin.*
+        else if (pages.highlightSemanticContent(command.prompt.*, .input)) |hl|
+            hl.end
+        else
+            command.prompt.*;
+        if (pinRangesOverlap(command.prompt.*, command_end, top, bottom)) {
+            self.clearCompleted(pages);
+        }
+    }
+}
+
+fn pinRangesOverlap(a_top: Pin, a_bottom: Pin, b_top: Pin, b_bottom: Pin) bool {
+    return !a_bottom.before(b_top) and !b_bottom.before(a_top);
+}
+
+/// With scrollback disabled, PageList shifts active rows in place rather than
+/// pruning a page, so tracked pins are not marked garbage.
+pub fn invalidateActiveTopRow(
+    self: *SemanticCommand,
+    pages: *PageList,
+) void {
+    const top = pages.getTopLeft(.active);
+
+    if (self.pending) |pin| {
+        if (pin.*.eql(top)) self.clearPending(pages);
+    }
+    if (self.active) |pin| {
+        if (pin.*.eql(top)) self.clearActive(pages);
+    }
+    if (self.completed) |command| {
+        if (command.prompt.*.eql(top)) self.clearCompleted(pages);
+    }
+}
+
+pub fn inputRegion(
+    self: *const SemanticCommand,
+    pages: *const PageList,
+) ?Region {
+    const command = self.lastCompleted() orelse return null;
+    const hl = pages.highlightSemanticContent(
+        command.prompt.*,
+        .input,
+    ) orelse return null;
+
+    return .{ .start = hl.start, .end = hl.end };
+}
+
+pub fn outputRegion(
+    self: *const SemanticCommand,
+    pages: *const PageList,
+) OutputRegion {
+    const command = self.lastCompleted() orelse return .unavailable;
+    const output_end = command.output_end orelse return .empty;
+    if (output_end.garbage) return .unavailable;
+
+    const hl = pages.highlightSemanticContent(
+        command.prompt.*,
+        .output,
+    ) orelse return .unavailable;
+    if (!output_end.*.isBetween(hl.start, hl.end)) return .unavailable;
+
+    return .{ .region = .{
+        .start = hl.start,
+        .end = output_end.*,
+    } };
+}
+
+fn clearPending(self: *SemanticCommand, pages: *PageList) void {
+    if (self.pending) |pin| pages.untrackPin(pin);
+    self.pending = null;
+}
+
+fn clearActive(self: *SemanticCommand, pages: *PageList) void {
+    if (self.active) |pin| pages.untrackPin(pin);
+    self.active = null;
+}
+
+fn clearCompleted(self: *SemanticCommand, pages: *PageList) void {
+    if (self.completed) |command| {
+        pages.untrackPin(command.prompt);
+        if (command.output_end) |pin| pages.untrackPin(pin);
+    }
+    self.completed = null;
+}
+
+fn lastCompleted(self: *const SemanticCommand) ?Completed {
+    const command = self.completed orelse return null;
+    if (!pinIsValid(command.prompt)) return null;
+    return command;
+}
+
+fn pinIsValid(pin: *const Pin) bool {
+    if (pin.garbage) return false;
+
+    // PageList callers require a real semantic prompt row before invoking
+    // promptIterator/highlightSemanticContent.
+    return switch (pin.rowAndCell().row.semantic_prompt) {
+        .prompt, .prompt_continuation => true,
+        .none => false,
+    };
+}

--- a/src/terminal/semantic_command.zig
+++ b/src/terminal/semantic_command.zig
@@ -34,6 +34,11 @@ pub const OutputRegion = union(enum) {
 };
 
 pub fn deinit(self: *SemanticCommand, pages: *PageList) void {
+    self.reset(pages);
+}
+
+/// Drop every retained pin. The tracker is reusable afterwards.
+pub fn reset(self: *SemanticCommand, pages: *PageList) void {
     self.clearPending(pages);
     self.clearActive(pages);
     self.clearCompleted(pages);
@@ -101,6 +106,15 @@ pub fn endCommand(
     // stale rows. Clamp to the last text cell at or before the D cursor.
     const output_end = if (pages.highlightSemanticContent(prompt.*, .output)) |hl| end: {
         if (!cursor.before(hl.end)) break :end try pages.trackPin(hl.end);
+
+        // The D cursor can land *above* the first cell the output highlight
+        // found — a command that printed nothing, with an older output-marked
+        // row still sitting below the cursor. There is no output region at
+        // all in that case. Falling through would both keep `hl.start` (a
+        // cell after D, so `copy_last_command_output` would hand back stale
+        // text) and build a `.left_up` iterator whose limit is after its
+        // start, which asserts under slow runtime safety.
+        if (cursor.before(hl.start)) break :end null;
 
         var clamped = hl.start;
         var cell_it = cursor.cellIterator(.left_up, hl.start);
@@ -243,7 +257,35 @@ fn clearCompleted(self: *SemanticCommand, pages: *PageList) void {
 fn lastCompleted(self: *const SemanticCommand) ?Completed {
     const command = self.completed orelse return null;
     if (!pinIsValid(command.prompt)) return null;
+    if (!self.precedesActiveInput(command)) return null;
     return command;
+}
+
+/// A completed command has to sit strictly above the prompt the user is
+/// typing into right now.
+///
+/// The invalidation hooks above cover the paths that erase rows, but they are
+/// not the only ways a row moves. `PageList.eraseRowBounded` (the scrolling
+/// fast path), `Terminal.insertLines` and `Terminal.deleteLines` all rotate
+/// row contents and then *shift tracked pins by hand* without marking them
+/// garbage — so a retained record can be carried onto the row holding
+/// unsubmitted input, and `pinIsValid` still passes because that row is a
+/// real prompt row. Rather than hooking every one of those hot paths (and
+/// paying for it on every scroll, and silently regressing the next time one
+/// is added), re-check the relationship at read time.
+///
+/// `pending` is the prompt whose OSC 133;B input mark has been seen but whose
+/// output has not — precisely "the line the user is typing". When no input
+/// mark is outstanding there is nothing unsubmitted to protect and the record
+/// stands.
+fn precedesActiveInput(self: *const SemanticCommand, command: Completed) bool {
+    const pending = self.pending orelse return true;
+    if (sameRow(command.prompt.*, pending.*)) return false;
+    return command.prompt.*.before(pending.*);
+}
+
+fn sameRow(a: Pin, b: Pin) bool {
+    return a.node == b.node and a.y == b.y;
 }
 
 fn pinIsValid(pin: *const Pin) bool {

--- a/src/terminal/semantic_command.zig
+++ b/src/terminal/semantic_command.zig
@@ -138,6 +138,20 @@ pub fn commandRunning(self: *const SemanticCommand) bool {
     return self.active != null;
 }
 
+/// Whether an OSC 133;B input mark is outstanding, i.e. something has told us
+/// it is reading a line of input right now.
+///
+/// Callers that only *read* history do not need this: absence of an input mark
+/// is harmless for copying. Callers that write bytes back do, because it is the
+/// only evidence we have that the bytes will land in a line editor at a prompt
+/// rather than in whatever else happens to own the pty. A child that emits
+/// OSC 133;A without a following B clears `active`, so a "no command is
+/// running" check alone would happily type into that child.
+pub fn inputPending(self: *const SemanticCommand) bool {
+    const pending = self.pending orelse return false;
+    return pinIsValid(pending);
+}
+
 /// Discard B/C state when a new prompt begins without a completing D mark.
 pub fn abortCommand(self: *SemanticCommand, pages: *PageList) void {
     self.clearPending(pages);

--- a/src/terminal/semantic_command.zig
+++ b/src/terminal/semantic_command.zig
@@ -152,6 +152,24 @@ pub fn inputPending(self: *const SemanticCommand) bool {
     return pinIsValid(pending);
 }
 
+/// Consume the outstanding input mark because noctty itself just wrote a
+/// submission (a carriage return, a newline, or an Enter key) to the pty.
+///
+/// The B mark is the shell's claim that it is reading a line. Once we have
+/// sent the line terminator, that claim is stale until the shell says
+/// otherwise: a shell with C/D marks will emit C next, but the A/B-only
+/// `cmd.exe` PROMPT integration emits nothing until the child command exits
+/// and the next prompt is drawn, so without this the mark would stay
+/// "pending" for the whole run of the child and `insert_last_command` could
+/// be satisfied while that child owns the pty. A new B re-arms it.
+///
+/// `active` and `completed` are untouched: a following C still has to find
+/// the prompt, and `startOutput` falls back to the prompt iterator when no
+/// pending pin exists, so C/D shells lose nothing.
+pub fn consumeInput(self: *SemanticCommand, pages: *PageList) void {
+    self.clearPending(pages);
+}
+
 /// Discard B/C state when a new prompt begins without a completing D mark.
 pub fn abortCommand(self: *SemanticCommand, pages: *PageList) void {
     self.clearPending(pages);


### PR DESCRIPTION
## Summary

Turns the already-shipped OSC 133 prompt marks into daily-usable verbs.
Jump-to-previous/next-prompt becomes discoverable in the command palette (the
`Ctrl+Shift+PageUp` / `Ctrl+Shift+PageDown` defaults were already there), and two
new actions are added over the same marks: `copy_last_command_output` copies the
133;C..D output region of the last completed command, and `insert_last_command`
puts the 133;B..C command text back on the prompt **without submitting it**. The
shell's line editor is never read or modified.

Fixes #128

Stacked on #125 (shared `docs/windows.md` shell-integration section and capability
matrix rows; #125 also extends these verbs to cmd.exe).

## Changes

- `src/input/command.zig`: palette entries for `jump_to_prompt:-1` / `:1` (it was
  in the "parameterized, no commands" list) plus the two new actions.
- `src/input/Binding.zig`: `copy_last_command_output` and `insert_last_command`
  actions.
- `src/terminal/Screen.zig`: tracks the OSC 133 B/C/D lifecycle with tracked pins
  and exposes `lastCommandOutputString` / `lastCommandString`. A running command,
  a trimmed region, or an erased region yields no result. The recorded output end
  is clamped to the actual 133;D cursor so stale rows below it are never copied,
  and retained state is dropped when the rows it points at are erased or when a
  new input mark starts on the same prompt row.
- `src/Surface.zig`: the two handlers. Insert refuses to act on the alternate
  screen (a TUI) or while a command is still running, reuses the existing
  `input.paste.isSafe` check, and additionally rejects empty, multi-line,
  over-4096-byte, invalid-UTF-8, control-character, and bidi/invisible-formatting
  text. It writes the command through the same encoder clipboard pastes use and
  appends **no** carriage return — see the security note below.
- `src/config/Config.zig`: `Ctrl+Shift+Y` default for copy on Windows.
  `insert_last_command` intentionally has **no** default binding — `ctrl+shift+r`
  is the chord `docs/getting-started.md` advertises for `reload_config`.
- Docs: `docs/windows.md` shell-integration section and
  `docs/windows-capability-matrix.md` notes.

## Validation (head `47b9ede85`, rebased onto #168 @ `ee33e007e`, which sits on #167 @ `e77679ed4` and `main` @ `13e07ba35`)

| Gate                                                             | Result                              |
| ---------------------------------------------------------------- | ----------------------------------- |
| `zig build -Demit-exe=true`                                      | exit 0                              |
| `zig build test -Demit-test-exe=true`                            | 4213 passed / 71 skipped / 0 failed |
| `scripts/check-zig-format.ps1`                                   | PASS (697 sources)                  |
| `scripts/check-source-format.ps1`                                | PASS                                |
| `test/windows/flagship/Test-VerificationContracts.ps1`           | PASS (2 scenarios)                  |
| `npx prettier@3 --check docs/windows.md`                         | PASS                                |
| `-Dtest-filter=` `semantic_command` / `shell_integration` / `utf8` | exit 0 each (see note)              |

Note on `-Dtest-filter`: a filtered `zig build test` run does apply the filter, but `--summary all` only prints the pass count on a cache miss; on a cached repeat it prints `run test ghostty-test success` with no count, which made an earlier round read the filtered rows as vacuous. Verified on `main` with a cleared cache: a bogus filter runs the 68 unnamed always-on test blocks, and a real filter runs those plus its matches. Filtered rows therefore prove only that the matched tests passed; the zero-failure full suite remains the real signal.

`npx prettier@3 --check` is clean on `docs/windows.md`;
`docs/windows-capability-matrix.md` fails it identically on `main` (pre-existing
table padding, not introduced here).
- `noctty.com +list-keybinds` shows `ctrl+shift+y=copy_last_command_output` and the
  two `jump_to_prompt` defaults, and no `ctrl+shift+r` binding
- The stale-record regression test was verified to fail when either guard is
  removed, so it is not tautological

## Residuals / user steps

- The interactive palette workflow (open palette, run the verbs against a live
  PowerShell session) was not exercised end to end: the GUI harness never observed
  its UIA readiness sentinel. Terminal-side extraction, keybinds, palette catalog
  entries, and safety rejection are covered by unit tests and by
  `+list-keybinds`/`+list-actions` against the built binary.
- Leading/trailing blank lines inside a command's output are trimmed by the
  existing selection-string path; exact blank-line fidelity is not attempted.
- The recovered command text comes from the shell's own OSC 133 marks, so it is
  only as trustworthy as the program that emitted them. Documented in
  `docs/windows.md`.

## Stacked on

#168 (issue #125), which is stacked on #167 (issue #124)

---

## Adversarial-review delta (ee69621b2..7f95c2150)

- **[high] second resurrection path — fixed.** `PageList.eraseRows` relocates a tracked
  pin inside the erased range to `(page, y=0, x=0)` **without** marking it garbage, so
  `ESC[3J` / `Screen.eraseHistory` and `Screen.eraseActive` could retarget a completed
  command record onto the row the user is currently typing — the reviewer's probe
  recovered `rm -rf secret` from an unsubmitted line. `Screen` now invalidates
  intersecting records before those erases and before the no-scrollback row-shrink
  resize. `PageList.eraseRows` is deliberately unchanged so selections and kitty images
  keep their existing relocation semantics. Regression test follows the reviewer's exact
  sequence; verified to fail when the guard is removed.
- **[medium] per-guard tests — added.** The previous single test only failed with *both*
  guards removed (the PR claim was wrong; corrected). There is now one test per guard —
  ED2, middle-row erase, same-row redraw, history erase, active erase, no-scrollback row
  shrink — each verified to fail when only its own guard is removed.
- **[low] output fidelity — fixed.** `lastCommandString` trims trailing whitespace
  (PSReadLine erases with spaces that stay tagged as input); `copy_last_command_output`
  is now a logged no-op instead of clobbering the clipboard with an empty string; the
  ConPTY full-repaint caveat (cells retagged as output after a resize/repaint) is
  documented in `docs/windows.md`.
- **[bloat] core isolation — done.** Command tracking moved to
  `src/terminal/semantic_command.zig` (248 lines, depends only on `PageList`/pins/points
  — it never takes a `*Screen`). `Screen` holds one field and calls a narrow hook
  surface, and `SemanticPrompt` is restored to its upstream `seen`/`click` shape, so the
  upstream-shared `Screen.zig` delta is now just the hook calls.

Rebased onto the updated #125 branch.

## Summary by Sourcery

Make OSC 133 prompt marks usable through discoverable navigation, command-output copying, and review-before-submit command insertion actions.

New Features:
- Expose previous/next prompt navigation and last-command actions through the command palette.
- Add copying of the most recent completed command output and safe insertion of the most recent recoverable single-line command without submitting it.

Bug Fixes:
- Prevent stale or erased OSC 133 state from resurrecting unsubmitted input or returning invalid command/output regions.
- Consume prompt input state when submissions are sent and reject unsafe recovered command text.

Enhancements:
- Track OSC 133 command boundaries independently of screen rendering and invalidate recovered state when terminal content is erased, shifted, resized, or repainted.
- Add a Windows default keybinding for copying the last command output while leaving command insertion palette-only.
- Document OSC 133 command recovery behavior, limitations, and security considerations.

Documentation:
- Document the new prompt navigation, command output copy, and command insertion actions in Windows shell-integration guidance and the capability matrix.

Tests:
- Add coverage for command and output extraction, prompt navigation action discovery, submission tracking, unsafe input rejection, stale-state invalidation, resizing, erasure, scrolling, and output-boundary handling.


---

## Bot-review round (2026-08-30) - 4 findings, all real, all fixed

Rebased onto current `main` first, so the suite is a true zero-failure result
rather than one tolerated baseline failure.

- **[P1, Greptile] Forged OSC 133 marks became shell input - fixed, by design change.**
  Greptile reproduced, through a real PTY, that any program writing to the
  terminal can emit a complete OSC 133 A/B/C/D lifecycle around text of its
  choosing and have it retained as "the last command"; `rerun_last_command`
  then appended a CR and submitted it. That turns "display untrusted output"
  into "execute an attacker-chosen command" on one keypress. There is no in-band
  provenance to check - the marks are indistinguishable from a real shell's by
  construction - so **the action no longer submits**. It is renamed
  `rerun_last_command` -> `insert_last_command` and writes the recovered text
  through `completeClipboardPaste` (bracketed when the terminal asked for it)
  with no trailing CR; the user reads what landed on the prompt and presses
  Enter. The rename is free: the action had no default binding and has never
  shipped. `copy_last_command_output` is deliberately unchanged - it reaches a
  clipboard, not a shell.
- **[P1, Codex] Row-shifting fast paths could resurrect unsubmitted input - fixed.**
  `PageList.eraseRowBounded`, `Terminal.insertLines` and `Terminal.deleteLines`
  rotate row contents and shift tracked pins by hand *without* marking them
  garbage, so a completed record could be carried onto the row holding
  unsubmitted input while `pinIsValid` still passed. We did **not** hook those
  paths (`eraseRowBounded` is the scrolling fast path, and an enumeration
  regresses the moment someone adds the next one). Instead `precedesActiveInput`
  re-checks at read time that a completed record sits strictly above the prompt
  whose OSC 133;B mark is still outstanding - closing the whole class at zero
  hot-path cost.
- **[P2, Codex] OSC 133;D above the output highlight start - fixed.** Kept a
  stale endpoint for `copy_last_command_output` and built a `.left_up` iterator
  whose limit was after its start, which asserts under slow runtime safety.
  Now treated as no output. Confirmed empirically: removing the guard makes the
  new test panic on that exact assert.
- **[P2, Codex] Non-reflow column shrink truncated a retained record - fixed.**
  The primary screen takes the non-reflow path whenever DEC wraparound is off;
  `resizeWithoutReflow` then clears cells past the new width and clamps pins, so
  the recovered text would be a shorter, *different* command. `Screen.resize`
  now drops retained command state on any non-reflow column shrink.

Each of the three terminal-side guards has its own regression test, verified to
fail when only that guard is removed.

**Validation (this round, all personally observed):**
`scripts/check-zig-format.ps1` PASS (671 sources) - `zig build -Demit-exe=true`
PASS - full suite **3809 passed, 70 skipped, 0 failed** -
`scripts/check-source-format.ps1` PASS.



---

## Bot-review round (2026-09-02/03) - 1 finding fixed, 2 duplicate findings declined

- **[P2, Codex] The OSC 133;B input mark stayed live for the whole run of a
  foreground child - fixed in `4713454cc` + `47b9ede85`.** With the A/B-only
  cmd.exe PROMPT integration from #168 (no Clink), cmd emits neither 133;C nor a
  new prompt until the child exits, so the B recorded for the prompt survived the
  entire command. `pending` was only cleared by `startOutput` (C), `abortCommand`
  (the next A) and the erase hooks. With a completed record left over from an
  earlier Clink-enabled command or a nested PowerShell, `commandRunning()` was
  false, `inputPending()` was true, `precedesActiveInput` accepted the older
  record, and `insert_last_command` could write into the running child instead of
  cmd's line editor. The same window existed for any shell between our Enter and
  the arrival of its C.

  The fix treats the B mark as a claim that goes stale the moment noctty writes
  the terminator: `SemanticCommand.consumeInput` /
  `Screen.semanticPromptInputSubmitted` clear `pending` only (`active` and
  `completed` are untouched, and `startOutput` already falls back to the prompt
  iterator when there is no pending pin, so C/D shells lose nothing);
  `Surface.queueIo` - the single chokepoint every pty write passes through -
  scans outgoing bytes for CR/LF, covering legacy Enter, `text:` bindings, IME
  commits and multi-line pastes; `keyCallback` also consumes on Enter / numpad
  Enter, for the Kitty keyboard protocol's `CSI 13 u` encoding that carries no
  CR; a fresh 133;B re-arms the gate. Covered by `Screen: semantic prompt input
  mark is consumed when input is submitted` (drives the exact cmd scenario) and
  `Surface: submissionInBytes recognises line terminators`.

- **[P1, Greptile x2, security-labelled] "Forged prompt state redirects
  insertion" - declined, with the code.** The described mechanism does not hold:
  a child that forges a completed record and then moves the cursor to an
  *earlier* row makes `startInput` pin `pending` to that earlier row, and
  `lastCompleted` then requires `command.prompt.before(pending)`
  (`src/terminal/semantic_command.zig:295-299`), which is false for a record on a
  later row, so `lastCommandString()` returns `null`. Reversed row order is
  exactly what that check rejects; the shipped test `Screen: last-command drops a
  record shifted onto the active input row` asserts the same rule from the other
  direction. The version that does work is the ordinary in-order forge, and that
  is the documented design of the feature (`docs/windows.md`, "It does not press
  Enter, by design"): OSC 133 marks carry no provenance, so any program that can
  print can forge a lifecycle, and the mitigation is that nothing is submitted.
  What the child receives is bytes it chose itself, on a pty it already owns. No
  cursor-position or row-order heuristic was added on top of `precedesActiveInput`.
  Both duplicate threads were answered and resolved.

## Rebase round (2026-09-03)

Rebased onto the new #168 head `ee33e007e` (which sits on #167 `e77679ed4` and
`main` @ `13e07ba35`) with no conflicts on this branch. The commit shas quoted in
the review threads above are the pre-rebase ones; their post-rebase equivalents
are `4713454cc` ("require a live input mark before inserting a command",
was `e3e706d23`) and `47b9ede85` ("consume the OSC 133;B input mark when a line
is submitted", was `2246582b3`). All 9 review threads are answered and resolved.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above
was verified against the code and the gate output.