### PR TITLE
feat(win32): Explorer "Open noctty here" context menu (#127)

### DIFF
--- a/dist/windows/noctty.iss
+++ b/dist/windows/noctty.iss
@@ -100,15 +100,6 @@ Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; Val
 Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
 Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
 
-; Sweep the per-user copies that `noctty +register-shell-menu` writes (portable
-; builds opt in that way). HKCU\Software\Classes OVERRIDES HKLM in the merged HKCR
-; view, so a stale per-user verb would both shadow the installer's verbs and
-; survive uninstall with no `+unregister-shell-menu` left to remove it.
-; `dontcreatekey` means these rows only ever delete.
-Root: HKCU; Subkey: "Software\Classes\Directory\shell\noctty"; Flags: uninsdeletekey dontcreatekey
-Root: HKCU; Subkey: "Software\Classes\Directory\Background\shell\noctty"; Flags: uninsdeletekey dontcreatekey
-Root: HKCU; Subkey: "Software\Classes\Drive\shell\noctty"; Flags: uninsdeletekey dontcreatekey
-
 [Run]
 Filename: "{app}\noctty.exe"; Description: "Launch noctty"; Flags: nowait postinstall skipifsilent
 

--- a/dist/windows/noctty.iss
+++ b/dist/windows/noctty.iss
@@ -45,7 +45,7 @@ ArchitecturesInstallIn64BitMode=arm64
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 #endif
-ChangesAssociations=no
+ChangesAssociations=yes
 CloseApplications=yes
 RestartApplications=yes
 UninstallDisplayIcon={app}\noctty.exe

--- a/dist/windows/noctty.iss
+++ b/dist/windows/noctty.iss
@@ -88,17 +88,17 @@ Root: HKLM; Subkey: "Software\Classes\CLSID\{{1D349824-21FB-46C7-ACF3-746EDC991D
 ; Shared Interface\{IID}\ProxyStubClsid32 values are registered per-user by
 ; +register-default-terminal so their prior values can be restored safely.
 
-Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
-Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: "{code:ShellMenuCommand}"; Flags: uninsdeletevalue uninsdeletekeyifempty
 
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: "{code:ShellMenuCommand}"; Flags: uninsdeletevalue uninsdeletekeyifempty
 
-Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
-Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: "{code:ShellMenuCommand}"; Flags: uninsdeletevalue uninsdeletekeyifempty
 
 [Run]
 Filename: "{app}\noctty.exe"; Description: "Launch noctty"; Flags: nowait postinstall skipifsilent
@@ -135,4 +135,13 @@ begin
       '',
       RegisteredProxy) and
     (CompareText(RegisteredProxy, ExpectedProxy) = 0);
+end;
+
+function ShellMenuCommand(Param: String): String;
+var
+  ExePath: String;
+begin
+  ExePath := ExpandConstant('{app}\noctty.exe');
+  StringChangeEx(ExePath, '%', '%%', True);
+  Result := AddQuotes(ExePath) + ' --working-directory="%V\."';
 end;

--- a/dist/windows/noctty.iss
+++ b/dist/windows/noctty.iss
@@ -88,6 +88,27 @@ Root: HKLM; Subkey: "Software\Classes\CLSID\{{1D349824-21FB-46C7-ACF3-746EDC991D
 ; Shared Interface\{IID}\ProxyStubClsid32 values are registered per-user by
 ; +register-default-terminal so their prior values can be restored safely.
 
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
+Root: HKA; Subkey: "Software\Classes\Directory\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: ""; ValueData: "Open noctty here"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\noctty.exe"
+Root: HKA; Subkey: "Software\Classes\Drive\shell\noctty\command"; ValueType: string; ValueName: ""; ValueData: """{app}\noctty.exe"" --working-directory=""%V\."""
+
+; Sweep the per-user copies that `noctty +register-shell-menu` writes (portable
+; builds opt in that way). HKCU\Software\Classes OVERRIDES HKLM in the merged HKCR
+; view, so a stale per-user verb would both shadow the installer's verbs and
+; survive uninstall with no `+unregister-shell-menu` left to remove it.
+; `dontcreatekey` means these rows only ever delete.
+Root: HKCU; Subkey: "Software\Classes\Directory\shell\noctty"; Flags: uninsdeletekey dontcreatekey
+Root: HKCU; Subkey: "Software\Classes\Directory\Background\shell\noctty"; Flags: uninsdeletekey dontcreatekey
+Root: HKCU; Subkey: "Software\Classes\Drive\shell\noctty"; Flags: uninsdeletekey dontcreatekey
+
 [Run]
 Filename: "{app}\noctty.exe"; Description: "Launch noctty"; Flags: nowait postinstall skipifsilent
 

--- a/dist/windows/noctty.iss
+++ b/dist/windows/noctty.iss
@@ -143,5 +143,5 @@ var
 begin
   ExePath := ExpandConstant('{app}\noctty.exe');
   StringChangeEx(ExePath, '%', '%%', True);
-  Result := AddQuotes(ExePath) + ' --working-directory="%V\."';
+  Result := AddQuotes(ExePath) + ' --single-instance=false --working-directory="%V\."';
 end;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ Keep the whole extracted folder together: `noctty.exe` needs the
 `share` folder next to it for themes, terminfo, and shell integration.
 
 Portable users can opt into Explorer's `Open noctty here` verb with
-`.\noctty.exe +register-shell-menu`.
+`.\noctty.com +register-shell-menu`.
 
 Neither the installer nor the portable ZIP adds `noctty` to your
 PATH. The `noctty +...` commands below assume you've either added
@@ -242,7 +242,9 @@ is documented in [automation.md](automation.md).
 
 - Installer builds: _Settings → Apps → Installed apps → noctty →
   Uninstall_.
