### PR TITLE
packaging: add a Chocolatey release channel (#139)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,44 +383,12 @@ jobs:
         run: ./scripts/release-publish-scoop.ps1 -Version $env:RELEASE_VERSION
 
       - name: Publish Chocolatey package
+        if: steps.meta.outputs.prerelease != 'true'
         shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-        run: |
-          if (-not $env:CHOCO_API_KEY) {
-            Write-Host "Skipping Chocolatey publish: CHOCO_API_KEY is not configured."
-            return
-          }
-
-          $version = "${{ steps.meta.outputs.version }}"
-          $artifactDirX64 = Join-Path $PWD "dist/artifacts/noctty-$version-windows-x64"
-          $metadataPath = Join-Path $artifactDirX64 "package-managers/metadata.json"
-          $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
-          $packageOutputDir = Join-Path $env:RUNNER_TEMP "noctty-chocolatey-$version"
-          if (Test-Path -LiteralPath $packageOutputDir) {
-            Remove-Item -LiteralPath $packageOutputDir -Recurse -Force
-          }
-          New-Item -ItemType Directory -Path $packageOutputDir -Force | Out-Null
-
-          & choco pack $metadata.chocolatey.nuspecPath `
-            --output-directory $packageOutputDir `
-            --limit-output
-          if ($LASTEXITCODE -ne 0) {
-            throw "choco pack failed with exit code $LASTEXITCODE."
-          }
-
-          $packages = @(Get-ChildItem -LiteralPath $packageOutputDir -Filter '*.nupkg' -File)
-          if ($packages.Count -ne 1) {
-            throw "Expected one Chocolatey package; found $($packages.Count)."
-          }
-
-          & choco push $packages[0].FullName `
-            --source "https://push.chocolatey.org/" `
-            --api-key $env:CHOCO_API_KEY `
-            --limit-output
-          if ($LASTEXITCODE -ne 0) {
-            throw "choco push failed with exit code $LASTEXITCODE."
-          }
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: ./scripts/release-publish-chocolatey.ps1 -Version $env:RELEASE_VERSION
 
       - name: Submit WinGet manifest update
         if: steps.meta.outputs.prerelease != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,46 @@ jobs:
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: ./scripts/release-publish-scoop.ps1 -Version $env:RELEASE_VERSION
 
+      - name: Publish Chocolatey package
+        shell: pwsh
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          if (-not $env:CHOCO_API_KEY) {
+            Write-Host "Skipping Chocolatey publish: CHOCO_API_KEY is not configured."
+            return
+          }
+
+          $version = "${{ steps.meta.outputs.version }}"
+          $artifactDirX64 = Join-Path $PWD "dist/artifacts/noctty-$version-windows-x64"
+          $metadataPath = Join-Path $artifactDirX64 "package-managers/metadata.json"
+          $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+          $packageOutputDir = Join-Path $env:RUNNER_TEMP "noctty-chocolatey-$version"
+          if (Test-Path -LiteralPath $packageOutputDir) {
+            Remove-Item -LiteralPath $packageOutputDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $packageOutputDir -Force | Out-Null
+
+          & choco pack $metadata.chocolatey.nuspecPath `
+            --output-directory $packageOutputDir `
+            --limit-output
+          if ($LASTEXITCODE -ne 0) {
+            throw "choco pack failed with exit code $LASTEXITCODE."
+          }
+
+          $packages = @(Get-ChildItem -LiteralPath $packageOutputDir -Filter '*.nupkg' -File)
+          if ($packages.Count -ne 1) {
+            throw "Expected one Chocolatey package; found $($packages.Count)."
+          }
+
+          & choco push $packages[0].FullName `
+            --source "https://push.chocolatey.org/" `
+            --api-key $env:CHOCO_API_KEY `
+            --limit-output
+          if ($LASTEXITCODE -ne 0) {
+            throw "choco push failed with exit code $LASTEXITCODE."
+          }
+
       - name: Submit WinGet manifest update
         if: steps.meta.outputs.prerelease != 'true'
         shell: pwsh

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -257,6 +257,7 @@ Recommended order:
 8. Confirm follow-on publishes:
    - Scoop manifest update
    - WinGet submission
+   - Chocolatey package push
 
 If a tag already exists and the workflow failed before publish, configure
 the missing signing secrets and then rerun the failed `Release` workflow or
@@ -299,6 +300,23 @@ scoop install noctty/noctty
 
 Release preflight verifies that the configured manifest exists, defaulting
 to `bucket/noctty.json` when `SCOOP_BUCKET_MANIFEST_PATH` is unset.
+
+### Chocolatey
+
+- Secret: `CHOCO_API_KEY`
+- Package id: `noctty`
+
+The release workflow always generates the Chocolatey package metadata. It
+skips `choco pack` and `choco push` cleanly when `CHOCO_API_KEY` is absent.
+To publish a generated package manually:
+
+```powershell
+choco pack .\noctty.nuspec --output-directory .\out
+choco push .\out\noctty.<version>.nupkg --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
+```
+
+Creating the chocolatey.org account and configuring its API key remain
+maintainer steps outside this repository.
 
 ## Zig version
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -181,6 +181,8 @@ Win32-validated VT protocol coverage is tracked in
 ### Windows package managers
 
 - WinGet package id: `AmanThanvi.noctty` (bootstrap pending).
+- Chocolatey package id: `noctty` (built by the release workflow; not yet
+  published).
 - Scoop bucket: `https://github.com/amanthanvi/scoop-noctty`.
 
 ### Crash reports

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -35,6 +35,10 @@ checksummed and bound to the canonical release workflow by GitHub build
 provenance. The legacy `SHA256SUMS.txt` file remains an x64 auto-update
 compatibility alias.
 
+A Chocolatey package (`noctty`) is built by the release workflow but has not
+been published yet, so `choco install noctty` does not work today. It will
+after the first push clears chocolatey.org moderation.
+
 [getting-started.md](getting-started.md) covers download and install,
 including the SmartScreen warning. [verify-release.md](verify-release.md)
 covers checksum, provenance, and signature checks.

--- a/scripts/package-package-managers.ps1
+++ b/scripts/package-package-managers.ps1
@@ -3,8 +3,12 @@ param(
     # $Version reaches a nuspec, artifact file names, and download URLs. The
     # release workflow already constrains it, but validate at the parameter so
     # manual and test invocations cannot inject path or URL fragments either.
+    # \A and \z rather than ^ and $ because .NET's $ also matches before a
+    # trailing newline, and [0-9] rather than \d because .NET's \d matches every
+    # Unicode decimal digit. Both would otherwise pass a value that is not a
+    # noctty release version.
     [Parameter(Mandatory = $true)]
-    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [ValidatePattern('\A[0-9]+\.[0-9]+\.[0-9]+\z')]
     [string]$Version,
 
     [string]$Tag,

--- a/scripts/package-package-managers.ps1
+++ b/scripts/package-package-managers.ps1
@@ -1,6 +1,10 @@
 [CmdletBinding()]
 param(
+    # $Version reaches a nuspec, artifact file names, and download URLs. The
+    # release workflow already constrains it, but validate at the parameter so
+    # manual and test invocations cannot inject path or URL fragments either.
     [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
     [string]$Version,
 
     [string]$Tag,

--- a/scripts/package-package-managers.ps1
+++ b/scripts/package-package-managers.ps1
@@ -50,6 +50,7 @@ $iconPath = Join-Path $primaryArtifactRootPath $iconName
 $releaseBaseUrl = "https://github.com/$Repo/releases/download/$tagValue"
 $projectUrl = "https://github.com/$Repo"
 $releaseUrl = "$projectUrl/releases/tag/$tagValue"
+$licenseUrl = "$projectUrl/blob/$tagValue/LICENSE"
 $iconUrl = "$releaseBaseUrl/$iconName"
 $packageDescription = @"
 noctty is a Windows terminal emulator that reuses Ghostty's terminal core under a native Win32 front end.
@@ -172,10 +173,15 @@ if ($UpstreamBaseVersion) {
 Reset-Directory -Path $outputRootPath
 
 $scoopRoot = Join-Path $outputRootPath "scoop"
+$chocolateyRoot = Join-Path $outputRootPath "chocolatey"
+$chocolateyToolsRoot = Join-Path $chocolateyRoot "tools"
 $metadataPath = Join-Path $outputRootPath "metadata.json"
 $scoopManifestPath = Join-Path $scoopRoot "$ScoopPackageName.json"
+$chocolateyNuspecPath = Join-Path $chocolateyRoot "noctty.nuspec"
+$chocolateyInstallPath = Join-Path $chocolateyToolsRoot "chocolateyInstall.ps1"
 
 New-Item -ItemType Directory -Path $scoopRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $chocolateyToolsRoot -Force | Out-Null
 
 $scoopManifest = [ordered]@{
     version      = $Version
@@ -194,6 +200,80 @@ foreach ($arch in $Architectures) {
     }
 }
 Set-Content -LiteralPath $scoopManifestPath -Value ($scoopManifest | ConvertTo-Json -Depth 5)
+
+$escapedDescription = [System.Security.SecurityElement]::Escape($packageDescription)
+$chocolateyNuspec = @"
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>noctty</id>
+    <version>$Version</version>
+    <title>noctty</title>
+    <authors>Aman Thanvi</authors>
+    <owners>Aman Thanvi</owners>
+    <projectUrl>$projectUrl</projectUrl>
+    <licenseUrl>$licenseUrl</licenseUrl>
+    <iconUrl>$iconUrl</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>$escapedDescription</summary>
+    <description>$escapedDescription</description>
+    <releaseNotes>$releaseUrl</releaseNotes>
+    <copyright>Copyright Aman Thanvi</copyright>
+    <tags>noctty terminal emulator windows ghostty</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>
+"@
+Set-Content -LiteralPath $chocolateyNuspecPath -Value $chocolateyNuspec -Encoding utf8
+
+$x64SetupUrl = if ($artifacts.Contains("x64")) { $artifacts["x64"].setupUrl } else { "" }
+$x64SetupSha256 = if ($artifacts.Contains("x64")) { $artifacts["x64"].setupSha256 } else { "" }
+$arm64SetupUrl = if ($artifacts.Contains("arm64")) { $artifacts["arm64"].setupUrl } else { "" }
+$arm64SetupSha256 = if ($artifacts.Contains("arm64")) { $artifacts["arm64"].setupSha256 } else { "" }
+$chocolateyInstall = @'
+$ErrorActionPreference = 'Stop'
+
+$machineArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$installers = @{
+    x64 = @{
+        url = '__X64_SETUP_URL__'
+        checksum = '__X64_SETUP_SHA256__'
+    }
+    arm64 = @{
+        url = '__ARM64_SETUP_URL__'
+        checksum = '__ARM64_SETUP_SHA256__'
+    }
+}
+
+if ($machineArchitecture -notin @('x64', 'arm64')) {
+    throw "Unsupported Windows architecture for noctty: $machineArchitecture"
+}
+
+$installer = $installers[$machineArchitecture]
+if ([string]::IsNullOrWhiteSpace($installer.url) -or [string]::IsNullOrWhiteSpace($installer.checksum)) {
+    throw "The noctty Chocolatey package does not include a $machineArchitecture installer."
+}
+
+$packageArgs = @{
+    packageName = 'noctty'
+    fileType = 'exe'
+    url = $installer.url
+    checksum = $installer.checksum
+    checksumType = 'sha256'
+    silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS'
+    validExitCodes = @(0, 1641, 3010)
+}
+
+Install-ChocolateyPackage @packageArgs
+'@
+$chocolateyInstall = $chocolateyInstall.
+    Replace("__X64_SETUP_URL__", $x64SetupUrl).
+    Replace("__X64_SETUP_SHA256__", $x64SetupSha256).
+    Replace("__ARM64_SETUP_URL__", $arm64SetupUrl).
+    Replace("__ARM64_SETUP_SHA256__", $arm64SetupSha256)
+Set-Content -LiteralPath $chocolateyInstallPath -Value $chocolateyInstall -Encoding utf8
 
 $metadataArchitectures = [ordered]@{}
 foreach ($arch in $Architectures) {
@@ -255,6 +335,11 @@ $metadata = [ordered]@{
         manifestPath  = $scoopManifestPath
         manifestRelPath = "$ScoopPackageName.json"
     }
+    chocolatey = [ordered]@{
+        packageName     = "noctty"
+        nuspecPath      = $chocolateyNuspecPath
+        packageDirectory = $chocolateyRoot
+    }
 }
 
 if ($UpstreamBaseVersion) {
@@ -270,4 +355,5 @@ if ($FirstForkPatch -gt 0) {
 Set-Content -LiteralPath $metadataPath -Value ($metadata | ConvertTo-Json -Depth 8)
 
 Write-Host "Scoop manifest         : $scoopManifestPath"
+Write-Host "Chocolatey nuspec      : $chocolateyNuspecPath"
 Write-Host "Metadata               : $metadataPath"

--- a/scripts/release-publish-chocolatey.ps1
+++ b/scripts/release-publish-chocolatey.ps1
@@ -1,0 +1,136 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    # $Version reaches a package file name and a public feed query. \A and \z
+    # rather than ^ and $ because .NET's $ also matches before a trailing
+    # newline, and [0-9] rather than \d because .NET's \d matches every Unicode
+    # decimal digit. Both would otherwise pass a value that is not a noctty
+    # release version.
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('\A[0-9]+\.[0-9]+\.[0-9]+\z')]
+    [string] $Version,
+
+    [string] $ArtifactRoot,
+
+    [string] $RunnerTemp = $env:RUNNER_TEMP,
+
+    [string] $PushSource = 'https://push.chocolatey.org/',
+
+    [string] $QuerySource = 'https://community.chocolatey.org/api/v2/'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'common.ps1')
+
+if (-not $env:CHOCO_API_KEY) {
+    Write-Host 'Skipping Chocolatey publish: CHOCO_API_KEY is not configured.'
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($RunnerTemp)) {
+    $RunnerTemp = [System.IO.Path]::GetTempPath()
+}
+$RunnerTemp = [System.IO.Path]::GetFullPath($RunnerTemp)
+
+$repoRoot = Get-RepoRoot
+if ([string]::IsNullOrWhiteSpace($ArtifactRoot)) {
+    $ArtifactRoot = Join-Path $repoRoot 'dist/artifacts'
+}
+$ArtifactRoot = [System.IO.Path]::GetFullPath($ArtifactRoot)
+$artifactDirectoryX64 = Join-Path $ArtifactRoot "noctty-$Version-windows-x64"
+$metadataPath = Join-Path $artifactDirectoryX64 'package-managers/metadata.json'
+$metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+
+$packageName = $metadata.chocolatey.packageName
+if ([string]::IsNullOrWhiteSpace($packageName)) {
+    throw 'metadata.json does not name the Chocolatey package.'
+}
+$nuspecPath = $metadata.chocolatey.nuspecPath
+if ([string]::IsNullOrWhiteSpace($nuspecPath)) {
+    throw 'metadata.json does not record the Chocolatey nuspec path.'
+}
+$packageDirectory = $metadata.chocolatey.packageDirectory
+if ([string]::IsNullOrWhiteSpace($packageDirectory)) {
+    throw 'metadata.json does not record the Chocolatey package directory.'
+}
+# The nuspec has to be the one inside the package directory the same run
+# generated; a mismatch means the metadata describes a different build.
+$nuspecParent = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::GetDirectoryName($nuspecPath)
+)
+if ($nuspecParent -ne [System.IO.Path]::GetFullPath($packageDirectory)) {
+    throw "Chocolatey nuspec is outside its package directory: $nuspecPath"
+}
+
+# A Chocolatey package version is immutable. Republishing one is a hard error
+# from the feed, which would otherwise stop a rerun before it reaches the
+# WinGet step, so ask the feed first and treat "already there" as done.
+function Test-ChocolateyVersionPublished {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string] $PackageVersion,
+        [Parameter(Mandatory)] [string] $Source
+    )
+
+    $uri = "$($Source.TrimEnd('/'))/Packages(Id='$Name',Version='$PackageVersion')"
+    try {
+        $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -ErrorAction Stop
+    }
+    catch {
+        $status = $_.Exception.Response.StatusCode.value__
+        if ($status -eq 404) { return $false }
+        # Anything other than a clean "not found" leaves publication state
+        # unknown. Say so instead of guessing in either direction.
+        throw "Could not determine whether $Name $PackageVersion is already published: $($_.Exception.Message)"
+    }
+    return $response.StatusCode -eq 200
+}
+
+if (Test-ChocolateyVersionPublished `
+        -Name $packageName `
+        -PackageVersion $Version `
+        -Source $QuerySource) {
+    Write-Host "Chocolatey already has $packageName $Version; nothing to push."
+    return
+}
+
+if (-not $PSCmdlet.ShouldProcess($PushSource, "publish $packageName $Version to Chocolatey")) {
+    return
+}
+
+$packageOutputDir = Join-Path $RunnerTemp "noctty-chocolatey-$Version"
+if (Test-Path -LiteralPath $packageOutputDir) {
+    Remove-Item -LiteralPath $packageOutputDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $packageOutputDir -Force | Out-Null
+
+& choco pack $nuspecPath `
+    --output-directory $packageOutputDir `
+    --limit-output
+if ($LASTEXITCODE -ne 0) {
+    throw "choco pack failed with exit code $LASTEXITCODE."
+}
+
+$packages = @(Get-ChildItem -LiteralPath $packageOutputDir -Filter '*.nupkg' -File)
+if ($packages.Count -ne 1) {
+    throw "Expected one Chocolatey package; found $($packages.Count)."
+}
+
+$pushOutput = & choco push $packages[0].FullName `
+    --source $PushSource `
+    --api-key $env:CHOCO_API_KEY `
+    --limit-output 2>&1
+$pushExitCode = $LASTEXITCODE
+$pushText = ($pushOutput | Out-String)
+Write-Host $pushText
+if ($pushExitCode -ne 0) {
+    # Only the duplicate-version response is tolerated, and only because it
+    # means the intended end state already holds. Every other failure stays a
+    # failure.
+    if ($pushText -match 'already exists' -or
+        $pushText -match 'A package with the ID.*and version.*already exists' -or
+        $pushText -match '409') {
+        Write-Host "Chocolatey reported $packageName $Version as already published; treating the push as complete."
+        return
+    }
+    throw "choco push failed with exit code $pushExitCode."
+}

--- a/test/windows/flagship/contracts/Contracts.80-Release.ps1
+++ b/test/windows/flagship/contracts/Contracts.80-Release.ps1
@@ -61,7 +61,7 @@ $releasePreflightStepSha256 =
 $readinessPreflightStepSha256 =
     '153aa1d2b13ac09f38ba3269bc78840e57a93c98e54b99168a5d937b8dab7989'
 $releaseWorkflowSha256 =
-    '332f31e6ce005edfafca003567935dbf380ca1dd8c188080af2c9f7297e2a100'
+    '54336d7316490ecbcf15d790eb22db9979e7fde8160484461bb4014250b741fa'
 $readinessWorkflowSha256 =
     '7c66f756a0219af4e791bccef9824c7373050e41aa753836f6f95577a5a1edc5'
 # Full-file pins deliberately make every workflow edit a semantic-review event,

--- a/test/windows/flagship/contracts/Contracts.91-Packaging.ps1
+++ b/test/windows/flagship/contracts/Contracts.91-Packaging.ps1
@@ -42,6 +42,18 @@ Invoke-ContractTable -Contracts @(
         Description = 'Windows x64 baseline disassembly is time-bounded and kills a timed-out tool'
     }
     @{
+        File = $releaseWorkflow
+        Pattern = '(?ms)- name: Publish Chocolatey package\r?\n\s+if: steps\.meta\.outputs\.prerelease != ''true'''
+        Kind = 'Workflow'
+        Description = 'a prerelease never reaches the public Chocolatey feed'
+    }
+    @{
+        File = (Join-Path $repoRoot 'scripts\release-publish-chocolatey.ps1')
+        Pattern = '(?ms)Test-ChocolateyVersionPublished.*?nothing to push.*?choco push.*?\$pushExitCode -ne 0.*?already exists.*?treating the push as complete.*?throw "choco push failed'
+        Kind = 'Workflow'
+        Description = 'Chocolatey publishing is rerun-safe and tolerates only the duplicate-version response'
+    }
+    @{
         File = "$releasePreflight :: Assert-WingetArchitectureCoverage"
         Content = {
             (Get-PowerShellBlockText -Content (Get-Content -LiteralPath $releasePreflight -Raw) -HeaderPattern '^function\s+Assert-WingetArchitectureCoverage(?=\s|\{)')

--- a/test/windows/package-chocolatey.ps1
+++ b/test/windows/package-chocolatey.ps1
@@ -1,0 +1,171 @@
+[CmdletBinding()]
+param(
+    [string] $Version = '0.0.1',
+    [string] $Architecture = $null,
+    [switch] $ShowGeneratedFiles
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts\windows-architecture.ps1')
+$Architecture = (Get-WindowsPackageArchitecture -Architecture $(if ($Architecture) { $Architecture } else { Get-DefaultWindowsPackageArchitecture })).Name
+$packageScript = Join-Path $repoRoot 'scripts\package-package-managers.ps1'
+$scratchName = 'package-chocolatey-{0}' -f [guid]::NewGuid().ToString('N')
+$scratchRelative = Join-Path 'dist' $scratchName
+$scratchRoot = Join-Path $repoRoot $scratchRelative
+$artifactRelative = Join-Path $scratchRelative 'artifacts'
+$artifactRoot = Join-Path $repoRoot $artifactRelative
+$outputRelative = Join-Path $scratchRelative 'output'
+$outputRoot = Join-Path $repoRoot $outputRelative
+$packRoot = Join-Path ([System.IO.Path]::GetTempPath()) $scratchName
+
+try {
+    New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
+
+    $setupName = New-WindowsPackageArtifactName -Version $Version -Architecture $Architecture -Kind setup
+    $portableName = New-WindowsPackageArtifactName -Version $Version -Architecture $Architecture -Kind portable
+    $checksumsName = New-WindowsPackageArtifactName -Version $Version -Architecture $Architecture -Kind checksums
+    $setupPath = Join-Path $artifactRoot $setupName
+    $portablePath = Join-Path $artifactRoot $portableName
+    $checksumsPath = Join-Path $artifactRoot $checksumsName
+    $iconPath = Join-Path $artifactRoot 'noctty-icon.svg'
+
+    Set-Content -LiteralPath $setupPath -Value "fake signed setup for $Architecture" -NoNewline
+    Set-Content -LiteralPath $portablePath -Value "fake portable archive for $Architecture" -NoNewline
+    Set-Content -LiteralPath $iconPath -Value '<svg xmlns="http://www.w3.org/2000/svg" />' -NoNewline
+    $setupSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $setupPath).Hash.ToLowerInvariant()
+    $portableSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $portablePath).Hash.ToLowerInvariant()
+    Set-Content -LiteralPath $checksumsPath -Value @(
+        "$setupSha256 *$setupName"
+        "$portableSha256 *$portableName"
+    )
+
+    & $packageScript `
+        -Version $Version `
+        -Architectures @($Architecture) `
+        -ArtifactRoot $artifactRelative `
+        -OutputRoot $outputRelative
+
+    $nuspecPath = Join-Path $outputRoot 'chocolatey\noctty.nuspec'
+    $installScriptPath = Join-Path $outputRoot 'chocolatey\tools\chocolateyInstall.ps1'
+    $metadataPath = Join-Path $outputRoot 'metadata.json'
+    foreach ($path in @($nuspecPath, $installScriptPath, $metadataPath)) {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "Missing generated Chocolatey path: $path"
+        }
+    }
+
+    $nuspec = [System.Xml.XmlDocument]::new()
+    $nuspec.Load($nuspecPath)
+    $nuspecNamespace = 'http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd'
+    if ($nuspec.DocumentElement.LocalName -cne 'package' -or $nuspec.DocumentElement.NamespaceURI -cne $nuspecNamespace) {
+        throw 'Generated nuspec does not use the expected NuGet package schema shape.'
+    }
+
+    $namespaceManager = [System.Xml.XmlNamespaceManager]::new($nuspec.NameTable)
+    $namespaceManager.AddNamespace('n', $nuspecNamespace)
+    $metadataNode = $nuspec.SelectSingleNode('/n:package/n:metadata', $namespaceManager)
+    if ($null -eq $metadataNode) {
+        throw 'Generated nuspec is missing its metadata element.'
+    }
+
+    $requiredMetadata = @(
+        'id',
+        'version',
+        'title',
+        'authors',
+        'owners',
+        'projectUrl',
+        'licenseUrl',
+        'iconUrl',
+        'requireLicenseAcceptance',
+        'summary',
+        'description',
+        'releaseNotes',
+        'copyright',
+        'tags'
+    )
+    foreach ($elementName in $requiredMetadata) {
+        $element = $metadataNode.SelectSingleNode("n:$elementName", $namespaceManager)
+        if ($null -eq $element -or [string]::IsNullOrWhiteSpace($element.InnerText)) {
+            throw "Generated nuspec is missing required metadata: $elementName"
+        }
+    }
+
+    if ($metadataNode.SelectSingleNode('n:id', $namespaceManager).InnerText -cne 'noctty') {
+        throw 'Generated nuspec package id is not noctty.'
+    }
+    if ($metadataNode.SelectSingleNode('n:version', $namespaceManager).InnerText -cne $Version) {
+        throw "Generated nuspec version does not match requested version $Version."
+    }
+    if ($metadataNode.SelectSingleNode('n:requireLicenseAcceptance', $namespaceManager).InnerText -cne 'false') {
+        throw 'Generated nuspec must not require license acceptance.'
+    }
+
+    $installScript = Get-Content -LiteralPath $installScriptPath -Raw
+    $expectedSetupUrl = "https://github.com/amanthanvi/noctty/releases/download/v$Version/$setupName"
+    foreach ($expectedText in @(
+        $setupSha256,
+        $expectedSetupUrl,
+        "checksumType = 'sha256'",
+        '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS',
+        'Install-ChocolateyPackage @packageArgs'
+    )) {
+        if (-not $installScript.Contains($expectedText, [StringComparison]::Ordinal)) {
+            throw "Generated install script is missing expected content: $expectedText"
+        }
+    }
+    foreach ($expectedArchitecture in @('x64', 'arm64')) {
+        if (-not $installScript.Contains($expectedArchitecture, [StringComparison]::Ordinal)) {
+            throw "Generated install script is missing architecture selection for $expectedArchitecture."
+        }
+    }
+
+    $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+    if ($metadata.chocolatey.packageName -cne 'noctty' -or
+        $metadata.chocolatey.nuspecPath -cne $nuspecPath -or
+        $metadata.chocolatey.packageDirectory -cne (Split-Path -Parent $nuspecPath)) {
+        throw 'metadata.json has an invalid Chocolatey block.'
+    }
+
+    $uninstallScriptPath = Join-Path $outputRoot 'chocolatey\tools\chocolateyUninstall.ps1'
+    if (Test-Path -LiteralPath $uninstallScriptPath) {
+        throw 'The Inno package should rely on Chocolatey auto-uninstall, not ship an uninstall script.'
+    }
+
+    if ($ShowGeneratedFiles) {
+        Write-Host '--- generated noctty.nuspec ---'
+        Get-Content -LiteralPath $nuspecPath
+        Write-Host '--- generated chocolateyInstall.ps1 ---'
+        Get-Content -LiteralPath $installScriptPath
+    }
+
+    $choco = Get-Command choco -ErrorAction SilentlyContinue
+    if ($null -eq $choco) {
+        Write-Host 'Skipping choco pack: choco is not on PATH.'
+    }
+    else {
+        New-Item -ItemType Directory -Path $packRoot -Force | Out-Null
+        & $choco.Source pack $nuspecPath "--output-directory=$packRoot" --limit-output
+        if ($LASTEXITCODE -ne 0) {
+            throw "choco pack failed with exit code $LASTEXITCODE."
+        }
+
+        $packages = @(Get-ChildItem -LiteralPath $packRoot -Filter '*.nupkg' -File)
+        if ($packages.Count -ne 1) {
+            throw "Expected one .nupkg from choco pack; found $($packages.Count)."
+        }
+        Write-Host "choco pack produced: $($packages[0].FullName)"
+    }
+
+    Write-Host "Chocolatey package validation: PASS (version=$Version, architecture=$Architecture)"
+}
+finally {
+    if (Test-Path -LiteralPath $packRoot) {
+        Remove-Item -LiteralPath $packRoot -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $scratchRoot) {
+        Remove-Item -LiteralPath $scratchRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

Enterprise fleets script Chocolatey. The release pipeline already generates WinGet and Scoop metadata, so a choco package is close to free reach.

Fixes #139

## Stacked on

Stacked on #172 (`issues/138-portable-mode`), which now targets `main` directly (#157 is merged). Stacked only to keep the shared docs edits conflict-free — nothing here depends on that code.

## Changes

- `scripts/package-package-managers.ps1` generates a Chocolatey package next to the existing Scoop manifest and `metadata.json`, following the same structure: a `noctty.nuspec`, an architecture-aware `tools/chocolateyInstall.ps1`, and a `chocolatey` block in `metadata.json`.
- The install script picks the x64 or ARM64 signed setup.exe from the release URLs, verifies it with the published SHA-256 (`checksumType sha256`), and installs silently with the exact Inno arguments the in-app updater already uses (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS`). Unsupported architectures and missing per-architecture assets fail loudly instead of installing the wrong thing.
- No `chocolateyUninstall.ps1`: the Inno installer registers a `QuietUninstallString`, so Chocolatey's built-in auto-uninstaller already handles removal. Adding a script would duplicate it.
- `.github/workflows/release.yml` gains a "Publish Chocolatey package" step alongside the Scoop and WinGet steps, gated on `if: steps.meta.outputs.prerelease != 'true'` so a prerelease never reaches the public feed. The step is a one-line call to `scripts/release-publish-chocolatey.ps1`, matching the extracted Scoop and WinGet steps. That script skips with `Skipping Chocolatey publish: CHOCO_API_KEY is not configured.` when the secret is absent, asks the community feed whether this id/version is already published and returns early if it is, packs, and pushes to `https://push.chocolatey.org/`. Only the duplicate-version response is tolerated on a failed push; every other failure throws. The key is never echoed.
- `test/windows/package-chocolatey.ps1` validates the generated nuspec's XML shape, required metadata, version, checksum, URL, silent flags and architecture selection, and runs a real `choco pack` when the CLI is present.
- Docs: `docs/status.md` package-manager list, `docs/windows.md` install section, and a `### Chocolatey` section in `PACKAGING.md` matching the existing WinGet/Scoop sections plus the release-runbook entry. Both docs say the package is built by the release workflow but not yet published, because it has not been pushed and the first submission still has to clear moderation, so `choco install noctty` does not work today.
- `$Version` is validated with an ASCII-only, absolutely anchored pattern in both the packaging entry point and the publish script. .NET's `$` also matches before a trailing newline and .NET's `\d` matches every Unicode decimal digit, so `1.2.3` with a trailing newline and non-ASCII digits previously passed parameter binding and could reach the nuspec, artifact names, and download URLs.
- `metadata.chocolatey.packageName` and `packageDirectory` are now read by the publish script (the id for the feed query, the directory the nuspec must live in), so the contract `test/windows/package-chocolatey.ps1` asserts is real rather than aspirational.
- `Contracts.91-Packaging` pins the prerelease gate and the rerun-safe publish shape, so neither can be quietly removed.

## Validation

Rebased onto #172 @ `bd30a8ed2`, itself on `main` @ `53c1bcd33` (post-#164, bundled ConPTY). Gates re-run on this head:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4228 passed, 72 skipped, 0 failed |
| `pwsh -NoProfile -File scripts/check-zig-format.ps1` | `Zig formatting checks passed (697 tracked sources).` |
| `pwsh -NoProfile -File scripts/check-source-format.ps1` | `PowerShell syntax and JSON validity checks passed.` |
| `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` | `flagship verification contracts: PASS (2 scenarios)` |
| `pwsh -NoProfile -File test/windows/package-chocolatey.ps1` | `Chocolatey package validation: PASS (version=0.0.1, architecture=x64)`, with a real `choco pack` producing `noctty.0.0.1.nupkg` |
| `npx prettier@3 --check docs/windows-capability-matrix.md docs/status.md docs/windows.md docs/getting-started.md PACKAGING.md` | `All matched files use Prettier code style!` |

Only `$releaseWorkflowSha256` was re-pinned in `Contracts.80-Release.ps1` (now `54336d73…`, the canonical-text SHA-256 of the merged `release.yml` that carries #164's Defender/attestation steps); no protected-step, body, readiness digest or mutation check was changed or relaxed. Two contracts were added in `Contracts.91-Packaging.ps1`, not removed.

Dual-architecture generator probe with `-Architectures @('x64','arm64')` produced distinct x64/ARM64 setup URLs and checksums (recorded on an earlier head, not re-run this round).

## Residuals / user steps

- **Create a chocolatey.org account and add `CHOCO_API_KEY` as a repository secret.** Until then the publish step no-ops and does not fail the release. The package id `noctty` also needs to survive chocolatey.org's moderation review on first submission.
- Nothing was pushed to chocolatey.org from here. The rerun-safety path (feed query, duplicate-version tolerance) has therefore never run against the real feed; it is asserted by contract, not by a live push.
- The attestation/verification work that #181 carried on this branch is already on `main` in a newer, refactored form, so that merge commit was dropped during the rebase rather than replayed. `scripts/verify-published-release.ps1` on `main` already contains the later "fail the CI provenance gate when gh cannot verify attestations" change, so nothing was cherry-picked.
- Chocolatey prereleases are not published anywhere. Gating the step was the fix; routing prereleases to a prerelease channel would need a SemVer prerelease suffix in the nuspec and is a separate decision.

## Summary by Sourcery

Add Chocolatey packaging and stable-release publishing support alongside the existing Windows package-manager channels.

New Features:
- Add Chocolatey package generation with architecture-specific installers, checksums, metadata, and silent installation configuration.
- Publish stable Chocolatey packages from the release workflow with configurable credentials and rerun-safe duplicate handling.

Bug Fixes:
- Reject malformed or unsafe release versions consistently during package generation and publishing.
- Prevent prerelease builds from being published to the public Chocolatey feed.

Enhancements:
- Reuse generated Chocolatey metadata to locate and validate the package during publishing.
- Add release contracts that protect the prerelease gate and duplicate-version handling.

Documentation:
- Document Chocolatey installation status, package configuration, manual publishing, and release runbook steps.

Tests:
- Add validation coverage for Chocolatey metadata, architecture selection, checksums, installer options, and package creation.

Chores:
- Update the release workflow verification hash for the Chocolatey publishing step.

## Review follow-up

Fable stack review (finding 8, INFO): `$Version` reaches the nuspec, artifact file names and download URLs but was only constrained workflow-side. `scripts/package-package-managers.ps1` now validates `^\d+\.\d+\.\d+$` at the parameter, so manual and test invocations cannot inject path or URL fragments either. Verified both ways: `test/windows/package-chocolatey.ps1` still passes end to end with a real `choco pack`, and `-Version '1.3.100/../evil'` is now rejected by parameter validation.
- Rely on the Inno installer’s registered quiet uninstall command instead of adding a duplicate Chocolatey uninstall script.

Documentation:
- Document Chocolatey installation, package details, publishing configuration, and release runbook steps.

Tests:
- Add validation coverage for Chocolatey package metadata, architecture selection, checksums, installer options, and package creation.

Chores:
- Update verification contract pins for the release workflow change.

## Stack-wide residuals (recorded on every PR in this stack)

- **Nothing in this stack has run in a real release.** All release-pipeline work was validated locally against a throwaway self-signed certificate and fixture payload trees. The first tag cut with #181 is the real test of manifest generation, signing, attestation and the ten-asset gate.
- **`$firstAttestedVersion = [version]'1.3.124'` in `scripts/verify-published-release.ps1` assumes the next release is 1.3.124.** If a tag is cut with a different number, provenance verification silently skips instead of failing. Move that constant with the tag.
- A working Windows code-signing certificate has existed in the `release` environment since 2026-04-30 (self-signed `CN=winghostty Local Dev Signing`, SPKI pinned in `src/update/github_releases.zig` and ADR-0005). The open SignPath-vs-OV decision governs SmartScreen **reputation**, not signing capability.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.