### PR TITLE
fix: adopt seven upstream fixes in the 2026-08 merge window (#141)

### DIFF
--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -217,9 +217,11 @@ fn kitty(
     const entry = entry_ orelse {
         // No entry found. If we have UTF-8 text this is a pure text event
         // (e.g. composed/IME text), so send it as-is so programs can
-        // still receive it.
-        if (event.utf8.len > 0) return try writer.writeAll(event.utf8);
-        return;
+        // still receive it. Release events never insert text, same as the
+        // plain-text path above.
+        if (event.action == .release) return;
+        if (event.utf8.len == 0) return;
+        return try writer.writeAll(event.utf8);
     };
 
     // If this is just a modifier we require "report all" to send the sequence.
@@ -1458,6 +1460,50 @@ test "kitty: composed text with report all" {
         },
     });
     try testing.expectEqualStrings("\xc3\xbb", writer.buffered());
+}
+
+// A key whose base (unshifted) keysym is a dead key has no unshifted
+// codepoint, so it has no kitty entry and falls back to writing the text
+// directly. That must not happen on release or the text is inserted twice.
+test "kitty: text fallback on release" {
+    for ([_]bool{ false, true }) |report_all| {
+        var buf: [128]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        try kitty(&writer, .{
+            .action = .release,
+            .key = .unidentified,
+            .mods = .{ .shift = true },
+            .utf8 = "!",
+        }, .{
+            .kitty_flags = .{
+                .disambiguate = true,
+                .report_events = true,
+                .report_alternates = true,
+                .report_all = report_all,
+                .report_associated = true,
+            },
+        });
+        try testing.expectEqualStrings("", writer.buffered());
+    }
+}
+
+test "kitty: text fallback on repeat" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{
+        .action = .repeat,
+        .key = .unidentified,
+        .mods = .{ .shift = true },
+        .utf8 = "!",
+    }, .{
+        .kitty_flags = .{
+            .disambiguate = true,
+            .report_events = true,
+            .report_alternates = true,
+            .report_associated = true,
+        },
+    });
+    try testing.expectEqualStrings("!", writer.buffered());
 }
 
 test "kitty: shift+a on US keyboard" {

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -195,7 +195,7 @@ pub const Preedit = struct {
 
         // If our preedit goes off the end of the screen, we adjust it so
         // that it shifts left.
-        const end = start + w;
+        const end = if (w > 0) start + (w - 1) else start;
         const start_offset = if (end > max) end - max else 0;
         return .{
             .start = start -| start_offset,
@@ -204,3 +204,41 @@ pub const Preedit = struct {
         };
     }
 };
+
+const test_hangul_ga: u21 = 0xAC00; // U+AC00 HANGUL SYLLABLE GA
+
+test "preedit range covers exact cell width" {
+    const testing = std.testing;
+
+    {
+        const p: Preedit = .{
+            .codepoints = &.{.{ .codepoint = 'a' }},
+        };
+        const range = p.range(2, 9);
+        try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 2), range.start);
+        try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 2), range.end);
+        try testing.expectEqual(@as(usize, 0), range.cp_offset);
+    }
+
+    {
+        const p: Preedit = .{
+            .codepoints = &.{.{ .codepoint = test_hangul_ga, .wide = true }},
+        };
+        const range = p.range(2, 9);
+        try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 2), range.start);
+        try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 3), range.end);
+        try testing.expectEqual(@as(usize, 0), range.cp_offset);
+    }
+}
+
+test "preedit range shifts left at right edge" {
+    const testing = std.testing;
+
+    const p: Preedit = .{
+        .codepoints = &.{.{ .codepoint = test_hangul_ga, .wide = true }},
+    };
+    const range = p.range(9, 9);
+    try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 8), range.start);
+    try testing.expectEqual(@as(terminalpkg.size.CellCountInt, 9), range.end);
+    try testing.expectEqual(@as(usize, 0), range.cp_offset);
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1208,6 +1208,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (self.terminal_state_frame_count >= max_terminal_state_frame_count) {
                 self.terminal_state.deinit(self.alloc);
                 self.terminal_state = .empty;
+                self.terminal_state_frame_count = 0;
             }
             self.terminal_state_frame_count += 1;
 

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -22,6 +22,20 @@ pub const Link = struct {
     pub fn deinit(self: *Link) void {
         self.regex.deinit();
     }
+
+    /// Returns true if this link's highlight condition matches the given mouse state.
+    fn active(
+        self: *const Link,
+        mouse_viewport: ?point.Coordinate,
+        mouse_mods: inputpkg.Mods,
+    ) bool {
+        return switch (self.highlight) {
+            .always => true,
+            .always_mods => |v| mouse_mods.equal(v),
+            .hover => mouse_viewport != null,
+            .hover_mods => |v| mouse_viewport != null and mouse_mods.equal(v),
+        };
+    }
 };
 
 /// A set of links. This provides a higher level API for renderers