-- Portable builds: delete the folder you extracted to.
+- Portable builds: if you enabled `Open noctty here`, run
+  `.\noctty.com +unregister-shell-menu` first, then delete the folder you
+  extracted to.
 
 Your config and any crash logs live under `%LOCALAPPDATA%\noctty\`
 and are not removed by either path. Delete that folder manually for a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,6 +70,9 @@ or extract that file; delete it and download it again.
 Keep the whole extracted folder together: `noctty.exe` needs the
 `share` folder next to it for themes, terminfo, and shell integration.
 
+Portable users can opt into Explorer's `Open noctty here` verb with
+`.\noctty.exe +register-shell-menu`.
+
 Neither the installer nor the portable ZIP adds `noctty` to your
 PATH. The `noctty +...` commands below assume you've either added
 the folder containing `noctty.exe` to PATH or are running them from

--- a/docs/status.md
+++ b/docs/status.md
@@ -55,6 +55,9 @@ Win32-validated VT protocol coverage is tracked in
   picker and universal palette and launch through the system `ssh.exe`.
 - Native taskbar jump list with recent working directories and detected
   shell profiles.
+- Classic Explorer `Open noctty here` verbs for folders, folder backgrounds,
+  and drives, registered by the installer or explicitly per-user for portable
+  builds.
 - Per-monitor DPI scaling.
 - DWM dark title bar that follows the app theme.
 - High-contrast mode detection and palette switching.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -252,6 +252,46 @@ The taskbar jump list has two categories:
 - **Profiles** lists the detected shell profiles. Selecting an entry launches
   noctty with that profile's command.
 
+### Explorer context menu
+
+| Explorer target   | Classic verb key                    |
+| ----------------- | ----------------------------------- |
+| Selected folder   | `Directory\shell\noctty`            |
+| Folder background | `Directory\Background\shell\noctty` |
+| Drive             | `Drive\shell\noctty`                |
+
+Each verb is named `Open noctty here` and launches `noctty.exe` with
+`--working-directory="%V\."`. The trailing `\.` is required: Explorer
+expands `%V` for a drive root as `C:\`, and a backslash immediately before
+the closing quote would be read as an escaped quote when Windows splits the
+command line. The installer writes the verbs under
+`HKA\Software\Classes`. The current administrative install mode maps `HKA`
+to `HKLM` and `{autopf}` to the common Program Files directory. Inno Setup
+maps `HKA` to `HKCU` and `{autopf}` to the user Program Files directory in
+non-administrative install mode.
+
+Portable users opt in per-user under `HKCU\Software\Classes` with
+`noctty +register-shell-menu` and remove the same six owned keys with
+`noctty +unregister-shell-menu`. The running app does not register these
+verbs automatically and never writes them to `HKLM`.
+
+A per-user verb wins over a per-machine one, because `HKCU\Software\Classes`
+overrides `HKLM` in the merged `HKCR` view. So if you registered the verbs from
+a portable build and later install noctty per-machine, the per-user copy keeps
+pointing at the portable executable until you remove it. Uninstalling sweeps
+the per-user copies as well as its own, so a leftover verb cannot outlive the
+app it points at.
+
+On Windows 11, these classic verbs appear under **Show more options**.
+`Shift+F10` opens the classic menu directly. A top-level modern command is
+not shipped. Shipping one requires a sparse MSIX manifest with package
+identity, an `IExplorerCommand` COM server, `windows.comServer` plus
+`Windows.FileExplorerContextMenus` (`windows.fileExplorerContextMenus` in
+the manifest) extension registration, and a signed package whose Publisher
+matches the signing certificate. The current self-signed release certificate
+must be trusted explicitly on each machine before Windows accepts that
+package.
+
 ## Notifications and progress
 
 Desktop notifications use WinRT toasts when available and fall back to

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -261,7 +261,10 @@ The taskbar jump list has two categories:
 | Drive             | `Drive\shell\noctty`                |
 
 Each verb is named `Open noctty here` and launches `noctty.exe` with
-`--working-directory="%V\."`. The trailing `\.` is required: Explorer
+`--single-instance=false --working-directory="%V\."`. The explicit new
+instance keeps the selected path in the launched process, so UNC folders do
+not cross the single-instance IPC boundary that deliberately rejects UNC
+working directories. The trailing `\.` is required: Explorer
 expands `%V` for a drive root as `C:\`, and a backslash immediately before
 the closing quote would be read as an escaped quote when Windows splits the
 command line. The installer writes the verbs under

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -278,9 +278,10 @@ verbs automatically and never writes them to `HKLM`.
 A per-user verb wins over a per-machine one, because `HKCU\Software\Classes`
 overrides `HKLM` in the merged `HKCR` view. So if you registered the verbs from
 a portable build and later install noctty per-machine, the per-user copy keeps
-pointing at the portable executable until you remove it. Uninstalling sweeps
-the per-user copies as well as its own, so a leftover verb cannot outlive the
-app it points at.
+pointing at the portable executable until you remove it. Before deleting a
+portable copy, run `.\noctty.com +unregister-shell-menu` as the same user that
+registered the verbs. The installer uninstaller removes only its own
+registration; it does not remove portable per-user registrations.
 
 On Windows 11, these classic verbs appear under **Show more options**.
 `Shift+F10` opens the classic menu directly. A top-level modern command is

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -26,6 +26,7 @@ pub const win32_settings_transaction = @import("apprt/win32_settings_transaction
 pub const win32_universal_palette = @import("apprt/win32_universal_palette.zig");
 pub const win32_tab_drop_zones = @import("apprt/win32_tab_drop_zones.zig");
 pub const win32_compositor = @import("apprt/win32_compositor.zig");
+pub const win32_shell_menu = @import("apprt/win32_shell_menu.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = none;
 pub const surface = @import("apprt/surface.zig");
@@ -76,4 +77,5 @@ test {
     _ = win32_tab_drop_zones;
     _ = win32_compositor;
     _ = win32_shell;
+    _ = win32_shell_menu;
 }

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -783,7 +783,8 @@ pub extern "advapi32" fn RegCreateKeyExW(
 
 pub extern "advapi32" fn RegSetValueExW(
     hKey: HKEY,
-    lpValueName: LPCWSTR,
+    // Optional: null names the key's default value.
+    lpValueName: ?LPCWSTR,
     Reserved: DWORD,
     dwType: DWORD,
     lpData: [*]const u8,

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -28,6 +28,13 @@ extern "advapi32" fn RegDeleteKeyExW(
     Reserved: DWORD,
 ) callconv(.winapi) i32;
 
+extern "shell32" fn SHChangeNotify(
+    wEventId: i32,
+    uFlags: u32,
+    dwItem1: ?*const anyopaque,
+    dwItem2: ?*const anyopaque,
+) callconv(.winapi) void;
+
 const HKEY_CURRENT_USER: HKEY = @ptrFromInt(consts.HKEY_CURRENT_USER);
 const KEY_WRITE: REGSAM = 0x20006;
 const REG_OPTION_NON_VOLATILE: DWORD = 0;
@@ -36,6 +43,8 @@ const ERROR_SUCCESS: i32 = consts.ERROR_SUCCESS;
 const ERROR_FILE_NOT_FOUND: i32 = consts.ERROR_FILE_NOT_FOUND;
 const ERROR_PATH_NOT_FOUND: i32 = 3;
 const REG_CREATED_NEW_KEY: DWORD = 1;
+const SHCNE_ASSOCCHANGED: i32 = 0x08000000;
+const SHCNF_IDLIST: u32 = 0;
 
 pub const display_name = "Open noctty here";
 
@@ -146,6 +155,7 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
         }
     }
 
+    notifyExplorerAssociationsChanged();
     return .success;
 }
 
@@ -153,6 +163,7 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
 /// Missing keys are successful no-ops.
 pub fn unregister(alloc: Allocator) ![unregister_key_paths.len]DeleteResult {
     var results: [unregister_key_paths.len]DeleteResult = undefined;
+    var removed_any = false;
     for (unregister_key_paths, 0..) |path, i| {
         const path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, path);
         defer alloc.free(path_wide);
@@ -163,12 +174,20 @@ pub fn unregister(alloc: Allocator) ![unregister_key_paths.len]DeleteResult {
             0,
             0,
         )) {
-            ERROR_SUCCESS => .removed,
+            ERROR_SUCCESS => removed: {
+                removed_any = true;
+                break :removed .removed;
+            },
             ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND => .absent,
             else => |status| .{ .failed = status },
         };
     }
+    if (removed_any) notifyExplorerAssociationsChanged();
     return results;
+}
+
+fn notifyExplorerAssociationsChanged() void {
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, null, null);
 }
 
 fn writeVerbKey(

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -175,10 +175,14 @@ pub fn executablePathAlloc(alloc: Allocator, self_path: []const u8) ![]u8 {
 /// keeps the last character before the quote non-backslash for every target,
 /// and `C:\\.` / `C:\dir\.` both resolve to the intended directory.
 pub fn commandValueAlloc(alloc: Allocator, exe_path: []const u8) ![]u8 {
+    // The Shell command template treats `%%` as one literal percent. Escape
+    // the executable path before adding our one intentional `%V` target.
+    const escaped_exe_path = try std.mem.replaceOwned(u8, alloc, exe_path, "%", "%%");
+    defer alloc.free(escaped_exe_path);
     return try std.fmt.allocPrint(
         alloc,
         "\"{s}\" --working-directory=\"%V\\.\"",
-        .{exe_path},
+        .{escaped_exe_path},
     );
 }
 
@@ -588,10 +592,30 @@ fn expandAndParseForTest(
     command_value: []const u8,
     target: []const u8,
 ) ![]const []const u8 {
-    const expanded = try std.mem.replaceOwned(u8, alloc, command_value, "%V", target);
-    defer alloc.free(expanded);
+    var expanded: std.Io.Writer.Allocating = .init(alloc);
+    defer expanded.deinit();
+    var index: usize = 0;
+    while (index < command_value.len) {
+        if (command_value[index] == '%' and index + 1 < command_value.len) {
+            switch (command_value[index + 1]) {
+                '%' => {
+                    try expanded.writer.writeByte('%');
+                    index += 2;
+                    continue;
+                },
+                'V', 'v' => {
+                    try expanded.writer.writeAll(target);
+                    index += 2;
+                    continue;
+                },
+                else => {},
+            }
+        }
+        try expanded.writer.writeByte(command_value[index]);
+        index += 1;
+    }
 
-    const expanded_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, expanded);
+    const expanded_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, expanded.written());
     defer alloc.free(expanded_w);
 
     var iter = try std.process.ArgIteratorWindows.init(alloc, expanded_w);
@@ -657,6 +681,23 @@ test "shell-menu command survives Windows argv parsing for folders and drive roo
             argv[1],
         );
     }
+}
+
+test "shell-menu command preserves percent placeholders in the executable path" {
+    const testing = std.testing;
+    const exe = "C:\\Apps\\100%Valid\\noctty.exe";
+    const value = try commandValueAlloc(testing.allocator, exe);
+    defer testing.allocator.free(value);
+    try testing.expectEqualStrings(
+        "\"C:\\Apps\\100%%Valid\\noctty.exe\" --working-directory=\"%V\\.\"",
+        value,
+    );
+
+    const argv = try expandAndParseForTest(testing.allocator, value, "D:\\Work");
+    defer freeParsedForTest(testing.allocator, argv);
+    try testing.expectEqual(@as(usize, 2), argv.len);
+    try testing.expectEqualStrings(exe, argv[0]);
+    try testing.expectEqualStrings("--working-directory=D:\\Work\\.", argv[1]);
 }
 
 test "shell-menu display name is stable" {

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -35,6 +35,7 @@ const REG_SZ: DWORD = 1;
 const ERROR_SUCCESS: i32 = consts.ERROR_SUCCESS;
 const ERROR_FILE_NOT_FOUND: i32 = consts.ERROR_FILE_NOT_FOUND;
 const ERROR_PATH_NOT_FOUND: i32 = 3;
+const REG_CREATED_NEW_KEY: DWORD = 1;
 
 pub const display_name = "Open noctty here";
 
@@ -92,6 +93,11 @@ pub const DeleteResult = union(enum) {
     failed: i32,
 };
 
+const WriteResult = struct {
+    created: bool,
+    failure: ?RegistryFailure = null,
+};
+
 /// Resolve the GUI executable next to the current launcher. This intentionally
 /// avoids registering `noctty.com` when the action was reached through PATH.
 pub fn executablePathAlloc(alloc: Allocator, self_path: []const u8) ![]u8 {
@@ -120,11 +126,22 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
     const command_value = try commandValueAlloc(alloc, exe_path);
     defer alloc.free(command_value);
 
-    inline for (verb_key_paths, command_key_paths) |verb_path, command_path| {
-        if (try writeVerbKey(alloc, verb_path, exe_path)) |failure| {
+    var created = [_]bool{false} ** register_key_paths.len;
+    errdefer rollbackCreatedKeys(alloc, &created);
+    inline for (verb_key_paths, command_key_paths, 0..) |verb_path, command_path, pair_index| {
+        const verb_index = pair_index * 2;
+        const verb = try writeVerbKey(alloc, verb_path, exe_path);
+        created[verb_index] = verb.created;
+        if (verb.failure) |failure| {
+            rollbackCreatedKeys(alloc, &created);
             return .{ .failure = failure };
         }
-        if (try writeDefaultValue(alloc, command_path, command_value)) |failure| {
+
+        const command_index = verb_index + 1;
+        const command = try writeDefaultValue(alloc, command_path, command_value);
+        created[command_index] = command.created;
+        if (command.failure) |failure| {
+            rollbackCreatedKeys(alloc, &created);
             return .{ .failure = failure };
         }
     }
@@ -158,11 +175,12 @@ fn writeVerbKey(
     alloc: Allocator,
     key_path: []const u8,
     exe_path: []const u8,
-) !?RegistryFailure {
+) !WriteResult {
     const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
     defer alloc.free(key_path_wide);
 
     var key: HKEY = undefined;
+    var disposition: DWORD = 0;
     const create_status = RegCreateKeyExW(
         HKEY_CURRENT_USER,
         key_path_wide,
@@ -172,23 +190,25 @@ fn writeVerbKey(
         KEY_WRITE,
         null,
         &key,
-        null,
+        &disposition,
     );
-    if (create_status != ERROR_SUCCESS) return .{
+    if (create_status != ERROR_SUCCESS) return .{ .created = false, .failure = .{
         .operation = .create_key,
         .key_path = key_path,
         .status = create_status,
-    };
+    } };
+    const created = disposition == REG_CREATED_NEW_KEY;
+    errdefer if (created) deleteKeyBestEffort(alloc, key_path);
     defer _ = RegCloseKey(key);
 
     const display_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, display_name);
     defer alloc.free(display_wide);
     const display_status = writeRegSz(key, null, display_wide);
-    if (display_status != ERROR_SUCCESS) return .{
+    if (display_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
         .operation = .set_value,
         .key_path = key_path,
         .status = display_status,
-    };
+    } };
 
     const exe_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, exe_path);
     defer alloc.free(exe_path_wide);
@@ -197,24 +217,25 @@ fn writeVerbKey(
         std.unicode.utf8ToUtf16LeStringLiteral("Icon"),
         exe_path_wide,
     );
-    if (icon_status != ERROR_SUCCESS) return .{
+    if (icon_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
         .operation = .set_value,
         .key_path = key_path,
         .status = icon_status,
-    };
+    } };
 
-    return null;
+    return .{ .created = created };
 }
 
 fn writeDefaultValue(
     alloc: Allocator,
     key_path: []const u8,
     value: []const u8,
-) !?RegistryFailure {
+) !WriteResult {
     const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
     defer alloc.free(key_path_wide);
 
     var key: HKEY = undefined;
+    var disposition: DWORD = 0;
     const create_status = RegCreateKeyExW(
         HKEY_CURRENT_USER,
         key_path_wide,
@@ -224,25 +245,63 @@ fn writeDefaultValue(
         KEY_WRITE,
         null,
         &key,
-        null,
+        &disposition,
     );
-    if (create_status != ERROR_SUCCESS) return .{
+    if (create_status != ERROR_SUCCESS) return .{ .created = false, .failure = .{
         .operation = .create_key,
         .key_path = key_path,
         .status = create_status,
-    };
+    } };
+    const created = disposition == REG_CREATED_NEW_KEY;
+    errdefer if (created) deleteKeyBestEffort(alloc, key_path);
     defer _ = RegCloseKey(key);
 
     const value_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, value);
     defer alloc.free(value_wide);
     const set_status = writeRegSz(key, null, value_wide);
-    if (set_status != ERROR_SUCCESS) return .{
+    if (set_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
         .operation = .set_value,
         .key_path = key_path,
         .status = set_status,
-    };
+    } };
 
+    return .{ .created = created };
+}
+
+fn previousCreatedPath(created: []const bool, before: *usize) ?[]const u8 {
+    while (before.* > 0) {
+        before.* -= 1;
+        if (created[before.*]) return register_key_paths[before.*];
+    }
     return null;
+}
+
+fn rollbackCreatedKeys(alloc: Allocator, created: []const bool) void {
+    var before = created.len;
+    while (previousCreatedPath(created, &before)) |path| {
+        deleteKeyBestEffort(alloc, path);
+    }
+}
+
+fn deleteKeyBestEffort(alloc: Allocator, path: []const u8) void {
+    const path_wide = std.unicode.utf8ToUtf16LeAllocZ(alloc, path) catch |err| {
+        std.log.scoped(.win32_shell_menu).warn(
+            "shell-menu registration rollback path allocation failed path={s} err={}",
+            .{ path, err },
+        );
+        return;
+    };
+    defer alloc.free(path_wide);
+    const status = RegDeleteKeyExW(HKEY_CURRENT_USER, path_wide, 0, 0);
+    if (status != ERROR_SUCCESS and
+        status != ERROR_FILE_NOT_FOUND and
+        status != ERROR_PATH_NOT_FOUND)
+    {
+        std.log.scoped(.win32_shell_menu).warn(
+            "shell-menu registration rollback failed path={s} status={d}",
+            .{ path, status },
+        );
+    }
 }
 
 fn writeRegSz(hkey: HKEY, value_name: ?LPCWSTR, value: [:0]const u16) i32 {
@@ -399,6 +458,22 @@ test "shell-menu unregister key list is exact and leaf first" {
     for (expected, unregister_key_paths) |want, actual| {
         try testing.expectEqualStrings(want, actual);
     }
+}
+
+test "shell-menu registration rollback visits only newly created keys leaf first" {
+    const testing = std.testing;
+    const created = [_]bool{ true, true, false, true, false, false };
+    const expected = [_][]const u8{
+        command_key_paths[1],
+        command_key_paths[0],
+        verb_key_paths[0],
+    };
+
+    var before = created.len;
+    for (expected) |path| {
+        try testing.expectEqualStrings(path, previousCreatedPath(&created, &before).?);
+    }
+    try testing.expect(previousCreatedPath(&created, &before) == null);
 }
 
 test "shell-menu executable path targets the GUI binary" {

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -1,0 +1,412 @@
+//! Classic Explorer context-menu registration for noctty.
+//!
+//! The CLI actions use HKCU only. Installer registration is owned by Inno
+//! Setup so its registry root follows the selected install scope.
+
+const std = @import("std");
+const win32_types = @import("win32_types.zig");
+const consts = @import("win32/consts.zig");
+const sys = @import("win32/sys.zig");
+
+const Allocator = std.mem.Allocator;
+const DWORD = win32_types.DWORD;
+const LPCWSTR = win32_types.LPCWSTR;
+const HKEY = sys.HKEY;
+const REGSAM = u32;
+
+// Aliased from the shared Win32 surface rather than re-declared, so this
+// module cannot drift from src/apprt/win32/sys.zig.
+const RegCreateKeyExW = sys.RegCreateKeyExW;
+const RegSetValueExW = sys.RegSetValueExW;
+const RegCloseKey = sys.RegCloseKey;
+
+// Only this module deletes registry keys, so this one stays local.
+extern "advapi32" fn RegDeleteKeyExW(
+    hKey: HKEY,
+    lpSubKey: LPCWSTR,
+    samDesired: REGSAM,
+    Reserved: DWORD,
+) callconv(.winapi) i32;
+
+const HKEY_CURRENT_USER: HKEY = @ptrFromInt(consts.HKEY_CURRENT_USER);
+const KEY_WRITE: REGSAM = 0x20006;
+const REG_OPTION_NON_VOLATILE: DWORD = 0;
+const REG_SZ: DWORD = 1;
+const ERROR_SUCCESS: i32 = consts.ERROR_SUCCESS;
+const ERROR_FILE_NOT_FOUND: i32 = consts.ERROR_FILE_NOT_FOUND;
+const ERROR_PATH_NOT_FOUND: i32 = 3;
+
+pub const display_name = "Open noctty here";
+
+pub const verb_key_paths = [_][]const u8{
+    "Software\\Classes\\Directory\\shell\\noctty",
+    "Software\\Classes\\Directory\\Background\\shell\\noctty",
+    "Software\\Classes\\Drive\\shell\\noctty",
+};
+
+pub const command_key_paths = [_][]const u8{
+    "Software\\Classes\\Directory\\shell\\noctty\\command",
+    "Software\\Classes\\Directory\\Background\\shell\\noctty\\command",
+    "Software\\Classes\\Drive\\shell\\noctty\\command",
+};
+
+pub const register_key_paths = [_][]const u8{
+    verb_key_paths[0],
+    command_key_paths[0],
+    verb_key_paths[1],
+    command_key_paths[1],
+    verb_key_paths[2],
+    command_key_paths[2],
+};
+
+/// Delete child keys before their parents. This exact list is deliberately
+/// non-recursive so unexpected subkeys are preserved and reported as errors.
+pub const unregister_key_paths = [_][]const u8{
+    command_key_paths[0],
+    verb_key_paths[0],
+    command_key_paths[1],
+    verb_key_paths[1],
+    command_key_paths[2],
+    verb_key_paths[2],
+};
+
+pub const RegistryOperation = enum {
+    create_key,
+    set_value,
+};
+
+pub const RegistryFailure = struct {
+    operation: RegistryOperation,
+    key_path: []const u8,
+    status: i32,
+};
+
+pub const RegisterResult = union(enum) {
+    success,
+    failure: RegistryFailure,
+};
+
+pub const DeleteResult = union(enum) {
+    removed,
+    absent,
+    failed: i32,
+};
+
+/// Resolve the GUI executable next to the current launcher. This intentionally
+/// avoids registering `noctty.com` when the action was reached through PATH.
+pub fn executablePathAlloc(alloc: Allocator, self_path: []const u8) ![]u8 {
+    const dir = std.fs.path.dirname(self_path) orelse return error.FileNotFound;
+    return try std.fs.path.join(alloc, &.{ dir, "noctty.exe" });
+}
+
+/// Build the `command` default value.
+///
+/// The trailing `\.` is load-bearing. Explorer expands `%V` to a drive root
+/// as `C:\`, so a bare `"%V"` would end the quoted argument with a backslash
+/// immediately before the closing quote — `CommandLineToArgvW` reads that as
+/// an escaped quote and hands us `--working-directory=C:"`. Appending `\.`
+/// keeps the last character before the quote non-backslash for every target,
+/// and `C:\\.` / `C:\dir\.` both resolve to the intended directory.
+pub fn commandValueAlloc(alloc: Allocator, exe_path: []const u8) ![]u8 {
+    return try std.fmt.allocPrint(
+        alloc,
+        "\"{s}\" --working-directory=\"%V\\.\"",
+        .{exe_path},
+    );
+}
+
+/// Register the three per-user classic Explorer verbs.
+pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
+    const command_value = try commandValueAlloc(alloc, exe_path);
+    defer alloc.free(command_value);
+
+    inline for (verb_key_paths, command_key_paths) |verb_path, command_path| {
+        if (try writeVerbKey(alloc, verb_path, exe_path)) |failure| {
+            return .{ .failure = failure };
+        }
+        if (try writeDefaultValue(alloc, command_path, command_value)) |failure| {
+            return .{ .failure = failure };
+        }
+    }
+
+    return .success;
+}
+
+/// Remove only the six keys owned by `register`, in leaf-first order.
+/// Missing keys are successful no-ops.
+pub fn unregister(alloc: Allocator) ![unregister_key_paths.len]DeleteResult {
+    var results: [unregister_key_paths.len]DeleteResult = undefined;
+    for (unregister_key_paths, 0..) |path, i| {
+        const path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, path);
+        defer alloc.free(path_wide);
+
+        results[i] = switch (RegDeleteKeyExW(
+            HKEY_CURRENT_USER,
+            path_wide,
+            0,
+            0,
+        )) {
+            ERROR_SUCCESS => .removed,
+            ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND => .absent,
+            else => |status| .{ .failed = status },
+        };
+    }
+    return results;
+}
+
+fn writeVerbKey(
+    alloc: Allocator,
+    key_path: []const u8,
+    exe_path: []const u8,
+) !?RegistryFailure {
+    const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
+    defer alloc.free(key_path_wide);
+
+    var key: HKEY = undefined;
+    const create_status = RegCreateKeyExW(
+        HKEY_CURRENT_USER,
+        key_path_wide,
+        0,
+        null,
+        REG_OPTION_NON_VOLATILE,
+        KEY_WRITE,
+        null,
+        &key,
+        null,
+    );
+    if (create_status != ERROR_SUCCESS) return .{
+        .operation = .create_key,
+        .key_path = key_path,
+        .status = create_status,
+    };
+    defer _ = RegCloseKey(key);
+
+    const display_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, display_name);
+    defer alloc.free(display_wide);
+    const display_status = writeRegSz(key, null, display_wide);
+    if (display_status != ERROR_SUCCESS) return .{
+        .operation = .set_value,
+        .key_path = key_path,
+        .status = display_status,
+    };
+
+    const exe_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, exe_path);
+    defer alloc.free(exe_path_wide);
+    const icon_status = writeRegSz(
+        key,
+        std.unicode.utf8ToUtf16LeStringLiteral("Icon"),
+        exe_path_wide,
+    );
+    if (icon_status != ERROR_SUCCESS) return .{
+        .operation = .set_value,
+        .key_path = key_path,
+        .status = icon_status,
+    };
+
+    return null;
+}
+
+fn writeDefaultValue(
+    alloc: Allocator,
+    key_path: []const u8,
+    value: []const u8,
+) !?RegistryFailure {
+    const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
+    defer alloc.free(key_path_wide);
+
+    var key: HKEY = undefined;
+    const create_status = RegCreateKeyExW(
+        HKEY_CURRENT_USER,
+        key_path_wide,
+        0,
+        null,
+        REG_OPTION_NON_VOLATILE,
+        KEY_WRITE,
+        null,
+        &key,
+        null,
+    );
+    if (create_status != ERROR_SUCCESS) return .{
+        .operation = .create_key,
+        .key_path = key_path,
+        .status = create_status,
+    };
+    defer _ = RegCloseKey(key);
+
+    const value_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, value);
+    defer alloc.free(value_wide);
+    const set_status = writeRegSz(key, null, value_wide);
+    if (set_status != ERROR_SUCCESS) return .{
+        .operation = .set_value,
+        .key_path = key_path,
+        .status = set_status,
+    };
+
+    return null;
+}
+
+fn writeRegSz(hkey: HKEY, value_name: ?LPCWSTR, value: [:0]const u16) i32 {
+    return RegSetValueExW(
+        hkey,
+        value_name,
+        0,
+        REG_SZ,
+        @ptrCast(value.ptr),
+        @intCast((value.len + 1) * @sizeOf(u16)),
+    );
+}
+
+test "shell-menu key paths cover folders backgrounds and drives" {
+    const testing = std.testing;
+    try testing.expectEqual(@as(usize, 3), verb_key_paths.len);
+    try testing.expectEqualStrings(
+        "Software\\Classes\\Directory\\shell\\noctty",
+        verb_key_paths[0],
+    );
+    try testing.expectEqualStrings(
+        "Software\\Classes\\Directory\\Background\\shell\\noctty",
+        verb_key_paths[1],
+    );
+    try testing.expectEqualStrings(
+        "Software\\Classes\\Drive\\shell\\noctty",
+        verb_key_paths[2],
+    );
+}
+
+test "shell-menu command quotes an executable path containing spaces" {
+    const testing = std.testing;
+    const value = try commandValueAlloc(
+        testing.allocator,
+        "C:\\Program Files\\noctty\\noctty.exe",
+    );
+    defer testing.allocator.free(value);
+
+    try testing.expectEqualStrings(
+        "\"C:\\Program Files\\noctty\\noctty.exe\" --working-directory=\"%V\\.\"",
+        value,
+    );
+}
+
+/// Expand Explorer's `%V` and parse the result the way Windows does, so the
+/// tests below assert what noctty actually receives in `argv`.
+fn expandAndParseForTest(
+    alloc: Allocator,
+    command_value: []const u8,
+    target: []const u8,
+) ![]const []const u8 {
+    const expanded = try std.mem.replaceOwned(u8, alloc, command_value, "%V", target);
+    defer alloc.free(expanded);
+
+    const expanded_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, expanded);
+    defer alloc.free(expanded_w);
+
+    var iter = try std.process.ArgIteratorWindows.init(alloc, expanded_w);
+    defer iter.deinit();
+
+    var argv: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (argv.items) |item| alloc.free(item);
+        argv.deinit(alloc);
+    }
+    while (iter.next()) |arg| try argv.append(alloc, try alloc.dupe(u8, arg));
+    return try argv.toOwnedSlice(alloc);
+}
+
+fn freeParsedForTest(alloc: Allocator, argv: []const []const u8) void {
+    for (argv) |item| alloc.free(item);
+    alloc.free(argv);
+}
+
+test "shell-menu command survives Windows argv parsing for folders and drive roots" {
+    const testing = std.testing;
+    const exe = "C:\\Program Files\\noctty\\noctty.exe";
+    const value = try commandValueAlloc(testing.allocator, exe);
+    defer testing.allocator.free(value);
+
+    // A drive root is the case a bare `"%V"` gets wrong: Explorer expands it
+    // with a trailing backslash, which would escape the closing quote.
+    {
+        const argv = try expandAndParseForTest(testing.allocator, value, "C:\\");
+        defer freeParsedForTest(testing.allocator, argv);
+        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqualStrings(exe, argv[0]);
+        try testing.expectEqualStrings("--working-directory=C:\\\\.", argv[1]);
+    }
+
+    // A normal folder, including one whose name contains a space.
+    {
+        const argv = try expandAndParseForTest(
+            testing.allocator,
+            value,
+            "D:\\My Projects\\noctty",
+        );
+        defer freeParsedForTest(testing.allocator, argv);
+        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqualStrings(exe, argv[0]);
+        try testing.expectEqualStrings("--working-directory=D:\\My Projects\\noctty\\.", argv[1]);
+    }
+
+    // Non-ASCII folder names survive the UTF-8 -> UTF-16 -> argv round trip.
+    // `"` is illegal in an NTFS name, so there is no quote to break out with;
+    // these are the realistic hostile-looking names.
+    {
+        const argv = try expandAndParseForTest(
+            testing.allocator,
+            value,
+            "E:\\\u{9805}\u{76EE} \u{1F680}\\\u{5F00}\u{53D1}",
+        );
+        defer freeParsedForTest(testing.allocator, argv);
+        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqualStrings(exe, argv[0]);
+        try testing.expectEqualStrings(
+            "--working-directory=E:\\\u{9805}\u{76EE} \u{1F680}\\\u{5F00}\u{53D1}\\.",
+            argv[1],
+        );
+    }
+}
+
+test "shell-menu display name is stable" {
+    try std.testing.expectEqualStrings("Open noctty here", display_name);
+}
+
+test "shell-menu register key list is exact" {
+    const testing = std.testing;
+    const expected = [_][]const u8{
+        "Software\\Classes\\Directory\\shell\\noctty",
+        "Software\\Classes\\Directory\\shell\\noctty\\command",
+        "Software\\Classes\\Directory\\Background\\shell\\noctty",
+        "Software\\Classes\\Directory\\Background\\shell\\noctty\\command",
+        "Software\\Classes\\Drive\\shell\\noctty",
+        "Software\\Classes\\Drive\\shell\\noctty\\command",
+    };
+    try testing.expectEqual(expected.len, register_key_paths.len);
+    for (expected, register_key_paths) |want, actual| {
+        try testing.expectEqualStrings(want, actual);
+    }
+}
+
+test "shell-menu unregister key list is exact and leaf first" {
+    const testing = std.testing;
+    const expected = [_][]const u8{
+        "Software\\Classes\\Directory\\shell\\noctty\\command",
+        "Software\\Classes\\Directory\\shell\\noctty",
+        "Software\\Classes\\Directory\\Background\\shell\\noctty\\command",
+        "Software\\Classes\\Directory\\Background\\shell\\noctty",
+        "Software\\Classes\\Drive\\shell\\noctty\\command",
+        "Software\\Classes\\Drive\\shell\\noctty",
+    };
+    try testing.expectEqual(expected.len, unregister_key_paths.len);
+    for (expected, unregister_key_paths) |want, actual| {
+        try testing.expectEqualStrings(want, actual);
+    }
+}
+
+test "shell-menu executable path targets the GUI binary" {
+    const testing = std.testing;
+    const path = try executablePathAlloc(
+        testing.allocator,
+        "C:\\Tools\\noctty\\noctty.com",
+    );
+    defer testing.allocator.free(path);
+    try testing.expectEqualStrings("C:\\Tools\\noctty\\noctty.exe", path);
+}

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -174,6 +174,9 @@ pub fn executablePathAlloc(alloc: Allocator, self_path: []const u8) ![]u8 {
 /// an escaped quote and hands us `--working-directory=C:"`. Appending `\.`
 /// keeps the last character before the quote non-backslash for every target,
 /// and `C:\\.` / `C:\dir\.` both resolve to the intended directory.
+/// `--single-instance=false` keeps the selected path in this new process rather
+/// than sending it through the IPC working-directory allowlist. That preserves
+/// an intentional Explorer launch from a UNC folder without weakening IPC.
 pub fn commandValueAlloc(alloc: Allocator, exe_path: []const u8) ![]u8 {
     // The Shell command template treats `%%` as one literal percent. Escape
     // the executable path before adding our one intentional `%V` target.
@@ -181,7 +184,7 @@ pub fn commandValueAlloc(alloc: Allocator, exe_path: []const u8) ![]u8 {
     defer alloc.free(escaped_exe_path);
     return try std.fmt.allocPrint(
         alloc,
-        "\"{s}\" --working-directory=\"%V\\.\"",
+        "\"{s}\" --single-instance=false --working-directory=\"%V\\.\"",
         .{escaped_exe_path},
     );
 }
@@ -580,7 +583,7 @@ test "shell-menu command quotes an executable path containing spaces" {
     defer testing.allocator.free(value);
 
     try testing.expectEqualStrings(
-        "\"C:\\Program Files\\noctty\\noctty.exe\" --working-directory=\"%V\\.\"",
+        "\"C:\\Program Files\\noctty\\noctty.exe\" --single-instance=false --working-directory=\"%V\\.\"",
         value,
     );
 }
@@ -635,7 +638,7 @@ fn freeParsedForTest(alloc: Allocator, argv: []const []const u8) void {
     alloc.free(argv);
 }
 
-test "shell-menu command survives Windows argv parsing for folders and drive roots" {
+test "shell-menu command survives Windows argv parsing for local and UNC folders" {
     const testing = std.testing;
     const exe = "C:\\Program Files\\noctty\\noctty.exe";
     const value = try commandValueAlloc(testing.allocator, exe);
@@ -646,9 +649,10 @@ test "shell-menu command survives Windows argv parsing for folders and drive roo
     {
         const argv = try expandAndParseForTest(testing.allocator, value, "C:\\");
         defer freeParsedForTest(testing.allocator, argv);
-        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqual(@as(usize, 3), argv.len);
         try testing.expectEqualStrings(exe, argv[0]);
-        try testing.expectEqualStrings("--working-directory=C:\\\\.", argv[1]);
+        try testing.expectEqualStrings("--single-instance=false", argv[1]);
+        try testing.expectEqualStrings("--working-directory=C:\\\\.", argv[2]);
     }
 
     // A normal folder, including one whose name contains a space.
@@ -659,9 +663,10 @@ test "shell-menu command survives Windows argv parsing for folders and drive roo
             "D:\\My Projects\\noctty",
         );
         defer freeParsedForTest(testing.allocator, argv);
-        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqual(@as(usize, 3), argv.len);
         try testing.expectEqualStrings(exe, argv[0]);
-        try testing.expectEqualStrings("--working-directory=D:\\My Projects\\noctty\\.", argv[1]);
+        try testing.expectEqualStrings("--single-instance=false", argv[1]);
+        try testing.expectEqualStrings("--working-directory=D:\\My Projects\\noctty\\.", argv[2]);
     }
 
     // Non-ASCII folder names survive the UTF-8 -> UTF-16 -> argv round trip.
@@ -674,11 +679,30 @@ test "shell-menu command survives Windows argv parsing for folders and drive roo
             "E:\\\u{9805}\u{76EE} \u{1F680}\\\u{5F00}\u{53D1}",
         );
         defer freeParsedForTest(testing.allocator, argv);
-        try testing.expectEqual(@as(usize, 2), argv.len);
+        try testing.expectEqual(@as(usize, 3), argv.len);
         try testing.expectEqualStrings(exe, argv[0]);
+        try testing.expectEqualStrings("--single-instance=false", argv[1]);
         try testing.expectEqualStrings(
             "--working-directory=E:\\\u{9805}\u{76EE} \u{1F680}\\\u{5F00}\u{53D1}\\.",
-            argv[1],
+            argv[2],
+        );
+    }
+
+    // UNC targets stay in this new process instead of crossing the IPC
+    // working-directory boundary, which deliberately rejects UNC syntax.
+    {
+        const argv = try expandAndParseForTest(
+            testing.allocator,
+            value,
+            "\\\\server\\share\\project",
+        );
+        defer freeParsedForTest(testing.allocator, argv);
+        try testing.expectEqual(@as(usize, 3), argv.len);
+        try testing.expectEqualStrings(exe, argv[0]);
+        try testing.expectEqualStrings("--single-instance=false", argv[1]);
+        try testing.expectEqualStrings(
+            "--working-directory=\\\\server\\share\\project\\.",
+            argv[2],
         );
     }
 }
