### PR TITLE
feat(win32): taskbar jump lists with recent directories and profiles (#126)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -53,6 +53,8 @@ Win32-validated VT protocol coverage is tracked in
   PowerShell, `cmd`, Git Bash, and WSL distributions when WSL responds.
 - Concrete aliases from `%USERPROFILE%\.ssh\config` appear in the profile
   picker and universal palette and launch through the system `ssh.exe`.
+- Native taskbar jump list with recent working directories and detected
+  shell profiles.
 - Per-monitor DPI scaling.
 - DWM dark title bar that follows the app theme.
 - High-contrast mode detection and palette switching.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -56,6 +56,7 @@ Last reviewed: 2026-08-21.
 | Power-aware rendering                                                             | `unfocused-render-fps` caps visible background presentation; `power-saver-rendering` controls saver pacing; minimized and DWM-cloaked windows do not present. See [power and battery](windows.md#power-and-battery). |
 | SSH host discovery                                                                | Concrete aliases from `%USERPROFILE%\.ssh\config` appear as system `ssh.exe` launch entries in the picker and palette.    |
 | Windows default terminal                                                          | `+register-default-terminal` selects noctty per user through the Windows Terminal 1.24-or-newer OpenConsole handoff; see [windows.md](windows.md#default-terminal). |
+| Taskbar jump lists                                                                | Recent working directories and detected shell profiles launch from the pinned or running taskbar button.                   |
 
 ## Notes
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -56,7 +56,7 @@ Last reviewed: 2026-08-21.
 | Power-aware rendering                                                             | `unfocused-render-fps` caps visible background presentation; `power-saver-rendering` controls saver pacing; minimized and DWM-cloaked windows do not present. See [power and battery](windows.md#power-and-battery). |
 | SSH host discovery                                                                | Concrete aliases from `%USERPROFILE%\.ssh\config` appear as system `ssh.exe` launch entries in the picker and palette.    |
 | Windows default terminal                                                          | `+register-default-terminal` selects noctty per user through the Windows Terminal 1.24-or-newer OpenConsole handoff; see [windows.md](windows.md#default-terminal). |
-| Taskbar jump lists                                                                | Recent working directories and detected shell profiles launch from the pinned or running taskbar button.                   |
+| Taskbar jump lists                                                                | Recent working directories and detected shell profiles launch from the pinned or running taskbar button. See [taskbar jump list](windows.md#taskbar-jump-list). |
 
 ## Notes
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -240,6 +240,18 @@ registration time only when noctty is still selected, then removes noctty's
 per-user COM registration. It does not overwrite a default-terminal choice
 made after noctty was registered. Both commands are idempotent.
 
+## Launch topology
+
+The taskbar jump list has two categories:
+
+- **Recent** lists up to 10 absolute local working directories reported by
+  shell pwd/OSC integration, newest first. Selecting an entry launches noctty
+  in that directory. Entries persist in
+  `%LOCALAPPDATA%\noctty\jump-list-recents.json`; to clear them, close noctty,
+  delete that file, and start noctty once so Windows receives the empty list.
+- **Profiles** lists the detected shell profiles. Selecting an entry launches
+  noctty with that profile's command.
+
 ## Notifications and progress
 
 Desktop notifications use WinRT toasts when available and fall back to

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -240,7 +240,7 @@ registration time only when noctty is still selected, then removes noctty's
 per-user COM registration. It does not overwrite a default-terminal choice
 made after noctty was registered. Both commands are idempotent.
 
-## Launch topology
+## Taskbar jump list
 
 The taskbar jump list has two categories:
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4818,6 +4818,9 @@ pub const App = struct {
                             }
                             if (host.overlay_mode == .command_palette) host.rebuildPaletteList();
                         }
+                        if (jump_list_profiles_pending) {
+                            self.jump_list.?.requestProfileDiscovery();
+                        }
                         self.scheduleGlobalHotkeySync();
                         self.reconfigureTheme();
                         for (self.windows.items) |surface| {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -11664,7 +11664,12 @@ const Host = struct {
         );
         if (self.profiles) |profiles| windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
         self.profiles = next_profiles;
-        if (self.app.jump_list) |*jump_list| jump_list.updateProfiles(next_profiles);
+        if (self.app.jump_list) |*jump_list| {
+            // A later user-initiated load recovers startup discovery after its
+            // bounded transient-failure retry budget has been exhausted.
+            jump_list.completeStartupProfileDiscovery();
+            jump_list.updateProfiles(next_profiles);
+        }
         if (replacing and self.overlay_mode == .command_palette) self.rebuildPaletteList();
         self.app.applyLauncherQuickSlotPreferences(self.profiles.?);
         const profiles = self.profiles.?;

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2355,6 +2355,23 @@ fn sessionRestorePolicyAllows(
         !explicit_startup_working_directory;
 }
 
+fn sessionSavePolicyAllows(
+    safe_mode: bool,
+    policy: configpkg.Config.WindowSaveState,
+    initial_window: bool,
+    has_initial_command: bool,
+    startup_profile_picker: bool,
+) bool {
+    return sessionRestorePolicyAllows(
+        safe_mode,
+        policy,
+        initial_window,
+        has_initial_command,
+        startup_profile_picker,
+        false,
+    );
+}
+
 pub const App = struct {
     pub const must_draw_from_app_thread = true;
 
@@ -3094,9 +3111,12 @@ pub const App = struct {
         // Safe mode is deliberately non-destructive. It starts without
         // restoring the saved session and must not replace or delete that
         // session when the diagnostic run exits.
-        return sessionStatePolicyAllows(
+        return sessionSavePolicyAllows(
             self.safe_mode,
             self.config.@"window-save-state",
+            self.config.@"initial-window",
+            self.config.@"initial-command" != null,
+            self.startup_profile_picker,
         );
     }
 
@@ -31769,7 +31789,10 @@ test "win32 explicit startup flows bypass session restore" {
     try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, true, true, true));
 
     // Startup-only restore bypasses must not disable later session saves.
-    try std.testing.expect(sessionStatePolicyAllows(false, .default));
+    try std.testing.expect(sessionSavePolicyAllows(false, .default, true, false, false));
+    try std.testing.expect(!sessionSavePolicyAllows(false, .default, false, false, false));
+    try std.testing.expect(!sessionSavePolicyAllows(false, .default, true, true, false));
+    try std.testing.expect(!sessionSavePolicyAllows(false, .default, true, false, true));
 }
 
 test "win32 session restore transaction preserves first surface state" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2898,13 +2898,18 @@ pub const App = struct {
                         // `initial-window=false` starts without a primary
                         // surface. The request stays pending until one exists.
                         if (self.hosts.items.len > 0 and
-                            jump_list.takeStartupProfileDiscovery())
+                            jump_list.startupProfileDiscoveryPending())
                         {
                             const host = self.hosts.items[0];
                             if (host.profiles == null) {
-                                _ = host.ensureProfiles() catch |err| {
+                                _ = host.ensureProfiles() catch |err| retry: {
                                     log.warn("jump list deferred profile discovery failed err={}", .{err});
+                                    jump_list.scheduleIfStartupPending();
+                                    break :retry false;
                                 };
+                            }
+                            if (host.profiles != null) {
+                                jump_list.completeStartupProfileDiscovery();
                             }
                         }
                         continue;

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -3094,7 +3094,10 @@ pub const App = struct {
         // Safe mode is deliberately non-destructive. It starts without
         // restoring the saved session and must not replace or delete that
         // session when the diagnostic run exits.
-        return self.sessionRestoreEligible();
+        return sessionStatePolicyAllows(
+            self.safe_mode,
+            self.config.@"window-save-state",
+        );
     }
 
     fn sessionRestoreEligible(self: *const App) bool {
@@ -31764,6 +31767,9 @@ test "win32 explicit startup flows bypass session restore" {
     try std.testing.expect(!sessionRestorePolicyAllows(true, .always, true, false, false, false));
     try std.testing.expect(!sessionRestorePolicyAllows(false, .never, true, false, false, false));
     try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, true, true, true));
+
+    // Startup-only restore bypasses must not disable later session saves.
+    try std.testing.expect(sessionStatePolicyAllows(false, .default));
 }
 
 test "win32 session restore transaction preserves first surface state" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2934,15 +2934,17 @@ pub const App = struct {
                             jump_list.startupProfileDiscoveryPending())
                         {
                             const host = self.hosts.items[0];
-                            if (host.profiles == null) {
-                                _ = host.ensureProfiles() catch |err| retry: {
+                            if (host.profiles == null or !host.profiles_complete) {
+                                _ = host.reloadProfiles() catch |err| {
                                     log.warn("jump list deferred profile discovery failed err={}", .{err});
                                     jump_list.retryStartupProfileDiscovery();
-                                    break :retry false;
+                                    continue;
                                 };
                             }
-                            if (host.profiles != null) {
+                            if (host.profiles != null and host.profiles_complete) {
                                 jump_list.completeStartupProfileDiscovery();
+                            } else {
+                                jump_list.retryStartupProfileDiscovery();
                             }
                         }
                         continue;
@@ -8590,6 +8592,7 @@ const Host = struct {
     overlay_completion_value: ?[:0]const u8 = null,
     overlay_completion_result_id: ?PaletteStableId = null,
     profiles: ?[]windows_shell.Profile = null,
+    profiles_complete: bool = false,
     selected_profile: usize = 0,
     selected_profile_key: ?[:0]const u8 = null,
     chrome_brush: HBRUSH = null,
@@ -11687,16 +11690,18 @@ const Host = struct {
 
     fn reloadProfiles(self: *Host) !bool {
         const replacing = self.profiles != null;
-        const next_profiles = try windows_shell.listProfiles(
+        const discovery = try windows_shell.discoverProfiles(
             self.app.core_app.alloc,
             self.app.config.@"ssh-config-hosts",
         );
+        const next_profiles = discovery.profiles;
         if (self.profiles) |profiles| windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
         self.profiles = next_profiles;
+        self.profiles_complete = discovery.complete;
         if (self.app.jump_list) |*jump_list| {
             // A later user-initiated load recovers startup discovery after its
             // bounded transient-failure retry budget has been exhausted.
-            jump_list.completeStartupProfileDiscovery();
+            if (discovery.complete) jump_list.completeStartupProfileDiscovery();
             jump_list.updateProfiles(next_profiles);
         }
         if (replacing and self.overlay_mode == .command_palette) self.rebuildPaletteList();
@@ -11727,6 +11732,7 @@ const Host = struct {
             windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
             self.profiles = null;
         }
+        self.profiles_complete = false;
     }
 
     fn reapplyLauncherProfilePreferences(self: *Host) !void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4803,14 +4803,17 @@ pub const App = struct {
                         self.config = config;
                         self.config_revision +%= 1;
                         if (self.config_revision == 0) self.config_revision = 1;
+                        var jump_list_profiles_pending = ssh_config_hosts_changed and self.jump_list != null;
+                        if (jump_list_profiles_pending) self.jump_list.?.updateProfiles(&.{});
                         for (self.hosts.items) |host| {
                             if (ssh_config_hosts_changed) {
                                 host.invalidateProfiles();
-                                if (host.overlay_mode == .profile) {
-                                    _ = host.reloadProfiles() catch |err| blk: {
+                                if (host.overlay_mode == .profile or jump_list_profiles_pending) {
+                                    const reloaded = host.reloadProfiles() catch |err| blk: {
                                         log.warn("SSH profile reload after config change failed err={}", .{err});
                                         break :blk false;
                                     };
+                                    if (reloaded or host.profiles != null) jump_list_profiles_pending = false;
                                 }
                             }
                             if (host.overlay_mode == .command_palette) host.rebuildPaletteList();

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4834,11 +4834,13 @@ pub const App = struct {
                             if (ssh_config_hosts_changed) {
                                 host.invalidateProfiles();
                                 if (host.overlay_mode == .profile or jump_list_profiles_pending) {
-                                    const reloaded = host.reloadProfiles() catch |err| blk: {
+                                    _ = host.reloadProfiles() catch |err| blk: {
                                         log.warn("SSH profile reload after config change failed err={}", .{err});
                                         break :blk false;
                                     };
-                                    if (reloaded or host.profiles != null) jump_list_profiles_pending = false;
+                                    if (host.profiles != null and host.profiles_complete) {
+                                        jump_list_profiles_pending = false;
+                                    }
                                 }
                             }
                             if (host.overlay_mode == .command_palette) host.rebuildPaletteList();

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1787,6 +1787,15 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
     return descriptor orelse error.IpcSecurityDescriptorFailed;
 }
 
+fn detectExplicitStartupWorkingDirectory(alloc: Allocator) bool {
+    var iter = cli_args.argsIterator(alloc) catch return false;
+    defer iter.deinit();
+    while (iter.next()) |arg| {
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) return true;
+    }
+    return false;
+}
+
 fn ipcServerMain(app: *App) void {
     const pipe_name = app.ipc_pipe_name orelse return;
 
@@ -2337,11 +2346,13 @@ fn sessionRestorePolicyAllows(
     initial_window: bool,
     has_initial_command: bool,
     startup_profile_picker: bool,
+    explicit_startup_working_directory: bool,
 ) bool {
     return sessionStatePolicyAllows(safe_mode, policy) and
         initial_window and
         !has_initial_command and
-        !startup_profile_picker;
+        !startup_profile_picker and
+        !explicit_startup_working_directory;
 }
 
 pub const App = struct {
@@ -2380,6 +2391,10 @@ pub const App = struct {
     launcher_quick_slot_keys: [3]?[:0]const u8 = .{ null, null, null },
     launcher_profile_target: ProfileOpenTarget = .tab,
     startup_profile_picker: bool = false,
+    /// True when argv explicitly selects a working directory. Such cold-start
+    /// flows must create their requested window rather than restore a saved
+    /// session and discard the CLI destination.
+    explicit_startup_working_directory: bool = false,
     wheel_settings: SystemWheelSettings = .{},
     system_dynamic_scrollbars: bool = true,
     ipc_pipe_name: ?[:0]const u16 = null,
@@ -2524,6 +2539,7 @@ pub const App = struct {
             .launcher_profile_order_hint = windows_shell.profileOrderHint(core_app.alloc),
             .launcher_profile_target = detectDefaultProfileTarget(core_app.alloc),
             .startup_profile_picker = detectStartupProfilePicker(core_app.alloc),
+            .explicit_startup_working_directory = detectExplicitStartupWorkingDirectory(core_app.alloc),
         };
         // Install before any host window exists, so the very first
         // SetWinEventHook registration already has somewhere to deliver.
@@ -2904,7 +2920,7 @@ pub const App = struct {
                             if (host.profiles == null) {
                                 _ = host.ensureProfiles() catch |err| retry: {
                                     log.warn("jump list deferred profile discovery failed err={}", .{err});
-                                    jump_list.scheduleIfStartupPending();
+                                    jump_list.retryStartupProfileDiscovery();
                                     break :retry false;
                                 };
                             }
@@ -3089,6 +3105,7 @@ pub const App = struct {
             self.config.@"initial-window",
             self.config.@"initial-command" != null,
             self.startup_profile_picker,
+            self.explicit_startup_working_directory,
         );
     }
 
@@ -31727,14 +31744,15 @@ test "win32 layout action result propagates automation failure" {
 }
 
 test "win32 explicit startup flows bypass session restore" {
-    try std.testing.expect(sessionRestorePolicyAllows(false, .default, true, false, false));
-    try std.testing.expect(sessionRestorePolicyAllows(false, .always, true, false, false));
-    try std.testing.expect(!sessionRestorePolicyAllows(false, .default, true, true, false));
-    try std.testing.expect(!sessionRestorePolicyAllows(false, .default, true, false, true));
-    try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, false, false));
-    try std.testing.expect(!sessionRestorePolicyAllows(true, .always, true, false, false));
-    try std.testing.expect(!sessionRestorePolicyAllows(false, .never, true, false, false));
-    try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, true, true));
+    try std.testing.expect(sessionRestorePolicyAllows(false, .default, true, false, false, false));
+    try std.testing.expect(sessionRestorePolicyAllows(false, .always, true, false, false, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .default, true, true, false, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .default, true, false, true, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .default, true, false, false, true));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, false, false, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(true, .always, true, false, false, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .never, true, false, false, false));
+    try std.testing.expect(!sessionRestorePolicyAllows(false, .always, false, true, true, true));
 }
 
 test "win32 session restore transaction preserves first surface state" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -35,6 +35,7 @@ const win32_clipboard_html = @import("win32_clipboard_html.zig");
 const win32_undo = @import("win32_undo.zig");
 const win32_toast_winrt = @import("win32_toast_winrt.zig");
 const win32_taskbar_progress = @import("win32_taskbar_progress.zig");
+const win32_jump_list = @import("win32_jump_list.zig");
 const win32_powershell_install = @import("win32_powershell_install.zig");
 const win32_link_preview = @import("win32_link_preview.zig");
 const win32_quick_terminal = @import("win32_quick_terminal.zig");
@@ -2459,6 +2460,9 @@ pub const App = struct {
     /// unavailable, in which case progress continues to render only in
     /// the window title/status text.
     taskbar_progress: ?win32_taskbar_progress.TaskbarProgress = null,
+    /// Persisted taskbar destinations and their debounced shell COM commit.
+    /// `null` when the app-state path cannot be resolved or initialized.
+    jump_list: ?win32_jump_list.JumpList = null,
     toast_activation_post_pending: std.atomic.Value(bool) = .init(false),
     /// Absolute path supplied via `--config-file <path>` on the CLI.
     /// Resolved ONCE against the startup cwd during `App.init` — that's
@@ -2598,6 +2602,13 @@ pub const App = struct {
             std.log.warn("taskbar progress init failed err={}; falling back to title-only progress", .{err});
             break :blk null;
         };
+        if (localAppDataPathAlloc(core_app.alloc, win32_jump_list.state_filename)) |path| {
+            defer core_app.alloc.free(path);
+            self.jump_list = win32_jump_list.JumpList.init(core_app.alloc, path) catch |err| blk: {
+                log.warn("jump list state init failed err={}", .{err});
+                break :blk null;
+            };
+        }
         self.refreshSystemWheelSettings();
         self.refreshSystemScrollbarPreference();
         self.resolved_theme = resolveTheme(&self.config);
@@ -2747,6 +2758,7 @@ pub const App = struct {
             log.info("initial-window is disabled; win32 runtime waiting without a window", .{});
         }
 
+        if (!self.embedding_mode) self.initializeJumpList();
         if (!self.embedding_mode) self.scheduleGlobalHotkeySync();
         if (!self.embedding_mode and self.global_hotkeys_dirty and self.windows.items.len == 0) {
             self.global_hotkeys_dirty = false;
@@ -2876,6 +2888,28 @@ pub const App = struct {
                         continue;
                     }
                 }
+                // Our timer is a thread timer (`SetTimer(null, ...)`), which
+                // posts with a null hwnd. Checking that keeps us from
+                // swallowing a window timer whose numeric id happens to
+                // collide.
+                if (self.jump_list) |*jump_list| {
+                    if (@intFromPtr(msg.hwnd) == 0 and jump_list.handleTimer(msg.wParam)) {
+                        // Profile discovery is app-wide, so any host will do —
+                        // `initial-window=false` starts without a primary
+                        // surface. The request stays pending until one exists.
+                        if (self.hosts.items.len > 0 and
+                            jump_list.takeStartupProfileDiscovery())
+                        {
+                            const host = self.hosts.items[0];
+                            if (host.profiles == null) {
+                                _ = host.ensureProfiles() catch |err| {
+                                    log.warn("jump list deferred profile discovery failed err={}", .{err});
+                                };
+                            }
+                        }
+                        continue;
+                    }
+                }
                 if (self.quit_timer_id) |timer_id| {
                     if (msg.wParam == timer_id) {
                         self.stopQuitTimer();
@@ -2981,6 +3015,10 @@ pub const App = struct {
             taskbar.deinit();
             self.taskbar_progress = null;
         }
+        if (self.jump_list) |*jump_list| {
+            jump_list.deinit();
+            self.jump_list = null;
+        }
         if (self.cli_config_override_path) |path| {
             self.core_app.alloc.free(path);
             self.cli_config_override_path = null;
@@ -3002,6 +3040,11 @@ pub const App = struct {
     /// or allocation fails.
     fn localAppDataPath(self: *const App, name: []const u8) ?[]u8 {
         return localAppDataPathAlloc(self.core_app.alloc, name);
+    }
+
+    fn initializeJumpList(self: *App) void {
+        const jump_list = if (self.jump_list) |*value| value else return;
+        jump_list.startup();
     }
 
     /// Resolve `%LOCALAPPDATA%\noctty\palette-mru.txt`. Caller frees
@@ -5079,6 +5122,7 @@ pub const App = struct {
             .pwd => {
                 if (self.findSurfaceForTarget(target)) |surface| {
                     try surface.setPwd(value.pwd);
+                    if (self.jump_list) |*jump_list| jump_list.noteRecent(value.pwd);
                     return true;
                 }
 
@@ -5983,6 +6027,7 @@ pub const App = struct {
             }
             self.removeHost(host);
         }
+        if (self.jump_list) |*jump_list| jump_list.scheduleIfStartupPending();
         if (clone_state_from) |source| {
             if (source.host) |existing| try self.inheritHostWindowState(host, existing);
         }
@@ -11597,6 +11642,7 @@ const Host = struct {
         );
         if (self.profiles) |profiles| windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
         self.profiles = next_profiles;
+        if (self.app.jump_list) |*jump_list| jump_list.updateProfiles(next_profiles);
         if (replacing and self.overlay_mode == .command_palette) self.rebuildPaletteList();
         self.app.applyLauncherQuickSlotPreferences(self.profiles.?);
         const profiles = self.profiles.?;
@@ -11767,6 +11813,7 @@ const Host = struct {
         const profile = self.selectedProfile() orelse return false;
         const source = self.activeSurface() orelse return false;
         const surface = self.app.createProfileSurface(.{ .surface = source.core() }, profile, open_target) catch return false;
+        if (self.app.jump_list) |*jump_list| jump_list.noteProfileUsed(profile.key);
         if (self.overlay_mode == .profile) {
             self.hideOverlay();
             runUiActionOrLog("profile launch layout failed", self.layout());

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -263,6 +263,7 @@ const IPropertyStore = extern struct {
 const RecentState = struct {
     schema_version: u32 = 1,
     directories: []const []const u8 = &.{},
+    removed_directories: []const []const u8 = &.{},
     hidden_profiles: []const []const u8 = &.{},
 };
 
@@ -285,12 +286,14 @@ fn parseRecentStateAlloc(alloc: Allocator, raw: []const u8) !std.json.Parsed(Rec
 fn encodeRecentStateAlloc(
     alloc: Allocator,
     directories: []const []const u8,
+    removed_directories: []const []const u8,
     hidden_profiles: []const []const u8,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
     try std.json.Stringify.value(RecentState{
         .directories = directories,
+        .removed_directories = removed_directories,
         .hidden_profiles = hidden_profiles,
     }, .{
         .whitespace = .minified,
@@ -344,10 +347,29 @@ const RecentList = struct {
         try self.items.append(alloc, owned);
     }
 
+    fn contains(self: *const RecentList, alloc: Allocator, path: []const u8) !bool {
+        for (self.items.items) |item| {
+            if (try pathsEqualIgnoreCase(alloc, item, path)) return true;
+        }
+        return false;
+    }
+
+    fn removePath(self: *RecentList, alloc: Allocator, path: []const u8) !bool {
+        for (self.items.items, 0..) |item, index| {
+            if (!try pathsEqualIgnoreCase(alloc, item, path)) continue;
+            alloc.free(item);
+            _ = self.items.orderedRemove(index);
+            return true;
+        }
+        return false;
+    }
+
     fn removeArguments(
         self: *RecentList,
         alloc: Allocator,
         removed_arguments: []const []const u8,
+        protected: *const RecentList,
+        pending_removals: *RecentList,
     ) !bool {
         var changed = false;
         var index: usize = 0;
@@ -359,6 +381,12 @@ const RecentList = struct {
                 continue;
             }
 
+            if (try protected.contains(alloc, self.items.items[index])) {
+                index += 1;
+                continue;
+            }
+
+            _ = try pending_removals.insert(alloc, self.items.items[index]);
             alloc.free(self.items.items[index]);
             _ = self.items.orderedRemove(index);
             changed = true;
@@ -407,14 +435,32 @@ const ProfileTombstones = struct {
 
 const LoadedState = struct {
     recents: RecentList = .{},
+    removed_recents: RecentList = .{},
     hidden_profiles: ProfileTombstones = .{},
 
     fn deinit(self: *LoadedState, alloc: Allocator) void {
         self.recents.deinit(alloc);
+        self.removed_recents.deinit(alloc);
         self.hidden_profiles.deinit(alloc);
         self.* = .{};
     }
 };
+
+fn stringSlicesEqual(lhs: []const []const u8, rhs: []const []const u8) bool {
+    if (lhs.len != rhs.len) return false;
+    for (lhs, rhs) |left, right| {
+        if (!std.mem.eql(u8, left, right)) return false;
+    }
+    return true;
+}
+
+fn recentListsEqual(lhs: *const RecentList, rhs: *const RecentList) bool {
+    return stringSlicesEqual(lhs.items.items, rhs.items.items);
+}
+
+fn profileTombstonesEqual(lhs: *const ProfileTombstones, rhs: *const ProfileTombstones) bool {
+    return stringSlicesEqual(lhs.items.items, rhs.items.items);
+}
 
 fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
     var result: LoadedState = .{};
@@ -440,6 +486,12 @@ fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
     for (parsed.value.directories) |directory| {
         result.recents.appendLoaded(alloc, directory) catch |err| {
             log.warn("jump list recent state entry allocation failed err={}", .{err});
+            break;
+        };
+    }
+    for (parsed.value.removed_directories) |directory| {
+        result.removed_recents.appendLoaded(alloc, directory) catch |err| {
+            log.warn("jump list removed recent state allocation failed err={}", .{err});
             break;
         };
     }
@@ -615,7 +667,13 @@ pub const JumpList = struct {
     state_path: []u8,
     exe_path: ?[]u8,
     recents: RecentList,
+    removed_recents: RecentList,
     hidden_profiles: ProfileTombstones,
+    pending_recent_additions: RecentList = .{},
+    pending_recent_removals: RecentList = .{},
+    pending_recent_uses: RecentList = .{},
+    pending_profile_hides: ProfileTombstones = .{},
+    pending_profile_uses: ProfileTombstones = .{},
     profiles: std.ArrayListUnmanaged(ProfileItem) = .empty,
     timer_id: ?UINT_PTR = null,
     persist_dirty: bool = false,
@@ -636,15 +694,23 @@ pub const JumpList = struct {
                 break :exe null;
             },
             .recents = loaded.recents,
+            .removed_recents = loaded.removed_recents,
             .hidden_profiles = loaded.hidden_profiles,
         };
     }
 
     pub fn deinit(self: *JumpList) void {
         self.stopTimer();
-        if (self.persist_dirty) self.persist();
+        if (self.persist_dirty) _ = self.persist();
+        self.stopTimer();
         self.recents.deinit(self.alloc);
+        self.removed_recents.deinit(self.alloc);
         self.hidden_profiles.deinit(self.alloc);
+        self.pending_recent_additions.deinit(self.alloc);
+        self.pending_recent_removals.deinit(self.alloc);
+        self.pending_recent_uses.deinit(self.alloc);
+        self.pending_profile_hides.deinit(self.alloc);
+        self.pending_profile_uses.deinit(self.alloc);
         self.clearProfiles();
         self.profiles.deinit(self.alloc);
         if (self.exe_path) |path| self.alloc.free(path);
@@ -659,10 +725,12 @@ pub const JumpList = struct {
         self.schedule();
     }
 
-    pub fn takeStartupProfileDiscovery(self: *JumpList) bool {
-        if (!self.startup_profile_discovery_pending) return false;
+    pub fn startupProfileDiscoveryPending(self: *const JumpList) bool {
+        return self.startup_profile_discovery_pending;
+    }
+
+    pub fn completeStartupProfileDiscovery(self: *JumpList) void {
         self.startup_profile_discovery_pending = false;
-        return true;
     }
 
     pub fn updateProfiles(self: *JumpList, profiles: []const windows_shell.Profile) void {
@@ -719,7 +787,13 @@ pub const JumpList = struct {
     }
 
     pub fn noteProfileUsed(self: *JumpList, key: []const u8) void {
-        if (!self.hidden_profiles.remove(self.alloc, key)) return;
+        const removed = self.hidden_profiles.remove(self.alloc, key);
+        _ = self.pending_profile_hides.remove(self.alloc, key);
+        const recorded = self.pending_profile_uses.insert(self.alloc, key) catch |err| {
+            log.warn("jump list profile-use snapshot failed err={}", .{err});
+            return;
+        };
+        if (!removed and !recorded) return;
         self.persist_dirty = true;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
@@ -727,11 +801,28 @@ pub const JumpList = struct {
     }
 
     pub fn noteRecent(self: *JumpList, path: []const u8) void {
+        const reinstated = self.removed_recents.removePath(self.alloc, path) catch |err| {
+            log.warn("jump list recent reinstatement failed err={}", .{err});
+            return;
+        };
+        if (reinstated) {
+            _ = self.pending_recent_removals.removePath(self.alloc, path) catch {};
+            _ = self.pending_recent_uses.insert(self.alloc, path) catch |err| {
+                log.warn("jump list recent-use snapshot failed err={}", .{err});
+                return;
+            };
+        }
         const changed = self.recents.insert(self.alloc, path) catch |err| {
             log.warn("jump list recent update failed err={}", .{err});
             return;
         };
-        if (!changed) return;
+        if (changed) {
+            _ = self.pending_recent_additions.insert(self.alloc, path) catch |err| {
+                log.warn("jump list recent persistence snapshot failed err={}", .{err});
+                return;
+            };
+        }
+        if (!changed and !reinstated) return;
         self.persist_dirty = true;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
@@ -746,10 +837,12 @@ pub const JumpList = struct {
     }
 
     pub fn flush(self: *JumpList) void {
+        var rebuild_committed = false;
         if (self.rebuild_dirty and !self.com_disabled) {
             if (self.rebuildCom()) |_| {
                 self.rebuild_dirty = false;
                 self.rebuild_retry_count = 0;
+                rebuild_committed = true;
             } else |err| switch (err) {
                 error.ComNotInitialized => {
                     self.com_disabled = true;
@@ -766,7 +859,11 @@ pub const JumpList = struct {
                 },
             }
         }
-        if (self.persist_dirty) self.persist();
+        const persisted = if (self.persist_dirty) self.persist() else true;
+        if (rebuild_committed and persisted) {
+            self.pending_recent_uses.deinit(self.alloc);
+            self.pending_profile_uses.deinit(self.alloc);
+        }
     }
 
     /// Re-arm the debounce if the deferred startup profile discovery still
@@ -794,49 +891,115 @@ pub const JumpList = struct {
         }
     }
 
-    /// Write the recent/tombstone model out.
-    ///
-    /// Two noctty processes each own their own in-memory model and replace
-    /// this file atomically, so the last writer wins. That is deliberate: the
-    /// payload is an MRU convenience list, and it matches how
-    /// `session-state.json` and `palette-mru.txt` already behave. Merging on
-    /// write would have to reconcile removals too, which is more machinery
-    /// than a recents list is worth.
-    fn persist(self: *JumpList) void {
-        const encoded = encodeRecentStateAlloc(
-            self.alloc,
-            self.recents.items.items,
-            self.hidden_profiles.items.items,
-        ) catch |err| {
-            log.warn("jump list recent encode failed err={}", .{err});
-            return;
-        };
-        defer self.alloc.free(encoded);
-
+    /// Serialize the cross-process read-modify-write transaction, reload the
+    /// latest snapshot, and apply only this process's pending model events.
+    /// This preserves another process's newer entries without letting a stale
+    /// in-memory snapshot overwrite them.
+    fn persist(self: *JumpList) bool {
         if (std.fs.path.dirname(self.state_path)) |directory| {
             std.fs.makeDirAbsolute(directory) catch |err| switch (err) {
                 error.PathAlreadyExists => {},
                 else => {
                     log.warn("jump list recent directory create failed path={s} err={}", .{ directory, err });
-                    return;
+                    return false;
                 },
             };
         }
+
+        const lock_path = std.fmt.allocPrint(self.alloc, "{s}.lock", .{self.state_path}) catch |err| {
+            log.warn("jump list state lock path allocation failed err={}", .{err});
+            return false;
+        };
+        defer self.alloc.free(lock_path);
+        const lock_file = std.fs.createFileAbsolute(lock_path, .{
+            .read = true,
+            .truncate = false,
+            .lock = .exclusive,
+        }) catch |err| {
+            log.warn("jump list state lock unavailable path={s} err={}", .{ lock_path, err });
+            return false;
+        };
+        defer lock_file.close();
+
+        var merged = loadStateAlloc(self.alloc, self.state_path);
+        defer merged.deinit(self.alloc);
+        self.applyPendingState(&merged) catch |err| {
+            log.warn("jump list state merge failed err={}", .{err});
+            return false;
+        };
+
+        const model_changed = !recentListsEqual(&self.recents, &merged.recents) or
+            !recentListsEqual(&self.removed_recents, &merged.removed_recents) or
+            !profileTombstonesEqual(&self.hidden_profiles, &merged.hidden_profiles);
+        const encoded = encodeRecentStateAlloc(
+            self.alloc,
+            merged.recents.items.items,
+            merged.removed_recents.items.items,
+            merged.hidden_profiles.items.items,
+        ) catch |err| {
+            log.warn("jump list recent encode failed err={}", .{err});
+            return false;
+        };
+        defer self.alloc.free(encoded);
+
         const temporary_path = std.fmt.allocPrint(
             self.alloc,
             "{s}.tmp-{x}-{x}",
             .{ self.state_path, GetCurrentProcessId(), @as(u64, @bitCast(std.time.milliTimestamp())) },
         ) catch |err| {
             log.warn("jump list recent temp path allocation failed err={}", .{err});
-            return;
+            return false;
         };
         defer self.alloc.free(temporary_path);
 
         persistence.writeFileAtomic(self.state_path, temporary_path, encoded) catch |err| {
             log.warn("jump list recent write failed path={s} err={}", .{ self.state_path, err });
-            return;
+            return false;
         };
+
+        self.recents.deinit(self.alloc);
+        self.recents = merged.recents;
+        merged.recents = .{};
+        self.removed_recents.deinit(self.alloc);
+        self.removed_recents = merged.removed_recents;
+        merged.removed_recents = .{};
+        self.hidden_profiles.deinit(self.alloc);
+        self.hidden_profiles = merged.hidden_profiles;
+        merged.hidden_profiles = .{};
+
+        self.pending_recent_additions.deinit(self.alloc);
+        self.pending_recent_removals.deinit(self.alloc);
+        self.pending_profile_hides.deinit(self.alloc);
         self.persist_dirty = false;
+        if (model_changed) {
+            self.rebuild_retry_count = 0;
+            self.rebuild_dirty = true;
+            self.schedule();
+        }
+        return true;
+    }
+
+    fn applyPendingState(self: *const JumpList, merged: *LoadedState) !void {
+        for (self.pending_recent_removals.items.items) |path| {
+            _ = try merged.recents.removePath(self.alloc, path);
+            _ = try merged.removed_recents.insert(self.alloc, path);
+        }
+        for (self.pending_recent_uses.items.items) |path| {
+            _ = try merged.removed_recents.removePath(self.alloc, path);
+        }
+        var remaining = self.pending_recent_additions.items.items.len;
+        while (remaining > 0) {
+            remaining -= 1;
+            const path = self.pending_recent_additions.items.items[remaining];
+            _ = try merged.removed_recents.removePath(self.alloc, path);
+            _ = try merged.recents.insert(self.alloc, path);
+        }
+        for (self.pending_profile_hides.items.items) |key| {
+            _ = try merged.hidden_profiles.insert(self.alloc, key);
+        }
+        for (self.pending_profile_uses.items.items) |key| {
+            _ = merged.hidden_profiles.remove(self.alloc, key);
+        }
     }
 
     fn clearProfiles(self: *JumpList) void {
@@ -887,14 +1050,27 @@ pub const JumpList = struct {
         if (raw_removed) |raw| {
             const removed = IObjectArray.fromRaw(raw);
             defer removed.release();
-            removed_arguments = try self.readRemovedArguments(removed, exe_w);
+            removed_arguments = try self.readRemovedArguments(removed);
         }
-        if (try self.recents.removeArguments(self.alloc, removed_arguments.items.items)) {
+        if (try self.recents.removeArguments(
+            self.alloc,
+            removed_arguments.items.items,
+            &self.pending_recent_uses,
+            &self.pending_recent_removals,
+        )) {
+            for (self.pending_recent_removals.items.items) |path| {
+                _ = try self.removed_recents.insert(self.alloc, path);
+                _ = self.pending_recent_additions.removePath(self.alloc, path) catch false;
+            }
             self.persist_dirty = true;
         }
         for (self.profiles.items) |item| {
             if (!containsArguments(removed_arguments.items.items, item.arguments)) continue;
-            if (try self.hidden_profiles.insert(self.alloc, item.key)) self.persist_dirty = true;
+            if (self.pending_profile_uses.contains(item.key)) continue;
+            if (try self.hidden_profiles.insert(self.alloc, item.key)) {
+                _ = try self.pending_profile_hides.insert(self.alloc, item.key);
+                self.persist_dirty = true;
+            }
         }
         if (!removed_arguments.complete) return error.RemovedDestinationsIncomplete;
 
@@ -970,7 +1146,6 @@ pub const JumpList = struct {
     fn readRemovedArguments(
         self: *JumpList,
         removed: *IObjectArray,
-        exe_w: [:0]const u16,
     ) !RemovedArguments {
         var result: RemovedArguments = .{};
         errdefer result.deinit(self.alloc);
@@ -981,8 +1156,6 @@ pub const JumpList = struct {
             result.complete = false;
             return result;
         }
-        const path_buffer = try self.alloc.alloc(u16, max_shell_link_chars);
-        defer self.alloc.free(path_buffer);
         const arguments_buffer = try self.alloc.alloc(u16, max_shell_link_chars);
         defer self.alloc.free(arguments_buffer);
 
@@ -1005,37 +1178,6 @@ pub const JumpList = struct {
             }
             const link = IShellLinkW.fromRaw(raw_link.?);
             defer link.release();
-
-            @memset(path_buffer, 0);
-            if (link.vtbl.GetPath(
-                link.asRaw(),
-                path_buffer.ptr,
-                @intCast(path_buffer.len),
-                null,
-                0,
-            ) < 0) {
-                log.debug("jump list removed link path unavailable index={d}", .{index});
-                result.complete = false;
-                continue;
-            }
-            const path_len = std.mem.indexOfScalar(u16, path_buffer, 0) orelse {
-                log.debug("jump list removed link path too long index={d}", .{index});
-                result.complete = false;
-                continue;
-            };
-            const path_comparison = CompareStringOrdinal(
-                exe_w.ptr,
-                @intCast(exe_w.len),
-                path_buffer.ptr,
-                @intCast(path_len),
-                1,
-            );
-            if (path_comparison == 0) {
-                log.debug("jump list removed link path comparison failed index={d}", .{index});
-                result.complete = false;
-                continue;
-            }
-            if (path_comparison != 2) continue;
 
             @memset(arguments_buffer, 0);
             if (link.vtbl.GetArguments(
@@ -1196,12 +1338,19 @@ test "jump_list recent insert caps at ten and rejects nonlocal paths" {
 test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     const values = [_][]const u8{ "C:\\src\\noctty", "D:\\work" };
     const hidden_profiles = [_][]const u8{"wsl:Ubuntu"};
-    const encoded = try encodeRecentStateAlloc(std.testing.allocator, &values, &hidden_profiles);
+    const removed_values = [_][]const u8{"E:\\removed"};
+    const encoded = try encodeRecentStateAlloc(
+        std.testing.allocator,
+        &values,
+        &removed_values,
+        &hidden_profiles,
+    );
     defer std.testing.allocator.free(encoded);
     var parsed = try parseRecentStateAlloc(std.testing.allocator, encoded);
     defer parsed.deinit();
     try std.testing.expectEqualStrings(values[0], parsed.value.directories[0]);
     try std.testing.expectEqualStrings(values[1], parsed.value.directories[1]);
+    try std.testing.expectEqualStrings(removed_values[0], parsed.value.removed_directories[0]);
     try std.testing.expectEqualStrings(hidden_profiles[0], parsed.value.hidden_profiles[0]);
     try std.testing.expectError(
         error.SyntaxError,
@@ -1245,7 +1394,7 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     @memset(oversized_key, 'x');
     try std.testing.expectError(
         error.StateTooLarge,
-        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{oversized_key}),
+        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}),
     );
 }
 
@@ -1325,15 +1474,62 @@ test "jump_list argument builders preserve Windows argv boundaries" {
 test "jump_list removed recent arguments clear tracked entries" {
     var recent: RecentList = .{};
     defer recent.deinit(std.testing.allocator);
+    var protected: RecentList = .{};
+    defer protected.deinit(std.testing.allocator);
+    var pending_removals: RecentList = .{};
+    defer pending_removals.deinit(std.testing.allocator);
     try std.testing.expect(try recent.insert(std.testing.allocator, "C:\\one"));
     try std.testing.expect(try recent.insert(std.testing.allocator, "D:\\two"));
     const removed = try buildWorkingDirectoryArgumentsAlloc(std.testing.allocator, "C:\\one");
     defer std.testing.allocator.free(removed);
 
-    try std.testing.expect(try recent.removeArguments(std.testing.allocator, &.{removed}));
+    try std.testing.expect(try recent.removeArguments(
+        std.testing.allocator,
+        &.{removed},
+        &protected,
+        &pending_removals,
+    ));
     try std.testing.expectEqual(@as(usize, 1), recent.items.items.len);
     try std.testing.expectEqualStrings("D:\\two", recent.items.items[0]);
-    try std.testing.expect(!try recent.removeArguments(std.testing.allocator, &.{removed}));
+    try std.testing.expect(try pending_removals.contains(std.testing.allocator, "C:\\one"));
+    try std.testing.expect(!try recent.removeArguments(
+        std.testing.allocator,
+        &.{removed},
+        &protected,
+        &pending_removals,
+    ));
+}
+
+test "jump_list persistence merge applies local events to the latest snapshot" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    try std.testing.expect(try jump.pending_recent_additions.insert(alloc, "D:\\local"));
+    try std.testing.expect(try jump.pending_recent_removals.insert(alloc, "C:\\removed"));
+    try std.testing.expect(try jump.pending_profile_hides.insert(alloc, "wsl:new-hidden"));
+    try std.testing.expect(try jump.pending_profile_uses.insert(alloc, "wsl:used"));
+
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    try merged.recents.appendLoaded(alloc, "C:\\removed");
+    try merged.recents.appendLoaded(alloc, "E:\\other-process");
+    try std.testing.expect(try merged.hidden_profiles.insert(alloc, "wsl:used"));
+
+    try jump.applyPendingState(&merged);
+    try std.testing.expectEqual(@as(usize, 2), merged.recents.items.items.len);
+    try std.testing.expectEqualStrings("D:\\local", merged.recents.items.items[0]);
+    try std.testing.expectEqualStrings("E:\\other-process", merged.recents.items.items[1]);
+    try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\removed"));
+    try std.testing.expect(merged.hidden_profiles.contains("wsl:new-hidden"));
+    try std.testing.expect(!merged.hidden_profiles.contains("wsl:used"));
 }
 
 test "jump_list slot budget reserves profiles before recents" {
@@ -1373,6 +1569,27 @@ test "jump_list rebuild retry budget is bounded" {
         try std.testing.expectEqual(expected, retry_count);
     }
     try std.testing.expect(nextRebuildRetryCount(retry_count) == null);
+}
+
+test "jump_list startup profile discovery stays pending until completion" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+        .startup_profile_discovery_pending = true,
+    };
+    defer jump.deinit();
+
+    try std.testing.expect(jump.startupProfileDiscoveryPending());
+    // A failed discovery leaves the request untouched; only the caller's
+    // explicit success transition consumes it.
+    try std.testing.expect(jump.startupProfileDiscoveryPending());
+    jump.completeStartupProfileDiscovery();
+    try std.testing.expect(!jump.startupProfileDiscoveryPending());
 }
 
 test "jump_list raw COM interfaces preserve pointer layout and PROPVARIANT ABI" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -1073,11 +1073,12 @@ pub const JumpList = struct {
             log.warn("jump list recent event snapshot failed err={}", .{err});
             return;
         };
-        if (!changed and !reinstated and !recorded) return;
         self.persist_dirty = true;
         self.persist_retry_count = 0;
-        self.rebuild_retry_count = 0;
-        self.rebuild_dirty = true;
+        if (changed or reinstated or recorded) {
+            self.rebuild_retry_count = 0;
+            self.rebuild_dirty = true;
+        }
         self.schedule();
     }
 
@@ -2087,6 +2088,17 @@ test "jump_list unchanged recent directory still records a use event" {
     try std.testing.expect(jump.persist_dirty);
     try std.testing.expect(try jump.pending_recent_additions.contains(alloc, "D:\\same-head"));
     try std.testing.expect(try jump.pending_recent_uses.contains(alloc, "D:\\same-head"));
+
+    // A repeated use refreshes its event timestamp and must restart bounded
+    // persistence even when the visible MRU model is unchanged.
+    jump.persist_dirty = false;
+    jump.persist_retry_count = max_rebuild_retries;
+    jump.rebuild_dirty = false;
+    jump.noteRecent("D:\\same-head");
+    try std.testing.expect(jump.persist_dirty);
+    try std.testing.expectEqual(@as(u8, 0), jump.persist_retry_count);
+    try std.testing.expect(!jump.rebuild_dirty);
+    try std.testing.expect(jump.timer_id != null);
 }
 
 test "jump_list rejects invalid recent use before queuing events" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -33,6 +33,7 @@ pub const max_recents: usize = 10;
 pub const max_state_bytes: usize = 64 * 1024;
 pub const debounce_ms: UINT = 500;
 const max_profile_tombstones: usize = 128;
+const max_profile_events: usize = max_profile_tombstones * 2;
 const max_rebuild_retries: u8 = 3;
 const max_shell_link_chars: usize = 32_768;
 
@@ -266,6 +267,7 @@ const RecentState = struct {
     removed_directories: []const []const u8 = &.{},
     hidden_profiles: []const []const u8 = &.{},
     recent_events: []const RecentEvent = &.{},
+    profile_events: []const ProfileEvent = &.{},
 };
 
 const RecentEventKind = enum {
@@ -276,6 +278,17 @@ const RecentEventKind = enum {
 const RecentEvent = struct {
     path: []const u8,
     kind: RecentEventKind,
+    changed_ns: i64,
+};
+
+const ProfileEventKind = enum {
+    hidden,
+    used,
+};
+
+const ProfileEvent = struct {
+    key: []const u8,
+    kind: ProfileEventKind,
     changed_ns: i64,
 };
 
@@ -301,6 +314,7 @@ fn encodeRecentStateAlloc(
     removed_directories: []const []const u8,
     hidden_profiles: []const []const u8,
     recent_events: []const RecentEvent,
+    profile_events: []const ProfileEvent,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -309,6 +323,7 @@ fn encodeRecentStateAlloc(
         .removed_directories = removed_directories,
         .hidden_profiles = hidden_profiles,
         .recent_events = recent_events,
+        .profile_events = profile_events,
     }, .{
         .whitespace = .minified,
     }, &out.writer);
@@ -448,7 +463,59 @@ const RecentEventList = struct {
             .changed_ns = changed_ns,
         });
         if (self.items.items.len > max_recents * 2) {
-            alloc.free(self.items.orderedRemove(0).path);
+            var oldest: usize = 0;
+            for (self.items.items[1..], 1..) |item, index| {
+                if (item.changed_ns < self.items.items[oldest].changed_ns) oldest = index;
+            }
+            alloc.free(self.items.orderedRemove(oldest).path);
+        }
+    }
+};
+
+const ProfileEventList = struct {
+    items: std.ArrayListUnmanaged(ProfileEvent) = .empty,
+
+    fn deinit(self: *ProfileEventList, alloc: Allocator) void {
+        for (self.items.items) |item| alloc.free(item.key);
+        self.items.deinit(alloc);
+        self.* = .{};
+    }
+
+    fn latest(self: *const ProfileEventList, key: []const u8) ?ProfileEvent {
+        for (self.items.items) |item| {
+            if (std.mem.eql(u8, item.key, key)) return item;
+        }
+        return null;
+    }
+
+    fn upsert(
+        self: *ProfileEventList,
+        alloc: Allocator,
+        key: []const u8,
+        kind: ProfileEventKind,
+        changed_ns: i64,
+    ) !void {
+        for (self.items.items, 0..) |item, index| {
+            if (!std.mem.eql(u8, item.key, key)) continue;
+            if (item.changed_ns > changed_ns) return;
+            alloc.free(item.key);
+            _ = self.items.orderedRemove(index);
+            break;
+        }
+
+        const owned = try alloc.dupe(u8, key);
+        errdefer alloc.free(owned);
+        try self.items.append(alloc, .{
+            .key = owned,
+            .kind = kind,
+            .changed_ns = changed_ns,
+        });
+        if (self.items.items.len > max_profile_events) {
+            var oldest: usize = 0;
+            for (self.items.items[1..], 1..) |item, index| {
+                if (item.changed_ns < self.items.items[oldest].changed_ns) oldest = index;
+            }
+            alloc.free(self.items.orderedRemove(oldest).key);
         }
     }
 };
@@ -496,12 +563,14 @@ const LoadedState = struct {
     removed_recents: RecentList = .{},
     hidden_profiles: ProfileTombstones = .{},
     recent_events: RecentEventList = .{},
+    profile_events: ProfileEventList = .{},
 
     fn deinit(self: *LoadedState, alloc: Allocator) void {
         self.recents.deinit(alloc);
         self.removed_recents.deinit(alloc);
         self.hidden_profiles.deinit(alloc);
         self.recent_events.deinit(alloc);
+        self.profile_events.deinit(alloc);
         self.* = .{};
     }
 };
@@ -569,6 +638,17 @@ fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
             event.changed_ns,
         ) catch |err| {
             log.warn("jump list recent event state allocation failed err={}", .{err});
+            break;
+        };
+    }
+    for (parsed.value.profile_events) |event| {
+        result.profile_events.upsert(
+            alloc,
+            event.key,
+            event.kind,
+            event.changed_ns,
+        ) catch |err| {
+            log.warn("jump list profile event state allocation failed err={}", .{err});
             break;
         };
     }
@@ -704,6 +784,10 @@ fn recentSlotCount(slot_budget: UINT, recent_count: usize, profile_count: usize)
     return @min(recent_count, slots - reserved_profiles);
 }
 
+fn profileSlotCount(slot_budget: UINT, recent_count: usize, profile_count: usize) usize {
+    return @min(profile_count, @as(usize, slot_budget) -| recent_count);
+}
+
 fn nextRebuildRetryCount(current: u8) ?u8 {
     if (current >= max_rebuild_retries) return null;
     return current + 1;
@@ -741,10 +825,12 @@ pub const JumpList = struct {
     removed_recents: RecentList,
     hidden_profiles: ProfileTombstones,
     recent_events: RecentEventList = .{},
+    profile_events: ProfileEventList = .{},
     pending_recent_additions: RecentList = .{},
     pending_recent_removals: RecentList = .{},
     pending_recent_uses: RecentList = .{},
     pending_recent_events: RecentEventList = .{},
+    pending_profile_events: ProfileEventList = .{},
     pending_profile_hides: ProfileTombstones = .{},
     pending_profile_uses: ProfileTombstones = .{},
     profiles: std.ArrayListUnmanaged(ProfileItem) = .empty,
@@ -771,6 +857,7 @@ pub const JumpList = struct {
             .removed_recents = loaded.removed_recents,
             .hidden_profiles = loaded.hidden_profiles,
             .recent_events = loaded.recent_events,
+            .profile_events = loaded.profile_events,
         };
     }
 
@@ -782,10 +869,12 @@ pub const JumpList = struct {
         self.removed_recents.deinit(self.alloc);
         self.hidden_profiles.deinit(self.alloc);
         self.recent_events.deinit(self.alloc);
+        self.profile_events.deinit(self.alloc);
         self.pending_recent_additions.deinit(self.alloc);
         self.pending_recent_removals.deinit(self.alloc);
         self.pending_recent_uses.deinit(self.alloc);
         self.pending_recent_events.deinit(self.alloc);
+        self.pending_profile_events.deinit(self.alloc);
         self.pending_profile_hides.deinit(self.alloc);
         self.pending_profile_uses.deinit(self.alloc);
         self.clearProfiles();
@@ -876,13 +965,19 @@ pub const JumpList = struct {
     }
 
     pub fn noteProfileUsed(self: *JumpList, key: []const u8) void {
+        const changed_ns: i64 = @intCast(std.time.nanoTimestamp());
         const removed = self.hidden_profiles.remove(self.alloc, key);
         _ = self.pending_profile_hides.remove(self.alloc, key);
         const recorded = self.pending_profile_uses.insert(self.alloc, key) catch |err| {
             log.warn("jump list profile-use snapshot failed err={}", .{err});
             return;
         };
-        if (!removed and !recorded) return;
+        self.pending_profile_events.upsert(self.alloc, key, .used, changed_ns) catch |err| {
+            log.warn("jump list profile event snapshot failed err={}", .{err});
+            return;
+        };
+        _ = removed;
+        _ = recorded;
         self.persist_dirty = true;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
@@ -1037,6 +1132,7 @@ pub const JumpList = struct {
             merged.removed_recents.items.items,
             merged.hidden_profiles.items.items,
             merged.recent_events.items.items,
+            merged.profile_events.items.items,
         ) catch |err| {
             log.warn("jump list recent encode failed err={}", .{err});
             return false;
@@ -1070,10 +1166,14 @@ pub const JumpList = struct {
         self.recent_events.deinit(self.alloc);
         self.recent_events = merged.recent_events;
         merged.recent_events = .{};
+        self.profile_events.deinit(self.alloc);
+        self.profile_events = merged.profile_events;
+        merged.profile_events = .{};
 
         self.pending_recent_additions.deinit(self.alloc);
         self.pending_recent_removals.deinit(self.alloc);
         self.pending_recent_events.deinit(self.alloc);
+        self.pending_profile_events.deinit(self.alloc);
         self.pending_profile_hides.deinit(self.alloc);
         self.persist_dirty = false;
         if (model_changed) {
@@ -1092,7 +1192,6 @@ pub const JumpList = struct {
             switch (event.kind) {
                 .used => {
                     _ = try merged.removed_recents.removePath(self.alloc, event.path);
-                    _ = try merged.recents.insert(self.alloc, event.path);
                 },
                 .removed => {
                     _ = try merged.recents.removePath(self.alloc, event.path);
@@ -1106,12 +1205,54 @@ pub const JumpList = struct {
                 event.changed_ns,
             );
         }
-        for (self.pending_profile_hides.items.items) |key| {
-            _ = try merged.hidden_profiles.insert(self.alloc, key);
+        try self.rebuildMergedRecents(merged);
+        for (self.pending_profile_events.items.items) |event| {
+            if (merged.profile_events.latest(event.key)) |latest| {
+                if (latest.changed_ns > event.changed_ns) continue;
+            }
+            switch (event.kind) {
+                .hidden => _ = try merged.hidden_profiles.insert(self.alloc, event.key),
+                .used => _ = merged.hidden_profiles.remove(self.alloc, event.key),
+            }
+            try merged.profile_events.upsert(
+                self.alloc,
+                event.key,
+                event.kind,
+                event.changed_ns,
+            );
         }
-        for (self.pending_profile_uses.items.items) |key| {
-            _ = merged.hidden_profiles.remove(self.alloc, key);
+    }
+
+    fn rebuildMergedRecents(self: *const JumpList, merged: *LoadedState) !void {
+        var next: RecentList = .{};
+        errdefer next.deinit(self.alloc);
+
+        while (next.items.items.len < max_recents) {
+            var chosen: ?usize = null;
+            for (merged.recent_events.items.items, 0..) |event, index| {
+                if (event.kind != .used or
+                    try merged.removed_recents.contains(self.alloc, event.path) or
+                    try next.contains(self.alloc, event.path)) continue;
+                const current = if (chosen) |value| merged.recent_events.items.items[value] else {
+                    chosen = index;
+                    continue;
+                };
+                if (event.changed_ns >= current.changed_ns) chosen = index;
+            }
+            const index = chosen orelse break;
+            try next.appendLoaded(self.alloc, merged.recent_events.items.items[index].path);
         }
+
+        // Preserve legacy schema-v1 entries until they receive a timestamped
+        // use/removal event. They follow all globally ordered event entries.
+        for (merged.recents.items.items) |path| {
+            if (next.items.items.len >= max_recents) break;
+            if (try merged.recent_events.latest(self.alloc, path) != null) continue;
+            try next.appendLoaded(self.alloc, path);
+        }
+
+        merged.recents.deinit(self.alloc);
+        merged.recents = next;
     }
 
     fn clearProfiles(self: *JumpList) void {
@@ -1187,6 +1328,12 @@ pub const JumpList = struct {
             if (self.pending_profile_uses.contains(item.key)) continue;
             if (try self.hidden_profiles.insert(self.alloc, item.key)) {
                 _ = try self.pending_profile_hides.insert(self.alloc, item.key);
+                try self.pending_profile_events.upsert(
+                    self.alloc,
+                    item.key,
+                    .hidden,
+                    @intCast(std.time.nanoTimestamp()),
+                );
                 self.persist_dirty = true;
             }
         }
@@ -1204,8 +1351,9 @@ pub const JumpList = struct {
         if (recent_count > 0) {
             try self.appendRecentCategory(destination, exe_w, recent_count);
         }
-        if (visible_profile_count > 0) {
-            try self.appendProfilesCategory(destination, exe_w);
+        const profile_count = profileSlotCount(slot_budget, recent_count, visible_profile_count);
+        if (profile_count > 0) {
+            try self.appendProfilesCategory(destination, exe_w, profile_count);
         }
         // Named layouts (C17, #133) will add a third category here, built
         // from win32_layouts.listNamesAlloc + launchArgvAlloc rather than
@@ -1244,15 +1392,19 @@ pub const JumpList = struct {
         self: *JumpList,
         destination: *ICustomDestinationList,
         exe_w: [:0]const u16,
+        count: usize,
     ) !void {
         const collection = try createObjectCollection();
         defer collection.release();
 
+        var appended: usize = 0;
         for (self.profiles.items) |item| {
             if (self.hidden_profiles.contains(item.key)) continue;
+            if (appended == count) break;
             const link = try self.createShellLink(exe_w, item.arguments, item.title, null);
             defer link.release();
             if (collection.addObject(link.asRaw()) < 0) return error.AddProfileLinkFailed;
+            appended += 1;
         }
 
         const category = std.unicode.utf8ToUtf16LeStringLiteral("Profiles");
@@ -1462,12 +1614,18 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
         .kind = .removed,
         .changed_ns = 42,
     }};
+    const profile_events = [_]ProfileEvent{.{
+        .key = "wsl:Ubuntu",
+        .kind = .hidden,
+        .changed_ns = 43,
+    }};
     const encoded = try encodeRecentStateAlloc(
         std.testing.allocator,
         &values,
         &removed_values,
         &hidden_profiles,
         &recent_events,
+        &profile_events,
     );
     defer std.testing.allocator.free(encoded);
     var parsed = try parseRecentStateAlloc(std.testing.allocator, encoded);
@@ -1479,6 +1637,9 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     try std.testing.expectEqualStrings(recent_events[0].path, parsed.value.recent_events[0].path);
     try std.testing.expectEqual(recent_events[0].kind, parsed.value.recent_events[0].kind);
     try std.testing.expectEqual(recent_events[0].changed_ns, parsed.value.recent_events[0].changed_ns);
+    try std.testing.expectEqualStrings(profile_events[0].key, parsed.value.profile_events[0].key);
+    try std.testing.expectEqual(profile_events[0].kind, parsed.value.profile_events[0].kind);
+    try std.testing.expectEqual(profile_events[0].changed_ns, parsed.value.profile_events[0].changed_ns);
     try std.testing.expectError(
         error.SyntaxError,
         parseRecentStateAlloc(std.testing.allocator, "{not json"),
@@ -1521,7 +1682,7 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     @memset(oversized_key, 'x');
     try std.testing.expectError(
         error.StateTooLarge,
-        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}, &.{}),
+        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}, &.{}, &.{}),
     );
 }
 
@@ -1645,6 +1806,8 @@ test "jump_list persistence merge applies local events to the latest snapshot" {
     try jump.pending_recent_events.upsert(alloc, "C:\\removed", .removed, 21);
     try std.testing.expect(try jump.pending_profile_hides.insert(alloc, "wsl:new-hidden"));
     try std.testing.expect(try jump.pending_profile_uses.insert(alloc, "wsl:used"));
+    try jump.pending_profile_events.upsert(alloc, "wsl:new-hidden", .hidden, 22);
+    try jump.pending_profile_events.upsert(alloc, "wsl:used", .used, 23);
 
     var merged: LoadedState = .{};
     defer merged.deinit(alloc);
@@ -1689,6 +1852,67 @@ test "jump_list persistence keeps the newer cross-process recent event" {
     try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
 }
 
+test "jump_list persistence orders recent destinations across paths" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+    try jump.pending_recent_events.upsert(alloc, "D:\\older", .used, 10);
+
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    var buffer: [32]u8 = undefined;
+    for (0..max_recents) |index| {
+        const path = try std.fmt.bufPrint(&buffer, "C:\\newer-{d}", .{index});
+        try merged.recents.appendLoaded(alloc, path);
+        try merged.recent_events.upsert(alloc, path, .used, @intCast(20 + index));
+    }
+
+    try jump.applyPendingState(&merged);
+    try std.testing.expectEqual(max_recents, merged.recents.items.items.len);
+    try std.testing.expectEqualStrings("C:\\newer-9", merged.recents.items.items[0]);
+    try std.testing.expect(!try merged.recents.contains(alloc, "D:\\older"));
+}
+
+test "jump_list persistence keeps the newer cross-process profile event" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+    try jump.pending_profile_events.upsert(alloc, "wsl:Ubuntu", .hidden, 10);
+
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    try merged.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 20);
+
+    try jump.applyPendingState(&merged);
+    try std.testing.expect(!merged.hidden_profiles.contains("wsl:Ubuntu"));
+    const latest = merged.profile_events.latest("wsl:Ubuntu").?;
+    try std.testing.expectEqual(ProfileEventKind.used, latest.kind);
+    try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
+
+    // The inverse ordering must also hold: an older delayed use cannot
+    // unhide a profile removed later by another process.
+    try jump.pending_profile_events.upsert(alloc, "wsl:Ubuntu", .used, 30);
+    try merged.profile_events.upsert(alloc, "wsl:Ubuntu", .hidden, 40);
+    try std.testing.expect(try merged.hidden_profiles.insert(alloc, "wsl:Ubuntu"));
+    try jump.applyPendingState(&merged);
+    try std.testing.expect(merged.hidden_profiles.contains("wsl:Ubuntu"));
+    try std.testing.expectEqual(ProfileEventKind.hidden, merged.profile_events.latest("wsl:Ubuntu").?.kind);
+}
+
 test "jump_list unchanged recent directory still records a use event" {
     const alloc = std.testing.allocator;
     var jump: JumpList = .{
@@ -1719,6 +1943,8 @@ test "jump_list slot budget reserves profiles before recents" {
     try std.testing.expectEqual(@as(usize, 0), recentSlotCount(0, 10, 2));
     try std.testing.expectEqual(@as(usize, 1), recentSlotCount(1, 10, 2));
     try std.testing.expectEqual(@as(usize, 2), recentSlotCount(10, 2, 2));
+    try std.testing.expectEqual(@as(usize, 2), profileSlotCount(3, 1, 5));
+    try std.testing.expectEqual(@as(usize, 0), profileSlotCount(3, 3, 5));
 }
 
 test "jump_list removed profile tombstone persists until profile use" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -1343,6 +1343,16 @@ pub const JumpList = struct {
         self.profiles.clearRetainingCapacity();
     }
 
+    fn recentRemovalCausalTimestamp(self: *const JumpList, path: []const u8) !i64 {
+        const latest = try self.recent_events.latest(self.alloc, path);
+        return if (latest) |event| event.changed_ns else 0;
+    }
+
+    fn profileRemovalCausalTimestamp(self: *const JumpList, key: []const u8) i64 {
+        const latest = self.profile_events.latest(key);
+        return if (latest) |event| event.changed_ns else 0;
+    }
+
     fn rebuildCom(self: *JumpList) !void {
         const exe_path = self.exe_path orelse return error.ExecutableUnavailable;
         const exe_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, exe_path);
@@ -1397,11 +1407,14 @@ pub const JumpList = struct {
             for (self.pending_recent_removals.items.items) |path| {
                 _ = try self.removed_recents.insert(self.alloc, path);
                 _ = self.pending_recent_additions.removePath(self.alloc, path) catch false;
+                // The Shell does not expose when a destination was removed.
+                // Tie the tombstone to the event that published this link so
+                // a later use persisted by another process can reinstate it.
                 try self.pending_recent_events.upsert(
                     self.alloc,
                     path,
                     .removed,
-                    @intCast(std.time.nanoTimestamp()),
+                    try self.recentRemovalCausalTimestamp(path),
                 );
             }
             self.persist_dirty = true;
@@ -1417,7 +1430,7 @@ pub const JumpList = struct {
                     self.alloc,
                     item.key,
                     .hidden,
-                    @intCast(std.time.nanoTimestamp()),
+                    self.profileRemovalCausalTimestamp(item.key),
                 );
                 self.persist_dirty = true;
                 self.persist_retry_count = 0;
@@ -2004,6 +2017,51 @@ test "jump_list persistence keeps the newer cross-process recent event" {
     const latest = (try merged.recent_events.latest(alloc, "C:\\stale")).?;
     try std.testing.expectEqual(RecentEventKind.removed, latest.kind);
     try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
+}
+
+test "jump_list observed removal does not outrank a later cross-process use" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    try jump.recent_events.upsert(alloc, "C:\\reused", .used, 100);
+    try jump.pending_recent_events.upsert(
+        alloc,
+        "C:\\reused",
+        .removed,
+        try jump.recentRemovalCausalTimestamp("C:\\reused"),
+    );
+
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    try merged.recent_events.upsert(alloc, "C:\\reused", .used, 200);
+
+    try jump.applyPendingState(&merged);
+    try std.testing.expect(try merged.recents.contains(alloc, "C:\\reused"));
+    const latest = (try merged.recent_events.latest(alloc, "C:\\reused")).?;
+    try std.testing.expectEqual(RecentEventKind.used, latest.kind);
+    try std.testing.expectEqual(@as(i64, 200), latest.changed_ns);
+
+    try jump.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 300);
+    try jump.pending_profile_events.upsert(
+        alloc,
+        "wsl:Ubuntu",
+        .hidden,
+        jump.profileRemovalCausalTimestamp("wsl:Ubuntu"),
+    );
+    try merged.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 400);
+    try jump.applyPendingState(&merged);
+    try std.testing.expect(!merged.hidden_profiles.contains("wsl:Ubuntu"));
+    const latest_profile = merged.profile_events.latest("wsl:Ubuntu").?;
+    try std.testing.expectEqual(ProfileEventKind.used, latest_profile.kind);
+    try std.testing.expectEqual(@as(i64, 400), latest_profile.changed_ns);
 }
 
 test "jump_list persistence orders recent destinations across paths" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -286,6 +286,7 @@ const RecentEvent = struct {
     path: []const u8,
     kind: RecentEventKind,
     changed_ns: i64,
+    order_seq: u64 = 0,
 };
 
 const ProfileEventKind = enum {
@@ -297,7 +298,18 @@ const ProfileEvent = struct {
     key: []const u8,
     kind: ProfileEventKind,
     changed_ns: i64,
+    order_seq: u64 = 0,
 };
+
+fn eventOrderAfter(
+    changed_ns: i64,
+    order_seq: u64,
+    other_changed_ns: i64,
+    other_order_seq: u64,
+) bool {
+    return changed_ns > other_changed_ns or
+        (changed_ns == other_changed_ns and order_seq > other_order_seq);
+}
 
 const VersionHeader = struct {
     schema_version: u32,
@@ -459,13 +471,24 @@ const RecentEventList = struct {
         kind: RecentEventKind,
         changed_ns: i64,
     ) !void {
+        return self.upsertOrdered(alloc, path, kind, changed_ns, 0);
+    }
+
+    fn upsertOrdered(
+        self: *RecentEventList,
+        alloc: Allocator,
+        path: []const u8,
+        kind: RecentEventKind,
+        changed_ns: i64,
+        order_seq: u64,
+    ) !void {
         if (!isRecentLocalPath(path)) return;
         const normalized = try normalizeRecentPathAlloc(alloc, path);
         var normalized_owned = true;
         defer if (normalized_owned) alloc.free(normalized);
         for (self.items.items, 0..) |item, index| {
             if (!try pathsEqualIgnoreCase(alloc, item.path, normalized)) continue;
-            if (item.changed_ns > changed_ns) return;
+            if (eventOrderAfter(item.changed_ns, item.order_seq, changed_ns, order_seq)) return;
             alloc.free(item.path);
             _ = self.items.orderedRemove(index);
             break;
@@ -475,12 +498,16 @@ const RecentEventList = struct {
             .path = normalized,
             .kind = kind,
             .changed_ns = changed_ns,
+            .order_seq = order_seq,
         });
         normalized_owned = false;
         if (self.items.items.len > max_recents * 2) {
             var oldest: usize = 0;
             for (self.items.items[1..], 1..) |item, index| {
-                if (item.changed_ns < self.items.items[oldest].changed_ns) oldest = index;
+                const current = self.items.items[oldest];
+                if (eventOrderAfter(current.changed_ns, current.order_seq, item.changed_ns, item.order_seq)) {
+                    oldest = index;
+                }
             }
             alloc.free(self.items.orderedRemove(oldest).path);
         }
@@ -510,9 +537,20 @@ const ProfileEventList = struct {
         kind: ProfileEventKind,
         changed_ns: i64,
     ) !void {
+        return self.upsertOrdered(alloc, key, kind, changed_ns, 0);
+    }
+
+    fn upsertOrdered(
+        self: *ProfileEventList,
+        alloc: Allocator,
+        key: []const u8,
+        kind: ProfileEventKind,
+        changed_ns: i64,
+        order_seq: u64,
+    ) !void {
         for (self.items.items, 0..) |item, index| {
             if (!std.mem.eql(u8, item.key, key)) continue;
-            if (item.changed_ns > changed_ns) return;
+            if (eventOrderAfter(item.changed_ns, item.order_seq, changed_ns, order_seq)) return;
             alloc.free(item.key);
             _ = self.items.orderedRemove(index);
             break;
@@ -524,11 +562,15 @@ const ProfileEventList = struct {
             .key = owned,
             .kind = kind,
             .changed_ns = changed_ns,
+            .order_seq = order_seq,
         });
         if (self.items.items.len > max_profile_events) {
             var oldest: usize = 0;
             for (self.items.items[1..], 1..) |item, index| {
-                if (item.changed_ns < self.items.items[oldest].changed_ns) oldest = index;
+                const current = self.items.items[oldest];
+                if (eventOrderAfter(current.changed_ns, current.order_seq, item.changed_ns, item.order_seq)) {
+                    oldest = index;
+                }
             }
             alloc.free(self.items.orderedRemove(oldest).key);
         }
@@ -616,10 +658,22 @@ fn decodeStateAlloc(alloc: Allocator, raw: []const u8) !LoadedState {
     for (parsed.value.removed_directories) |directory| try result.removed_recents.appendLoaded(alloc, directory);
     for (parsed.value.hidden_profiles) |key| _ = try result.hidden_profiles.insert(alloc, key);
     for (parsed.value.recent_events) |event| {
-        try result.recent_events.upsert(alloc, event.path, event.kind, event.changed_ns);
+        try result.recent_events.upsertOrdered(
+            alloc,
+            event.path,
+            event.kind,
+            event.changed_ns,
+            event.order_seq,
+        );
     }
     for (parsed.value.profile_events) |event| {
-        try result.profile_events.upsert(alloc, event.key, event.kind, event.changed_ns);
+        try result.profile_events.upsertOrdered(
+            alloc,
+            event.key,
+            event.kind,
+            event.changed_ns,
+            event.order_seq,
+        );
     }
     return result;
 }
@@ -1205,6 +1259,10 @@ pub const JumpList = struct {
             return false;
         };
         defer merged.deinit(self.alloc);
+        self.assignPendingEventSequences(&merged) catch |err| {
+            log.warn("jump list event ordering failed err={}", .{err});
+            return false;
+        };
         self.applyPendingState(&merged) catch |err| {
             log.warn("jump list state merge failed err={}", .{err});
             return false;
@@ -1274,7 +1332,12 @@ pub const JumpList = struct {
     fn applyPendingState(self: *const JumpList, merged: *LoadedState) !void {
         for (self.pending_recent_events.items.items) |event| {
             if (try merged.recent_events.latest(self.alloc, event.path)) |latest| {
-                if (latest.changed_ns > event.changed_ns) continue;
+                if (eventOrderAfter(
+                    latest.changed_ns,
+                    latest.order_seq,
+                    event.changed_ns,
+                    event.order_seq,
+                )) continue;
             }
             switch (event.kind) {
                 .used => {
@@ -1285,28 +1348,51 @@ pub const JumpList = struct {
                     _ = try merged.removed_recents.insert(self.alloc, event.path);
                 },
             }
-            try merged.recent_events.upsert(
+            try merged.recent_events.upsertOrdered(
                 self.alloc,
                 event.path,
                 event.kind,
                 event.changed_ns,
+                event.order_seq,
             );
         }
         try self.rebuildMergedRecents(merged);
         for (self.pending_profile_events.items.items) |event| {
             if (merged.profile_events.latest(event.key)) |latest| {
-                if (latest.changed_ns > event.changed_ns) continue;
+                if (eventOrderAfter(
+                    latest.changed_ns,
+                    latest.order_seq,
+                    event.changed_ns,
+                    event.order_seq,
+                )) continue;
             }
             switch (event.kind) {
                 .hidden => _ = try merged.hidden_profiles.insert(self.alloc, event.key),
                 .used => _ = merged.hidden_profiles.remove(self.alloc, event.key),
             }
-            try merged.profile_events.upsert(
+            try merged.profile_events.upsertOrdered(
                 self.alloc,
                 event.key,
                 event.kind,
                 event.changed_ns,
+                event.order_seq,
             );
+        }
+    }
+
+    fn assignPendingEventSequences(self: *JumpList, merged: *const LoadedState) !void {
+        var sequence: u64 = 0;
+        for (merged.recent_events.items.items) |event| sequence = @max(sequence, event.order_seq);
+        for (merged.profile_events.items.items) |event| sequence = @max(sequence, event.order_seq);
+        for (self.pending_recent_events.items.items) |*event| {
+            if (sequence == std.math.maxInt(u64)) return error.EventSequenceExhausted;
+            sequence += 1;
+            event.order_seq = sequence;
+        }
+        for (self.pending_profile_events.items.items) |*event| {
+            if (sequence == std.math.maxInt(u64)) return error.EventSequenceExhausted;
+            sequence += 1;
+            event.order_seq = sequence;
         }
     }
 
@@ -1325,7 +1411,12 @@ pub const JumpList = struct {
                     chosen = index;
                     continue;
                 };
-                if (event.changed_ns >= current.changed_ns) chosen = index;
+                if (!eventOrderAfter(
+                    current.changed_ns,
+                    current.order_seq,
+                    event.changed_ns,
+                    event.order_seq,
+                )) chosen = index;
             }
             const index = chosen orelse break;
             try next.appendLoaded(self.alloc, merged.recent_events.items.items[index].path);
@@ -1576,20 +1667,31 @@ pub const JumpList = struct {
                 link.asRaw(),
                 arguments_buffer.ptr,
                 @intCast(arguments_buffer.len),
-            ) >= 0) {
-                const description_len = std.mem.indexOfScalar(u16, arguments_buffer, 0) orelse continue;
-                const description = std.unicode.utf16LeToUtf8Alloc(
-                    self.alloc,
-                    arguments_buffer[0..description_len],
-                ) catch |err| switch (err) {
-                    error.OutOfMemory => return err,
-                    else => continue,
-                };
-                defer self.alloc.free(description);
-                if (std.mem.startsWith(u8, description, profile_description_prefix)) {
-                    const key = description[profile_description_prefix.len..];
-                    _ = try result.profile_keys.insert(self.alloc, key);
-                }
+            ) < 0) {
+                log.debug("jump list removed link description unavailable index={d}", .{index});
+                result.complete = false;
+                continue;
+            }
+            const description_len = std.mem.indexOfScalar(u16, arguments_buffer, 0) orelse {
+                log.debug("jump list removed link description too long index={d}", .{index});
+                result.complete = false;
+                continue;
+            };
+            const description = std.unicode.utf16LeToUtf8Alloc(
+                self.alloc,
+                arguments_buffer[0..description_len],
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => {
+                    log.debug("jump list removed link description invalid index={d} err={}", .{ index, err });
+                    result.complete = false;
+                    continue;
+                },
+            };
+            defer self.alloc.free(description);
+            if (std.mem.startsWith(u8, description, profile_description_prefix)) {
+                const key = description[profile_description_prefix.len..];
+                _ = try result.profile_keys.insert(self.alloc, key);
             }
         }
         return result;
@@ -1742,11 +1844,13 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
         .path = "E:\\removed",
         .kind = .removed,
         .changed_ns = 42,
+        .order_seq = 7,
     }};
     const profile_events = [_]ProfileEvent{.{
         .key = "wsl:Ubuntu",
         .kind = .hidden,
         .changed_ns = 43,
+        .order_seq = 8,
     }};
     const encoded = try encodeRecentStateAlloc(
         std.testing.allocator,
@@ -1766,9 +1870,11 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     try std.testing.expectEqualStrings(recent_events[0].path, parsed.value.recent_events[0].path);
     try std.testing.expectEqual(recent_events[0].kind, parsed.value.recent_events[0].kind);
     try std.testing.expectEqual(recent_events[0].changed_ns, parsed.value.recent_events[0].changed_ns);
+    try std.testing.expectEqual(recent_events[0].order_seq, parsed.value.recent_events[0].order_seq);
     try std.testing.expectEqualStrings(profile_events[0].key, parsed.value.profile_events[0].key);
     try std.testing.expectEqual(profile_events[0].kind, parsed.value.profile_events[0].kind);
     try std.testing.expectEqual(profile_events[0].changed_ns, parsed.value.profile_events[0].changed_ns);
+    try std.testing.expectEqual(profile_events[0].order_seq, parsed.value.profile_events[0].order_seq);
     try std.testing.expectError(
         error.SyntaxError,
         parseRecentStateAlloc(std.testing.allocator, "{not json"),
@@ -2056,6 +2162,43 @@ test "jump_list later cross-process use outranks an observed removal" {
     const latest_profile = merged.profile_events.latest("wsl:Ubuntu").?;
     try std.testing.expectEqual(ProfileEventKind.used, latest_profile.kind);
     try std.testing.expectEqual(@as(i64, 400), latest_profile.changed_ns);
+}
+
+test "jump_list equal timestamps use locked persistence sequence" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    try jump.pending_recent_events.upsert(alloc, "C:\\equal", .used, 100);
+    try jump.pending_profile_events.upsert(alloc, "wsl:Equal", .used, 200);
+
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    try merged.removed_recents.appendLoaded(alloc, "C:\\equal");
+    try merged.recent_events.upsertOrdered(alloc, "C:\\equal", .removed, 100, 5);
+    try std.testing.expect(try merged.hidden_profiles.insert(alloc, "wsl:Equal"));
+    try merged.profile_events.upsertOrdered(alloc, "wsl:Equal", .hidden, 200, 6);
+
+    try jump.assignPendingEventSequences(&merged);
+    try jump.applyPendingState(&merged);
+    try std.testing.expect(try merged.recents.contains(alloc, "C:\\equal"));
+    try std.testing.expect(!try merged.removed_recents.contains(alloc, "C:\\equal"));
+    try std.testing.expect(!merged.hidden_profiles.contains("wsl:Equal"));
+    try std.testing.expectEqual(
+        @as(u64, 7),
+        (try merged.recent_events.latest(alloc, "C:\\equal")).?.order_seq,
+    );
+    try std.testing.expectEqual(
+        @as(u64, 8),
+        merged.profile_events.latest("wsl:Equal").?.order_seq,
+    );
 }
 
 test "jump_list persistence orders recent destinations across paths" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -265,6 +265,18 @@ const RecentState = struct {
     directories: []const []const u8 = &.{},
     removed_directories: []const []const u8 = &.{},
     hidden_profiles: []const []const u8 = &.{},
+    recent_events: []const RecentEvent = &.{},
+};
+
+const RecentEventKind = enum {
+    used,
+    removed,
+};
+
+const RecentEvent = struct {
+    path: []const u8,
+    kind: RecentEventKind,
+    changed_ns: i64,
 };
 
 const VersionHeader = struct {
@@ -288,6 +300,7 @@ fn encodeRecentStateAlloc(
     directories: []const []const u8,
     removed_directories: []const []const u8,
     hidden_profiles: []const []const u8,
+    recent_events: []const RecentEvent,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -295,6 +308,7 @@ fn encodeRecentStateAlloc(
         .directories = directories,
         .removed_directories = removed_directories,
         .hidden_profiles = hidden_profiles,
+        .recent_events = recent_events,
     }, .{
         .whitespace = .minified,
     }, &out.writer);
@@ -395,6 +409,50 @@ const RecentList = struct {
     }
 };
 
+const RecentEventList = struct {
+    items: std.ArrayListUnmanaged(RecentEvent) = .empty,
+
+    fn deinit(self: *RecentEventList, alloc: Allocator) void {
+        for (self.items.items) |item| alloc.free(item.path);
+        self.items.deinit(alloc);
+        self.* = .{};
+    }
+
+    fn latest(self: *const RecentEventList, alloc: Allocator, path: []const u8) !?RecentEvent {
+        for (self.items.items) |item| {
+            if (try pathsEqualIgnoreCase(alloc, item.path, path)) return item;
+        }
+        return null;
+    }
+
+    fn upsert(
+        self: *RecentEventList,
+        alloc: Allocator,
+        path: []const u8,
+        kind: RecentEventKind,
+        changed_ns: i64,
+    ) !void {
+        for (self.items.items, 0..) |item, index| {
+            if (!try pathsEqualIgnoreCase(alloc, item.path, path)) continue;
+            if (item.changed_ns > changed_ns) return;
+            alloc.free(item.path);
+            _ = self.items.orderedRemove(index);
+            break;
+        }
+
+        const owned = try alloc.dupe(u8, path);
+        errdefer alloc.free(owned);
+        try self.items.append(alloc, .{
+            .path = owned,
+            .kind = kind,
+            .changed_ns = changed_ns,
+        });
+        if (self.items.items.len > max_recents * 2) {
+            alloc.free(self.items.orderedRemove(0).path);
+        }
+    }
+};
+
 const ProfileTombstones = struct {
     items: std.ArrayListUnmanaged([]u8) = .empty,
 
@@ -437,11 +495,13 @@ const LoadedState = struct {
     recents: RecentList = .{},
     removed_recents: RecentList = .{},
     hidden_profiles: ProfileTombstones = .{},
+    recent_events: RecentEventList = .{},
 
     fn deinit(self: *LoadedState, alloc: Allocator) void {
         self.recents.deinit(alloc);
         self.removed_recents.deinit(alloc);
         self.hidden_profiles.deinit(alloc);
+        self.recent_events.deinit(alloc);
         self.* = .{};
     }
 };
@@ -498,6 +558,17 @@ fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
     for (parsed.value.hidden_profiles) |key| {
         _ = result.hidden_profiles.insert(alloc, key) catch |err| {
             log.warn("jump list hidden profile state allocation failed err={}", .{err});
+            break;
+        };
+    }
+    for (parsed.value.recent_events) |event| {
+        result.recent_events.upsert(
+            alloc,
+            event.path,
+            event.kind,
+            event.changed_ns,
+        ) catch |err| {
+            log.warn("jump list recent event state allocation failed err={}", .{err});
             break;
         };
     }
@@ -669,9 +740,11 @@ pub const JumpList = struct {
     recents: RecentList,
     removed_recents: RecentList,
     hidden_profiles: ProfileTombstones,
+    recent_events: RecentEventList = .{},
     pending_recent_additions: RecentList = .{},
     pending_recent_removals: RecentList = .{},
     pending_recent_uses: RecentList = .{},
+    pending_recent_events: RecentEventList = .{},
     pending_profile_hides: ProfileTombstones = .{},
     pending_profile_uses: ProfileTombstones = .{},
     profiles: std.ArrayListUnmanaged(ProfileItem) = .empty,
@@ -681,6 +754,7 @@ pub const JumpList = struct {
     rebuild_retry_count: u8 = 0,
     com_disabled: bool = false,
     startup_profile_discovery_pending: bool = false,
+    startup_profile_discovery_retry_count: u8 = 0,
 
     pub fn init(alloc: Allocator, state_path: []const u8) !JumpList {
         const owned_state_path = try alloc.dupe(u8, state_path);
@@ -696,6 +770,7 @@ pub const JumpList = struct {
             .recents = loaded.recents,
             .removed_recents = loaded.removed_recents,
             .hidden_profiles = loaded.hidden_profiles,
+            .recent_events = loaded.recent_events,
         };
     }
 
@@ -706,9 +781,11 @@ pub const JumpList = struct {
         self.recents.deinit(self.alloc);
         self.removed_recents.deinit(self.alloc);
         self.hidden_profiles.deinit(self.alloc);
+        self.recent_events.deinit(self.alloc);
         self.pending_recent_additions.deinit(self.alloc);
         self.pending_recent_removals.deinit(self.alloc);
         self.pending_recent_uses.deinit(self.alloc);
+        self.pending_recent_events.deinit(self.alloc);
         self.pending_profile_hides.deinit(self.alloc);
         self.pending_profile_uses.deinit(self.alloc);
         self.clearProfiles();
@@ -722,6 +799,7 @@ pub const JumpList = struct {
         self.stopTimer();
         self.flush();
         self.startup_profile_discovery_pending = true;
+        self.startup_profile_discovery_retry_count = 0;
         self.schedule();
     }
 
@@ -731,6 +809,17 @@ pub const JumpList = struct {
 
     pub fn completeStartupProfileDiscovery(self: *JumpList) void {
         self.startup_profile_discovery_pending = false;
+        self.startup_profile_discovery_retry_count = 0;
+    }
+
+    pub fn retryStartupProfileDiscovery(self: *JumpList) void {
+        if (!self.startup_profile_discovery_pending) return;
+        if (nextRebuildRetryCount(self.startup_profile_discovery_retry_count)) |next| {
+            self.startup_profile_discovery_retry_count = next;
+            self.schedule();
+        } else {
+            log.warn("jump list profile discovery retries exhausted; waiting for a new host", .{});
+        }
     }
 
     pub fn updateProfiles(self: *JumpList, profiles: []const windows_shell.Profile) void {
@@ -801,17 +890,18 @@ pub const JumpList = struct {
     }
 
     pub fn noteRecent(self: *JumpList, path: []const u8) void {
+        const changed_ns: i64 = @intCast(std.time.nanoTimestamp());
         const reinstated = self.removed_recents.removePath(self.alloc, path) catch |err| {
             log.warn("jump list recent reinstatement failed err={}", .{err});
             return;
         };
         if (reinstated) {
             _ = self.pending_recent_removals.removePath(self.alloc, path) catch {};
-            _ = self.pending_recent_uses.insert(self.alloc, path) catch |err| {
-                log.warn("jump list recent-use snapshot failed err={}", .{err});
-                return;
-            };
         }
+        _ = self.pending_recent_uses.insert(self.alloc, path) catch |err| {
+            log.warn("jump list recent-use snapshot failed err={}", .{err});
+            return;
+        };
         const changed = self.recents.insert(self.alloc, path) catch |err| {
             log.warn("jump list recent update failed err={}", .{err});
             return;
@@ -821,6 +911,10 @@ pub const JumpList = struct {
         // written by another process is removed during the next merge.
         const recorded = self.pending_recent_additions.insert(self.alloc, path) catch |err| {
             log.warn("jump list recent persistence snapshot failed err={}", .{err});
+            return;
+        };
+        self.pending_recent_events.upsert(self.alloc, path, .used, changed_ns) catch |err| {
+            log.warn("jump list recent event snapshot failed err={}", .{err});
             return;
         };
         if (!changed and !reinstated and !recorded) return;
@@ -873,7 +967,10 @@ pub const JumpList = struct {
     /// `initial-window=false` launch is not stranded without a Profiles
     /// category until something else happens to dirty the model.
     pub fn scheduleIfStartupPending(self: *JumpList) void {
-        if (self.startup_profile_discovery_pending) self.schedule();
+        if (self.startup_profile_discovery_pending) {
+            self.startup_profile_discovery_retry_count = 0;
+            self.schedule();
+        }
     }
 
     fn schedule(self: *JumpList) void {
@@ -939,6 +1036,7 @@ pub const JumpList = struct {
             merged.recents.items.items,
             merged.removed_recents.items.items,
             merged.hidden_profiles.items.items,
+            merged.recent_events.items.items,
         ) catch |err| {
             log.warn("jump list recent encode failed err={}", .{err});
             return false;
@@ -969,9 +1067,13 @@ pub const JumpList = struct {
         self.hidden_profiles.deinit(self.alloc);
         self.hidden_profiles = merged.hidden_profiles;
         merged.hidden_profiles = .{};
+        self.recent_events.deinit(self.alloc);
+        self.recent_events = merged.recent_events;
+        merged.recent_events = .{};
 
         self.pending_recent_additions.deinit(self.alloc);
         self.pending_recent_removals.deinit(self.alloc);
+        self.pending_recent_events.deinit(self.alloc);
         self.pending_profile_hides.deinit(self.alloc);
         self.persist_dirty = false;
         if (model_changed) {
@@ -983,19 +1085,26 @@ pub const JumpList = struct {
     }
 
     fn applyPendingState(self: *const JumpList, merged: *LoadedState) !void {
-        for (self.pending_recent_removals.items.items) |path| {
-            _ = try merged.recents.removePath(self.alloc, path);
-            _ = try merged.removed_recents.insert(self.alloc, path);
-        }
-        for (self.pending_recent_uses.items.items) |path| {
-            _ = try merged.removed_recents.removePath(self.alloc, path);
-        }
-        var remaining = self.pending_recent_additions.items.items.len;
-        while (remaining > 0) {
-            remaining -= 1;
-            const path = self.pending_recent_additions.items.items[remaining];
-            _ = try merged.removed_recents.removePath(self.alloc, path);
-            _ = try merged.recents.insert(self.alloc, path);
+        for (self.pending_recent_events.items.items) |event| {
+            if (try merged.recent_events.latest(self.alloc, event.path)) |latest| {
+                if (latest.changed_ns > event.changed_ns) continue;
+            }
+            switch (event.kind) {
+                .used => {
+                    _ = try merged.removed_recents.removePath(self.alloc, event.path);
+                    _ = try merged.recents.insert(self.alloc, event.path);
+                },
+                .removed => {
+                    _ = try merged.recents.removePath(self.alloc, event.path);
+                    _ = try merged.removed_recents.insert(self.alloc, event.path);
+                },
+            }
+            try merged.recent_events.upsert(
+                self.alloc,
+                event.path,
+                event.kind,
+                event.changed_ns,
+            );
         }
         for (self.pending_profile_hides.items.items) |key| {
             _ = try merged.hidden_profiles.insert(self.alloc, key);
@@ -1064,6 +1173,12 @@ pub const JumpList = struct {
             for (self.pending_recent_removals.items.items) |path| {
                 _ = try self.removed_recents.insert(self.alloc, path);
                 _ = self.pending_recent_additions.removePath(self.alloc, path) catch false;
+                try self.pending_recent_events.upsert(
+                    self.alloc,
+                    path,
+                    .removed,
+                    @intCast(std.time.nanoTimestamp()),
+                );
             }
             self.persist_dirty = true;
         }
@@ -1342,11 +1457,17 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     const values = [_][]const u8{ "C:\\src\\noctty", "D:\\work" };
     const hidden_profiles = [_][]const u8{"wsl:Ubuntu"};
     const removed_values = [_][]const u8{"E:\\removed"};
+    const recent_events = [_]RecentEvent{.{
+        .path = "E:\\removed",
+        .kind = .removed,
+        .changed_ns = 42,
+    }};
     const encoded = try encodeRecentStateAlloc(
         std.testing.allocator,
         &values,
         &removed_values,
         &hidden_profiles,
+        &recent_events,
     );
     defer std.testing.allocator.free(encoded);
     var parsed = try parseRecentStateAlloc(std.testing.allocator, encoded);
@@ -1355,6 +1476,9 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     try std.testing.expectEqualStrings(values[1], parsed.value.directories[1]);
     try std.testing.expectEqualStrings(removed_values[0], parsed.value.removed_directories[0]);
     try std.testing.expectEqualStrings(hidden_profiles[0], parsed.value.hidden_profiles[0]);
+    try std.testing.expectEqualStrings(recent_events[0].path, parsed.value.recent_events[0].path);
+    try std.testing.expectEqual(recent_events[0].kind, parsed.value.recent_events[0].kind);
+    try std.testing.expectEqual(recent_events[0].changed_ns, parsed.value.recent_events[0].changed_ns);
     try std.testing.expectError(
         error.SyntaxError,
         parseRecentStateAlloc(std.testing.allocator, "{not json"),
@@ -1397,7 +1521,7 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     @memset(oversized_key, 'x');
     try std.testing.expectError(
         error.StateTooLarge,
-        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}),
+        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}, &.{}),
     );
 }
 
@@ -1517,6 +1641,8 @@ test "jump_list persistence merge applies local events to the latest snapshot" {
 
     try std.testing.expect(try jump.pending_recent_additions.insert(alloc, "D:\\local"));
     try std.testing.expect(try jump.pending_recent_removals.insert(alloc, "C:\\removed"));
+    try jump.pending_recent_events.upsert(alloc, "D:\\local", .used, 20);
+    try jump.pending_recent_events.upsert(alloc, "C:\\removed", .removed, 21);
     try std.testing.expect(try jump.pending_profile_hides.insert(alloc, "wsl:new-hidden"));
     try std.testing.expect(try jump.pending_profile_uses.insert(alloc, "wsl:used"));
 
@@ -1533,6 +1659,34 @@ test "jump_list persistence merge applies local events to the latest snapshot" {
     try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\removed"));
     try std.testing.expect(merged.hidden_profiles.contains("wsl:new-hidden"));
     try std.testing.expect(!merged.hidden_profiles.contains("wsl:used"));
+}
+
+test "jump_list persistence keeps the newer cross-process recent event" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    // Process A observed the directory first, then process B removed it and
+    // persisted that newer event before A acquired the state-file lock.
+    try jump.pending_recent_events.upsert(alloc, "C:\\stale", .used, 10);
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+    try merged.removed_recents.appendLoaded(alloc, "C:\\stale");
+    try merged.recent_events.upsert(alloc, "C:\\stale", .removed, 20);
+
+    try jump.applyPendingState(&merged);
+    try std.testing.expectEqual(@as(usize, 0), merged.recents.items.items.len);
+    try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\stale"));
+    const latest = (try merged.recent_events.latest(alloc, "C:\\stale")).?;
+    try std.testing.expectEqual(RecentEventKind.removed, latest.kind);
+    try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
 }
 
 test "jump_list unchanged recent directory still records a use event" {
@@ -1555,6 +1709,7 @@ test "jump_list unchanged recent directory still records a use event" {
     jump.noteRecent("D:\\same-head");
     try std.testing.expect(jump.persist_dirty);
     try std.testing.expect(try jump.pending_recent_additions.contains(alloc, "D:\\same-head"));
+    try std.testing.expect(try jump.pending_recent_uses.contains(alloc, "D:\\same-head"));
 }
 
 test "jump_list slot budget reserves profiles before recents" {
@@ -1610,6 +1765,10 @@ test "jump_list startup profile discovery stays pending until completion" {
     defer jump.deinit();
 
     try std.testing.expect(jump.startupProfileDiscoveryPending());
+    jump.startup_profile_discovery_retry_count = max_rebuild_retries;
+    jump.retryStartupProfileDiscovery();
+    try std.testing.expect(jump.timer_id == null);
+    try std.testing.expectEqual(max_rebuild_retries, jump.startup_profile_discovery_retry_count);
     // A failed discovery leaves the request untouched; only the caller's
     // explicit success transition consumes it.
     try std.testing.expect(jump.startupProfileDiscoveryPending());

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -36,6 +36,11 @@ pub const debounce_ms: UINT = 500;
 const max_profile_tombstones: usize = 128;
 const max_profile_events: usize = max_profile_tombstones * 2;
 const max_rebuild_retries: u8 = 3;
+
+fn eventTimestamp() i64 {
+    // std.time.nanoTimestamp is UTC calendar time, not a boot-relative clock.
+    return @intCast(std.time.nanoTimestamp());
+}
 const max_shell_link_chars: usize = 32_768;
 const profile_description_prefix = "noctty-profile:";
 
@@ -1019,7 +1024,7 @@ pub const JumpList = struct {
     }
 
     pub fn noteProfileUsed(self: *JumpList, key: []const u8) void {
-        const changed_ns: i64 = @intCast(std.time.nanoTimestamp());
+        const changed_ns = eventTimestamp();
         const removed = self.hidden_profiles.remove(self.alloc, key);
         _ = self.pending_profile_hides.remove(self.alloc, key);
         const recorded = self.pending_profile_uses.insert(self.alloc, key) catch |err| {
@@ -1046,7 +1051,7 @@ pub const JumpList = struct {
             return;
         };
         defer self.alloc.free(normalized);
-        const changed_ns: i64 = @intCast(std.time.nanoTimestamp());
+        const changed_ns = eventTimestamp();
         const reinstated = self.removed_recents.removePath(self.alloc, normalized) catch |err| {
             log.warn("jump list recent reinstatement failed err={}", .{err});
             return;
@@ -1200,6 +1205,10 @@ pub const JumpList = struct {
             return false;
         };
         defer merged.deinit(self.alloc);
+        self.orderPendingRemovalEvents(&merged) catch |err| {
+            log.warn("jump list removal ordering failed err={}", .{err});
+            return false;
+        };
         self.applyPendingState(&merged) catch |err| {
             log.warn("jump list state merge failed err={}", .{err});
             return false;
@@ -1305,6 +1314,34 @@ pub const JumpList = struct {
         }
     }
 
+    fn orderPendingRemovalEvents(self: *JumpList, merged: *const LoadedState) !void {
+        // A process can observe a Shell removal from a list published by a
+        // different process. Reconcile against the locked shared history so
+        // the removal is not timestamped before the destination it removes.
+        for (self.pending_recent_removals.items.items) |path| {
+            const pending = (try self.pending_recent_events.latest(self.alloc, path)) orelse continue;
+            const latest = (try merged.recent_events.latest(self.alloc, path)) orelse continue;
+            if (latest.changed_ns <= pending.changed_ns) continue;
+            try self.pending_recent_events.upsert(
+                self.alloc,
+                path,
+                .removed,
+                latest.changed_ns,
+            );
+        }
+        for (self.pending_profile_hides.items.items) |key| {
+            const pending = self.pending_profile_events.latest(key) orelse continue;
+            const latest = merged.profile_events.latest(key) orelse continue;
+            if (latest.changed_ns <= pending.changed_ns) continue;
+            try self.pending_profile_events.upsert(
+                self.alloc,
+                key,
+                .hidden,
+                latest.changed_ns,
+            );
+        }
+    }
+
     fn rebuildMergedRecents(self: *const JumpList, merged: *LoadedState) !void {
         var next: RecentList = .{};
         errdefer next.deinit(self.alloc);
@@ -1341,16 +1378,6 @@ pub const JumpList = struct {
     fn clearProfiles(self: *JumpList) void {
         for (self.profiles.items) |*item| item.deinit(self.alloc);
         self.profiles.clearRetainingCapacity();
-    }
-
-    fn recentRemovalCausalTimestamp(self: *const JumpList, path: []const u8) !i64 {
-        const latest = try self.recent_events.latest(self.alloc, path);
-        return if (latest) |event| event.changed_ns else 0;
-    }
-
-    fn profileRemovalCausalTimestamp(self: *const JumpList, key: []const u8) i64 {
-        const latest = self.profile_events.latest(key);
-        return if (latest) |event| event.changed_ns else 0;
     }
 
     fn rebuildCom(self: *JumpList) !void {
@@ -1407,14 +1434,11 @@ pub const JumpList = struct {
             for (self.pending_recent_removals.items.items) |path| {
                 _ = try self.removed_recents.insert(self.alloc, path);
                 _ = self.pending_recent_additions.removePath(self.alloc, path) catch false;
-                // The Shell does not expose when a destination was removed.
-                // Tie the tombstone to the event that published this link so
-                // a later use persisted by another process can reinstate it.
                 try self.pending_recent_events.upsert(
                     self.alloc,
                     path,
                     .removed,
-                    try self.recentRemovalCausalTimestamp(path),
+                    eventTimestamp(),
                 );
             }
             self.persist_dirty = true;
@@ -1430,7 +1454,7 @@ pub const JumpList = struct {
                     self.alloc,
                     item.key,
                     .hidden,
-                    self.profileRemovalCausalTimestamp(item.key),
+                    eventTimestamp(),
                 );
                 self.persist_dirty = true;
                 self.persist_retry_count = 0;
@@ -2019,7 +2043,7 @@ test "jump_list persistence keeps the newer cross-process recent event" {
     try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
 }
 
-test "jump_list observed removal does not outrank a later cross-process use" {
+test "jump_list removal orders against the latest locked event history" {
     const alloc = std.testing.allocator;
     var jump: JumpList = .{
         .alloc = alloc,
@@ -2031,36 +2055,40 @@ test "jump_list observed removal does not outrank a later cross-process use" {
     };
     defer jump.deinit();
 
-    try jump.recent_events.upsert(alloc, "C:\\reused", .used, 100);
+    try std.testing.expect(try jump.pending_recent_removals.insert(alloc, "C:\\reused"));
     try jump.pending_recent_events.upsert(
         alloc,
         "C:\\reused",
         .removed,
-        try jump.recentRemovalCausalTimestamp("C:\\reused"),
+        100,
     );
 
     var merged: LoadedState = .{};
     defer merged.deinit(alloc);
+    try merged.recents.appendLoaded(alloc, "C:\\reused");
     try merged.recent_events.upsert(alloc, "C:\\reused", .used, 200);
 
+    try jump.orderPendingRemovalEvents(&merged);
     try jump.applyPendingState(&merged);
-    try std.testing.expect(try merged.recents.contains(alloc, "C:\\reused"));
+    try std.testing.expect(!try merged.recents.contains(alloc, "C:\\reused"));
+    try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\reused"));
     const latest = (try merged.recent_events.latest(alloc, "C:\\reused")).?;
-    try std.testing.expectEqual(RecentEventKind.used, latest.kind);
+    try std.testing.expectEqual(RecentEventKind.removed, latest.kind);
     try std.testing.expectEqual(@as(i64, 200), latest.changed_ns);
 
-    try jump.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 300);
+    try std.testing.expect(try jump.pending_profile_hides.insert(alloc, "wsl:Ubuntu"));
     try jump.pending_profile_events.upsert(
         alloc,
         "wsl:Ubuntu",
         .hidden,
-        jump.profileRemovalCausalTimestamp("wsl:Ubuntu"),
+        300,
     );
     try merged.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 400);
+    try jump.orderPendingRemovalEvents(&merged);
     try jump.applyPendingState(&merged);
-    try std.testing.expect(!merged.hidden_profiles.contains("wsl:Ubuntu"));
+    try std.testing.expect(merged.hidden_profiles.contains("wsl:Ubuntu"));
     const latest_profile = merged.profile_events.latest("wsl:Ubuntu").?;
-    try std.testing.expectEqual(ProfileEventKind.used, latest_profile.kind);
+    try std.testing.expectEqual(ProfileEventKind.hidden, latest_profile.kind);
     try std.testing.expectEqual(@as(i64, 400), latest_profile.changed_ns);
 }
 

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -36,6 +36,7 @@ const max_profile_tombstones: usize = 128;
 const max_profile_events: usize = max_profile_tombstones * 2;
 const max_rebuild_retries: u8 = 3;
 const max_shell_link_chars: usize = 32_768;
+const profile_description_prefix = "noctty-profile:";
 
 const CLSCTX_INPROC_SERVER: DWORD = 0x1;
 const CO_E_NOTINITIALIZED: HRESULT = @bitCast(@as(u32, 0x800401F0));
@@ -795,11 +796,13 @@ fn nextRebuildRetryCount(current: u8) ?u8 {
 
 const RemovedArguments = struct {
     items: std.ArrayListUnmanaged([]u8) = .empty,
+    profile_keys: ProfileTombstones = .{},
     complete: bool = true,
 
     fn deinit(self: *RemovedArguments, alloc: Allocator) void {
         for (self.items.items) |item| alloc.free(item);
         self.items.deinit(alloc);
+        self.profile_keys.deinit(alloc);
         self.* = .{};
     }
 };
@@ -1324,7 +1327,8 @@ pub const JumpList = struct {
             self.persist_dirty = true;
         }
         for (self.profiles.items) |item| {
-            if (!containsArguments(removed_arguments.items.items, item.arguments)) continue;
+            if (!removed_arguments.profile_keys.contains(item.key) and
+                !containsArguments(removed_arguments.items.items, item.arguments)) continue;
             if (self.pending_profile_uses.contains(item.key)) continue;
             if (try self.hidden_profiles.insert(self.alloc, item.key)) {
                 _ = try self.pending_profile_hides.insert(self.alloc, item.key);
@@ -1377,7 +1381,7 @@ pub const JumpList = struct {
             defer self.alloc.free(title);
             const arguments = try buildWorkingDirectoryArgumentsAlloc(self.alloc, path);
             defer self.alloc.free(arguments);
-            const link = try self.createShellLink(exe_w, arguments, title, path);
+            const link = try self.createShellLink(exe_w, arguments, title, path, null);
             defer link.release();
             if (collection.addObject(link.asRaw()) < 0) return error.AddRecentLinkFailed;
         }
@@ -1401,7 +1405,7 @@ pub const JumpList = struct {
         for (self.profiles.items) |item| {
             if (self.hidden_profiles.contains(item.key)) continue;
             if (appended == count) break;
-            const link = try self.createShellLink(exe_w, item.arguments, item.title, null);
+            const link = try self.createShellLink(exe_w, item.arguments, item.title, null, item.key);
             defer link.release();
             if (collection.addObject(link.asRaw()) < 0) return error.AddProfileLinkFailed;
             appended += 1;
@@ -1477,6 +1481,27 @@ pub const JumpList = struct {
             };
             errdefer self.alloc.free(arguments);
             try result.items.append(self.alloc, arguments);
+
+            @memset(arguments_buffer, 0);
+            if (link.vtbl.GetDescription(
+                link.asRaw(),
+                arguments_buffer.ptr,
+                @intCast(arguments_buffer.len),
+            ) >= 0) {
+                const description_len = std.mem.indexOfScalar(u16, arguments_buffer, 0) orelse continue;
+                const description = std.unicode.utf16LeToUtf8Alloc(
+                    self.alloc,
+                    arguments_buffer[0..description_len],
+                ) catch |err| switch (err) {
+                    error.OutOfMemory => return err,
+                    else => continue,
+                };
+                defer self.alloc.free(description);
+                if (std.mem.startsWith(u8, description, profile_description_prefix)) {
+                    const key = description[profile_description_prefix.len..];
+                    _ = try result.profile_keys.insert(self.alloc, key);
+                }
+            }
         }
         return result;
     }
@@ -1487,6 +1512,7 @@ pub const JumpList = struct {
         arguments: []const u8,
         title: []const u8,
         working_directory: ?[]const u8,
+        profile_key: ?[]const u8,
     ) !*IShellLinkW {
         var raw_link: ?*anyopaque = null;
         const create_hr = CoCreateInstance(
@@ -1509,6 +1535,20 @@ pub const JumpList = struct {
         if (link.vtbl.SetPath(link.asRaw(), exe_w.ptr) < 0) return error.SetLinkPathFailed;
         if (link.vtbl.SetArguments(link.asRaw(), arguments_w.ptr) < 0) return error.SetLinkArgumentsFailed;
         if (link.vtbl.SetIconLocation(link.asRaw(), exe_w.ptr, 0) < 0) return error.SetLinkIconFailed;
+
+        if (profile_key) |key| {
+            const description = try std.fmt.allocPrint(
+                self.alloc,
+                "{s}{s}",
+                .{ profile_description_prefix, key },
+            );
+            defer self.alloc.free(description);
+            const description_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, description);
+            defer self.alloc.free(description_w);
+            if (link.vtbl.SetDescription(link.asRaw(), description_w.ptr) < 0) {
+                return error.SetLinkDescriptionFailed;
+            }
+        }
 
         if (working_directory) |path| {
             const path_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, path);

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -1205,10 +1205,6 @@ pub const JumpList = struct {
             return false;
         };
         defer merged.deinit(self.alloc);
-        self.orderPendingRemovalEvents(&merged) catch |err| {
-            log.warn("jump list removal ordering failed err={}", .{err});
-            return false;
-        };
         self.applyPendingState(&merged) catch |err| {
             log.warn("jump list state merge failed err={}", .{err});
             return false;
@@ -1310,34 +1306,6 @@ pub const JumpList = struct {
                 event.key,
                 event.kind,
                 event.changed_ns,
-            );
-        }
-    }
-
-    fn orderPendingRemovalEvents(self: *JumpList, merged: *const LoadedState) !void {
-        // A process can observe a Shell removal from a list published by a
-        // different process. Reconcile against the locked shared history so
-        // the removal is not timestamped before the destination it removes.
-        for (self.pending_recent_removals.items.items) |path| {
-            const pending = (try self.pending_recent_events.latest(self.alloc, path)) orelse continue;
-            const latest = (try merged.recent_events.latest(self.alloc, path)) orelse continue;
-            if (latest.changed_ns <= pending.changed_ns) continue;
-            try self.pending_recent_events.upsert(
-                self.alloc,
-                path,
-                .removed,
-                latest.changed_ns,
-            );
-        }
-        for (self.pending_profile_hides.items.items) |key| {
-            const pending = self.pending_profile_events.latest(key) orelse continue;
-            const latest = merged.profile_events.latest(key) orelse continue;
-            if (latest.changed_ns <= pending.changed_ns) continue;
-            try self.pending_profile_events.upsert(
-                self.alloc,
-                key,
-                .hidden,
-                latest.changed_ns,
             );
         }
     }
@@ -2043,7 +2011,7 @@ test "jump_list persistence keeps the newer cross-process recent event" {
     try std.testing.expectEqual(@as(i64, 20), latest.changed_ns);
 }
 
-test "jump_list removal orders against the latest locked event history" {
+test "jump_list later cross-process use outranks an observed removal" {
     const alloc = std.testing.allocator;
     var jump: JumpList = .{
         .alloc = alloc,
@@ -2068,12 +2036,11 @@ test "jump_list removal orders against the latest locked event history" {
     try merged.recents.appendLoaded(alloc, "C:\\reused");
     try merged.recent_events.upsert(alloc, "C:\\reused", .used, 200);
 
-    try jump.orderPendingRemovalEvents(&merged);
     try jump.applyPendingState(&merged);
-    try std.testing.expect(!try merged.recents.contains(alloc, "C:\\reused"));
-    try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\reused"));
+    try std.testing.expect(try merged.recents.contains(alloc, "C:\\reused"));
+    try std.testing.expect(!try merged.removed_recents.contains(alloc, "C:\\reused"));
     const latest = (try merged.recent_events.latest(alloc, "C:\\reused")).?;
-    try std.testing.expectEqual(RecentEventKind.removed, latest.kind);
+    try std.testing.expectEqual(RecentEventKind.used, latest.kind);
     try std.testing.expectEqual(@as(i64, 200), latest.changed_ns);
 
     try std.testing.expect(try jump.pending_profile_hides.insert(alloc, "wsl:Ubuntu"));
@@ -2084,11 +2051,10 @@ test "jump_list removal orders against the latest locked event history" {
         300,
     );
     try merged.profile_events.upsert(alloc, "wsl:Ubuntu", .used, 400);
-    try jump.orderPendingRemovalEvents(&merged);
     try jump.applyPendingState(&merged);
-    try std.testing.expect(merged.hidden_profiles.contains("wsl:Ubuntu"));
+    try std.testing.expect(!merged.hidden_profiles.contains("wsl:Ubuntu"));
     const latest_profile = merged.profile_events.latest("wsl:Ubuntu").?;
-    try std.testing.expectEqual(ProfileEventKind.hidden, latest_profile.kind);
+    try std.testing.expectEqual(ProfileEventKind.used, latest_profile.kind);
     try std.testing.expectEqual(@as(i64, 400), latest_profile.changed_ns);
 }
 

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -1138,6 +1138,13 @@ pub const JumpList = struct {
             self.rebuild_retry_count = 0;
             self.rebuild_dirty = true;
         }
+        // Directory activity is an external recovery trigger after the
+        // bounded startup discovery retries have been exhausted.
+        if (self.startup_profile_discovery_pending and
+            self.startup_profile_discovery_retry_count == max_rebuild_retries)
+        {
+            self.startup_profile_discovery_retry_count = 0;
+        }
         self.schedule();
     }
 
@@ -2425,13 +2432,19 @@ test "jump_list startup profile discovery stays pending until completion" {
         .hidden_profiles = .{},
         .startup_profile_discovery_pending = true,
     };
-    defer jump.deinit();
+    defer {
+        jump.persist_dirty = false;
+        jump.deinit();
+    }
 
     try std.testing.expect(jump.startupProfileDiscoveryPending());
     jump.startup_profile_discovery_retry_count = max_rebuild_retries;
     jump.retryStartupProfileDiscovery();
     try std.testing.expect(jump.timer_id == null);
     try std.testing.expectEqual(max_rebuild_retries, jump.startup_profile_discovery_retry_count);
+    jump.noteRecent("C:\\recovery-trigger");
+    try std.testing.expectEqual(@as(u8, 0), jump.startup_profile_discovery_retry_count);
+    try std.testing.expect(jump.timer_id != null);
     // A failed discovery leaves the request untouched; only the caller's
     // explicit success transition consumes it.
     try std.testing.expect(jump.startupProfileDiscoveryPending());

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -890,7 +890,10 @@ pub const JumpList = struct {
     pub fn init(alloc: Allocator, state_path: []const u8) !JumpList {
         const owned_state_path = try alloc.dupe(u8, state_path);
         errdefer alloc.free(owned_state_path);
-        const loaded = loadStateAlloc(alloc, state_path);
+        // Do not publish an empty taskbar list when an existing state file is
+        // temporarily unreadable or invalid. Failing initialization preserves
+        // the Shell's last committed list; a later process can retry safely.
+        const loaded = try loadStateForMergeAlloc(alloc, state_path);
         return .{
             .alloc = alloc,
             .state_path = owned_state_path,
@@ -944,6 +947,12 @@ pub const JumpList = struct {
     pub fn completeStartupProfileDiscovery(self: *JumpList) void {
         self.startup_profile_discovery_pending = false;
         self.startup_profile_discovery_retry_count = 0;
+    }
+
+    pub fn requestProfileDiscovery(self: *JumpList) void {
+        self.startup_profile_discovery_pending = true;
+        self.startup_profile_discovery_retry_count = 0;
+        self.schedule();
     }
 
     pub fn retryStartupProfileDiscovery(self: *JumpList) void {
@@ -1776,6 +1785,10 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
         error.SyntaxError,
         loadStateForMergeAlloc(std.testing.allocator, corrupt_path),
     );
+    try std.testing.expectError(
+        error.SyntaxError,
+        JumpList.init(std.testing.allocator, corrupt_path),
+    );
 
     {
         var file = try tmp.dir.createFile("oversized.json", .{});
@@ -1794,6 +1807,10 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     defer oversized.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), oversized.recents.items.items.len);
     try std.testing.expectEqual(@as(usize, 0), oversized.hidden_profiles.items.items.len);
+    try std.testing.expectError(
+        error.FileTooBig,
+        JumpList.init(std.testing.allocator, oversized_path),
+    );
 
     const oversized_key = try std.testing.allocator.alloc(u8, max_state_bytes);
     defer std.testing.allocator.free(oversized_key);

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -350,6 +350,106 @@ fn encodeRecentStateAlloc(
     return try out.toOwnedSlice();
 }
 
+const BoundedStateEncoding = struct {
+    bytes: []u8,
+    pruned_records: usize,
+};
+
+fn encodeRecentStateBoundedAlloc(
+    alloc: Allocator,
+    state: *LoadedState,
+) !BoundedStateEncoding {
+    var pruned_records: usize = 0;
+    while (true) {
+        const bytes = encodeRecentStateAlloc(
+            alloc,
+            state.recents.items.items,
+            state.removed_recents.items.items,
+            state.hidden_profiles.items.items,
+            state.recent_events.items.items,
+            state.profile_events.items.items,
+        ) catch |err| switch (err) {
+            error.StateTooLarge => {
+                if (!try pruneOldestPersistedRecord(alloc, state)) return err;
+                pruned_records += 1;
+                continue;
+            },
+            else => return err,
+        };
+        return .{ .bytes = bytes, .pruned_records = pruned_records };
+    }
+}
+
+fn pruneOldestPersistedRecord(alloc: Allocator, state: *LoadedState) !bool {
+    const Record = union(enum) {
+        recent: usize,
+        profile: usize,
+    };
+    var oldest: ?Record = null;
+    var oldest_changed_ns: i64 = 0;
+    var oldest_order_seq: u64 = 0;
+
+    for (state.recent_events.items.items, 0..) |event, index| {
+        if (oldest == null or eventOrderAfter(
+            oldest_changed_ns,
+            oldest_order_seq,
+            event.changed_ns,
+            event.order_seq,
+        )) {
+            oldest = .{ .recent = index };
+            oldest_changed_ns = event.changed_ns;
+            oldest_order_seq = event.order_seq;
+        }
+    }
+    for (state.profile_events.items.items, 0..) |event, index| {
+        if (oldest == null or eventOrderAfter(
+            oldest_changed_ns,
+            oldest_order_seq,
+            event.changed_ns,
+            event.order_seq,
+        )) {
+            oldest = .{ .profile = index };
+            oldest_changed_ns = event.changed_ns;
+            oldest_order_seq = event.order_seq;
+        }
+    }
+
+    if (oldest) |record| switch (record) {
+        .recent => |index| {
+            const event = state.recent_events.items.orderedRemove(index);
+            defer alloc.free(event.path);
+            switch (event.kind) {
+                .used => _ = try state.recents.removePath(alloc, event.path),
+                .removed => _ = try state.removed_recents.removePath(alloc, event.path),
+            }
+            return true;
+        },
+        .profile => |index| {
+            const event = state.profile_events.items.orderedRemove(index);
+            if (event.kind == .hidden) _ = state.hidden_profiles.remove(alloc, event.key);
+            alloc.free(event.key);
+            return true;
+        },
+    };
+
+    // Schema-v1 snapshots can contain model entries without event records.
+    // Drop their oldest retained entries only after all ordered history is
+    // exhausted so any newer cross-process ordering evidence wins first.
+    if (state.hidden_profiles.items.items.len > 0) {
+        alloc.free(state.hidden_profiles.items.orderedRemove(0));
+        return true;
+    }
+    if (state.removed_recents.items.items.len > 0) {
+        alloc.free(state.removed_recents.items.pop().?);
+        return true;
+    }
+    if (state.recents.items.items.len > 0) {
+        alloc.free(state.recents.items.pop().?);
+        return true;
+    }
+    return false;
+}
+
 const RecentList = struct {
     items: std.ArrayListUnmanaged([]u8) = .empty,
 
@@ -1275,21 +1375,19 @@ pub const JumpList = struct {
             return false;
         };
 
-        const model_changed = !recentListsEqual(&self.recents, &merged.recents) or
-            !recentListsEqual(&self.removed_recents, &merged.removed_recents) or
-            !profileTombstonesEqual(&self.hidden_profiles, &merged.hidden_profiles);
-        const encoded = encodeRecentStateAlloc(
-            self.alloc,
-            merged.recents.items.items,
-            merged.removed_recents.items.items,
-            merged.hidden_profiles.items.items,
-            merged.recent_events.items.items,
-            merged.profile_events.items.items,
-        ) catch |err| {
+        const bounded = encodeRecentStateBoundedAlloc(self.alloc, &merged) catch |err| {
             log.warn("jump list recent encode failed err={}", .{err});
             return false;
         };
-        defer self.alloc.free(encoded);
+        defer self.alloc.free(bounded.bytes);
+        if (bounded.pruned_records > 0) {
+            log.warn("jump list state pruned to persistence budget records={}", .{bounded.pruned_records});
+        }
+        // The bounded encoder can prune visible model entries. Compare after
+        // pruning so a committed Shell list cannot remain stale.
+        const model_changed = !recentListsEqual(&self.recents, &merged.recents) or
+            !recentListsEqual(&self.removed_recents, &merged.removed_recents) or
+            !profileTombstonesEqual(&self.hidden_profiles, &merged.hidden_profiles);
 
         const temporary_path = std.fmt.allocPrint(
             self.alloc,
@@ -1301,7 +1399,7 @@ pub const JumpList = struct {
         };
         defer self.alloc.free(temporary_path);
 
-        persistence.writeFileAtomic(self.state_path, temporary_path, encoded) catch |err| {
+        persistence.writeFileAtomic(self.state_path, temporary_path, bounded.bytes) catch |err| {
             log.warn("jump list recent write failed path={s} err={}", .{ self.state_path, err });
             return false;
         };
@@ -1938,6 +2036,99 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
         error.StateTooLarge,
         encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{}, &.{oversized_key}, &.{}, &.{}),
     );
+}
+
+test "jump_list bounded state encoding prunes oldest records" {
+    const alloc = std.testing.allocator;
+    var state: LoadedState = .{};
+    defer state.deinit(alloc);
+
+    var oldest_key: ?[]u8 = null;
+    defer if (oldest_key) |key| alloc.free(key);
+    var newest_key: ?[]u8 = null;
+    defer if (newest_key) |key| alloc.free(key);
+    for (0..max_profile_tombstones) |index| {
+        var key: [windows_ssh_hosts.max_alias_len + 4]u8 = undefined;
+        @memset(&key, 'x');
+        _ = try std.fmt.bufPrint(key[0..12], "ssh:{d:0>3}:", .{index});
+        if (index == 0) oldest_key = try alloc.dupe(u8, &key);
+        if (index == max_profile_tombstones - 1) newest_key = try alloc.dupe(u8, &key);
+        try std.testing.expect(try state.hidden_profiles.insert(alloc, &key));
+        try state.profile_events.upsert(alloc, &key, .hidden, @intCast(index + 1));
+    }
+
+    const bounded = try encodeRecentStateBoundedAlloc(alloc, &state);
+    defer alloc.free(bounded.bytes);
+    try std.testing.expect(bounded.pruned_records > 0);
+    try std.testing.expect(bounded.bytes.len <= max_state_bytes);
+    try std.testing.expect(!state.hidden_profiles.contains(oldest_key.?));
+    try std.testing.expect(state.hidden_profiles.contains(newest_key.?));
+
+    var decoded = try decodeStateAlloc(alloc, bounded.bytes);
+    defer decoded.deinit(alloc);
+    try std.testing.expect(!decoded.hidden_profiles.contains(oldest_key.?));
+    try std.testing.expect(decoded.hidden_profiles.contains(newest_key.?));
+
+    var oversized: LoadedState = .{};
+    defer oversized.deinit(alloc);
+    const key = try alloc.alloc(u8, max_state_bytes + 1);
+    defer alloc.free(key);
+    @memset(key, 'x');
+    try std.testing.expect(try oversized.hidden_profiles.insert(alloc, key));
+    const empty = try encodeRecentStateBoundedAlloc(alloc, &oversized);
+    defer alloc.free(empty.bytes);
+    try std.testing.expectEqual(@as(usize, 1), empty.pruned_records);
+    try std.testing.expect(empty.bytes.len <= max_state_bytes);
+    try std.testing.expectEqual(@as(usize, 0), oversized.hidden_profiles.items.items.len);
+}
+
+test "jump_list persistence recovers from an oversized valid model" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const directory = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(directory);
+    const state_path = try std.fs.path.join(alloc, &.{ directory, state_filename });
+    defer alloc.free(state_path);
+
+    var jump = try JumpList.init(alloc, state_path);
+    defer {
+        jump.persist_dirty = false;
+        jump.deinit();
+    }
+    jump.rebuild_dirty = false;
+
+    var oldest_key: ?[]u8 = null;
+    defer if (oldest_key) |key| alloc.free(key);
+    var newest_key: ?[]u8 = null;
+    defer if (newest_key) |key| alloc.free(key);
+    for (0..max_profile_tombstones) |index| {
+        var key: [windows_ssh_hosts.max_alias_len + 4]u8 = undefined;
+        @memset(&key, 'x');
+        _ = try std.fmt.bufPrint(key[0..12], "ssh:{d:0>3}:", .{index});
+        if (index == 0) oldest_key = try alloc.dupe(u8, &key);
+        if (index == max_profile_tombstones - 1) newest_key = try alloc.dupe(u8, &key);
+        try jump.pending_profile_events.upsert(alloc, &key, .hidden, @intCast(index + 1));
+    }
+    jump.persist_dirty = true;
+
+    try std.testing.expect(jump.persist());
+    try std.testing.expect(!jump.persist_dirty);
+    try std.testing.expectEqual(@as(usize, 0), jump.pending_profile_events.items.items.len);
+    try std.testing.expect(jump.rebuild_dirty);
+    try std.testing.expect(!jump.hidden_profiles.contains(oldest_key.?));
+    try std.testing.expect(jump.hidden_profiles.contains(newest_key.?));
+
+    const raw = try persistence.readFileBoundedAlloc(alloc, state_path, max_state_bytes);
+    defer alloc.free(raw);
+    try std.testing.expect(raw.len <= max_state_bytes);
+
+    jump.noteRecent("C:\\after-prune");
+    try std.testing.expect(jump.persist());
+    var reloaded = try loadStateForMergeAlloc(alloc, state_path);
+    defer reloaded.deinit(alloc);
+    try std.testing.expect(try reloaded.recents.contains(alloc, "C:\\after-prune"));
+    try std.testing.expect(reloaded.hidden_profiles.contains(newest_key.?));
 }
 
 test "jump_list titles drop bidi controls and keep everything else" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -552,14 +552,14 @@ fn isBidiControl(cp: u21) bool {
 
 /// Copy `text` for use as a jump-list item title, dropping bidi controls.
 pub fn buildTitleAlloc(alloc: Allocator, text: []const u8) ![]u8 {
+    var view = std.unicode.Utf8View.init(text) catch {
+        // Not valid UTF-8; nothing to reorder, so copy it through unchanged.
+        return try alloc.dupe(u8, text);
+    };
+
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
 
-    var view = std.unicode.Utf8View.init(text) catch {
-        // Not valid UTF-8; nothing to reorder, so copy it through unchanged.
-        out.deinit();
-        return try alloc.dupe(u8, text);
-    };
     var iter = view.iterator();
     while (iter.nextCodepointSlice()) |slice| {
         const cp = std.unicode.utf8Decode(slice) catch continue;
@@ -816,13 +816,14 @@ pub const JumpList = struct {
             log.warn("jump list recent update failed err={}", .{err});
             return;
         };
-        if (changed) {
-            _ = self.pending_recent_additions.insert(self.alloc, path) catch |err| {
-                log.warn("jump list recent persistence snapshot failed err={}", .{err});
-                return;
-            };
-        }
-        if (!changed and !reinstated) return;
+        // A pwd report is also a use event when this process's stale MRU
+        // already has the path at the front. Record it so a newer tombstone
+        // written by another process is removed during the next merge.
+        const recorded = self.pending_recent_additions.insert(self.alloc, path) catch |err| {
+            log.warn("jump list recent persistence snapshot failed err={}", .{err});
+            return;
+        };
+        if (!changed and !reinstated and !recorded) return;
         self.persist_dirty = true;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
@@ -860,6 +861,7 @@ pub const JumpList = struct {
             }
         }
         const persisted = if (self.persist_dirty) self.persist() else true;
+        if (!persisted) self.schedule();
         if (rebuild_committed and persisted) {
             self.pending_recent_uses.deinit(self.alloc);
             self.pending_profile_uses.deinit(self.alloc);
@@ -915,6 +917,7 @@ pub const JumpList = struct {
             .read = true,
             .truncate = false,
             .lock = .exclusive,
+            .lock_nonblocking = true,
         }) catch |err| {
             log.warn("jump list state lock unavailable path={s} err={}", .{ lock_path, err });
             return false;
@@ -1530,6 +1533,28 @@ test "jump_list persistence merge applies local events to the latest snapshot" {
     try std.testing.expect(try merged.removed_recents.contains(alloc, "C:\\removed"));
     try std.testing.expect(merged.hidden_profiles.contains("wsl:new-hidden"));
     try std.testing.expect(!merged.hidden_profiles.contains("wsl:used"));
+}
+
+test "jump_list unchanged recent directory still records a use event" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer {
+        // This test exercises the in-memory event seam only.
+        jump.persist_dirty = false;
+        jump.deinit();
+    }
+
+    try std.testing.expect(try jump.recents.insert(alloc, "D:\\same-head"));
+    jump.noteRecent("D:\\same-head");
+    try std.testing.expect(jump.persist_dirty);
+    try std.testing.expect(try jump.pending_recent_additions.contains(alloc, "D:\\same-head"));
 }
 
 test "jump_list slot budget reserves profiles before recents" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -601,68 +601,51 @@ fn profileTombstonesEqual(lhs: *const ProfileTombstones, rhs: *const ProfileTomb
     return stringSlicesEqual(lhs.items.items, rhs.items.items);
 }
 
-fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
+fn decodeStateAlloc(alloc: Allocator, raw: []const u8) !LoadedState {
     var result: LoadedState = .{};
+    errdefer result.deinit(alloc);
+    var parsed = try parseRecentStateAlloc(alloc, raw);
+    defer parsed.deinit();
+
+    for (parsed.value.directories) |directory| try result.recents.appendLoaded(alloc, directory);
+    for (parsed.value.removed_directories) |directory| try result.removed_recents.appendLoaded(alloc, directory);
+    for (parsed.value.hidden_profiles) |key| _ = try result.hidden_profiles.insert(alloc, key);
+    for (parsed.value.recent_events) |event| {
+        try result.recent_events.upsert(alloc, event.path, event.kind, event.changed_ns);
+    }
+    for (parsed.value.profile_events) |event| {
+        try result.profile_events.upsert(alloc, event.key, event.kind, event.changed_ns);
+    }
+    return result;
+}
+
+fn loadStateForMergeAlloc(alloc: Allocator, path: []const u8) !LoadedState {
+    const raw = persistence.readFileBoundedAlloc(alloc, path, max_state_bytes) catch |err| switch (err) {
+        error.FileNotFound => return .{},
+        else => return err,
+    };
+    defer alloc.free(raw);
+    return try decodeStateAlloc(alloc, raw);
+}
+
+fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
     const raw = persistence.readFileBoundedAlloc(alloc, path, max_state_bytes) catch |err| {
         switch (err) {
             error.FileNotFound => {},
             error.FileTooBig => log.warn("jump list recent state exceeds size limit path={s}", .{path}),
             else => log.warn("jump list recent state read failed path={s} err={}", .{ path, err }),
         }
-        return result;
+        return .{};
     };
     defer alloc.free(raw);
 
-    var parsed = parseRecentStateAlloc(alloc, raw) catch |err| {
+    return decodeStateAlloc(alloc, raw) catch |err| {
         switch (err) {
             error.OutOfMemory => log.warn("jump list recent state parse allocation failed path={s}", .{path}),
             else => log.warn("jump list recent state ignored path={s} err={}", .{ path, err }),
         }
-        return result;
+        return .{};
     };
-    defer parsed.deinit();
-
-    for (parsed.value.directories) |directory| {
-        result.recents.appendLoaded(alloc, directory) catch |err| {
-            log.warn("jump list recent state entry allocation failed err={}", .{err});
-            break;
-        };
-    }
-    for (parsed.value.removed_directories) |directory| {
-        result.removed_recents.appendLoaded(alloc, directory) catch |err| {
-            log.warn("jump list removed recent state allocation failed err={}", .{err});
-            break;
-        };
-    }
-    for (parsed.value.hidden_profiles) |key| {
-        _ = result.hidden_profiles.insert(alloc, key) catch |err| {
-            log.warn("jump list hidden profile state allocation failed err={}", .{err});
-            break;
-        };
-    }
-    for (parsed.value.recent_events) |event| {
-        result.recent_events.upsert(
-            alloc,
-            event.path,
-            event.kind,
-            event.changed_ns,
-        ) catch |err| {
-            log.warn("jump list recent event state allocation failed err={}", .{err});
-            break;
-        };
-    }
-    for (parsed.value.profile_events) |event| {
-        result.profile_events.upsert(
-            alloc,
-            event.key,
-            event.kind,
-            event.changed_ns,
-        ) catch |err| {
-            log.warn("jump list profile event state allocation failed err={}", .{err});
-            break;
-        };
-    }
-    return result;
 }
 
 pub fn isRecentLocalPath(path: []const u8) bool {
@@ -799,6 +782,10 @@ fn buildProfileArgumentsWithLaunchConfigAlloc(
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
+    // Profile command arguments are intentionally excluded from the
+    // single-instance forwarding allowlist. Keep this shell link in its own
+    // process so the selected command reaches the new surface unchanged.
+    try out.writer.writeAll("--single-instance=false ");
     // Match in-app profile launches: start at home instead of inheriting the caller's cwd.
     const working_directory_option = try std.fmt.allocPrint(
         alloc,
@@ -1185,7 +1172,13 @@ pub const JumpList = struct {
         };
         defer lock_file.close();
 
-        var merged = loadStateAlloc(self.alloc, self.state_path);
+        var merged = loadStateForMergeAlloc(self.alloc, self.state_path) catch |err| {
+            log.warn("jump list state reload failed; preserving prior snapshot path={s} err={}", .{
+                self.state_path,
+                err,
+            });
+            return false;
+        };
         defer merged.deinit(self.alloc);
         self.applyPendingState(&merged) catch |err| {
             log.warn("jump list state merge failed err={}", .{err});
@@ -1767,6 +1760,10 @@ test "jump_list JSON round trips and corrupt or oversized state starts empty" {
     defer corrupt.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), corrupt.recents.items.items.len);
     try std.testing.expectEqual(@as(usize, 0), corrupt.hidden_profiles.items.items.len);
+    try std.testing.expectError(
+        error.SyntaxError,
+        loadStateForMergeAlloc(std.testing.allocator, corrupt_path),
+    );
 
     {
         var file = try tmp.dir.createFile("oversized.json", .{});
@@ -1834,12 +1831,13 @@ test "jump_list argument builders preserve Windows argv boundaries" {
     });
     defer std.testing.allocator.free(profile);
     try std.testing.expectEqualStrings(
-        "--working-directory=home \"--command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\" \"--initial-command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\"",
+        "--single-instance=false --working-directory=home \"--command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\" \"--initial-command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\"",
         profile,
     );
 
     var argv = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, profile);
     defer argv.deinit();
+    try std.testing.expectEqualStrings("--single-instance=false", argv.next().?);
     try std.testing.expectEqualStrings("--working-directory=home", argv.next().?);
     const command_option = argv.next().?;
     const initial_command_option = argv.next().?;
@@ -1872,6 +1870,7 @@ test "jump_list argument builders preserve Windows argv boundaries" {
     defer std.testing.allocator.free(ssh_profile);
     var ssh_argv = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, ssh_profile);
     defer ssh_argv.deinit();
+    try std.testing.expectEqualStrings("--single-instance=false", ssh_argv.next().?);
     try std.testing.expectEqualStrings("--working-directory=C:\\Users\\Aman Thanvi", ssh_argv.next().?);
     try std.testing.expectEqualStrings("--shell-integration=none", ssh_argv.next().?);
     try std.testing.expect(std.mem.startsWith(u8, ssh_argv.next().?, "--command="));

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -343,9 +343,12 @@ const RecentList = struct {
 
     fn insert(self: *RecentList, alloc: Allocator, path: []const u8) !bool {
         if (!isRecentLocalPath(path)) return false;
+        const normalized = try normalizeRecentPathAlloc(alloc, path);
+        var normalized_owned = true;
+        defer if (normalized_owned) alloc.free(normalized);
 
         for (self.items.items, 0..) |item, index| {
-            if (!try pathsEqualIgnoreCase(alloc, item, path)) continue;
+            if (!try pathsEqualIgnoreCase(alloc, item, normalized)) continue;
             if (index == 0) return false;
             var i = index;
             while (i > 0) : (i -= 1) self.items.items[i] = self.items.items[i - 1];
@@ -353,28 +356,30 @@ const RecentList = struct {
             return true;
         }
 
-        const owned = try alloc.dupe(u8, path);
-        errdefer alloc.free(owned);
         if (self.items.items.len < max_recents) {
-            try self.items.append(alloc, owned);
+            try self.items.append(alloc, normalized);
         } else {
             alloc.free(self.items.items[max_recents - 1]);
         }
 
         var i = @min(self.items.items.len, max_recents) - 1;
         while (i > 0) : (i -= 1) self.items.items[i] = self.items.items[i - 1];
-        self.items.items[0] = owned;
+        self.items.items[0] = normalized;
+        normalized_owned = false;
         return true;
     }
 
     fn appendLoaded(self: *RecentList, alloc: Allocator, path: []const u8) !void {
         if (self.items.items.len >= max_recents or !isRecentLocalPath(path)) return;
+        const normalized = try normalizeRecentPathAlloc(alloc, path);
+        errdefer alloc.free(normalized);
         for (self.items.items) |item| {
-            if (try pathsEqualIgnoreCase(alloc, item, path)) return;
+            if (try pathsEqualIgnoreCase(alloc, item, normalized)) {
+                alloc.free(normalized);
+                return;
+            }
         }
-        const owned = try alloc.dupe(u8, path);
-        errdefer alloc.free(owned);
-        try self.items.append(alloc, owned);
+        try self.items.append(alloc, normalized);
     }
 
     fn contains(self: *const RecentList, alloc: Allocator, path: []const u8) !bool {
@@ -448,21 +453,24 @@ const RecentEventList = struct {
         kind: RecentEventKind,
         changed_ns: i64,
     ) !void {
+        if (!isRecentLocalPath(path)) return;
+        const normalized = try normalizeRecentPathAlloc(alloc, path);
+        var normalized_owned = true;
+        defer if (normalized_owned) alloc.free(normalized);
         for (self.items.items, 0..) |item, index| {
-            if (!try pathsEqualIgnoreCase(alloc, item.path, path)) continue;
+            if (!try pathsEqualIgnoreCase(alloc, item.path, normalized)) continue;
             if (item.changed_ns > changed_ns) return;
             alloc.free(item.path);
             _ = self.items.orderedRemove(index);
             break;
         }
 
-        const owned = try alloc.dupe(u8, path);
-        errdefer alloc.free(owned);
         try self.items.append(alloc, .{
-            .path = owned,
+            .path = normalized,
             .kind = kind,
             .changed_ns = changed_ns,
         });
+        normalized_owned = false;
         if (self.items.items.len > max_recents * 2) {
             var oldest: usize = 0;
             for (self.items.items[1..], 1..) |item, index| {
@@ -674,10 +682,24 @@ pub fn isRecentLocalPath(path: []const u8) bool {
     return true;
 }
 
+fn normalizeRecentPathAlloc(alloc: Allocator, path: []const u8) ![]u8 {
+    var end = path.len;
+    while (end > 3 and (path[end - 1] == '\\' or path[end - 1] == '/')) end -= 1;
+    const normalized = try alloc.dupe(u8, path[0..end]);
+    for (normalized[2..]) |*byte| {
+        if (byte.* == '/') byte.* = '\\';
+    }
+    return normalized;
+}
+
 fn pathsEqualIgnoreCase(alloc: Allocator, lhs: []const u8, rhs: []const u8) !bool {
-    const lhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, lhs);
+    const lhs_normalized = try normalizeRecentPathAlloc(alloc, lhs);
+    defer alloc.free(lhs_normalized);
+    const rhs_normalized = try normalizeRecentPathAlloc(alloc, rhs);
+    defer alloc.free(rhs_normalized);
+    const lhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, lhs_normalized);
     defer alloc.free(lhs_w);
-    const rhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, rhs);
+    const rhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, rhs_normalized);
     defer alloc.free(rhs_w);
     const result = CompareStringOrdinal(
         lhs_w.ptr,
@@ -844,6 +866,7 @@ pub const JumpList = struct {
     com_disabled: bool = false,
     startup_profile_discovery_pending: bool = false,
     startup_profile_discovery_retry_count: u8 = 0,
+    use_guards_rebuild_committed: bool = false,
 
     pub fn init(alloc: Allocator, state_path: []const u8) !JumpList {
         const owned_state_path = try alloc.dupe(u8, state_path);
@@ -988,30 +1011,36 @@ pub const JumpList = struct {
     }
 
     pub fn noteRecent(self: *JumpList, path: []const u8) void {
+        if (!isRecentLocalPath(path)) return;
+        const normalized = normalizeRecentPathAlloc(self.alloc, path) catch |err| {
+            log.warn("jump list recent normalization failed err={}", .{err});
+            return;
+        };
+        defer self.alloc.free(normalized);
         const changed_ns: i64 = @intCast(std.time.nanoTimestamp());
-        const reinstated = self.removed_recents.removePath(self.alloc, path) catch |err| {
+        const reinstated = self.removed_recents.removePath(self.alloc, normalized) catch |err| {
             log.warn("jump list recent reinstatement failed err={}", .{err});
             return;
         };
         if (reinstated) {
-            _ = self.pending_recent_removals.removePath(self.alloc, path) catch {};
+            _ = self.pending_recent_removals.removePath(self.alloc, normalized) catch {};
         }
-        _ = self.pending_recent_uses.insert(self.alloc, path) catch |err| {
+        _ = self.pending_recent_uses.insert(self.alloc, normalized) catch |err| {
             log.warn("jump list recent-use snapshot failed err={}", .{err});
             return;
         };
-        const changed = self.recents.insert(self.alloc, path) catch |err| {
+        const changed = self.recents.insert(self.alloc, normalized) catch |err| {
             log.warn("jump list recent update failed err={}", .{err});
             return;
         };
         // A pwd report is also a use event when this process's stale MRU
         // already has the path at the front. Record it so a newer tombstone
         // written by another process is removed during the next merge.
-        const recorded = self.pending_recent_additions.insert(self.alloc, path) catch |err| {
+        const recorded = self.pending_recent_additions.insert(self.alloc, normalized) catch |err| {
             log.warn("jump list recent persistence snapshot failed err={}", .{err});
             return;
         };
-        self.pending_recent_events.upsert(self.alloc, path, .used, changed_ns) catch |err| {
+        self.pending_recent_events.upsert(self.alloc, normalized, .used, changed_ns) catch |err| {
             log.warn("jump list recent event snapshot failed err={}", .{err});
             return;
         };
@@ -1054,9 +1083,15 @@ pub const JumpList = struct {
         }
         const persisted = if (self.persist_dirty) self.persist() else true;
         if (!persisted) self.schedule();
-        if (rebuild_committed and persisted) {
+        if (rebuild_committed) self.use_guards_rebuild_committed = true;
+        self.finishUseGuards(persisted);
+    }
+
+    fn finishUseGuards(self: *JumpList, persisted: bool) void {
+        if (self.use_guards_rebuild_committed and persisted) {
             self.pending_recent_uses.deinit(self.alloc);
             self.pending_profile_uses.deinit(self.alloc);
+            self.use_guards_rebuild_committed = false;
         }
     }
 
@@ -1234,6 +1269,7 @@ pub const JumpList = struct {
             var chosen: ?usize = null;
             for (merged.recent_events.items.items, 0..) |event, index| {
                 if (event.kind != .used or
+                    !isRecentLocalPath(event.path) or
                     try merged.removed_recents.contains(self.alloc, event.path) or
                     try next.contains(self.alloc, event.path)) continue;
                 const current = if (chosen) |value| merged.recent_events.items.items[value] else {
@@ -1479,8 +1515,10 @@ pub const JumpList = struct {
                     continue;
                 },
             };
-            errdefer self.alloc.free(arguments);
+            var arguments_owned = true;
+            errdefer if (arguments_owned) self.alloc.free(arguments);
             try result.items.append(self.alloc, arguments);
+            arguments_owned = false;
 
             @memset(arguments_buffer, 0);
             if (link.vtbl.GetDescription(
@@ -1974,6 +2012,83 @@ test "jump_list unchanged recent directory still records a use event" {
     try std.testing.expect(jump.persist_dirty);
     try std.testing.expect(try jump.pending_recent_additions.contains(alloc, "D:\\same-head"));
     try std.testing.expect(try jump.pending_recent_uses.contains(alloc, "D:\\same-head"));
+}
+
+test "jump_list rejects invalid recent use before queuing events" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    jump.noteRecent("/home/user");
+    try std.testing.expectEqual(@as(usize, 0), jump.pending_recent_events.items.items.len);
+    try std.testing.expectEqual(@as(usize, 0), jump.pending_recent_uses.items.items.len);
+    try std.testing.expect(!jump.persist_dirty);
+}
+
+test "jump_list normalizes separators and trailing directory syntax" {
+    const alloc = std.testing.allocator;
+    var recents: RecentList = .{};
+    defer recents.deinit(alloc);
+
+    try std.testing.expect(try recents.insert(alloc, "C:/work/"));
+    try std.testing.expectEqualStrings("C:\\work", recents.items.items[0]);
+    try std.testing.expect(!try recents.insert(alloc, "c:\\WORK\\"));
+    try std.testing.expectEqual(@as(usize, 1), recents.items.items.len);
+}
+
+test "jump_list rebuild skips an invalid persisted recent event" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+    var merged: LoadedState = .{};
+    defer merged.deinit(alloc);
+
+    try merged.recent_events.items.append(alloc, .{
+        .path = try alloc.dupe(u8, "/home/user"),
+        .kind = .used,
+        .changed_ns = 2,
+    });
+    try merged.recent_events.upsert(alloc, "C:\\valid", .used, 1);
+    try jump.rebuildMergedRecents(&merged);
+    try std.testing.expectEqual(@as(usize, 1), merged.recents.items.items.len);
+    try std.testing.expectEqualStrings("C:\\valid", merged.recents.items.items[0]);
+}
+
+test "jump_list clears use guards after a committed rebuild is persisted later" {
+    const alloc = std.testing.allocator;
+    var jump: JumpList = .{
+        .alloc = alloc,
+        .state_path = try alloc.dupe(u8, "unused"),
+        .exe_path = null,
+        .recents = .{},
+        .removed_recents = .{},
+        .hidden_profiles = .{},
+    };
+    defer jump.deinit();
+
+    try std.testing.expect(try jump.pending_recent_uses.insert(alloc, "C:\\used"));
+    try std.testing.expect(try jump.pending_profile_uses.insert(alloc, "wsl:used"));
+    jump.use_guards_rebuild_committed = true;
+    jump.finishUseGuards(false);
+    try std.testing.expectEqual(@as(usize, 1), jump.pending_recent_uses.items.items.len);
+    jump.finishUseGuards(true);
+    try std.testing.expectEqual(@as(usize, 0), jump.pending_recent_uses.items.items.len);
+    try std.testing.expectEqual(@as(usize, 0), jump.pending_profile_uses.items.items.len);
+    try std.testing.expect(!jump.use_guards_rebuild_committed);
 }
 
 test "jump_list slot budget reserves profiles before recents" {

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -1,0 +1,1418 @@
+//! Taskbar jump list: a "Recent" category of working directories and a
+//! "Profiles" category of detected shells.
+//!
+//! Recent entries come from the terminal's pwd stream, which means a program
+//! running inside a session can emit OSC 7 for any path it likes and seed a
+//! persistent, user-visible entry. That is inherent to the data source and the
+//! blast radius is small (activating an entry only sets noctty's working
+//! directory), but titles are rendered by the shell, so `buildTitleAlloc`
+//! strips Unicode bidi/isolate controls to keep a seeded entry from
+//! misrepresenting where it points.
+
+const std = @import("std");
+const windows = std.os.windows;
+const windows_shell = @import("../config/windows_shell.zig");
+const Command = @import("../config/command.zig").Command;
+const win32_aumid = @import("win32_aumid.zig");
+const persistence = @import("win32_session_persistence.zig");
+const sys = @import("win32/sys.zig");
+
+const Allocator = std.mem.Allocator;
+const DWORD = u32;
+const HRESULT = windows.HRESULT;
+const GUID = windows.GUID;
+const HWND = ?*anyopaque;
+const UINT = u32;
+const UINT_PTR = usize;
+const WORD = u16;
+
+const log = std.log.scoped(.win32_jump_list);
+
+pub const state_filename = "jump-list-recents.json";
+pub const max_recents: usize = 10;
+pub const max_state_bytes: usize = 64 * 1024;
+pub const debounce_ms: UINT = 500;
+const max_profile_tombstones: usize = 128;
+const max_rebuild_retries: u8 = 3;
+const max_shell_link_chars: usize = 32_768;
+
+const CLSCTX_INPROC_SERVER: DWORD = 0x1;
+const CO_E_NOTINITIALIZED: HRESULT = @bitCast(@as(u32, 0x800401F0));
+const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
+const VT_LPWSTR: u16 = 31;
+
+const CLSID_DestinationList = GUID.parse("{77F10CF0-3DB5-4966-B520-B7C54FD35ED6}");
+const IID_ICustomDestinationList = GUID.parse("{6332DEBF-87B5-4670-90C0-5E57B408A49E}");
+const CLSID_EnumerableObjectCollection = GUID.parse("{2D3468C1-36A7-43B6-AC24-D3F02FD9607A}");
+const IID_IObjectCollection = GUID.parse("{5632B1A4-E38A-400A-928A-D4CD63230295}");
+const IID_IObjectArray = GUID.parse("{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}");
+const CLSID_ShellLink = GUID.parse("{00021401-0000-0000-C000-000000000046}");
+const IID_IShellLinkW = GUID.parse("{000214F9-0000-0000-C000-000000000046}");
+const IID_IPropertyStore = GUID.parse("{886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99}");
+
+const PROPERTYKEY = extern struct {
+    fmtid: GUID,
+    pid: DWORD,
+};
+
+const PKEY_Title = PROPERTYKEY{
+    .fmtid = GUID.parse("{F29F85E0-4FF9-1068-AB91-08002B27B3D9}"),
+    .pid = 2,
+};
+const PKEY_AppUserModel_ID = PROPERTYKEY{
+    .fmtid = GUID.parse("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}"),
+    .pid = 5,
+};
+
+const PROPVARIANT = extern struct {
+    vt: u16,
+    reserved1: u16 = 0,
+    reserved2: u16 = 0,
+    reserved3: u16 = 0,
+    value: extern union {
+        pwsz: [*:0]const u16,
+        raw: [2]usize,
+    },
+
+    fn fromString(value: [:0]const u16) PROPVARIANT {
+        return .{
+            .vt = VT_LPWSTR,
+            .value = .{ .pwsz = value.ptr },
+        };
+    }
+};
+
+// Aliased from the shared Win32 surface rather than re-declared, so this
+// module cannot drift from src/apprt/win32/sys.zig.
+const CoCreateInstance = sys.CoCreateInstance;
+const GetCurrentProcessId = sys.GetCurrentProcessId;
+const SetTimer = sys.SetTimer;
+const KillTimer = sys.KillTimer;
+
+// Only this module needs ordinal string comparison, so it stays local.
+extern "kernel32" fn CompareStringOrdinal(
+    [*]const u16,
+    i32,
+    [*]const u16,
+    i32,
+    i32,
+) callconv(.winapi) i32;
+
+const IObjectArrayVtbl = extern struct {
+    QueryInterface: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*anyopaque) callconv(.winapi) u32,
+    Release: *const fn (*anyopaque) callconv(.winapi) u32,
+    GetCount: *const fn (*anyopaque, *UINT) callconv(.winapi) HRESULT,
+    GetAt: *const fn (*anyopaque, UINT, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+};
+
+const IObjectArray = extern struct {
+    vtbl: *const IObjectArrayVtbl,
+
+    fn fromRaw(raw: *anyopaque) *IObjectArray {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn asRaw(self: *IObjectArray) *anyopaque {
+        return @ptrCast(self);
+    }
+
+    fn release(self: *IObjectArray) void {
+        _ = self.vtbl.Release(self.asRaw());
+    }
+};
+
+const IObjectCollectionVtbl = extern struct {
+    QueryInterface: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*anyopaque) callconv(.winapi) u32,
+    Release: *const fn (*anyopaque) callconv(.winapi) u32,
+    GetCount: *const fn (*anyopaque, *UINT) callconv(.winapi) HRESULT,
+    GetAt: *const fn (*anyopaque, UINT, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddObject: *const fn (*anyopaque, *anyopaque) callconv(.winapi) HRESULT,
+    AddFromArray: *const fn (*anyopaque, *IObjectArray) callconv(.winapi) HRESULT,
+    RemoveObjectAt: *const fn (*anyopaque, UINT) callconv(.winapi) HRESULT,
+    Clear: *const fn (*anyopaque) callconv(.winapi) HRESULT,
+};
+
+const IObjectCollection = extern struct {
+    vtbl: *const IObjectCollectionVtbl,
+
+    fn fromRaw(raw: *anyopaque) *IObjectCollection {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn asRaw(self: *IObjectCollection) *anyopaque {
+        return @ptrCast(self);
+    }
+
+    fn asArray(self: *IObjectCollection) *IObjectArray {
+        return @ptrCast(self);
+    }
+
+    fn release(self: *IObjectCollection) void {
+        _ = self.vtbl.Release(self.asRaw());
+    }
+
+    fn addObject(self: *IObjectCollection, object: *anyopaque) HRESULT {
+        return self.vtbl.AddObject(self.asRaw(), object);
+    }
+};
+
+const ICustomDestinationListVtbl = extern struct {
+    QueryInterface: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*anyopaque) callconv(.winapi) u32,
+    Release: *const fn (*anyopaque) callconv(.winapi) u32,
+    SetAppID: *const fn (*anyopaque, [*:0]const u16) callconv(.winapi) HRESULT,
+    BeginList: *const fn (*anyopaque, *UINT, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AppendCategory: *const fn (*anyopaque, [*:0]const u16, *IObjectArray) callconv(.winapi) HRESULT,
+    AppendKnownCategory: *const fn (*anyopaque, i32) callconv(.winapi) HRESULT,
+    AddUserTasks: *const fn (*anyopaque, *IObjectArray) callconv(.winapi) HRESULT,
+    CommitList: *const fn (*anyopaque) callconv(.winapi) HRESULT,
+    GetRemovedDestinations: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    DeleteList: *const fn (*anyopaque, ?[*:0]const u16) callconv(.winapi) HRESULT,
+    AbortList: *const fn (*anyopaque) callconv(.winapi) HRESULT,
+};
+
+const ICustomDestinationList = extern struct {
+    vtbl: *const ICustomDestinationListVtbl,
+
+    fn fromRaw(raw: *anyopaque) *ICustomDestinationList {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn asRaw(self: *ICustomDestinationList) *anyopaque {
+        return @ptrCast(self);
+    }
+
+    fn release(self: *ICustomDestinationList) void {
+        _ = self.vtbl.Release(self.asRaw());
+    }
+};
+
+const IShellLinkWVtbl = extern struct {
+    QueryInterface: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*anyopaque) callconv(.winapi) u32,
+    Release: *const fn (*anyopaque) callconv(.winapi) u32,
+    GetPath: *const fn (*anyopaque, [*]u16, i32, ?*anyopaque, DWORD) callconv(.winapi) HRESULT,
+    GetIDList: *const fn (*anyopaque, *?*anyopaque) callconv(.winapi) HRESULT,
+    SetIDList: *const fn (*anyopaque, ?*const anyopaque) callconv(.winapi) HRESULT,
+    GetDescription: *const fn (*anyopaque, [*]u16, i32) callconv(.winapi) HRESULT,
+    SetDescription: *const fn (*anyopaque, [*:0]const u16) callconv(.winapi) HRESULT,
+    GetWorkingDirectory: *const fn (*anyopaque, [*]u16, i32) callconv(.winapi) HRESULT,
+    SetWorkingDirectory: *const fn (*anyopaque, [*:0]const u16) callconv(.winapi) HRESULT,
+    GetArguments: *const fn (*anyopaque, [*]u16, i32) callconv(.winapi) HRESULT,
+    SetArguments: *const fn (*anyopaque, [*:0]const u16) callconv(.winapi) HRESULT,
+    GetHotkey: *const fn (*anyopaque, *WORD) callconv(.winapi) HRESULT,
+    SetHotkey: *const fn (*anyopaque, WORD) callconv(.winapi) HRESULT,
+    GetShowCmd: *const fn (*anyopaque, *i32) callconv(.winapi) HRESULT,
+    SetShowCmd: *const fn (*anyopaque, i32) callconv(.winapi) HRESULT,
+    GetIconLocation: *const fn (*anyopaque, [*]u16, i32, *i32) callconv(.winapi) HRESULT,
+    SetIconLocation: *const fn (*anyopaque, [*:0]const u16, i32) callconv(.winapi) HRESULT,
+    SetRelativePath: *const fn (*anyopaque, [*:0]const u16, DWORD) callconv(.winapi) HRESULT,
+    Resolve: *const fn (*anyopaque, HWND, DWORD) callconv(.winapi) HRESULT,
+    SetPath: *const fn (*anyopaque, [*:0]const u16) callconv(.winapi) HRESULT,
+};
+
+const IShellLinkW = extern struct {
+    vtbl: *const IShellLinkWVtbl,
+
+    fn fromRaw(raw: *anyopaque) *IShellLinkW {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn asRaw(self: *IShellLinkW) *anyopaque {
+        return @ptrCast(self);
+    }
+
+    fn release(self: *IShellLinkW) void {
+        _ = self.vtbl.Release(self.asRaw());
+    }
+};
+
+const IPropertyStoreVtbl = extern struct {
+    QueryInterface: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    AddRef: *const fn (*anyopaque) callconv(.winapi) u32,
+    Release: *const fn (*anyopaque) callconv(.winapi) u32,
+    GetCount: *const fn (*anyopaque, *DWORD) callconv(.winapi) HRESULT,
+    GetAt: *const fn (*anyopaque, DWORD, *PROPERTYKEY) callconv(.winapi) HRESULT,
+    GetValue: *const fn (*anyopaque, *const PROPERTYKEY, *PROPVARIANT) callconv(.winapi) HRESULT,
+    SetValue: *const fn (*anyopaque, *const PROPERTYKEY, *const PROPVARIANT) callconv(.winapi) HRESULT,
+    Commit: *const fn (*anyopaque) callconv(.winapi) HRESULT,
+};
+
+const IPropertyStore = extern struct {
+    vtbl: *const IPropertyStoreVtbl,
+
+    fn fromRaw(raw: *anyopaque) *IPropertyStore {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn asRaw(self: *IPropertyStore) *anyopaque {
+        return @ptrCast(self);
+    }
+
+    fn release(self: *IPropertyStore) void {
+        _ = self.vtbl.Release(self.asRaw());
+    }
+
+    fn setValue(self: *IPropertyStore, key: *const PROPERTYKEY, value: *const PROPVARIANT) HRESULT {
+        return self.vtbl.SetValue(self.asRaw(), key, value);
+    }
+};
+
+const RecentState = struct {
+    schema_version: u32 = 1,
+    directories: []const []const u8 = &.{},
+    hidden_profiles: []const []const u8 = &.{},
+};
+
+const VersionHeader = struct {
+    schema_version: u32,
+};
+
+fn parseRecentStateAlloc(alloc: Allocator, raw: []const u8) !std.json.Parsed(RecentState) {
+    var header = try std.json.parseFromSlice(VersionHeader, alloc, raw, .{
+        .ignore_unknown_fields = true,
+    });
+    defer header.deinit();
+    if (header.value.schema_version != 1) return error.UnsupportedVersion;
+
+    return try std.json.parseFromSlice(RecentState, alloc, raw, .{
+        .ignore_unknown_fields = false,
+    });
+}
+
+fn encodeRecentStateAlloc(
+    alloc: Allocator,
+    directories: []const []const u8,
+    hidden_profiles: []const []const u8,
+) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try std.json.Stringify.value(RecentState{
+        .directories = directories,
+        .hidden_profiles = hidden_profiles,
+    }, .{
+        .whitespace = .minified,
+    }, &out.writer);
+    if (out.written().len > max_state_bytes) return error.StateTooLarge;
+    return try out.toOwnedSlice();
+}
+
+const RecentList = struct {
+    items: std.ArrayListUnmanaged([]u8) = .empty,
+
+    fn deinit(self: *RecentList, alloc: Allocator) void {
+        for (self.items.items) |item| alloc.free(item);
+        self.items.deinit(alloc);
+        self.* = .{};
+    }
+
+    fn insert(self: *RecentList, alloc: Allocator, path: []const u8) !bool {
+        if (!isRecentLocalPath(path)) return false;
+
+        for (self.items.items, 0..) |item, index| {
+            if (!try pathsEqualIgnoreCase(alloc, item, path)) continue;
+            if (index == 0) return false;
+            var i = index;
+            while (i > 0) : (i -= 1) self.items.items[i] = self.items.items[i - 1];
+            self.items.items[0] = item;
+            return true;
+        }
+
+        const owned = try alloc.dupe(u8, path);
+        errdefer alloc.free(owned);
+        if (self.items.items.len < max_recents) {
+            try self.items.append(alloc, owned);
+        } else {
+            alloc.free(self.items.items[max_recents - 1]);
+        }
+
+        var i = @min(self.items.items.len, max_recents) - 1;
+        while (i > 0) : (i -= 1) self.items.items[i] = self.items.items[i - 1];
+        self.items.items[0] = owned;
+        return true;
+    }
+
+    fn appendLoaded(self: *RecentList, alloc: Allocator, path: []const u8) !void {
+        if (self.items.items.len >= max_recents or !isRecentLocalPath(path)) return;
+        for (self.items.items) |item| {
+            if (try pathsEqualIgnoreCase(alloc, item, path)) return;
+        }
+        const owned = try alloc.dupe(u8, path);
+        errdefer alloc.free(owned);
+        try self.items.append(alloc, owned);
+    }
+
+    fn removeArguments(
+        self: *RecentList,
+        alloc: Allocator,
+        removed_arguments: []const []const u8,
+    ) !bool {
+        var changed = false;
+        var index: usize = 0;
+        while (index < self.items.items.len) {
+            const arguments = try buildWorkingDirectoryArgumentsAlloc(alloc, self.items.items[index]);
+            defer alloc.free(arguments);
+            if (!containsArguments(removed_arguments, arguments)) {
+                index += 1;
+                continue;
+            }
+
+            alloc.free(self.items.items[index]);
+            _ = self.items.orderedRemove(index);
+            changed = true;
+        }
+        return changed;
+    }
+};
+
+const ProfileTombstones = struct {
+    items: std.ArrayListUnmanaged([]u8) = .empty,
+
+    fn deinit(self: *ProfileTombstones, alloc: Allocator) void {
+        for (self.items.items) |item| alloc.free(item);
+        self.items.deinit(alloc);
+        self.* = .{};
+    }
+
+    fn contains(self: *const ProfileTombstones, key: []const u8) bool {
+        for (self.items.items) |item| {
+            if (std.mem.eql(u8, item, key)) return true;
+        }
+        return false;
+    }
+
+    fn insert(self: *ProfileTombstones, alloc: Allocator, key: []const u8) !bool {
+        if (key.len == 0 or self.contains(key)) return false;
+        const owned = try alloc.dupe(u8, key);
+        errdefer alloc.free(owned);
+        if (self.items.items.len == max_profile_tombstones) {
+            alloc.free(self.items.orderedRemove(0));
+        }
+        try self.items.append(alloc, owned);
+        return true;
+    }
+
+    fn remove(self: *ProfileTombstones, alloc: Allocator, key: []const u8) bool {
+        for (self.items.items, 0..) |item, index| {
+            if (!std.mem.eql(u8, item, key)) continue;
+            alloc.free(item);
+            _ = self.items.orderedRemove(index);
+            return true;
+        }
+        return false;
+    }
+};
+
+const LoadedState = struct {
+    recents: RecentList = .{},
+    hidden_profiles: ProfileTombstones = .{},
+
+    fn deinit(self: *LoadedState, alloc: Allocator) void {
+        self.recents.deinit(alloc);
+        self.hidden_profiles.deinit(alloc);
+        self.* = .{};
+    }
+};
+
+fn loadStateAlloc(alloc: Allocator, path: []const u8) LoadedState {
+    var result: LoadedState = .{};
+    const raw = persistence.readFileBoundedAlloc(alloc, path, max_state_bytes) catch |err| {
+        switch (err) {
+            error.FileNotFound => {},
+            error.FileTooBig => log.warn("jump list recent state exceeds size limit path={s}", .{path}),
+            else => log.warn("jump list recent state read failed path={s} err={}", .{ path, err }),
+        }
+        return result;
+    };
+    defer alloc.free(raw);
+
+    var parsed = parseRecentStateAlloc(alloc, raw) catch |err| {
+        switch (err) {
+            error.OutOfMemory => log.warn("jump list recent state parse allocation failed path={s}", .{path}),
+            else => log.warn("jump list recent state ignored path={s} err={}", .{ path, err }),
+        }
+        return result;
+    };
+    defer parsed.deinit();
+
+    for (parsed.value.directories) |directory| {
+        result.recents.appendLoaded(alloc, directory) catch |err| {
+            log.warn("jump list recent state entry allocation failed err={}", .{err});
+            break;
+        };
+    }
+    for (parsed.value.hidden_profiles) |key| {
+        _ = result.hidden_profiles.insert(alloc, key) catch |err| {
+            log.warn("jump list hidden profile state allocation failed err={}", .{err});
+            break;
+        };
+    }
+    return result;
+}
+
+pub fn isRecentLocalPath(path: []const u8) bool {
+    if (!std.unicode.utf8ValidateSlice(path)) return false;
+    if (path.len < 3 or !std.ascii.isAlphabetic(path[0]) or path[1] != ':' or
+        (path[2] != '\\' and path[2] != '/'))
+    {
+        return false;
+    }
+    for (path, 0..) |byte, index| {
+        if (byte < 32) return false;
+        switch (byte) {
+            '"', '<', '>', '|', '?', '*' => return false,
+            ':' => if (index != 1) return false,
+            else => {},
+        }
+    }
+    return true;
+}
+
+fn pathsEqualIgnoreCase(alloc: Allocator, lhs: []const u8, rhs: []const u8) !bool {
+    const lhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, lhs);
+    defer alloc.free(lhs_w);
+    const rhs_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, rhs);
+    defer alloc.free(rhs_w);
+    const result = CompareStringOrdinal(
+        lhs_w.ptr,
+        @intCast(lhs_w.len),
+        rhs_w.ptr,
+        @intCast(rhs_w.len),
+        1,
+    );
+    if (result == 0) return error.PathComparisonFailed;
+    return result == 2;
+}
+
+/// Unicode controls that reorder or isolate the text around them. A jump-list
+/// title is drawn by the shell, so leaving these in lets a seeded Recent entry
+/// render as a path it does not point at.
+fn isBidiControl(cp: u21) bool {
+    return switch (cp) {
+        0x061C, 0x200E, 0x200F => true,
+        0x202A...0x202E => true,
+        0x2066...0x2069 => true,
+        else => false,
+    };
+}
+
+/// Copy `text` for use as a jump-list item title, dropping bidi controls.
+pub fn buildTitleAlloc(alloc: Allocator, text: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+
+    var view = std.unicode.Utf8View.init(text) catch {
+        // Not valid UTF-8; nothing to reorder, so copy it through unchanged.
+        out.deinit();
+        return try alloc.dupe(u8, text);
+    };
+    var iter = view.iterator();
+    while (iter.nextCodepointSlice()) |slice| {
+        const cp = std.unicode.utf8Decode(slice) catch continue;
+        if (isBidiControl(cp)) continue;
+        try out.writer.writeAll(slice);
+    }
+    return try out.toOwnedSlice();
+}
+
+pub fn buildWorkingDirectoryArgumentsAlloc(alloc: Allocator, path: []const u8) ![]u8 {
+    if (!isRecentLocalPath(path)) return error.InvalidWorkingDirectory;
+    const option = try std.fmt.allocPrint(alloc, "--working-directory={s}", .{path});
+    defer alloc.free(option);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try Command.writeDirectArg(&out.writer, option);
+    return try out.toOwnedSlice();
+}
+
+pub fn buildProfileArgumentsAlloc(alloc: Allocator, command: Command) ![]u8 {
+    const argv = switch (command) {
+        .direct => |value| value,
+        .shell => return error.UnsupportedProfileCommand,
+    };
+    if (argv.len == 0) return error.UnsupportedProfileCommand;
+
+    var command_value: std.Io.Writer.Allocating = .init(alloc);
+    defer command_value.deinit();
+    try command_value.writer.writeAll("direct:");
+    for (argv, 0..) |arg, index| {
+        if (index > 0) try command_value.writer.writeByte(' ');
+        try Command.writeDirectArg(&command_value.writer, arg);
+    }
+
+    const command_option = try std.fmt.allocPrint(
+        alloc,
+        "--command={s}",
+        .{command_value.written()},
+    );
+    defer alloc.free(command_option);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    // Match in-app profile launches: start at home instead of inheriting the caller's cwd.
+    try out.writer.writeAll("--working-directory=home ");
+    try Command.writeDirectArg(&out.writer, command_option);
+    try out.writer.writeByte(' ');
+    const initial_command_option = try std.fmt.allocPrint(
+        alloc,
+        "--initial-command={s}",
+        .{command_value.written()},
+    );
+    defer alloc.free(initial_command_option);
+    try Command.writeDirectArg(&out.writer, initial_command_option);
+    return try out.toOwnedSlice();
+}
+
+fn containsArguments(values: []const []const u8, arguments: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, arguments)) return true;
+    }
+    return false;
+}
+
+fn recentSlotCount(slot_budget: UINT, recent_count: usize, profile_count: usize) usize {
+    const slots: usize = slot_budget;
+    if (slots == 0 or recent_count == 0) return 0;
+    if (profile_count == 0 or slots == 1) return @min(recent_count, slots);
+    const reserved_profiles = @min(slots - 1, profile_count);
+    return @min(recent_count, slots - reserved_profiles);
+}
+
+fn nextRebuildRetryCount(current: u8) ?u8 {
+    if (current >= max_rebuild_retries) return null;
+    return current + 1;
+}
+
+const RemovedArguments = struct {
+    items: std.ArrayListUnmanaged([]u8) = .empty,
+    complete: bool = true,
+
+    fn deinit(self: *RemovedArguments, alloc: Allocator) void {
+        for (self.items.items) |item| alloc.free(item);
+        self.items.deinit(alloc);
+        self.* = .{};
+    }
+};
+
+const ProfileItem = struct {
+    key: []u8,
+    title: []u8,
+    arguments: []u8,
+
+    fn deinit(self: *ProfileItem, alloc: Allocator) void {
+        alloc.free(self.key);
+        alloc.free(self.title);
+        alloc.free(self.arguments);
+        self.* = undefined;
+    }
+};
+
+pub const JumpList = struct {
+    alloc: Allocator,
+    state_path: []u8,
+    exe_path: ?[]u8,
+    recents: RecentList,
+    hidden_profiles: ProfileTombstones,
+    profiles: std.ArrayListUnmanaged(ProfileItem) = .empty,
+    timer_id: ?UINT_PTR = null,
+    persist_dirty: bool = false,
+    rebuild_dirty: bool = true,
+    rebuild_retry_count: u8 = 0,
+    com_disabled: bool = false,
+    startup_profile_discovery_pending: bool = false,
+
+    pub fn init(alloc: Allocator, state_path: []const u8) !JumpList {
+        const owned_state_path = try alloc.dupe(u8, state_path);
+        errdefer alloc.free(owned_state_path);
+        const loaded = loadStateAlloc(alloc, state_path);
+        return .{
+            .alloc = alloc,
+            .state_path = owned_state_path,
+            .exe_path = std.fs.selfExePathAlloc(alloc) catch |err| exe: {
+                log.warn("jump list executable path unavailable err={}", .{err});
+                break :exe null;
+            },
+            .recents = loaded.recents,
+            .hidden_profiles = loaded.hidden_profiles,
+        };
+    }
+
+    pub fn deinit(self: *JumpList) void {
+        self.stopTimer();
+        if (self.persist_dirty) self.persist();
+        self.recents.deinit(self.alloc);
+        self.hidden_profiles.deinit(self.alloc);
+        self.clearProfiles();
+        self.profiles.deinit(self.alloc);
+        if (self.exe_path) |path| self.alloc.free(path);
+        self.alloc.free(self.state_path);
+        self.* = undefined;
+    }
+
+    pub fn startup(self: *JumpList) void {
+        self.stopTimer();
+        self.flush();
+        self.startup_profile_discovery_pending = true;
+        self.schedule();
+    }
+
+    pub fn takeStartupProfileDiscovery(self: *JumpList) bool {
+        if (!self.startup_profile_discovery_pending) return false;
+        self.startup_profile_discovery_pending = false;
+        return true;
+    }
+
+    pub fn updateProfiles(self: *JumpList, profiles: []const windows_shell.Profile) void {
+        self.updateProfilesAlloc(profiles) catch |err| {
+            log.warn("jump list profile snapshot failed err={}", .{err});
+        };
+    }
+
+    fn updateProfilesAlloc(self: *JumpList, profiles: []const windows_shell.Profile) !void {
+        var next: std.ArrayListUnmanaged(ProfileItem) = .empty;
+        errdefer {
+            for (next.items) |*item| item.deinit(self.alloc);
+            next.deinit(self.alloc);
+        }
+
+        for (profiles) |profile| {
+            const title = try buildTitleAlloc(self.alloc, profile.label);
+            const key = self.alloc.dupe(u8, profile.key) catch |err| {
+                self.alloc.free(title);
+                return err;
+            };
+            const arguments = buildProfileArgumentsAlloc(self.alloc, profile.command) catch |err| switch (err) {
+                error.UnsupportedProfileCommand => {
+                    self.alloc.free(key);
+                    self.alloc.free(title);
+                    continue;
+                },
+                else => {
+                    self.alloc.free(key);
+                    self.alloc.free(title);
+                    return err;
+                },
+            };
+            next.append(self.alloc, .{ .key = key, .title = title, .arguments = arguments }) catch |err| {
+                self.alloc.free(key);
+                self.alloc.free(title);
+                self.alloc.free(arguments);
+                return err;
+            };
+        }
+
+        if (profileItemsEqual(self.profiles.items, next.items)) {
+            for (next.items) |*item| item.deinit(self.alloc);
+            next.deinit(self.alloc);
+            return;
+        }
+
+        self.clearProfiles();
+        self.profiles.deinit(self.alloc);
+        self.profiles = next;
+        self.rebuild_retry_count = 0;
+        self.rebuild_dirty = true;
+        self.schedule();
+    }
+
+    pub fn noteProfileUsed(self: *JumpList, key: []const u8) void {
+        if (!self.hidden_profiles.remove(self.alloc, key)) return;
+        self.persist_dirty = true;
+        self.rebuild_retry_count = 0;
+        self.rebuild_dirty = true;
+        self.schedule();
+    }
+
+    pub fn noteRecent(self: *JumpList, path: []const u8) void {
+        const changed = self.recents.insert(self.alloc, path) catch |err| {
+            log.warn("jump list recent update failed err={}", .{err});
+            return;
+        };
+        if (!changed) return;
+        self.persist_dirty = true;
+        self.rebuild_retry_count = 0;
+        self.rebuild_dirty = true;
+        self.schedule();
+    }
+
+    pub fn handleTimer(self: *JumpList, timer_id: UINT_PTR) bool {
+        if (self.timer_id == null or timer_id != self.timer_id.?) return false;
+        self.stopTimer();
+        self.flush();
+        return true;
+    }
+
+    pub fn flush(self: *JumpList) void {
+        if (self.rebuild_dirty and !self.com_disabled) {
+            if (self.rebuildCom()) |_| {
+                self.rebuild_dirty = false;
+                self.rebuild_retry_count = 0;
+            } else |err| switch (err) {
+                error.ComNotInitialized => {
+                    self.com_disabled = true;
+                    log.warn("jump list COM unavailable; disabling rebuilds for this process", .{});
+                },
+                else => {
+                    log.warn("jump list rebuild unavailable err={}", .{err});
+                    if (nextRebuildRetryCount(self.rebuild_retry_count)) |next| {
+                        self.rebuild_retry_count = next;
+                        self.schedule();
+                    } else {
+                        log.warn("jump list rebuild retries exhausted; waiting for a model change", .{});
+                    }
+                },
+            }
+        }
+        if (self.persist_dirty) self.persist();
+    }
+
+    /// Re-arm the debounce if the deferred startup profile discovery still
+    /// has not found a host. Called when one is created, so an
+    /// `initial-window=false` launch is not stranded without a Profiles
+    /// category until something else happens to dirty the model.
+    pub fn scheduleIfStartupPending(self: *JumpList) void {
+        if (self.startup_profile_discovery_pending) self.schedule();
+    }
+
+    fn schedule(self: *JumpList) void {
+        self.stopTimer();
+        const timer_id = SetTimer(null, 0, debounce_ms, null);
+        if (timer_id == 0) {
+            log.warn("jump list debounce timer unavailable", .{});
+            return;
+        }
+        self.timer_id = timer_id;
+    }
+
+    fn stopTimer(self: *JumpList) void {
+        if (self.timer_id) |timer_id| {
+            _ = KillTimer(null, timer_id);
+            self.timer_id = null;
+        }
+    }
+
+    /// Write the recent/tombstone model out.
+    ///
+    /// Two noctty processes each own their own in-memory model and replace
+    /// this file atomically, so the last writer wins. That is deliberate: the
+    /// payload is an MRU convenience list, and it matches how
+    /// `session-state.json` and `palette-mru.txt` already behave. Merging on
+    /// write would have to reconcile removals too, which is more machinery
+    /// than a recents list is worth.
+    fn persist(self: *JumpList) void {
+        const encoded = encodeRecentStateAlloc(
+            self.alloc,
+            self.recents.items.items,
+            self.hidden_profiles.items.items,
+        ) catch |err| {
+            log.warn("jump list recent encode failed err={}", .{err});
+            return;
+        };
+        defer self.alloc.free(encoded);
+
+        if (std.fs.path.dirname(self.state_path)) |directory| {
+            std.fs.makeDirAbsolute(directory) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => {
+                    log.warn("jump list recent directory create failed path={s} err={}", .{ directory, err });
+                    return;
+                },
+            };
+        }
+        const temporary_path = std.fmt.allocPrint(
+            self.alloc,
+            "{s}.tmp-{x}-{x}",
+            .{ self.state_path, GetCurrentProcessId(), @as(u64, @bitCast(std.time.milliTimestamp())) },
+        ) catch |err| {
+            log.warn("jump list recent temp path allocation failed err={}", .{err});
+            return;
+        };
+        defer self.alloc.free(temporary_path);
+
+        persistence.writeFileAtomic(self.state_path, temporary_path, encoded) catch |err| {
+            log.warn("jump list recent write failed path={s} err={}", .{ self.state_path, err });
+            return;
+        };
+        self.persist_dirty = false;
+    }
+
+    fn clearProfiles(self: *JumpList) void {
+        for (self.profiles.items) |*item| item.deinit(self.alloc);
+        self.profiles.clearRetainingCapacity();
+    }
+
+    fn rebuildCom(self: *JumpList) !void {
+        const exe_path = self.exe_path orelse return error.ExecutableUnavailable;
+        const exe_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, exe_path);
+        defer self.alloc.free(exe_w);
+        const aumid_w = std.unicode.utf8ToUtf16LeStringLiteral(win32_aumid.aumid_utf8);
+
+        var raw_destination: ?*anyopaque = null;
+        const create_hr = CoCreateInstance(
+            &CLSID_DestinationList,
+            null,
+            CLSCTX_INPROC_SERVER,
+            &IID_ICustomDestinationList,
+            &raw_destination,
+        );
+        if (create_hr == CO_E_NOTINITIALIZED) return error.ComNotInitialized;
+        if (create_hr < 0 or raw_destination == null) return error.DestinationListUnavailable;
+        const destination = ICustomDestinationList.fromRaw(raw_destination.?);
+        defer destination.release();
+
+        if (destination.vtbl.SetAppID(destination.asRaw(), aumid_w) < 0) {
+            return error.SetAppIdFailed;
+        }
+
+        var slot_budget: UINT = 0;
+        var raw_removed: ?*anyopaque = null;
+        if (destination.vtbl.BeginList(
+            destination.asRaw(),
+            &slot_budget,
+            &IID_IObjectArray,
+            &raw_removed,
+        ) < 0) return error.BeginListFailed;
+
+        var transaction_open = true;
+        defer if (transaction_open) {
+            const abort_hr = destination.vtbl.AbortList(destination.asRaw());
+            if (abort_hr < 0) log.debug("jump list AbortList failed hr=0x{x}", .{@as(u32, @bitCast(abort_hr))});
+        };
+
+        var removed_arguments: RemovedArguments = .{};
+        defer removed_arguments.deinit(self.alloc);
+        if (raw_removed) |raw| {
+            const removed = IObjectArray.fromRaw(raw);
+            defer removed.release();
+            removed_arguments = try self.readRemovedArguments(removed, exe_w);
+        }
+        if (try self.recents.removeArguments(self.alloc, removed_arguments.items.items)) {
+            self.persist_dirty = true;
+        }
+        for (self.profiles.items) |item| {
+            if (!containsArguments(removed_arguments.items.items, item.arguments)) continue;
+            if (try self.hidden_profiles.insert(self.alloc, item.key)) self.persist_dirty = true;
+        }
+        if (!removed_arguments.complete) return error.RemovedDestinationsIncomplete;
+
+        var visible_profile_count: usize = 0;
+        for (self.profiles.items) |item| {
+            if (!self.hidden_profiles.contains(item.key)) visible_profile_count += 1;
+        }
+        const recent_count = recentSlotCount(
+            slot_budget,
+            self.recents.items.items.len,
+            visible_profile_count,
+        );
+        if (recent_count > 0) {
+            try self.appendRecentCategory(destination, exe_w, recent_count);
+        }
+        if (visible_profile_count > 0) {
+            try self.appendProfilesCategory(destination, exe_w);
+        }
+        // Named layouts (C17, #133) will add a third category here, built
+        // from win32_layouts.listNamesAlloc + launchArgvAlloc rather than
+        // any layout enumeration of our own.
+
+        if (destination.vtbl.CommitList(destination.asRaw()) < 0) return error.CommitListFailed;
+        transaction_open = false;
+    }
+
+    fn appendRecentCategory(
+        self: *JumpList,
+        destination: *ICustomDestinationList,
+        exe_w: [:0]const u16,
+        count: usize,
+    ) !void {
+        const collection = try createObjectCollection();
+        defer collection.release();
+
+        for (self.recents.items.items[0..count]) |path| {
+            const title = try buildTitleAlloc(self.alloc, path);
+            defer self.alloc.free(title);
+            const arguments = try buildWorkingDirectoryArgumentsAlloc(self.alloc, path);
+            defer self.alloc.free(arguments);
+            const link = try self.createShellLink(exe_w, arguments, title, path);
+            defer link.release();
+            if (collection.addObject(link.asRaw()) < 0) return error.AddRecentLinkFailed;
+        }
+
+        const category = std.unicode.utf8ToUtf16LeStringLiteral("Recent");
+        if (destination.vtbl.AppendCategory(destination.asRaw(), category, collection.asArray()) < 0) {
+            return error.AppendRecentCategoryFailed;
+        }
+    }
+
+    fn appendProfilesCategory(
+        self: *JumpList,
+        destination: *ICustomDestinationList,
+        exe_w: [:0]const u16,
+    ) !void {
+        const collection = try createObjectCollection();
+        defer collection.release();
+
+        for (self.profiles.items) |item| {
+            if (self.hidden_profiles.contains(item.key)) continue;
+            const link = try self.createShellLink(exe_w, item.arguments, item.title, null);
+            defer link.release();
+            if (collection.addObject(link.asRaw()) < 0) return error.AddProfileLinkFailed;
+        }
+
+        const category = std.unicode.utf8ToUtf16LeStringLiteral("Profiles");
+        if (destination.vtbl.AppendCategory(destination.asRaw(), category, collection.asArray()) < 0) {
+            return error.AppendProfilesCategoryFailed;
+        }
+    }
+
+    fn readRemovedArguments(
+        self: *JumpList,
+        removed: *IObjectArray,
+        exe_w: [:0]const u16,
+    ) !RemovedArguments {
+        var result: RemovedArguments = .{};
+        errdefer result.deinit(self.alloc);
+
+        var count: UINT = 0;
+        if (removed.vtbl.GetCount(removed.asRaw(), &count) < 0) {
+            log.debug("jump list removed item count unavailable", .{});
+            result.complete = false;
+            return result;
+        }
+        const path_buffer = try self.alloc.alloc(u16, max_shell_link_chars);
+        defer self.alloc.free(path_buffer);
+        const arguments_buffer = try self.alloc.alloc(u16, max_shell_link_chars);
+        defer self.alloc.free(arguments_buffer);
+
+        for (0..count) |index| {
+            var raw_link: ?*anyopaque = null;
+            const get_hr = removed.vtbl.GetAt(
+                removed.asRaw(),
+                @intCast(index),
+                &IID_IShellLinkW,
+                &raw_link,
+            );
+            if (get_hr == E_NOINTERFACE) continue;
+            if (get_hr < 0 or raw_link == null) {
+                log.debug("jump list removed item ignored index={d} hr=0x{x}", .{
+                    index,
+                    @as(u32, @bitCast(get_hr)),
+                });
+                result.complete = false;
+                continue;
+            }
+            const link = IShellLinkW.fromRaw(raw_link.?);
+            defer link.release();
+
+            @memset(path_buffer, 0);
+            if (link.vtbl.GetPath(
+                link.asRaw(),
+                path_buffer.ptr,
+                @intCast(path_buffer.len),
+                null,
+                0,
+            ) < 0) {
+                log.debug("jump list removed link path unavailable index={d}", .{index});
+                result.complete = false;
+                continue;
+            }
+            const path_len = std.mem.indexOfScalar(u16, path_buffer, 0) orelse {
+                log.debug("jump list removed link path too long index={d}", .{index});
+                result.complete = false;
+                continue;
+            };
+            const path_comparison = CompareStringOrdinal(
+                exe_w.ptr,
+                @intCast(exe_w.len),
+                path_buffer.ptr,
+                @intCast(path_len),
+                1,
+            );
+            if (path_comparison == 0) {
+                log.debug("jump list removed link path comparison failed index={d}", .{index});
+                result.complete = false;
+                continue;
+            }
+            if (path_comparison != 2) continue;
+
+            @memset(arguments_buffer, 0);
+            if (link.vtbl.GetArguments(
+                link.asRaw(),
+                arguments_buffer.ptr,
+                @intCast(arguments_buffer.len),
+            ) < 0) {
+                log.debug("jump list removed link arguments unavailable index={d}", .{index});
+                result.complete = false;
+                continue;
+            }
+            const arguments_len = std.mem.indexOfScalar(u16, arguments_buffer, 0) orelse {
+                log.debug("jump list removed link arguments too long index={d}", .{index});
+                result.complete = false;
+                continue;
+            };
+            const arguments = std.unicode.utf16LeToUtf8Alloc(
+                self.alloc,
+                arguments_buffer[0..arguments_len],
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => {
+                    log.debug("jump list removed link arguments invalid index={d} err={}", .{ index, err });
+                    result.complete = false;
+                    continue;
+                },
+            };
+            errdefer self.alloc.free(arguments);
+            try result.items.append(self.alloc, arguments);
+        }
+        return result;
+    }
+
+    fn createShellLink(
+        self: *JumpList,
+        exe_w: [:0]const u16,
+        arguments: []const u8,
+        title: []const u8,
+        working_directory: ?[]const u8,
+    ) !*IShellLinkW {
+        var raw_link: ?*anyopaque = null;
+        const create_hr = CoCreateInstance(
+            &CLSID_ShellLink,
+            null,
+            CLSCTX_INPROC_SERVER,
+            &IID_IShellLinkW,
+            &raw_link,
+        );
+        if (create_hr == CO_E_NOTINITIALIZED) return error.ComNotInitialized;
+        if (create_hr < 0 or raw_link == null) return error.ShellLinkUnavailable;
+        const link = IShellLinkW.fromRaw(raw_link.?);
+        errdefer link.release();
+
+        const arguments_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, arguments);
+        defer self.alloc.free(arguments_w);
+        const title_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, title);
+        defer self.alloc.free(title_w);
+
+        if (link.vtbl.SetPath(link.asRaw(), exe_w.ptr) < 0) return error.SetLinkPathFailed;
+        if (link.vtbl.SetArguments(link.asRaw(), arguments_w.ptr) < 0) return error.SetLinkArgumentsFailed;
+        if (link.vtbl.SetIconLocation(link.asRaw(), exe_w.ptr, 0) < 0) return error.SetLinkIconFailed;
+
+        if (working_directory) |path| {
+            const path_w = try std.unicode.utf8ToUtf16LeAllocZ(self.alloc, path);
+            defer self.alloc.free(path_w);
+            if (link.vtbl.SetWorkingDirectory(link.asRaw(), path_w.ptr) < 0) {
+                return error.SetLinkWorkingDirectoryFailed;
+            }
+        }
+
+        var raw_store: ?*anyopaque = null;
+        if (link.vtbl.QueryInterface(link.asRaw(), &IID_IPropertyStore, &raw_store) < 0 or raw_store == null) {
+            return error.PropertyStoreUnavailable;
+        }
+        const store = IPropertyStore.fromRaw(raw_store.?);
+        defer store.release();
+
+        const aumid_w = std.unicode.utf8ToUtf16LeStringLiteral(win32_aumid.aumid_utf8);
+        const aumid_value = PROPVARIANT.fromString(aumid_w);
+        if (store.setValue(&PKEY_AppUserModel_ID, &aumid_value) < 0) return error.SetLinkAumidFailed;
+        const title_value = PROPVARIANT.fromString(title_w);
+        if (store.setValue(&PKEY_Title, &title_value) < 0) return error.SetLinkTitleFailed;
+        if (store.vtbl.Commit(store.asRaw()) < 0) return error.CommitLinkPropertiesFailed;
+
+        return link;
+    }
+};
+
+fn profileItemsEqual(lhs: []const ProfileItem, rhs: []const ProfileItem) bool {
+    if (lhs.len != rhs.len) return false;
+    for (lhs, rhs) |left, right| {
+        if (!std.mem.eql(u8, left.key, right.key) or
+            !std.mem.eql(u8, left.title, right.title) or
+            !std.mem.eql(u8, left.arguments, right.arguments)) return false;
+    }
+    return true;
+}
+
+fn createObjectCollection() !*IObjectCollection {
+    var raw_collection: ?*anyopaque = null;
+    const create_hr = CoCreateInstance(
+        &CLSID_EnumerableObjectCollection,
+        null,
+        CLSCTX_INPROC_SERVER,
+        &IID_IObjectCollection,
+        &raw_collection,
+    );
+    if (create_hr == CO_E_NOTINITIALIZED) return error.ComNotInitialized;
+    if (create_hr < 0 or raw_collection == null) return error.ObjectCollectionUnavailable;
+    return IObjectCollection.fromRaw(raw_collection.?);
+}
+
+test "jump_list recent insert dedupes case insensitively and keeps newest first" {
+    var recent: RecentList = .{};
+    defer recent.deinit(std.testing.allocator);
+
+    try std.testing.expect(try recent.insert(std.testing.allocator, "C:\\one"));
+    try std.testing.expect(try recent.insert(std.testing.allocator, "D:\\two"));
+    try std.testing.expect(try recent.insert(std.testing.allocator, "E:\\three"));
+    try std.testing.expect(try recent.insert(std.testing.allocator, "c:\\ONE"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "C:\\one"));
+
+    try std.testing.expectEqual(@as(usize, 3), recent.items.items.len);
+    try std.testing.expectEqualStrings("C:\\one", recent.items.items[0]);
+    try std.testing.expectEqualStrings("E:\\three", recent.items.items[1]);
+    try std.testing.expectEqualStrings("D:\\two", recent.items.items[2]);
+
+    var unicode: RecentList = .{};
+    defer unicode.deinit(std.testing.allocator);
+    try std.testing.expect(try unicode.insert(std.testing.allocator, "C:\\Üser\\Source"));
+    try std.testing.expect(!try unicode.insert(std.testing.allocator, "c:\\üSER\\source"));
+    try std.testing.expectEqual(@as(usize, 1), unicode.items.items.len);
+}
+
+test "jump_list recent insert caps at ten and rejects nonlocal paths" {
+    var recent: RecentList = .{};
+    defer recent.deinit(std.testing.allocator);
+
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "relative\\path"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "\\\\server\\share"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "/mnt/c/project"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "C:relative"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "C:\\bad*name"));
+    try std.testing.expect(!try recent.insert(std.testing.allocator, "C:\\bad\tname"));
+    const invalid_utf8 = [_]u8{ 'C', ':', '\\', 0xFF };
+    try std.testing.expect(!try recent.insert(std.testing.allocator, &invalid_utf8));
+
+    var buffer: [32]u8 = undefined;
+    for (0..12) |index| {
+        const path = try std.fmt.bufPrint(&buffer, "C:\\project-{d}", .{index});
+        try std.testing.expect(try recent.insert(std.testing.allocator, path));
+    }
+    try std.testing.expectEqual(max_recents, recent.items.items.len);
+    try std.testing.expectEqualStrings("C:\\project-11", recent.items.items[0]);
+    try std.testing.expectEqualStrings("C:\\project-2", recent.items.items[9]);
+}
+
+test "jump_list JSON round trips and corrupt or oversized state starts empty" {
+    const values = [_][]const u8{ "C:\\src\\noctty", "D:\\work" };
+    const hidden_profiles = [_][]const u8{"wsl:Ubuntu"};
+    const encoded = try encodeRecentStateAlloc(std.testing.allocator, &values, &hidden_profiles);
+    defer std.testing.allocator.free(encoded);
+    var parsed = try parseRecentStateAlloc(std.testing.allocator, encoded);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings(values[0], parsed.value.directories[0]);
+    try std.testing.expectEqualStrings(values[1], parsed.value.directories[1]);
+    try std.testing.expectEqualStrings(hidden_profiles[0], parsed.value.hidden_profiles[0]);
+    try std.testing.expectError(
+        error.SyntaxError,
+        parseRecentStateAlloc(std.testing.allocator, "{not json"),
+    );
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        var file = try tmp.dir.createFile("corrupt.json", .{});
+        defer file.close();
+        try file.writeAll("{not json");
+    }
+    const corrupt_path = try tmp.dir.realpathAlloc(std.testing.allocator, "corrupt.json");
+    defer std.testing.allocator.free(corrupt_path);
+    var corrupt = loadStateAlloc(std.testing.allocator, corrupt_path);
+    defer corrupt.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), corrupt.recents.items.items.len);
+    try std.testing.expectEqual(@as(usize, 0), corrupt.hidden_profiles.items.items.len);
+
+    {
+        var file = try tmp.dir.createFile("oversized.json", .{});
+        defer file.close();
+        var remaining = max_state_bytes + 1;
+        const chunk = [_]u8{'x'} ** 1024;
+        while (remaining > 0) {
+            const count = @min(remaining, chunk.len);
+            try file.writeAll(chunk[0..count]);
+            remaining -= count;
+        }
+    }
+    const oversized_path = try tmp.dir.realpathAlloc(std.testing.allocator, "oversized.json");
+    defer std.testing.allocator.free(oversized_path);
+    var oversized = loadStateAlloc(std.testing.allocator, oversized_path);
+    defer oversized.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), oversized.recents.items.items.len);
+    try std.testing.expectEqual(@as(usize, 0), oversized.hidden_profiles.items.items.len);
+
+    const oversized_key = try std.testing.allocator.alloc(u8, max_state_bytes);
+    defer std.testing.allocator.free(oversized_key);
+    @memset(oversized_key, 'x');
+    try std.testing.expectError(
+        error.StateTooLarge,
+        encodeRecentStateAlloc(std.testing.allocator, &.{}, &.{oversized_key}),
+    );
+}
+
+test "jump_list titles drop bidi controls and keep everything else" {
+    const testing = std.testing;
+
+    // U+202E RIGHT-TO-LEFT OVERRIDE around a segment is what lets a seeded
+    // entry render as a path it does not point at.
+    const spoofed = try buildTitleAlloc(
+        testing.allocator,
+        "C:\\Users\\a\\\u{202E}gpj.exe\u{202C}",
+    );
+    defer testing.allocator.free(spoofed);
+    try testing.expectEqualStrings("C:\\Users\\a\\gpj.exe", spoofed);
+
+    // Ordinary non-ASCII is untouched.
+    const unicode_path = try buildTitleAlloc(testing.allocator, "D:\\\u{9805}\u{76EE}\\\u{1F680}");
+    defer testing.allocator.free(unicode_path);
+    try testing.expectEqualStrings("D:\\\u{9805}\u{76EE}\\\u{1F680}", unicode_path);
+
+    // Invalid UTF-8 is copied through rather than silently emptied.
+    const invalid = try buildTitleAlloc(testing.allocator, "C:\\bad\xff");
+    defer testing.allocator.free(invalid);
+    try testing.expectEqualStrings("C:\\bad\xff", invalid);
+}
+
+test "jump_list argument builders preserve Windows argv boundaries" {
+    const recent = try buildWorkingDirectoryArgumentsAlloc(
+        std.testing.allocator,
+        "C:\\Users\\Aman Thanvi\\src",
+    );
+    defer std.testing.allocator.free(recent);
+    try std.testing.expectEqualStrings(
+        "\"--working-directory=C:\\Users\\Aman Thanvi\\src\"",
+        recent,
+    );
+
+    const profile = try buildProfileArgumentsAlloc(std.testing.allocator, .{
+        .direct = &.{ "C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo", "a b" },
+    });
+    defer std.testing.allocator.free(profile);
+    try std.testing.expectEqualStrings(
+        "--working-directory=home \"--command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\" \"--initial-command=direct:\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoLogo \\\"a b\\\"\"",
+        profile,
+    );
+
+    var argv = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, profile);
+    defer argv.deinit();
+    try std.testing.expectEqualStrings("--working-directory=home", argv.next().?);
+    const command_option = argv.next().?;
+    const initial_command_option = argv.next().?;
+    try std.testing.expect(argv.next() == null);
+    try std.testing.expect(std.mem.startsWith(u8, command_option, "--command="));
+    try std.testing.expect(std.mem.startsWith(u8, initial_command_option, "--initial-command="));
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var parsed_command: Command = undefined;
+    try parsed_command.parseCLI(arena.allocator(), command_option["--command=".len..]);
+    try std.testing.expect(parsed_command == .direct);
+    try std.testing.expectEqual(@as(usize, 3), parsed_command.direct.len);
+    try std.testing.expectEqualStrings("C:\\Program Files\\PowerShell\\7\\pwsh.exe", parsed_command.direct[0]);
+    try std.testing.expectEqualStrings("-NoLogo", parsed_command.direct[1]);
+    try std.testing.expectEqualStrings("a b", parsed_command.direct[2]);
+    var parsed_initial_command: Command = undefined;
+    try parsed_initial_command.parseCLI(
+        arena.allocator(),
+        initial_command_option["--initial-command=".len..],
+    );
+    try std.testing.expectEqualDeep(parsed_command, parsed_initial_command);
+    try std.testing.expectError(
+        error.UnsupportedProfileCommand,
+        buildProfileArgumentsAlloc(std.testing.allocator, .{ .shell = "pwsh.exe" }),
+    );
+}
+
+test "jump_list removed recent arguments clear tracked entries" {
+    var recent: RecentList = .{};
+    defer recent.deinit(std.testing.allocator);
+    try std.testing.expect(try recent.insert(std.testing.allocator, "C:\\one"));
+    try std.testing.expect(try recent.insert(std.testing.allocator, "D:\\two"));
+    const removed = try buildWorkingDirectoryArgumentsAlloc(std.testing.allocator, "C:\\one");
+    defer std.testing.allocator.free(removed);
+
+    try std.testing.expect(try recent.removeArguments(std.testing.allocator, &.{removed}));
+    try std.testing.expectEqual(@as(usize, 1), recent.items.items.len);
+    try std.testing.expectEqualStrings("D:\\two", recent.items.items[0]);
+    try std.testing.expect(!try recent.removeArguments(std.testing.allocator, &.{removed}));
+}
+
+test "jump_list slot budget reserves profiles before recents" {
+    try std.testing.expectEqual(@as(usize, 5), recentSlotCount(10, 10, 5));
+    try std.testing.expectEqual(@as(usize, 1), recentSlotCount(3, 10, 5));
+    try std.testing.expectEqual(@as(usize, 3), recentSlotCount(3, 10, 0));
+    try std.testing.expectEqual(@as(usize, 0), recentSlotCount(0, 10, 2));
+    try std.testing.expectEqual(@as(usize, 1), recentSlotCount(1, 10, 2));
+    try std.testing.expectEqual(@as(usize, 2), recentSlotCount(10, 2, 2));
+}
+
+test "jump_list removed profile tombstone persists until profile use" {
+    var hidden: ProfileTombstones = .{};
+    defer hidden.deinit(std.testing.allocator);
+    try std.testing.expect(try hidden.insert(std.testing.allocator, "wsl:Ubuntu"));
+    try std.testing.expect(!try hidden.insert(std.testing.allocator, "wsl:Ubuntu"));
+    try std.testing.expect(hidden.contains("wsl:Ubuntu"));
+    try std.testing.expect(hidden.remove(std.testing.allocator, "wsl:Ubuntu"));
+    try std.testing.expect(!hidden.contains("wsl:Ubuntu"));
+    try std.testing.expect(!hidden.remove(std.testing.allocator, "wsl:Ubuntu"));
+
+    var key_buffer: [32]u8 = undefined;
+    for (0..max_profile_tombstones + 1) |index| {
+        const key = try std.fmt.bufPrint(&key_buffer, "wsl:distro-{d}", .{index});
+        try std.testing.expect(try hidden.insert(std.testing.allocator, key));
+    }
+    try std.testing.expectEqual(max_profile_tombstones, hidden.items.items.len);
+    try std.testing.expect(!hidden.contains("wsl:distro-0"));
+    try std.testing.expect(hidden.contains("wsl:distro-128"));
+}
+
+test "jump_list rebuild retry budget is bounded" {
+    var retry_count: u8 = 0;
+    var expected: u8 = 1;
+    while (expected <= max_rebuild_retries) : (expected += 1) {
+        retry_count = nextRebuildRetryCount(retry_count).?;
+        try std.testing.expectEqual(expected, retry_count);
+    }
+    try std.testing.expect(nextRebuildRetryCount(retry_count) == null);
+}
+
+test "jump_list raw COM interfaces preserve pointer layout and PROPVARIANT ABI" {
+    const pointer_size = @sizeOf(*anyopaque);
+
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(ICustomDestinationList, "vtbl"));
+    try std.testing.expectEqual(3 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "SetAppID"));
+    try std.testing.expectEqual(4 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "BeginList"));
+    try std.testing.expectEqual(5 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "AppendCategory"));
+    try std.testing.expectEqual(8 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "CommitList"));
+    try std.testing.expectEqual(9 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "GetRemovedDestinations"));
+    try std.testing.expectEqual(11 * pointer_size, @offsetOf(ICustomDestinationListVtbl, "AbortList"));
+    try std.testing.expectEqual(5 * pointer_size, @offsetOf(IObjectCollectionVtbl, "AddObject"));
+    try std.testing.expectEqual(10 * pointer_size, @offsetOf(IShellLinkWVtbl, "GetArguments"));
+    try std.testing.expectEqual(11 * pointer_size, @offsetOf(IShellLinkWVtbl, "SetArguments"));
+    try std.testing.expectEqual(17 * pointer_size, @offsetOf(IShellLinkWVtbl, "SetIconLocation"));
+    try std.testing.expectEqual(20 * pointer_size, @offsetOf(IShellLinkWVtbl, "SetPath"));
+    try std.testing.expectEqual(6 * pointer_size, @offsetOf(IPropertyStoreVtbl, "SetValue"));
+    try std.testing.expectEqual(7 * pointer_size, @offsetOf(IPropertyStoreVtbl, "Commit"));
+
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(PROPERTYKEY, "fmtid"));
+    try std.testing.expectEqual(@as(usize, 16), @offsetOf(PROPERTYKEY, "pid"));
+    try std.testing.expectEqual(@as(usize, 20), @sizeOf(PROPERTYKEY));
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(PROPVARIANT, "vt"));
+    try std.testing.expectEqual(@as(usize, 2), @offsetOf(PROPVARIANT, "reserved1"));
+    try std.testing.expectEqual(@as(usize, 4), @offsetOf(PROPVARIANT, "reserved2"));
+    try std.testing.expectEqual(@as(usize, 6), @offsetOf(PROPVARIANT, "reserved3"));
+    try std.testing.expectEqual(@as(usize, 8), @offsetOf(PROPVARIANT, "value"));
+    try std.testing.expectEqual(if (@sizeOf(usize) == 8) @as(usize, 24) else 16, @sizeOf(PROPVARIANT));
+}
+
+test "jump_list property keys and AUMID match Windows shell contracts" {
+    try std.testing.expectEqualDeep(
+        GUID.parse("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}"),
+        PKEY_AppUserModel_ID.fmtid,
+    );
+    try std.testing.expectEqual(@as(DWORD, 5), PKEY_AppUserModel_ID.pid);
+    try std.testing.expectEqualDeep(
+        GUID.parse("{F29F85E0-4FF9-1068-AB91-08002B27B3D9}"),
+        PKEY_Title.fmtid,
+    );
+    try std.testing.expectEqualStrings("io.github.amanthanvi.noctty", win32_aumid.aumid_utf8);
+}

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -12,6 +12,7 @@
 const std = @import("std");
 const windows = std.os.windows;
 const windows_shell = @import("../config/windows_shell.zig");
+const windows_ssh_hosts = @import("../config/windows_ssh_hosts.zig");
 const Command = @import("../config/command.zig").Command;
 const win32_aumid = @import("win32_aumid.zig");
 const persistence = @import("win32_session_persistence.zig");
@@ -755,6 +756,26 @@ pub fn buildWorkingDirectoryArgumentsAlloc(alloc: Allocator, path: []const u8) !
 }
 
 pub fn buildProfileArgumentsAlloc(alloc: Allocator, command: Command) ![]u8 {
+    return buildProfileArgumentsWithLaunchConfigAlloc(alloc, command, "home", false);
+}
+
+fn buildProfileArgumentsForProfileAlloc(
+    alloc: Allocator,
+    profile: *const windows_shell.Profile,
+) ![]u8 {
+    if (profile.kind != .ssh) return buildProfileArgumentsAlloc(alloc, profile.command);
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = (try windows_ssh_hosts.userProfileDir(&home_buf)) orelse
+        return error.UnsupportedProfileCommand;
+    return buildProfileArgumentsWithLaunchConfigAlloc(alloc, profile.command, home, true);
+}
+
+fn buildProfileArgumentsWithLaunchConfigAlloc(
+    alloc: Allocator,
+    command: Command,
+    working_directory: []const u8,
+    disable_shell_integration: bool,
+) ![]u8 {
     const argv = switch (command) {
         .direct => |value| value,
         .shell => return error.UnsupportedProfileCommand,
@@ -779,7 +800,17 @@ pub fn buildProfileArgumentsAlloc(alloc: Allocator, command: Command) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
     // Match in-app profile launches: start at home instead of inheriting the caller's cwd.
-    try out.writer.writeAll("--working-directory=home ");
+    const working_directory_option = try std.fmt.allocPrint(
+        alloc,
+        "--working-directory={s}",
+        .{working_directory},
+    );
+    defer alloc.free(working_directory_option);
+    try Command.writeDirectArg(&out.writer, working_directory_option);
+    try out.writer.writeByte(' ');
+    if (disable_shell_integration) {
+        try out.writer.writeAll("--shell-integration=none ");
+    }
     try Command.writeDirectArg(&out.writer, command_option);
     try out.writer.writeByte(' ');
     const initial_command_option = try std.fmt.allocPrint(
@@ -956,7 +987,7 @@ pub const JumpList = struct {
                 self.alloc.free(title);
                 return err;
             };
-            const arguments = buildProfileArgumentsAlloc(self.alloc, profile.command) catch |err| switch (err) {
+            const arguments = buildProfileArgumentsForProfileAlloc(self.alloc, &profile) catch |err| switch (err) {
                 error.UnsupportedProfileCommand => {
                     self.alloc.free(key);
                     self.alloc.free(title);
@@ -1831,6 +1862,22 @@ test "jump_list argument builders preserve Windows argv boundaries" {
         initial_command_option["--initial-command=".len..],
     );
     try std.testing.expectEqualDeep(parsed_command, parsed_initial_command);
+
+    const ssh_profile = try buildProfileArgumentsWithLaunchConfigAlloc(
+        std.testing.allocator,
+        .{ .direct = &.{ "C:\\Windows\\System32\\OpenSSH\\ssh.exe", "production" } },
+        "C:\\Users\\Aman Thanvi",
+        true,
+    );
+    defer std.testing.allocator.free(ssh_profile);
+    var ssh_argv = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, ssh_profile);
+    defer ssh_argv.deinit();
+    try std.testing.expectEqualStrings("--working-directory=C:\\Users\\Aman Thanvi", ssh_argv.next().?);
+    try std.testing.expectEqualStrings("--shell-integration=none", ssh_argv.next().?);
+    try std.testing.expect(std.mem.startsWith(u8, ssh_argv.next().?, "--command="));
+    try std.testing.expect(std.mem.startsWith(u8, ssh_argv.next().?, "--initial-command="));
+    try std.testing.expect(ssh_argv.next() == null);
+
     try std.testing.expectError(
         error.UnsupportedProfileCommand,
         buildProfileArgumentsAlloc(std.testing.allocator, .{ .shell = "pwsh.exe" }),

--- a/src/apprt/win32_jump_list.zig
+++ b/src/apprt/win32_jump_list.zig
@@ -879,6 +879,7 @@ pub const JumpList = struct {
     profiles: std.ArrayListUnmanaged(ProfileItem) = .empty,
     timer_id: ?UINT_PTR = null,
     persist_dirty: bool = false,
+    persist_retry_count: u8 = 0,
     rebuild_dirty: bool = true,
     rebuild_retry_count: u8 = 0,
     com_disabled: bool = false,
@@ -1023,6 +1024,7 @@ pub const JumpList = struct {
         _ = removed;
         _ = recorded;
         self.persist_dirty = true;
+        self.persist_retry_count = 0;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
         self.schedule();
@@ -1064,6 +1066,7 @@ pub const JumpList = struct {
         };
         if (!changed and !reinstated and !recorded) return;
         self.persist_dirty = true;
+        self.persist_retry_count = 0;
         self.rebuild_retry_count = 0;
         self.rebuild_dirty = true;
         self.schedule();
@@ -1100,7 +1103,14 @@ pub const JumpList = struct {
             }
         }
         const persisted = if (self.persist_dirty) self.persist() else true;
-        if (!persisted) self.schedule();
+        if (persisted) {
+            self.persist_retry_count = 0;
+        } else if (nextRebuildRetryCount(self.persist_retry_count)) |next| {
+            self.persist_retry_count = next;
+            self.schedule();
+        } else {
+            log.warn("jump list persistence retries exhausted; waiting for a model change", .{});
+        }
         if (rebuild_committed) self.use_guards_rebuild_committed = true;
         self.finishUseGuards(persisted);
     }
@@ -1385,6 +1395,7 @@ pub const JumpList = struct {
                 );
             }
             self.persist_dirty = true;
+            self.persist_retry_count = 0;
         }
         for (self.profiles.items) |item| {
             if (!removed_arguments.profile_keys.contains(item.key) and
@@ -1399,6 +1410,7 @@ pub const JumpList = struct {
                     @intCast(std.time.nanoTimestamp()),
                 );
                 self.persist_dirty = true;
+                self.persist_retry_count = 0;
             }
         }
         if (!removed_arguments.complete) return error.RemovedDestinationsIncomplete;

--- a/src/apprt/win32_session_persistence.zig
+++ b/src/apprt/win32_session_persistence.zig
@@ -107,7 +107,7 @@ pub fn writeFileAtomic(absolute_path: []const u8, temporary_path: []const u8, by
     temporary_created = false;
 }
 
-fn readFileBoundedAlloc(alloc: Allocator, absolute_path: []const u8, max_bytes: usize) ![]u8 {
+pub fn readFileBoundedAlloc(alloc: Allocator, absolute_path: []const u8, max_bytes: usize) ![]u8 {
     var file = try std.fs.openFileAbsolute(absolute_path, .{});
     defer file.close();
     const stat = try file.stat();

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -904,6 +904,23 @@ fn lookupGitBash(alloc: Allocator, lookup: anytype) !?[]u8 {
     return null;
 }
 
+const WslOutputDrain = struct {
+    stdout: std.fs.File,
+    bytes: ?[]u8 = null,
+    err: ?anyerror = null,
+
+    fn run(self: *WslOutputDrain) void {
+        self.bytes = self.stdout.readToEndAlloc(std.heap.page_allocator, 64 * 1024) catch |err| {
+            self.err = err;
+            return;
+        };
+    }
+
+    fn deinit(self: *WslOutputDrain) void {
+        if (self.bytes) |bytes| std.heap.page_allocator.free(bytes);
+    }
+};
+
 fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
     var child = std.process.Child.init(&.{ exe_path, "-l", "-q" }, alloc);
     child.stdin_behavior = .Ignore;
@@ -922,6 +939,16 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
         return error.Unexpected;
     };
 
+    // Drain concurrently so a large distro list cannot fill the anonymous
+    // pipe and prevent wsl.exe from reaching the signaled state below.
+    var drain: WslOutputDrain = .{ .stdout = stdout };
+    const drain_thread = try std.Thread.spawn(.{}, WslOutputDrain.run, .{&drain});
+    var drain_joined = false;
+    defer {
+        if (!drain_joined) drain_thread.join();
+        drain.deinit();
+    }
+
     windows.WaitForSingleObjectEx(child.id, wsl_list_timeout_ms, false) catch |err| switch (err) {
         error.WaitTimeOut => {
             log.warn("WSL distro enumeration timed out exe={s} timeout_ms={}", .{
@@ -931,18 +958,24 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
             _ = child.kill() catch {};
             _ = child.wait() catch {};
             child_running = false;
+            drain_thread.join();
+            drain_joined = true;
             return error.WslListTimeout;
         },
         else => {
             _ = child.kill() catch {};
             _ = child.wait() catch {};
             child_running = false;
+            drain_thread.join();
+            drain_joined = true;
             return err;
         },
     };
 
-    const raw_bytes = try stdout.readToEndAlloc(alloc, 64 * 1024);
-    defer alloc.free(raw_bytes);
+    drain_thread.join();
+    drain_joined = true;
+    if (drain.err) |err| return err;
+    const raw_bytes = drain.bytes orelse return error.Unexpected;
 
     _ = try child.wait();
     child_running = false;

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -974,7 +974,11 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
 
     drain_thread.join();
     drain_joined = true;
-    if (drain.err) |err| return err;
+    if (drain.err) |err| {
+        _ = try child.wait();
+        child_running = false;
+        return err;
+    }
     const raw_bytes = drain.bytes orelse return error.Unexpected;
 
     _ = try child.wait();

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -98,7 +98,7 @@ pub fn listProfiles(alloc: Allocator, include_ssh_hosts: bool) ![]Profile {
         order_hint,
         null,
     );
-    return try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts);
+    return try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts, null);
 }
 
 pub fn discoverProfiles(alloc: Allocator, include_ssh_hosts: bool) !ProfileDiscovery {
@@ -115,7 +115,7 @@ pub fn discoverProfiles(alloc: Allocator, include_ssh_hosts: bool) !ProfileDisco
         &complete,
     );
     return .{
-        .profiles = try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts),
+        .profiles = try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts, &complete),
         .complete = complete,
     };
 }
@@ -124,6 +124,7 @@ fn appendConfiguredSshProfiles(
     alloc: Allocator,
     shell_profiles: []Profile,
     include_ssh_hosts: bool,
+    complete: ?*bool,
 ) ![]Profile {
     if (!include_ssh_hosts) return shell_profiles;
 
@@ -132,6 +133,7 @@ fn appendConfiguredSshProfiles(
     // "no profiles at all" and would leave the user with no picker.
     const hosts = windows_ssh_hosts.load(alloc) catch |err| {
         warnSshDiscoveryOnce(err);
+        if (complete) |value| value.* = false;
         return shell_profiles;
     };
     defer windows_ssh_hosts.deinitHosts(alloc, hosts);
@@ -139,6 +141,7 @@ fn appendConfiguredSshProfiles(
 
     const ssh_path = resolveSshExecutable(alloc, lookupExecutable, accessAbsolute) catch |err| {
         warnSshDiscoveryOnce(err);
+        if (complete) |value| value.* = false;
         return shell_profiles;
     };
     if (ssh_path == null) {
@@ -1028,15 +1031,16 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
 
     drain_thread.join();
     drain_joined = true;
+    const term = try child.wait();
+    child_running = false;
     if (drain.err) |err| {
-        _ = try child.wait();
-        child_running = false;
         return err;
     }
+    if (!childTermSucceeded(term)) {
+        log.warn("WSL distro enumeration exited unsuccessfully exe={s}", .{exe_path});
+        return error.WslListFailed;
+    }
     const raw_bytes = drain.bytes orelse return error.Unexpected;
-
-    _ = try child.wait();
-    child_running = false;
 
     // wsl.exe outputs UTF-16LE. Convert to UTF-8 before parsing.
     // bytesAsSlice returns align(1) u16, but utf16LeToUtf8Alloc needs align(2).
@@ -1072,6 +1076,13 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
     }
 
     return try result.toOwnedSlice(alloc);
+}
+
+fn childTermSucceeded(term: std.process.Child.Term) bool {
+    return switch (term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
 }
 
 /// Returns true for WSL distros that are internal service distributions
@@ -1409,6 +1420,12 @@ test "profile discovery reports a retryable WSL probe failure" {
     try testing.expect(complete);
     try testing.expectEqual(@as(usize, 2), recovered.len);
     try testing.expectEqual(ProfileKind.wsl_default, recovered[0].kind);
+}
+
+test "WSL enumeration requires a successful child exit" {
+    try std.testing.expect(childTermSucceeded(.{ .Exited = 0 }));
+    try std.testing.expect(!childTermSucceeded(.{ .Exited = 1 }));
+    try std.testing.expect(!childTermSucceeded(.{ .Unknown = 1 }));
 }
 
 test "ssh profiles append after shells with alias-only argv" {

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -12,6 +12,7 @@ const wsl_probe_timeout_ms: windows.DWORD = 1500;
 const wsl_list_timeout_ms: windows.DWORD = 1500;
 var wsl_probe_mutex: std.Thread.Mutex = .{};
 var wsl_probe_cache: ?bool = null;
+var wsl_profile_probe_cache: ?bool = null;
 var ssh_missing_mutex: std.Thread.Mutex = .{};
 var ssh_missing_logged = false;
 const wsl_shell_integration_next_step =
@@ -54,6 +55,11 @@ pub const Profile = struct {
     }
 };
 
+pub const ProfileDiscovery = struct {
+    profiles: []Profile,
+    complete: bool,
+};
+
 /// Determine the default shell order for Windows:
 /// WSL -> pwsh -> powershell -> cmd.
 pub fn defaultShell(alloc: Allocator) !DefaultShell {
@@ -90,7 +96,35 @@ pub fn listProfiles(alloc: Allocator, include_ssh_hosts: bool) ![]Profile {
         probeWslExecutableCached,
         listWslDistros,
         order_hint,
+        null,
     );
+    return try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts);
+}
+
+pub fn discoverProfiles(alloc: Allocator, include_ssh_hosts: bool) !ProfileDiscovery {
+    const order_hint = detectProfileOrderHint(alloc);
+    defer if (order_hint) |value| alloc.free(value);
+
+    var complete = true;
+    const shell_profiles = try listProfilesWithLookupAndProbeAndWslListAndOrder(
+        alloc,
+        lookupExecutable,
+        probeWslExecutableForProfiles,
+        listWslDistros,
+        order_hint,
+        &complete,
+    );
+    return .{
+        .profiles = try appendConfiguredSshProfiles(alloc, shell_profiles, include_ssh_hosts),
+        .complete = complete,
+    };
+}
+
+fn appendConfiguredSshProfiles(
+    alloc: Allocator,
+    shell_profiles: []Profile,
+    include_ssh_hosts: bool,
+) ![]Profile {
     if (!include_ssh_hosts) return shell_profiles;
 
     // SSH discovery is additive. Any failure below degrades to the detected
@@ -450,6 +484,7 @@ fn listProfilesWithLookupAndProbeAndWslList(
         probe,
         list_wsl,
         null,
+        null,
     );
 }
 
@@ -459,6 +494,7 @@ fn listProfilesWithLookupAndProbeAndWslListAndOrder(
     probe: anytype,
     list_wsl: anytype,
     order_hint: ?[]const u8,
+    complete: ?*bool,
 ) ![]Profile {
     var profiles: std.ArrayList(Profile) = .empty;
     errdefer {
@@ -469,7 +505,10 @@ fn listProfilesWithLookupAndProbeAndWslListAndOrder(
     if (try lookup(alloc, "wsl.exe")) |path| {
         defer alloc.free(path);
 
-        if (try probe(alloc, path)) {
+        const wsl_ready = try probe(alloc, path);
+        if (!wsl_ready) {
+            if (complete) |value| value.* = false;
+        } else {
             try appendProfile(
                 alloc,
                 &profiles,
@@ -734,6 +773,21 @@ fn probeWslExecutableCached(alloc: Allocator, exe_path: []const u8) !bool {
 
     const result = try probeWslExecutable(alloc, exe_path);
     wsl_probe_cache = result;
+    return result;
+}
+
+fn probeWslExecutableForProfiles(alloc: Allocator, exe_path: []const u8) !bool {
+    if (builtin.os.tag != .windows) return true;
+
+    wsl_probe_mutex.lock();
+    defer wsl_probe_mutex.unlock();
+
+    if ((wsl_profile_probe_cache orelse false) or (wsl_probe_cache orelse false)) return true;
+
+    const result = try probeWslExecutable(alloc, exe_path);
+    // Profile discovery keeps transient negative results retryable while a
+    // successful probe remains stable for later palette/jump-list refreshes.
+    if (result) wsl_profile_probe_cache = true;
     return result;
 }
 
@@ -1309,6 +1363,54 @@ test "listProfilesWithLookupAndProbeAndWslList enumerates windows profiles" {
     try testing.expectEqual(ProfileKind.cmd, profiles[6].kind);
 }
 
+test "profile discovery reports a retryable WSL probe failure" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var complete = true;
+    const profiles = try listProfilesWithLookupAndProbeAndWslListAndOrder(alloc, struct {
+        fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
+            if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
+            if (std.mem.eql(u8, exe, "cmd.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\cmd.exe");
+            return null;
+        }
+    }.lookup, struct {
+        fn probe(_: Allocator, _: []const u8) !bool {
+            return false;
+        }
+    }.probe, struct {
+        fn list(_: Allocator, _: []const u8) ![][]u8 {
+            return error.UnexpectedWslList;
+        }
+    }.list, null, &complete);
+    defer deinitProfiles(alloc, profiles);
+
+    try testing.expect(!complete);
+    try testing.expectEqual(@as(usize, 1), profiles.len);
+    try testing.expectEqual(ProfileKind.cmd, profiles[0].kind);
+
+    complete = true;
+    const recovered = try listProfilesWithLookupAndProbeAndWslListAndOrder(alloc, struct {
+        fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
+            if (std.mem.eql(u8, exe, "wsl.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\wsl.exe");
+            if (std.mem.eql(u8, exe, "cmd.exe")) return try a.dupe(u8, "C:\\Windows\\System32\\cmd.exe");
+            return null;
+        }
+    }.lookup, struct {
+        fn probe(_: Allocator, _: []const u8) !bool {
+            return true;
+        }
+    }.probe, struct {
+        fn list(a: Allocator, _: []const u8) ![][]u8 {
+            return try a.alloc([]u8, 0);
+        }
+    }.list, null, &complete);
+    defer deinitProfiles(alloc, recovered);
+    try testing.expect(complete);
+    try testing.expectEqual(@as(usize, 2), recovered.len);
+    try testing.expectEqual(ProfileKind.wsl_default, recovered[0].kind);
+}
+
 test "ssh profiles append after shells with alias-only argv" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -1457,7 +1559,7 @@ test "listProfilesWithLookupAndProbeAndWslListAndOrder reorders windows profiles
             try values.append(alloc_, try alloc_.dupe(u8, "Debian"));
             return try values.toOwnedSlice(alloc_);
         }
-    }.list, "git,pwsh,Ubuntu,cmd");
+    }.list, "git,pwsh,Ubuntu,cmd", null);
     defer deinitProfiles(alloc, profiles);
 
     try testing.expectEqual(@as(usize, 7), profiles.len);

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -9,6 +9,7 @@ const log = std.log.scoped(.windows_shell);
 const windows = std.os.windows;
 
 const wsl_probe_timeout_ms: windows.DWORD = 1500;
+const wsl_list_timeout_ms: windows.DWORD = 1500;
 var wsl_probe_mutex: std.Thread.Mutex = .{};
 var wsl_probe_cache: ?bool = null;
 var ssh_missing_mutex: std.Thread.Mutex = .{};
@@ -911,8 +912,9 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
     child.create_no_window = true;
 
     try child.spawn();
+    var child_running = true;
     errdefer {
-        _ = child.kill() catch {};
+        if (child_running) _ = child.kill() catch {};
     }
 
     const stdout = child.stdout orelse {
@@ -920,10 +922,30 @@ fn listWslDistros(alloc: Allocator, exe_path: []const u8) ![][]u8 {
         return error.Unexpected;
     };
 
+    windows.WaitForSingleObjectEx(child.id, wsl_list_timeout_ms, false) catch |err| switch (err) {
+        error.WaitTimeOut => {
+            log.warn("WSL distro enumeration timed out exe={s} timeout_ms={}", .{
+                exe_path,
+                wsl_list_timeout_ms,
+            });
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
+            child_running = false;
+            return error.WslListTimeout;
+        },
+        else => {
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
+            child_running = false;
+            return err;
+        },
+    };
+
     const raw_bytes = try stdout.readToEndAlloc(alloc, 64 * 1024);
     defer alloc.free(raw_bytes);
 
     _ = try child.wait();
+    child_running = false;
 
     // wsl.exe outputs UTF-16LE. Convert to UTF-8 before parsing.
     // bytesAsSlice returns align(1) u16, but utf16LeToUtf8Alloc needs align(2).


### PR DESCRIPTION
## Summary  Adds a native Windows taskbar jump list. Right-clicking the noctty taskbar button (pinned or running) offers a **Recent** category of recently used working directories and a **Profiles** category of the detected shell profiles; clicking an entry launches noctty into that directory or profile. Recents survive restarts.  This is roadmap entry C12 and the first half of PRODUCT.md design principle 6 ("compete on every path into a terminal").  Fixes #126  ## Changes  - New `src/apprt/win32_jump_list.zig`: `ICustomDestinationList` + `IObjectCollection` / `IObjectArray` / `IShellLinkW` / `IPropertyStore` over hand-written COM vtables, in the same raw style as `win32_taskbar_progress.zig`. No COM framework was introduced. - Every link carries `System.AppUserModel.ID` = `io.github.amanthanvi.noctty` (matching `win32_aumid.zig`) so the list attaches to the pinned taskbar button, plus `PKEY_Title`, the current exe as target, and the exe as icon. - **Recent**: drive-absolute local paths observed from the pwd stream that OSC 7 / OSC 9;9 already feed into surfaces, Unicode case-insensitively deduped via `CompareStringOrdinal`, newest first, capped at 10, persisted atomically at `%LOCALAPPDATA%\noctty\jump-list-recents.json` through the existing `win32_session_persistence` helpers (no new store; that module only gains a `pub` on its existing bounded reader). - **Profiles**: the same `windows_shell.Profile` list the in-app picker uses; links pass `--command=` / `--initial-command=` with the profile's argv, so no new CLI flag or config key was added. - Rebuilds run at startup and after real model changes, behind a 500 ms debounce on the existing `WM_TIMER` path. Profile discovery is deliberately deferred until after the message loop is pumping so a slow `wsl.exe` enumeration cannot stall startup. - The shell's removed-destination list is honored each cycle; transient COM failures keep the model dirty and retry under a bounded budget, `CO_E_NOTINITIALIZED` disables rebuilds for the process, and an incomplete removed-list read aborts the transaction rather than publishing an empty list. Every HRESULT failure degrades silently to a debug/warn log. - `src/apprt/win32.zig` gains only additive hooks: one field, init/deinit, a `WM_TIMER` branch, and pwd / profile-refresh notifications. - Docs: `docs/status.md` row, a "Launch topology" section in `docs/windows.md` (categories, storage path, how to clear), `docs/windows-capability-matrix.md` row. - A comment marks where named layouts (C17, #133) will add a third category and points at `win32_layouts.listNamesAlloc` / `launchArgvAlloc` from #186 so the follow-up consumes that hook instead of enumerating layouts here. No code for it in this PR.  ## Validation  Run in the team worktree at this commit:  - `zig fmt --check src` → only `src/build/uucode_tables.zig`, a generated file that is unformatted at baseline on `main`; every touched file is clean. - `zig build -Demit-exe=true` → pass. - `zig build test -Dtest-filter=jump_list` → 41/41 build steps, 76/77 tests passed, 1 skipped (the pre-existing baseline skip). - `zig build test -Dtest-filter=session` → 41/41 build steps, 108/109 tests passed, 1 skipped. - Rebased onto `main` @ 5220df49e and squashed to one commit. Re-validated there: `zig build -Demit-exe=true` pass, `zig build test -Dtest-filter=jump_list` 77/78 passed, `zig build test -Dtest-filter=session` 109/110 passed. - The one conflict with #177 was the `WM_TIMER` → `c.WM_TIMER` rename. While resolving it I also converted this module's duplicated `CoCreateInstance` / `GetCurrentProcessId` / `SetTimer` / `KillTimer` externs into `const X = sys.X;` aliases against `src/apprt/win32/sys.zig`, so it follows the post-#177 convention and cannot drift. `CompareStringOrdinal` is not in `sys.zig` and stays local. - `pwsh -NoProfile -File scripts/check-source-format.ps1` → pass. - Full suite `zig build test -Demit-test-exe=true` on the `issues/127-explorer-context-menu` tip (which contains both PRs) → 41/41 build steps, 3790/3860 tests passed, 70 skipped, **0 failed**. - `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` → `Windows x64 baseline checker probes: PASS`, `flagship verification contracts: PASS (2 scenarios)`.  Unit tests cover recent ordering/dedupe/cap and non-local rejection, JSON round-trip plus corrupt and oversized state, encoded-size limit and tombstone eviction, argument construction and Windows argv boundaries, slot budgeting, the retry cap, and vtable/`PROPERTYKEY`/`PROPVARIANT` field offsets.  An independent read-only review of this diff found no double-release, use-after-release, leak, ABI mismatch, or CLI-injection path, and confirmed the argument quoting round-trips through a live `CommandLineToArgvW` probe. Its four material findings (pre-message-loop WSL stall, a dropped rebuild after transient COM failure, an unbounded 2 Hz retry loop, and a writer that could exceed its own reader's size limit) are fixed in the first commit. Greptile then flagged that the deferred startup tick looked for a host through `primarySurface()`, which is null under `initial-window=false`. It now reads `hosts` directly, and host creation re-arms the debounce (`scheduleIfStartupPending`) so a windowless launch is not stranded without a Profiles category.  This PR deliberately does not consume #186's `win32_layouts` seam or stack on it — named layouts are C17/#133, out of scope here. The comment hook names the exact API so the follow-up plugs in without reimplementing anything.  ### Adversarial review dispositions (R-126/127, verdict APPROVE)  - **LOW, OSC-forged recents** — fixed as far as it can be. A program inside a session can emit OSC 7 for any path that passes `isRecentLocalPath` and seed a Recent entry; that is inherent to the data source and activating an entry only sets a cwd. `buildTitleAlloc` now strips Unicode bidi/isolate controls (U+061C, U+200E/F, U+202A–E, U+2066–9) so a seeded entry cannot render as a path it does not point at, with a test covering a U+202E spoof, ordinary CJK/emoji, and invalid UTF-8. The provenance caveat is now a module-doc paragraph. - **LOW, `WM_TIMER` swallow** — fixed. The debounce is a thread timer (`SetTimer(null, ...)`), so the swallow now requires `@intFromPtr(msg.hwnd) == 0` and cannot eat a window timer whose numeric id collides. (`msg.hwnd` is non-optional `HWND` in `sys.MSG`, hence the `@intFromPtr` form rather than `== null`.) - **TRIM** — taken. The two pure `alloc.dupe` title wrappers are gone, replaced by the single `buildTitleAlloc` above; `writeWindowsArg` is gone and the four call sites use `Command.writeDirectArg` directly. - **INFO, UI-thread fsync** — unchanged, documented at `persist()`. Cross-process recent and profile mutations are serialized under a nonblocking file lock and reconciled by per-key nanosecond event order.  ## Residuals / user steps  - **Not validated on a live desktop.** The agent session had no interactive desktop (`GetForegroundWindow() == 0`, no `Shell_TrayWnd`), so `CommitList` was rejected and no screenshots could be produced. Someone should, in a normal interactive session: pin the built `noctty.exe`, `cd` around a couple of directories, restart it, right-click the taskbar button, and confirm both categories render and both kinds of entry launch correctly. - The debounced fsync and the COM commit run on the UI thread. This is deliberate — it matches how session state is already written, and moving it to a worker is more machinery than this feature warrants — but pathological storage or antivirus latency would be felt as UI stall. - Concurrent noctty processes serialize jump-list state updates through `jump-list-recents.json.lock`. Each writer reloads the latest snapshot under the lock and applies only its pending recent/profile events; explicit recent removals are persisted as bounded tombstones so another stale process cannot immediately resurrect them. - A jump list needs an AUMID-matching taskbar button; dev builds without the Start Menu shortcut rely on the explicit process AUMID, which is the same constraint the toast pipeline already has.  ## Summary by Sourcery  Add native Windows taskbar jump lists for launching noctty into recent working directories or detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles detected from the terminal's shell profiles, launching noctty with the selected destination.  Bug Fixes: - Preserve explicit working-directory launches instead of replacing them with restored session state. - Handle jump-list persistence and COM update failures without publishing incomplete or stale destination lists.  Enhancements: - Persist recent directories and profile visibility across restarts and concurrent noctty processes with bounded, atomic state management. - Update jump lists from terminal directory and profile activity using debounced refreshes and deferred profile discovery. - Honor Windows taskbar removal actions and protect displayed paths from Unicode bidi spoofing.  Documentation: - Document jump-list behavior, persistence, clearing instructions, and Windows capability support.  Tests: - Add coverage for recent ordering, deduplication, validation, persistence, argument construction, removal handling, concurrency ordering, slot budgets, retry limits, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add native Windows taskbar jump lists for launching noctty through recent directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists that launch noctty into recent working directories or detected shell profiles.  Bug Fixes: - Preserve explicitly requested startup working directories instead of replacing them with restored session state. - Handle taskbar removal updates, transient COM failures, incomplete destination data, and concurrent persistence without publishing stale or incomplete lists.  Enhancements: - Persist bounded recent-directory and profile visibility state across restarts and concurrent processes. - Refresh jump-list contents from shell activity with debounced updates and deferred, bounded profile discovery. - Protect displayed recent paths from Unicode bidirectional spoofing and enforce Windows jump-list slot budgets.  Documentation: - Document jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add native Windows taskbar jump lists for launching noctty through recent directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories instead of replacing them with restored session state. - Handle taskbar removals, transient failures, invalid persisted events, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from stalling startup.  Enhancements: - Persist bounded recent-directory and profile visibility state across restarts and concurrent processes. - Refresh jump lists from shell activity with debounced updates and deferred profile discovery. - Validate and normalize recent paths, protect displayed titles from Unicode bidirectional spoofing, and respect taskbar slot budgets.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories during startup instead of replacing them with restored session state. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from blocking startup.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Ensure explicit working-directory launches bypass session restoration and preserve their requested destination. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from blocking startup.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories during startup instead of replacing them with restored session state. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from blocking startup.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories during startup instead of allowing session restoration to replace them. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from blocking startup.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories during startup without disabling subsequent session saves. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent slow WSL profile enumeration from blocking startup.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump lists with Recent working directories and Profiles categories that launch noctty with the selected destination.  Bug Fixes: - Preserve explicitly requested working directories during startup without allowing session restoration to replace them. - Handle taskbar removals, transient failures, invalid persisted state, and incomplete destination data without publishing stale or incomplete lists. - Prevent WSL profile enumeration failures or slow output from blocking startup and ensure retries remain bounded.  Enhancements: - Persist bounded recent directories and profile visibility across restarts and concurrent processes with debounced, atomic state updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add Windows taskbar jump lists that provide reliable launch paths for recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump-list categories for recently used local working directories and detected shell profiles. - Launch noctty with the selected directory or profile from pinned or running taskbar buttons.  Bug Fixes: - Preserve explicitly requested startup working directories without allowing session restoration to replace them. - Handle taskbar removals, invalid or incomplete persisted state, transient COM failures, and slow or failing WSL discovery without publishing stale lists or blocking startup. - Preserve session saving behavior after startup-only restore bypasses.  Enhancements: - Persist bounded recent-directory and profile visibility state across restarts and concurrent processes with debounced, atomic updates. - Refresh destinations from shell directory and profile activity while enforcing slot budgets and protecting displayed paths from Unicode bidirectional spoofing. - Bound and safely drain WSL profile enumeration.  Documentation: - Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrency ordering, retry limits, slot budgets, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.  ## Summary by Sourcery  Add reliable Windows taskbar jump lists for launching noctty through recent working directories and detected shell profiles.  New Features: - Add native Windows taskbar jump-list categories for recently used local working directories and detected shell profiles, with entries that launch noctty into the selected destination.  Bug Fixes: - Preserve explicitly requested startup working directories without allowing session restoration to replace them. - Handle taskbar removals, invalid or incomplete persisted state, transient COM failures, and WSL discovery failures without publishing stale lists or blocking startup. - Preserve session saving behavior when startup-only session restoration is bypassed.  Enhancements: - Persist bounded recent-directory and profile visibility state across restarts and concurrent processes with debounced, atomic updates. - Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety. - Bound WSL profile discovery and allow deferred startup discovery to recover after transient failures.  Documentation: - Document jump-list categories, persistence and clearing behavior, and Windows capability support.  Tests: - Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrent event ordering, retry limits, slot budgets, profile discovery, and Win32 ABI contracts.  Chores: - Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.

## Summary by Sourcery

Add reliable Windows taskbar jump lists for launching noctty through recent working directories and detected shell profiles.

New Features:
- Add native Windows taskbar jump-list categories for recently used local working directories and detected shell profiles, with entries that launch noctty into the selected destination.

Bug Fixes:
- Preserve explicitly requested startup working directories without allowing session restoration to replace them.
- Handle taskbar removals, invalid or incomplete persisted state, transient COM failures, and WSL discovery failures without publishing stale lists or blocking startup.
- Preserve session saving behavior when startup-only session restoration is bypassed.

Enhancements:
- Persist bounded recent-directory and profile visibility state across restarts and concurrent processes with debounced, atomic updates.
- Refresh jump-list contents from shell activity and profile changes while respecting removal actions, slot budgets, and Unicode bidirectional-text safety.
- Bound WSL profile discovery and allow deferred startup discovery to recover after transient failures.

Documentation:
- Document taskbar jump-list categories, persistence and clearing behavior, and Windows capability support.

Tests:
- Add coverage for recent-directory validation, ordering, deduplication, persistence, argument construction, removal handling, concurrent event ordering, retry limits, slot budgets, profile discovery, and Win32 ABI contracts.

Chores:
- Expose bounded file reading from the existing Windows session persistence module for jump-list state loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  ## New Features - Added native Windows taskbar jump lists for quickly launching recent working directories and detected shell profiles. - Jump-list entries are available from pinned or running taskbar buttons and persist across sessions. - Removed destinations are tracked and can be cleared when no longer available.  ## Bug Fixes - Improved Windows Subsystem for Linux distribution detection to avoid hangs and handle timeouts safely. - Explicit working-directory launches no longer restore previous sessions unexpectedly.  ## Documentation - Documented jump-list availability, behavior, persistence, and clearing instructions. <!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Final review-cycle validation

- Exact pushed head: `7b152d1deff45cc42f7d0eaaf680796701d5e5b1` on current `main` base `dae792245e77b3aa45e5248a4dba5fd91971b39d`.
- `zig fmt --check src/apprt/win32.zig src/config/windows_shell.zig` and `git diff --check` pass.
- `zig build test -Dtest-filter=WSL`, `zig build test -Dtest-filter=jump_list`, and the full `zig build test -Demit-test-exe=true` suite pass; emitted access-denied and file-lock traces are expected negative-test diagnostics.
- Final review fixes keep incomplete config-change profile refreshes pending, treat non-successful WSL enumeration exits as incomplete, and propagate transient SSH discovery failures into the existing bounded retry lifecycle.
- The three matching review threads were replied to and resolved; CodeRabbit, Greptile, and Codex were retriggered on this exact head.