@@ -91,6 +105,14 @@ pub const Set = struct {
         // Fast path, not very likely since we have default links.
         if (self.links.len == 0) return;
 
+        // Determine if any links are active before building the string and
+        // byte-to-cell map. Those buffers scale with viewport size and this
+        // function runs during frame updates, so avoid allocating them when
+        // the current mouse/modifier state can't highlight any regex links.
+        for (self.links) |*link| {
+            if (link.active(mouse_viewport, mouse_mods)) break;
+        } else return;
+
         // Convert our render state to a string + byte map.
         var builder: std.Io.Writer.Allocating = .init(alloc);
         defer builder.deinit();
@@ -105,20 +127,7 @@ pub const Set = struct {
 
         // Go through each link and see if we have any matches.
         for (self.links) |*link| {
-            // Determine if our highlight conditions are met. We use a
-            // switch here instead of an if so that we can get a compile
-            // error if any other conditions are added.
-            switch (link.highlight) {
-                .always => {},
-                .always_mods => |v| if (!mouse_mods.equal(v)) continue,
-
-                // We check the hover points later.
-                .hover => if (mouse_viewport == null) continue,
-                .hover_mods => |v| {
-                    if (mouse_viewport == null) continue;
-                    if (!mouse_mods.equal(v)) continue;
-                },
-            }
+            if (!link.active(mouse_viewport, mouse_mods)) continue;
 
             var offset: usize = 0;
             while (offset < str.len) {
@@ -289,6 +298,65 @@ test "renderCellMap hover links" {
         try testing.expect(result.contains(.{ .x = 1, .y = 1 }));
         try testing.expect(!result.contains(.{ .x = 1, .y = 2 }));
     }
+}
+
+test "renderCellMap inactive links don't allocate" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t: terminal.Terminal = try .init(alloc, .{
+        .cols = 5,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    const str = "1ABCD2EFGH\r\n3IJKL";
+    s.nextSlice(str);
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{
+        .{
+            .regex = "AB",
+            .action = .{ .open = {} },
+            .highlight = .{ .hover = {} },
+        },
+
+        .{
+            .regex = "EF",
+            .action = .{ .open = {} },
+            .highlight = .{ .always_mods = .{ .ctrl = true } },
+        },
+
+        .{
+            .regex = "IJ",
+            .action = .{ .open = {} },
+            .highlight = .{ .hover_mods = .{ .shift = true } },
+        },
+    });
+    defer set.deinit(alloc);
+
+    var failing = std.testing.FailingAllocator.init(
+        alloc,
+        .{ .fail_index = 0 },
+    );
+    const failing_alloc = failing.allocator();
+
+    var result: terminal.RenderState.CellSet = .empty;
+    defer result.deinit(failing_alloc);
+    try set.renderCellMap(
+        failing_alloc,
+        &result,
+        &state,
+        null,
+        .{},
+    );
+
+    try testing.expectEqual(@as(usize, 0), result.count());
 }
 
 test "renderCellMap mods no match" {

--- a/src/simd/base64.zig
+++ b/src/simd/base64.zig
@@ -53,9 +53,9 @@ fn decodeScalar(
 /// For non-SIMD enabled builds, we trim the padding from the end of the
 /// base64 input in order to get identical output with the SIMD version.
 fn scalarInput(input: []const u8) []const u8 {
-    var i: usize = 0;
-    while (input[input.len - i - 1] == '=') i += 1;
-    return input[0 .. input.len - i];
+    var end = input.len;
+    while (end > 0 and input[end - 1] == '=') end -= 1;
+    return input[0..end];
 }
 
 // base64.cpp
@@ -73,6 +73,14 @@ test "base64 maxLen" {
     const testing = std.testing;
     const len = maxLen("aGVsbG8gd29ybGQ=");
     try testing.expectEqual(11, len);
+}
+
+test "base64 empty input" {
+    const testing = std.testing;
+    var output: [0]u8 = .{};
+
+    try testing.expectEqual(0, maxLen(""));
+    try testing.expectEqualStrings("", try decode("", &output));
 }
 
 test "base64 decode" {

--- a/src/terminal/apc.zig
+++ b/src/terminal/apc.zig
@@ -46,6 +46,7 @@ pub const Handler = struct {
             .kitty => |*p| if (comptime build_options.kitty_graphics) {
                 p.feed(byte) catch |err| {
                     log.warn("kitty graphics protocol error: {}", .{err});
+                    p.deinit();
                     self.state = .ignore;
                 };
             } else unreachable,
@@ -167,6 +168,22 @@ test "Kitty command with overflow i32" {
     h.start();
     for ("Ga=p,i=1,z=-9999999999") |c| h.feed(alloc, c);
     try testing.expect(h.end() == null);
+}
+
+test "kitty feed error deinits parser" {
+    if (comptime !build_options.kitty_graphics) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Feed a valid kitty command start to allocate parser state, then
+    // trigger an error during feed via an integer overflow. The testing
+    // allocator will detect leaks if deinit is not called.
+    var h: Handler = .{};
+    defer h.deinit();
+    h.start();
+    for ("Ga=p,i=10000000000;") |c| h.feed(alloc, c);
+    try testing.expect(h.state == .ignore);
 }
 
 test "valid Kitty command" {

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -497,6 +497,15 @@ pub fn RefCountedSet(
             return self.lookupContext(base, value, self.context);
         }
         pub fn lookupContext(self: *const Self, base: anytype, value: T, ctx: Context) ?Id {
+            // A zero-capacity set (a valid special case of Layout.init)
+            // contains nothing and has a zero-size table, so we can't
+            // probe it: table[0] would read whatever memory follows the
+            // set in the backing buffer.
+            if (self.layout.table_cap == 0) {
+                @branchHint(.cold);
+                return null;
+            }
+
             const table = self.table.ptr(base);
             const items = self.items.ptr(base);
 

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -966,6 +966,36 @@ test "Set capacities" {
     _ = Set.Layout.init(16384);
 }
 
+test "Set zero capacity" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // A zero-capacity set is a valid special case (see Layout.init).
+    // It occurs in practice for pages with exact capacities where no
+    // cell is styled (see Page.exactRowCapacity).
+    const layout: Set.Layout = .init(0);
+    try testing.expectEqual(0, layout.total_size);
+
+    // We allocate a nonzero buffer filled with 0xFF to simulate the
+    // set being embedded in a larger structure (e.g. a Page) where
+    // other data follows it. Lookups must not probe the zero-size
+    // table: table[0] would read this adjacent memory and treat it
+    // as an item ID, leading to far out-of-bounds item reads.
+    const buf = try alloc.alignedAlloc(u8, Set.base_align, 64);
+    defer alloc.free(buf);
+    @memset(buf, 0xFF);
+
+    var set = Set.init(.init(buf), layout, .{});
+
+    const style: Style = .{ .flags = .{ .bold = true } };
+    try testing.expectEqual(null, set.lookup(buf, style));
+    try testing.expectError(error.OutOfMemory, set.add(buf, style));
+    try testing.expectEqual(0, set.count());
+
+    // The adjacent memory must be untouched.
+    for (buf) |b| try testing.expectEqual(0xFF, b);
+}
+
 test "Style HTML formatting basic bold" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
## Summary

The first upstream merge window under the policy published in #174. Seven
narrow upstream Ghostty fixes, each its own commit with a
`(cherry picked from upstream <sha>)` trailer. Nothing touches `src/apprt/**`,
no config default changes, no new features.

Selection rule: security-relevant or named by the C33 roadmap entry (kitty
key-release, UTF-8/VT fixes, renderer work), AND applies without structural
conflict, AND survives the build + full test suite.

Refs #141

## Stacked on

Stacked on #174 (`issues/141-upstream-merge-policy`). Base is the policy
branch, not `main`, so the policy can merge independently if this slice needs
more work.

## Changes

| Upstream SHA | Subject | Files |
| --- | --- | --- |
| `83027407e66e` | terminal: fix memory leak with invalid Kitty image cmd | `src/terminal/apc.zig` |
| `ac67a6160c81` | renderer: fix preedit range width | `src/renderer/State.zig` |
| `e44f5cb0fa1a` | terminal: guard RefCountedSet lookups against zero-capacity sets | `src/terminal/ref_counted_set.zig`, `src/terminal/style.zig` |
| `9c9cf3e82174` | renderer: avoid allocating when there are no active links | `src/renderer/link.zig` |
| `9e6e2ea96458` | renderer: reset terminal state cleanup counter | `src/renderer/generic.zig` |
| `a8c3ab1915c9` | simd: fix scalar base64 empty input handling causing a crash | `src/simd/base64.zig` |
| `bd647035e97d` | input: don't emit fallback text on key release | `src/input/key_encode.zig` |

`bd647035e97d` is the roadmap's named "kitty key-release" fix.

**Dropped: `997a2aff2afc`** (`terminal: preserve pending wrap in VT
formatter`). It applies without conflict but does not compile — it calls
`PageList.Node.page()`, added by later upstream `PageList` work this fork has
not merged. Moved to the deferred list in the drift report rather than adapted.
This is the policy's rule in action: textual applicability is not evidence.

## Validation

Rebased onto the updated #174 head `f73ac4aab` (itself on `main`
`e3a38268e`, 2026-09-02). All seven cherry-picks rebased with identical
patch-ids; no conflicts. Results observed at the final head `852daa51e`.

| Command | Result |
| --- | --- |
| `zig build -Demit-exe=true` | PASS |
| `zig build test -Demit-test-exe=true` | **4080 passed, 70 skipped, 0 failed** |
| `pwsh -NoProfile -File scripts/check-zig-format.ps1` | PASS (693 tracked sources) |
| `pwsh -NoProfile -File scripts/check-source-format.ps1` | PASS |
| `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| `zig build test -Dtest-filter=<key_encode, base64, RefCountedSet, preedit, link, apc>` | PASS: 148/8, 73/2, 68/1, 71/1, 148/1, 74/1 (passed/skipped), 0 failed |

### Status: provisional

The three terminal/SIMD picks (`83027407e66e`, `e44f5cb0fa1a`, `a8c3ab1915c9`)
are certified by the gates above. The four renderer/input picks
(`ac67a6160c81`, `9c9cf3e82174`, `9e6e2ea96458`, `bd647035e97d`) are
**provisional**: the merge policy this PR is stacked on requires the interactive
Windows 11 composite plus the affected IME/key-input harnesses for
renderer/input picks, and those results are not yet recorded. An interactive
validation run was attempted and stalled without producing usable evidence, so
nothing is claimed from it. Do not mark this PR ready until those results exist.

The interactive certification is pending an orchestrated run of
`test/windows/interactive-win11-validate.ps1` plus the IME and key-input
harnesses on the owner's machine; the results will be recorded in
`plans/upstream-drift-2026-08.md`.

Independent read-only review found **no Critical or High findings** and no
material correctness, regression, memory-safety, or security defect. It
specifically cleared the four Win32-sensitive picks:

- **Preedit range** is now inclusive; the sole production consumer
  (`generic.zig` `preedit_range`, `x <= range.x[1]`, resume at
  `range.x[1] + 1`) already read it inclusively, so the old code suppressed one
  extra cell. Win32's `imePoint()` does not independently derive the cell range,
  so there is no new disagreement.
- **Link fast path** returns only when *every* configured link is inactive; the
  fork's built-in URL matcher is in that set. Hover preview and `open_url` go
  through `Surface.linkAtPos`/`linkAtPin`, not this path.
- **Cleanup counter** previously deinitialized on every frame past the
  threshold; no Win32 present/vsync/scheduler path reads it.
- **Key release**: Win32 already skips text translation on releases; dead keys,
  AltGr, `WM_CHAR`, and IME commits all ride press/repeat events.
- `git diff origin/main...HEAD -- src/config src/config.zig` is empty — no
  default changed.

## Residuals / user steps

- **Outstanding gate:** interactive Win11 validation for the four
  renderer/input picks — `test/windows/interactive-win11-validate.ps1
  -ResetState -Rebuild`, plus `interactive-win11-ime-candidate.ps1` (preedit)
  and `interactive-win11-key-input.ps1` (key encoding), plus a hover-URL check.
  Pending the orchestrated run described above.

### Deferred to the next merge window

Itemized with per-group reasons in `plans/upstream-drift-2026-08.md`:

| Group | Commits | Reason |
| --- | --- | --- |
| VT formatter pending-wrap | `997a2aff2afc` | Applies cleanly, does not compile: needs `PageList.Node.page()` from unmerged upstream `PageList` work. |
| Critical UTF-8/VT security + correctness | `aea63d71fe66`, `cb4c49fbf206`, `c992658b2994`, `727b8a02f873`, `6cadad06f468`, `7cd2f65f5cb3` | Patches fail against upstream-dependent APIs, or cross fork-owned `Terminal.zig` / `osc.zig` / `color.zig` / `stream_handler.zig`. |
| VT fast-path chain | `47e26df60f53`, `1a88f3622b50`, `253e4f9c3c43`, `300f42c7a970` | Later patches depend on the first, which crosses fork-modified `Terminal.zig` and `stream_handler.zig`. Must move as a unit. |
| Kitty graphics security series | `64dcb91c1f3f`, `af2faa311a5a`, `e5840bb9bacd`, `ec04900ab957`, `f766f303a7d3`, `590d669c4a72` | Fork predates the upstream Kitty refactors these depend on; apply in upstream order with protocol tests. |
| Title-report injection fix | `38e891e6c0bb` | Patch fails, and opt-in title reports change user-visible behavior — out of scope for a fix-only slice. |
| Surface UAF fixes | `28f4676b5d89`, `ab82b8ab720c` | `src/Surface.zig` is a high-risk fork-owned seam (search, semantic output, renderer state, Win32 lifetime). |
| Terminal pointer/geometry safety | `33d34cf5ce7b`, `33cda4dc5dbf`, `c5a3c7e2e5b4` | Cross fork-modified `Terminal.zig` or the renderer image error-propagation seam. |
| Renderer scheduling and state | `14d9e600acf2`, `25e624569143`, `d34b54e9b4ec`, `446f80f4edd1`, `cde7f93435eb`, `aee7bf347564`, `9490f7134215` | Conflict with Win32 wake pacing, mailbox behavior, dirty-row uploads, vsync/presentation, error propagation. |
| Kitty placement lifecycle | `6760c6482be2`, `d0c516f8f384`, `b5e86a42844e`, `b8222f4a8403` | Cross fork-modified `renderer/image.zig`; depend on the upstream Kitty storage/pin model. |
| Zig 0.16 + build/dependency migration | `e8525c0fd907` and dependents | Repo-wide structural migration across the Windows-only build graph, lib-vt, packaging, and CI. Not an incremental pick. |

Deferred **security** items worth scheduling first: the Kitty graphics
loading-limit series, the two `Surface.zig` use-after-free fixes, bounded
OSC/grapheme allocations (`727b8a02f873`), and the UTF-8 grapheme length
overflow (`aea63d71fe66`).

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim
above was verified against the code and the gate output.

## Summary by Sourcery

Adopt seven upstream fixes covering terminal parsing, renderer state and link handling, SIMD base64 decoding, and Kitty keyboard input.

Bug Fixes:
- Fix Kitty graphics parser leaks after protocol errors.
- Prevent zero-capacity terminal style sets from performing invalid lookups.
- Handle empty scalar base64 input without crashing.
- Correct preedit ranges at exact and wide-character boundaries.
- Avoid duplicate fallback text emission for Kitty key-release events.
- Prevent unnecessary link-map allocations when no links are active.
- Reset renderer terminal-state cleanup tracking after deinitialization.

Tests:
- Add regression coverage for Kitty parser cleanup, key-release and repeat handling, preedit ranges, inactive links, empty base64 input, and zero-capacity style sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented key-release events from inserting text twice.
  - Corrected preedit selection ranges for single-cell and wide characters, including at the viewport edge.
  - Improved terminal rendering state reset behavior after reinitialization.
  - Fixed handling of empty Base64 input.
  - Improved recovery from kitty graphics parsing errors.
  - Prevented invalid lookups in empty terminal style and reference sets.
  - Reduced unnecessary work when inactive links are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->