@@ -689,15 +713,16 @@ test "shell-menu command preserves percent placeholders in the executable path" 
     const value = try commandValueAlloc(testing.allocator, exe);
     defer testing.allocator.free(value);
     try testing.expectEqualStrings(
-        "\"C:\\Apps\\100%%Valid\\noctty.exe\" --working-directory=\"%V\\.\"",
+        "\"C:\\Apps\\100%%Valid\\noctty.exe\" --single-instance=false --working-directory=\"%V\\.\"",
         value,
     );
 
     const argv = try expandAndParseForTest(testing.allocator, value, "D:\\Work");
     defer freeParsedForTest(testing.allocator, argv);
-    try testing.expectEqual(@as(usize, 2), argv.len);
+    try testing.expectEqual(@as(usize, 3), argv.len);
     try testing.expectEqualStrings(exe, argv[0]);
-    try testing.expectEqualStrings("--working-directory=D:\\Work\\.", argv[1]);
+    try testing.expectEqualStrings("--single-instance=false", argv[1]);
+    try testing.expectEqualStrings("--working-directory=D:\\Work\\.", argv[2]);
 }
 
 test "shell-menu display name is stable" {

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -137,18 +137,26 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
 
     var created = [_]bool{false} ** register_key_paths.len;
     errdefer rollbackCreatedKeys(alloc, &created);
-    inline for (verb_key_paths, command_key_paths, 0..) |verb_path, command_path, pair_index| {
-        const verb_index = pair_index * 2;
+    // Prove all six keys are writable before overwriting any existing values.
+    // Newly created empty keys are tracked and rolled back if preflight or a
+    // later value write fails.
+    for (register_key_paths, 0..) |path, index| {
+        const preflight = try ensureWritableKey(alloc, path);
+        created[index] = preflight.created;
+        if (preflight.failure) |failure| {
+            rollbackCreatedKeys(alloc, &created);
+            return .{ .failure = failure };
+        }
+    }
+
+    inline for (verb_key_paths, command_key_paths) |verb_path, command_path| {
         const verb = try writeVerbKey(alloc, verb_path, exe_path);
-        created[verb_index] = verb.created;
         if (verb.failure) |failure| {
             rollbackCreatedKeys(alloc, &created);
             return .{ .failure = failure };
         }
 
-        const command_index = verb_index + 1;
         const command = try writeDefaultValue(alloc, command_path, command_value);
-        created[command_index] = command.created;
         if (command.failure) |failure| {
             rollbackCreatedKeys(alloc, &created);
             return .{ .failure = failure };
@@ -157,6 +165,32 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
 
     notifyExplorerAssociationsChanged();
     return .success;
+}
+
+fn ensureWritableKey(alloc: Allocator, key_path: []const u8) !WriteResult {
+    const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
+    defer alloc.free(key_path_wide);
+
+    var key: HKEY = undefined;
+    var disposition: DWORD = 0;
+    const status = RegCreateKeyExW(
+        HKEY_CURRENT_USER,
+        key_path_wide,
+        0,
+        null,
+        REG_OPTION_NON_VOLATILE,
+        KEY_WRITE,
+        null,
+        &key,
+        &disposition,
+    );
+    if (status != ERROR_SUCCESS) return .{ .created = false, .failure = .{
+        .operation = .create_key,
+        .key_path = key_path,
+        .status = status,
+    } };
+    defer _ = RegCloseKey(key);
+    return .{ .created = disposition == REG_CREATED_NEW_KEY };
 }
 
 /// Remove only the six keys owned by `register`, in leaf-first order.

--- a/src/apprt/win32_shell_menu.zig
+++ b/src/apprt/win32_shell_menu.zig
@@ -17,6 +17,7 @@ const REGSAM = u32;
 // Aliased from the shared Win32 surface rather than re-declared, so this
 // module cannot drift from src/apprt/win32/sys.zig.
 const RegCreateKeyExW = sys.RegCreateKeyExW;
+const RegOpenKeyExW = sys.RegOpenKeyExW;
 const RegSetValueExW = sys.RegSetValueExW;
 const RegCloseKey = sys.RegCloseKey;
 
@@ -28,6 +29,20 @@ extern "advapi32" fn RegDeleteKeyExW(
     Reserved: DWORD,
 ) callconv(.winapi) i32;
 
+extern "advapi32" fn RegDeleteValueW(
+    hKey: HKEY,
+    lpValueName: ?LPCWSTR,
+) callconv(.winapi) i32;
+
+extern "advapi32" fn RegQueryValueExW(
+    hKey: HKEY,
+    lpValueName: ?LPCWSTR,
+    lpReserved: ?*DWORD,
+    lpType: ?*DWORD,
+    lpData: ?*u8,
+    lpcbData: ?*DWORD,
+) callconv(.winapi) i32;
+
 extern "shell32" fn SHChangeNotify(
     wEventId: i32,
     uFlags: u32,
@@ -37,6 +52,7 @@ extern "shell32" fn SHChangeNotify(
 
 const HKEY_CURRENT_USER: HKEY = @ptrFromInt(consts.HKEY_CURRENT_USER);
 const KEY_WRITE: REGSAM = 0x20006;
+const KEY_READ: REGSAM = 0x20019;
 const REG_OPTION_NON_VOLATILE: DWORD = 0;
 const REG_SZ: DWORD = 1;
 const ERROR_SUCCESS: i32 = consts.ERROR_SUCCESS;
@@ -82,6 +98,7 @@ pub const unregister_key_paths = [_][]const u8{
 
 pub const RegistryOperation = enum {
     create_key,
+    query_value,
     set_value,
 };
 
@@ -104,7 +121,42 @@ pub const DeleteResult = union(enum) {
 
 const WriteResult = struct {
     created: bool,
+    mutated: bool = false,
     failure: ?RegistryFailure = null,
+};
+
+const ValueName = enum { default, icon };
+
+const ValueSpec = struct {
+    key_index: usize,
+    name: ValueName,
+};
+
+const value_specs = [_]ValueSpec{
+    .{ .key_index = 0, .name = .default },
+    .{ .key_index = 0, .name = .icon },
+    .{ .key_index = 1, .name = .default },
+    .{ .key_index = 2, .name = .default },
+    .{ .key_index = 2, .name = .icon },
+    .{ .key_index = 3, .name = .default },
+    .{ .key_index = 4, .name = .default },
+    .{ .key_index = 4, .name = .icon },
+    .{ .key_index = 5, .name = .default },
+};
+
+const ValueSnapshot = struct {
+    value_type: DWORD = REG_SZ,
+    data: ?[]u8 = null,
+
+    fn deinit(self: *ValueSnapshot, alloc: Allocator) void {
+        if (self.data) |data| alloc.free(data);
+        self.* = .{};
+    }
+};
+
+const SnapshotResult = union(enum) {
+    snapshot: ValueSnapshot,
+    failure: RegistryFailure,
 };
 
 /// Resolve the GUI executable next to the current launcher. This intentionally
@@ -149,16 +201,44 @@ pub fn register(alloc: Allocator, exe_path: []const u8) !RegisterResult {
         }
     }
 
+    var snapshots: [value_specs.len]ValueSnapshot = undefined;
+    var snapshot_count: usize = 0;
+    defer for (snapshots[0..snapshot_count]) |*snapshot| snapshot.deinit(alloc);
+    for (value_specs) |spec| {
+        const captured = try captureValue(alloc, spec);
+        switch (captured) {
+            .snapshot => |snapshot| {
+                snapshots[snapshot_count] = snapshot;
+                snapshot_count += 1;
+            },
+            .failure => |failure| {
+                rollbackCreatedKeys(alloc, &created);
+                return .{ .failure = failure };
+            },
+        }
+    }
+
+    var mutated = false;
+    errdefer {
+        rollbackValues(alloc, &snapshots, &created);
+        if (mutated) notifyExplorerAssociationsChanged();
+    }
     inline for (verb_key_paths, command_key_paths) |verb_path, command_path| {
         const verb = try writeVerbKey(alloc, verb_path, exe_path);
+        mutated = mutated or verb.mutated;
         if (verb.failure) |failure| {
+            rollbackValues(alloc, &snapshots, &created);
             rollbackCreatedKeys(alloc, &created);
+            if (mutated) notifyExplorerAssociationsChanged();
             return .{ .failure = failure };
         }
 
         const command = try writeDefaultValue(alloc, command_path, command_value);
+        mutated = mutated or command.mutated;
         if (command.failure) |failure| {
+            rollbackValues(alloc, &snapshots, &created);
             rollbackCreatedKeys(alloc, &created);
+            if (mutated) notifyExplorerAssociationsChanged();
             return .{ .failure = failure };
         }
     }
@@ -179,7 +259,7 @@ fn ensureWritableKey(alloc: Allocator, key_path: []const u8) !WriteResult {
         0,
         null,
         REG_OPTION_NON_VOLATILE,
-        KEY_WRITE,
+        KEY_READ | KEY_WRITE,
         null,
         &key,
         &disposition,
@@ -191,6 +271,104 @@ fn ensureWritableKey(alloc: Allocator, key_path: []const u8) !WriteResult {
     } };
     defer _ = RegCloseKey(key);
     return .{ .created = disposition == REG_CREATED_NEW_KEY };
+}
+
+fn valueNameWide(name: ValueName) ?LPCWSTR {
+    return switch (name) {
+        .default => null,
+        .icon => std.unicode.utf8ToUtf16LeStringLiteral("Icon"),
+    };
+}
+
+fn captureValue(alloc: Allocator, spec: ValueSpec) !SnapshotResult {
+    const key_path = register_key_paths[spec.key_index];
+    const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
+    defer alloc.free(key_path_wide);
+    var key: HKEY = undefined;
+    const open_status = RegOpenKeyExW(HKEY_CURRENT_USER, key_path_wide, 0, KEY_READ, &key);
+    if (open_status != ERROR_SUCCESS) return .{ .failure = .{
+        .operation = .query_value,
+        .key_path = key_path,
+        .status = open_status,
+    } };
+    defer _ = RegCloseKey(key);
+
+    var value_type: DWORD = 0;
+    var size: DWORD = 0;
+    const query_status = RegQueryValueExW(
+        key,
+        valueNameWide(spec.name),
+        null,
+        &value_type,
+        null,
+        &size,
+    );
+    if (query_status == ERROR_FILE_NOT_FOUND) return .{ .snapshot = .{} };
+    if (query_status != ERROR_SUCCESS) return .{ .failure = .{
+        .operation = .query_value,
+        .key_path = key_path,
+        .status = query_status,
+    } };
+
+    const data = try alloc.alloc(u8, size);
+    errdefer alloc.free(data);
+    var read_size = size;
+    const read_status = RegQueryValueExW(
+        key,
+        valueNameWide(spec.name),
+        null,
+        &value_type,
+        if (data.len == 0) null else &data[0],
+        &read_size,
+    );
+    if (read_status != ERROR_SUCCESS) return .{ .failure = .{
+        .operation = .query_value,
+        .key_path = key_path,
+        .status = read_status,
+    } };
+    return .{ .snapshot = .{ .value_type = value_type, .data = data } };
+}
+
+fn rollbackValues(
+    alloc: Allocator,
+    snapshots: *const [value_specs.len]ValueSnapshot,
+    created: *const [register_key_paths.len]bool,
+) void {
+    var index = value_specs.len;
+    while (index > 0) {
+        index -= 1;
+        const spec = value_specs[index];
+        if (created[spec.key_index]) continue;
+        restoreValueBestEffort(alloc, spec, snapshots[index]);
+    }
+}
+
+fn restoreValueBestEffort(alloc: Allocator, spec: ValueSpec, snapshot: ValueSnapshot) void {
+    const key_path = register_key_paths[spec.key_index];
+    const key_path_wide = std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path) catch return;
+    defer alloc.free(key_path_wide);
+    var key: HKEY = undefined;
+    const open_status = RegOpenKeyExW(HKEY_CURRENT_USER, key_path_wide, 0, KEY_WRITE, &key);
+    if (open_status != ERROR_SUCCESS) return;
+    defer _ = RegCloseKey(key);
+
+    const status = if (snapshot.data) |data|
+        RegSetValueExW(
+            key,
+            valueNameWide(spec.name),
+            0,
+            snapshot.value_type,
+            data.ptr,
+            @intCast(data.len),
+        )
+    else
+        RegDeleteValueW(key, valueNameWide(spec.name));
+    if (status != ERROR_SUCCESS and status != ERROR_FILE_NOT_FOUND) {
+        std.log.scoped(.win32_shell_menu).warn(
+            "shell-menu value rollback failed path={s} status={d}",
+            .{ key_path, status },
+        );
+    }
 }
 
 /// Remove only the six keys owned by `register`, in leaf-first order.
@@ -231,6 +409,10 @@ fn writeVerbKey(
 ) !WriteResult {
     const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
     defer alloc.free(key_path_wide);
+    const display_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, display_name);
+    defer alloc.free(display_wide);
+    const exe_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, exe_path);
+    defer alloc.free(exe_path_wide);
 
     var key: HKEY = undefined;
     var disposition: DWORD = 0;
@@ -254,8 +436,6 @@ fn writeVerbKey(
     errdefer if (created) deleteKeyBestEffort(alloc, key_path);
     defer _ = RegCloseKey(key);
 
-    const display_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, display_name);
-    defer alloc.free(display_wide);
     const display_status = writeRegSz(key, null, display_wide);
     if (display_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
         .operation = .set_value,
@@ -263,20 +443,18 @@ fn writeVerbKey(
         .status = display_status,
     } };
 
-    const exe_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, exe_path);
-    defer alloc.free(exe_path_wide);
     const icon_status = writeRegSz(
         key,
         std.unicode.utf8ToUtf16LeStringLiteral("Icon"),
         exe_path_wide,
     );
-    if (icon_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
+    if (icon_status != ERROR_SUCCESS) return .{ .created = created, .mutated = true, .failure = .{
         .operation = .set_value,
         .key_path = key_path,
         .status = icon_status,
     } };
 
-    return .{ .created = created };
+    return .{ .created = created, .mutated = true };
 }
 
 fn writeDefaultValue(
@@ -286,6 +464,8 @@ fn writeDefaultValue(
 ) !WriteResult {
     const key_path_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, key_path);
     defer alloc.free(key_path_wide);
+    const value_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, value);
+    defer alloc.free(value_wide);
 
     var key: HKEY = undefined;
     var disposition: DWORD = 0;
@@ -309,8 +489,6 @@ fn writeDefaultValue(
     errdefer if (created) deleteKeyBestEffort(alloc, key_path);
     defer _ = RegCloseKey(key);
 
-    const value_wide = try std.unicode.utf8ToUtf16LeAllocZ(alloc, value);
-    defer alloc.free(value_wide);
     const set_status = writeRegSz(key, null, value_wide);
     if (set_status != ERROR_SUCCESS) return .{ .created = created, .failure = .{
         .operation = .set_value,
@@ -318,7 +496,7 @@ fn writeDefaultValue(
         .status = set_status,
     } };
 
-    return .{ .created = created };
+    return .{ .created = created, .mutated = true };
 }
 
 fn previousCreatedPath(created: []const bool, before: *usize) ?[]const u8 {
@@ -383,6 +561,10 @@ test "shell-menu key paths cover folders backgrounds and drives" {
         "Software\\Classes\\Drive\\shell\\noctty",
         verb_key_paths[2],
     );
+    try testing.expectEqual(@as(usize, 9), value_specs.len);
+    var values_per_key = [_]usize{0} ** register_key_paths.len;
+    for (value_specs) |spec| values_per_key[spec.key_index] += 1;
+    try testing.expectEqualSlices(usize, &.{ 2, 1, 2, 1, 2, 1 }, &values_per_key);
 }
 
 test "shell-menu command quotes an executable path containing spaces" {

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -28,6 +28,8 @@ const focus = @import("focus.zig");
 const send_text = @import("send_text.zig");
 const new_tab = @import("new_tab.zig");
 const new_split = @import("new_split.zig");
+const register_shell_menu = @import("register_shell_menu.zig");
+const unregister_shell_menu = @import("unregister_shell_menu.zig");
 
 pub const Action = @import("ghostty_action.zig").Action;
 
@@ -85,6 +87,8 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .@"send-text" => try send_text.run(alloc),
         .@"new-tab" => try new_tab.run(alloc),
         .@"new-split" => try new_split.run(alloc),
+        .@"register-shell-menu" => try register_shell_menu.run(alloc),
+        .@"unregister-shell-menu" => try unregister_shell_menu.run(alloc),
     };
 }
 
@@ -119,6 +123,8 @@ pub fn options(comptime self: Action) type {
             .@"send-text" => send_text.Options,
             .@"new-tab" => new_tab.Options,
             .@"new-split" => new_split.Options,
+            .@"register-shell-menu" => register_shell_menu.Options,
+            .@"unregister-shell-menu" => unregister_shell_menu.Options,
         };
     }
 }

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -81,6 +81,12 @@ pub const Action = enum {
     // Create a split in a running noctty instance.
     @"new-split",
 
+    // Register per-user classic Explorer context-menu verbs.
+    @"register-shell-menu",
+
+    // Remove per-user classic Explorer context-menu verbs.
+    @"unregister-shell-menu",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables

--- a/src/cli/register_shell_menu.zig
+++ b/src/cli/register_shell_menu.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const actionpkg = @import("action.zig");
+const args = @import("args.zig");
+const shell_menu = @import("../apprt.zig").win32_shell_menu;
+
+const ERROR_ACCESS_DENIED: i32 = 5;
+
+pub const Options = struct {
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return actionpkg.help_error;
+    }
+};
+
+/// Register `Open noctty here` in the current user's classic Explorer
+/// context menus for folders, folder backgrounds, and drives.
+///
+/// The action writes only to `HKCU\Software\Classes`. It is idempotent and
+/// points every verb at the `noctty.exe` next to the current launcher.
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try args.argsIterator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
+    var stderr_buffer: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
+
+    const result = runInner(alloc, stdout, stderr);
+    try stdout.flush();
+    try stderr.flush();
+    return result;
+}
+
+fn runInner(
+    alloc: Allocator,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+) !u8 {
+    const self_path = std.fs.selfExePathAlloc(alloc) catch |err| {
+        try stderr.print(
+            "Failed to register Explorer shell menu: executable path unavailable ({s}).\n",
+            .{@errorName(err)},
+        );
+        return 1;
+    };
+    defer alloc.free(self_path);
+
+    const exe_path = shell_menu.executablePathAlloc(alloc, self_path) catch |err| {
+        try stderr.print(
+            "Failed to register Explorer shell menu: noctty.exe path unavailable ({s}).\n",
+            .{@errorName(err)},
+        );
+        return 1;
+    };
+    defer alloc.free(exe_path);
+
+    std.fs.accessAbsolute(exe_path, .{}) catch |err| {
+        try stderr.print(
+            "Failed to register Explorer shell menu: GUI executable not found at {s} ({s}).\n",
+            .{ exe_path, @errorName(err) },
+        );
+        return 1;
+    };
+
+    const registration = shell_menu.register(alloc, exe_path) catch |err| {
+        try stderr.print(
+            "Failed to register Explorer shell menu ({s}).\n",
+            .{@errorName(err)},
+        );
+        return 1;
+    };
+
+    switch (registration) {
+        .success => {
+            for (shell_menu.register_key_paths) |path| {
+                try stdout.print("Registered HKCU\\{s}\n", .{path});
+            }
+            return 0;
+        },
+        .failure => |failure| {
+            try writeRegistryFailure(stderr, failure);
+            // Earlier verbs may already be registered; tell the user how to
+            // get back to a clean state rather than leaving a half-installed
+            // Explorer menu behind silently.
+            try stderr.print(
+                "Some verbs may already be registered; run `noctty +unregister-shell-menu` to remove them.\n",
+                .{},
+            );
+            return 1;
+        },
+    }
+}
+
+fn writeRegistryFailure(
+    stderr: *std.Io.Writer,
+    failure: shell_menu.RegistryFailure,
+) !void {
+    if (failure.operation == .create_key and failure.status == ERROR_ACCESS_DENIED) {
+        try stderr.print(
+            "Failed to register Explorer shell menu at HKCU\\{s} during create_key: access denied; per-user registry writes may be blocked by policy or the process may have a restricted token (Win32 status 5).\n",
+            .{failure.key_path},
+        );
+        return;
+    }
+
+    try stderr.print(
+        "Failed to register Explorer shell menu at HKCU\\{s} during {s} (Win32 status {d}).\n",
+        .{ failure.key_path, @tagName(failure.operation), failure.status },
+    );
+}
+
+test "shell-menu access denied explains per-user policy causes" {
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+
+    try writeRegistryFailure(&output.writer, .{
+        .operation = .create_key,
+        .key_path = "Software\\Classes\\Directory\\shell\\noctty",
+        .status = ERROR_ACCESS_DENIED,
+    });
+
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        output.written(),
+        "per-user registry writes may be blocked by policy",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        output.written(),
+        "restricted token",
+    ) != null);
+}

