### PR TITLE
docs: lowercase former WingHostty references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 </p>
 
 <p align="center">
-  <strong>Noctty</strong> (formerly WingHostty) — <em>Ghostty's terminal core in a fast, native Windows app.</em>
+  <strong>Noctty</strong> (formerly winghostty) — <em>Ghostty's terminal core in a fast, native Windows app.</em>
   <br />
   Tabs, splits, and session restore · Native Win32, OpenGL renderer · No telemetry
 </p>
 
 <p align="center">
-  <sub>WingHostty was renamed to Noctty in August 2026 following a
+  <sub>winghostty was renamed to Noctty in August 2026 following a
   <a href="https://github.com/amanthanvi/noctty/issues/119">trademark request from the Ghostty team</a>;
   same project, same maintainer.</sub>
 </p>

--- a/scripts/check-site-copy.ps1
+++ b/scripts/check-site-copy.ps1
@@ -40,7 +40,7 @@ $requiredRules = @(
     @{ Path = Join-Path $siteRoot "terminal.js"; Pattern = "%LOCALAPPDATA%\\noctty\\config.ghostty"; Reason = "Landing page should mention the real Windows config path." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "https://github.com/amanthanvi/noctty"; Reason = "Landing page should keep a repo link." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "winget install AmanThanvi.noctty"; Reason = "Hero copy should surface the official WinGet install command." },
-    @{ Path = Join-Path $siteRoot "index.html"; Pattern = "formerly WingHostty"; Reason = "Hero should keep the rename note so former WingHostty users recognize the project." },
+    @{ Path = Join-Path $siteRoot "index.html"; Pattern = "formerly winghostty"; Reason = "Footer should keep the rename note so former winghostty users recognize the project." },
     @{ Path = Join-Path $siteRoot "install.js"; Pattern = "scoop install noctty/noctty"; Reason = "Copied install text should include the official Scoop install command." },
     @{ Path = Join-Path $siteRoot "install.js"; Pattern = "https://github.com/amanthanvi/scoop-noctty"; Reason = "Copied Scoop install text should include the official bucket source." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "Session restoration"; Reason = "Landing page should describe current session restoration." },

--- a/scripts/check-site-copy.ps1
+++ b/scripts/check-site-copy.ps1
@@ -40,7 +40,7 @@ $requiredRules = @(
     @{ Path = Join-Path $siteRoot "terminal.js"; Pattern = "%LOCALAPPDATA%\\noctty\\config.ghostty"; Reason = "Landing page should mention the real Windows config path." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "https://github.com/amanthanvi/noctty"; Reason = "Landing page should keep a repo link." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "winget install AmanThanvi.noctty"; Reason = "Hero copy should surface the official WinGet install command." },
-    @{ Path = Join-Path $siteRoot "index.html"; Pattern = "formerly winghostty"; Reason = "Footer should keep the rename note so former winghostty users recognize the project." },
+    @{ Path = Join-Path $siteRoot "index.html"; Pattern = "Formerly winghostty"; CaseSensitive = $true; Reason = "Footer should keep the rename note so former winghostty users recognize the project." },
     @{ Path = Join-Path $siteRoot "install.js"; Pattern = "scoop install noctty/noctty"; Reason = "Copied install text should include the official Scoop install command." },
     @{ Path = Join-Path $siteRoot "install.js"; Pattern = "https://github.com/amanthanvi/scoop-noctty"; Reason = "Copied Scoop install text should include the official bucket source." },
     @{ Path = Join-Path $siteRoot "index.html"; Pattern = "Session restoration"; Reason = "Landing page should describe current session restoration." },
@@ -72,7 +72,7 @@ foreach ($rule in $requiredRules) {
         continue
     }
 
-    $match = Select-String -Path $rule.Path -Pattern $rule.Pattern -SimpleMatch
+    $match = Select-String -Path $rule.Path -Pattern $rule.Pattern -SimpleMatch -CaseSensitive:([bool]$rule.CaseSensitive)
     if (-not $match) {
         $failures.Add(('{0}: missing required pattern "{1}" - {2}' -f $rule.Path, $rule.Pattern, $rule.Reason))
     }

--- a/site/index.html
+++ b/site/index.html
@@ -303,7 +303,7 @@ scoop install noctty/noctty</code></pre>
       <p class="nc-footer__fine">
         Built on Ghostty's terminal core by Mitchell Hashimoto and contributors.
         Win32 runtime by <a href="https://github.com/amanthanvi" target="_blank" rel="noopener noreferrer">@amanthanvi</a>.
-        MIT licensed. Not affiliated with upstream Ghostty. Formerly WingHostty.
+        MIT licensed. Not affiliated with upstream Ghostty. Formerly winghostty.
       </p>
     </div>
   </footer>

--- a/src/build/mdgen/ghostty_1_header.md
+++ b/src/build/mdgen/ghostty_1_header.md
@@ -6,7 +6,7 @@
 
 # DESCRIPTION
 
-noctty (formerly WingHostty) is a GPU-accelerated terminal emulator for
+noctty (formerly winghostty) is a GPU-accelerated terminal emulator for
 Windows. It embeds the terminal core from the Ghostty project inside a
 native Win32 application, adding tabs, splits, session restoration, a
 native settings window, and a keyboard-driven command palette.


### PR DESCRIPTION
## Summary

- Lowercase historical `WingHostty` references in project documentation and supporting copy to match the current Noctty branding.
- Preserve references to the former name where historical context is still needed.

## Validation

- [ ] `zig build test -Dtest-filter=win32` (not run; documentation-only change)
- [ ] `zig build test -Dtest-filter=scroll` (not run; documentation-only change)
- [ ] `zig build test -Dtest-filter=keybind` (not run; documentation-only change)
- [ ] `zig build -Demit-exe=true` (not run; documentation-only change)

## Risks / Follow-ups

- Review remaining historical-name references after merge to ensure intentional archival wording remains clear.
- No source files changed; no build or runtime validation is required for this documentation-only commit.

Changed files: none in this session.

Commands run: `git status -sb`; `git log --oneline -3`.

Validation: confirmed the head branch is `t3code/lowercase-winghostty-brand` and its latest commit is `docs: lowercase former winghostty references`.

Risks: the supplied branch diff includes unrelated baseline divergence; this change request describes the stated head commit only.

## Summary by Sourcery

Standardize historical WingHostty branding as lowercase winghostty across project documentation and site copy.

Enhancements:
- Standardize former project-name references as lowercase `winghostty` across the README, website footer, and generated project description.

CI:
- Update site-copy validation to enforce the lowercase historical brand reference with case-sensitive matching.

Documentation:
- Update documentation and website copy to use lowercase `winghostty` while preserving the rename context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the former project name to the standardized lowercase spelling, “winghostty,” across the README and generated project description.

* **Website**
  * Updated the site footer’s legacy name reference to “winghostty.”

* **Tests**
  * Updated site-copy validation to recognize the standardized lowercase name and the footer location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->