--- a/src/cli/register_shell_menu.zig
+++ b/src/cli/register_shell_menu.zig
@@ -111,10 +111,10 @@ fn writeRegistryFailure(
     stderr: *std.Io.Writer,
     failure: shell_menu.RegistryFailure,
 ) !void {
-    if (failure.operation == .create_key and failure.status == ERROR_ACCESS_DENIED) {
+    if (failure.status == ERROR_ACCESS_DENIED) {
         try stderr.print(
-            "Failed to register Explorer shell menu at HKCU\\{s} during create_key: access denied; per-user registry writes may be blocked by policy or the process may have a restricted token (Win32 status 5).\n",
-            .{failure.key_path},
+            "Failed to register Explorer shell menu at HKCU\\{s} during {s}: access denied; per-user registry writes may be blocked by policy or the process may have a restricted token (Win32 status 5).\n",
+            .{ failure.key_path, @tagName(failure.operation) },
         );
         return;
     }
@@ -144,5 +144,18 @@ test "shell-menu access denied explains per-user policy causes" {
         u8,
         output.written(),
         "restricted token",
+    ) != null);
+
+    output.clearRetainingCapacity();
+    try writeRegistryFailure(&output.writer, .{
+        .operation = .set_value,
+        .key_path = "Software\\Classes\\Drive\\shell\\noctty",
+        .status = ERROR_ACCESS_DENIED,
+    });
+    try std.testing.expect(std.mem.indexOf(u8, output.written(), "during set_value") != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        output.written(),
+        "per-user registry writes may be blocked by policy",
     ) != null);
 }

--- a/src/cli/unregister_shell_menu.zig
+++ b/src/cli/unregister_shell_menu.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const actionpkg = @import("action.zig");
+const args = @import("args.zig");
+const shell_menu = @import("../apprt.zig").win32_shell_menu;
+
+const ERROR_ACCESS_DENIED: i32 = 5;
+
+pub const Options = struct {
+    pub fn deinit(self: Options) void {
+        _ = self;
+    }
+
+    /// Enables `-h` and `--help` to work.
+    pub fn help(self: Options) !void {
+        _ = self;
+        return actionpkg.help_error;
+    }
+};
+
+/// Remove the current user's `Open noctty here` classic Explorer verbs for
+/// folders, folder backgrounds, and drives.
+///
+/// The action removes only noctty's six owned keys under
+/// `HKCU\Software\Classes` and succeeds when they are already absent.
+pub fn run(alloc: Allocator) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+
+    {
+        var iter = try args.argsIterator(alloc);
+        defer iter.deinit();
+        try args.parse(Options, alloc, &opts, &iter);
+    }
+
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
+    var stderr_buffer: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
+
+    const result = runInner(alloc, stdout, stderr);
+    try stdout.flush();
+    try stderr.flush();
+    return result;
+}
+
+fn runInner(
+    alloc: Allocator,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+) !u8 {
+    const results = shell_menu.unregister(alloc) catch |err| {
+        try stderr.print(
+            "Failed to unregister Explorer shell menu ({s}).\n",
+            .{@errorName(err)},
+        );
+        return 1;
+    };
+
+    var failed = false;
+    for (shell_menu.unregister_key_paths, results) |path, result| {
+        switch (result) {
+            .removed => try stdout.print("Removed HKCU\\{s}\n", .{path}),
+            .absent => try stdout.print("Already absent HKCU\\{s}\n", .{path}),
+            .failed => |status| {
+                failed = true;
+                try stderr.print(
+                    "Failed to unregister Explorer shell menu at HKCU\\{s} during delete_key (Win32 status {d}).\n",
+                    .{ path, status },
+                );
+                // The delete is deliberately non-recursive so foreign subkeys
+                // survive, which means a key someone else extended reports the
+                // same status as a policy denial. Say so, because the register
+                // action teaches that 5 means policy or a restricted token.
+                if (status == ERROR_ACCESS_DENIED) {
+                    try stderr.print(
+                        "  Status 5 here can also mean the key contains subkeys noctty did not create; unregister never deletes those. Inspect the key and remove them first.\n",
+                        .{},
+                    );
+                }
+            },
+        }
+    }
+    return if (failed) 1 else 0;
+}


### PR DESCRIPTION
## Summary  Adds the classic Explorer "Open noctty here" verb for folders, folder backgrounds, and drives, registered by the installer for installed builds and by a new CLI action pair for portable/ZIP users. Roadmap entry C13; second half of PRODUCT.md design principle 6.  Fixes #127  ## Base

Rebased directly onto main after #182 merged; this PR now contains only the Explorer context-menu changes.

## Changes  - New `src/apprt/win32_shell_menu.zig`: key-path and command-value builders plus raw `advapi32` `RegCreateKeyExW` / `RegSetValueExW` / `RegDeleteKeyExW` calls, following `win32_aumid.zig`. HKCU only. - Three verbs, each named `Open noctty here` with the exe as `Icon` and a `command` of `"<exe>" --single-instance=false --working-directory="%V\."`:   - `Software\Classes\Directory\shell\noctty`   - `Software\Classes\Directory\Background\shell\noctty`   - `Software\Classes\Drive\shell\noctty` - New CLI actions `noctty +register-shell-menu` / `+unregister-shell-menu` (`src/cli/register_shell_menu.zig`, `src/cli/unregister_shell_menu.zig`, wired through `ghostty_action.zig` / `ghostty.zig`). Register writes all six keys and prints them; unregister deletes exactly those six leaf-first and treats already-absent keys as success. Both support `--help` and return non-zero with a concrete stderr message on failure — `ERROR_ACCESS_DENIED` explains that per-user registry writes may be blocked by policy or a restricted token. - `executablePathAlloc` resolves the sibling `noctty.exe` so reaching the action through the `noctty.com` CLI shim still registers the GUI binary. - `dist/windows/noctty.iss` adds the verbs under `Root: HKA`. Each installer-owned value uses `uninsdeletevalue uninsdeletekeyifempty`, so uninstall removes owned values and deletes a key only when no user-added values or subkeys remain. - Docs: `docs/windows.md` Explorer-context-menu section (the three keys, installer vs portable opt-in, HKCU vs HKLM), `docs/status.md` row, one line in `docs/getting-started.md` for portable users.  ## Windows 11 modern context menu — deliberately not built  The modern top-level command requires an `IExplorerCommand` COM server shipped in a **sparse MSIX package with package identity**, registered via the `windows.comServer` + `windows.fileExplorerContextMenus` manifest extensions, and the package must be signed by a certificate whose publisher matches the manifest `Publisher`. noctty currently signs with a self-signed certificate that each machine would have to trust explicitly before Windows accepted the package, so shipping it here would mean a packaging and signing change, not a code change. This is recorded in `docs/windows.md`. On Windows 11 the classic verbs shipped here appear under **Show more options** (or directly via Shift+F10). Portable-mode auto-registration is #138 and belongs to another team; this PR only makes the opt-in action exist.  The trailing `\.` in the command value is load-bearing and is the second commit on this branch. Explorer expands `%V` for a drive root as `C:\`, so a bare `"%V"` ends the quoted argument with a backslash right before the closing quote; `CommandLineToArgvW` reads that as an escaped quote and noctty receives the literal value `C:"`. That made the `Drive` verb never work and broke the other two at a drive root. A test now expands `%V` and re-parses with `std.process.ArgIteratorWindows` for a drive root and for a folder name containing a space.  ## Validation

- `zig fmt --check` on touched Zig files and `git diff --check` pass.
- `zig build test -Dtest-filter=shell-menu`, `zig build -Demit-exe=true`, and full `zig build test -Demit-test-exe=true` pass on current `main`.
- `pwsh -NoProfile -File scripts/check-source-format.ps1` passes.
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` reports `Windows x64 baseline checker probes: PASS` and `flagship verification contracts: PASS (2 scenarios)`.
- `noctty.com +register-shell-menu --help` and `+unregister-shell-menu --help` both exit 0.
- Exact-head GitHub checks pass for Windows x64 build/tests, portable package smoke, and native Windows ARM64.

Unit tests cover all three registry roots, the six registration keys, leaf-first unregister behavior, rollback/restoration, access-denied diagnostics, command quoting, percent-bearing executable paths, drive roots, spaces, Unicode, and UNC targets.
### Adversarial review dispositions (R-126/127, verdict APPROVE-WITH-CHANGES)  - **MEDIUM — stale per-user registrations can shadow a per-machine install. Preserved and documented, not swept.** `HKCU\Software\Classes` overrides HKLM in the merged HKCR view, so a portable registration remains authoritative until its owner removes it. The installer intentionally removes only its own values with `uninsdeletevalue uninsdeletekeyifempty`; it does not delete CLI-owned HKCU registrations or user-added values/subkeys. `docs/windows.md` tells portable users to run `+unregister-shell-menu` before deleting that copy. This keeps ownership explicit and avoids destructive cross-install cleanup. - **LOW — duplicated advapi32 externs. Fixed.** `RegCreateKeyExW`, `RegSetValueExW` and `RegCloseKey` are now `const X = sys.X;` aliases against `src/apprt/win32/sys.zig`, matching what #182 did; `HKEY` and the status constants come from `win32/consts.zig`. Only `RegDeleteKeyExW` stays local, since nothing else deletes keys. `sys.RegSetValueExW`'s `lpValueName` was widened to `?LPCWSTR` (null names a key's default value) — a source-compatible change for its existing `win32_aumid.zig` callers. - **LOW — misleading status 5 on unregister. Fixed.** The delete stays non-recursive so foreign subkeys survive; when it fails with ACCESS_DENIED the action now adds that this can also mean the key contains subkeys noctty did not create, since the register-side help teaches that 5 means policy or a restricted token. - **Missing hostile-name test. Added.** A CJK + emoji folder name now goes through `expandAndParseForTest` alongside the drive root and the spaced path. - **INFO — partial registration rollback. Fixed.** Registration tracks which keys this invocation created and deletes only those keys in reverse leaf-first order if a later write fails; pre-existing keys and foreign subkeys are preserved.  The reviewer separately confirmed the structural safety story: this is a registry verb, not an in-process shell extension, so no DLL enters `explorer.exe`; Explorer substitutes `%V` and calls `CreateProcess` with no `cmd.exe` layer; both the CLI and the Inno rows write `REG_SZ` not `REG_EXPAND_SZ`; and `"` is illegal in an NTFS name so quote-breakout through `%V` inside `"...%V\."` is impossible.  ## Residuals / user steps  - **Not validated in live Explorer.** The agent session's process token denied the authorized `HKCU\Software\Classes\Directory\shell\noctty` create with Win32 status 5, so no verb could be registered and no screenshots were produced. A `reg query` afterwards confirmed all three roots are absent — the machine is unchanged. Someone should, from a normal interactive session: run `noctty +register-shell-menu`, right-click a folder / a folder background / a drive (via **Show more options** on Win11), invoke the verb, confirm the new window's cwd, then run `noctty +unregister-shell-menu` and confirm the keys are gone. - The installer path was validated by the flagship contracts and by review, not by actually running the built installer, which would mutate the machine. - `+register-shell-menu` rolls back only keys newly created by the failing invocation; it intentionally preserves pre-existing keys and foreign subkeys. - The `%V\.` fix is proven against `std.process.ArgIteratorWindows`, which implements the `CommandLineToArgvW` rules, but not yet against real Explorer.

### Final review-cycle validation

- Rebased directly onto `main` at `88e7a930c186996f1985191428e5dc5b70b55ac0`; exact pushed head `b60bff9dfd7a8663afd65c2c538888cefe6a0220`.
- `zig fmt --check` on touched Zig files, `git diff --check`, `zig build test -Dtest-filter=shell-menu`, `zig build -Demit-exe=true`, and the full `zig build test -Demit-test-exe=true` suite pass.
- `pwsh -NoProfile -File scripts/check-source-format.ps1` and `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` pass; both shell-menu CLI help paths exit 0.
- Exact-head GitHub checks pass for Windows x64 build/tests, portable package smoke, and native Windows ARM64.
- Explorer templates pass `--single-instance=false`, so local and UNC selections stay in the launched process instead of crossing the UNC-rejecting IPC boundary.
- Installer uninstall deletes only owned values and empty keys; portable HKCU registrations and user-added values/subkeys remain user-owned.
- All active review threads are resolved. CodeRabbit and Codex exact-head reviews were retriggered but rate-limited; Greptile was retriggered and its latest completed review remains 5/5 with no blocking failure.