### PR TITLE
perf(win32): power- and visibility-aware render pacing (#134)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -38,7 +38,8 @@ run fixes them; CI gates against them once measured):
 - Key-to-pixel latency: at most one frame at 60 Hz beyond the OS
   input/compositor floor.
 - Memory: under 20 MB steady-state per additional pane.
-- Idle: effectively 0% GPU/CPU with no timer wake churn.
+- Idle: effectively 0% GPU/CPU with no timer wake churn. See
+  [Windows power and battery behavior](docs/windows.md#power-and-battery).
 
 The benchmark suite (roadmap C01) defines the measurement methodology,
 workload, baseline machine, and tolerances; CI gates activate once that

--- a/docs/status.md
+++ b/docs/status.md
@@ -77,6 +77,10 @@ Win32-validated VT protocol coverage is tracked in
 - Terminal content renders with OpenGL 4.3+ via WGL.
 - Window chrome uses a separate D3D11/DirectComposition + DirectWrite
   pipeline with GDI fallback; it never touches the terminal renderer.
+- Presentation is power- and visibility-aware: focused non-saver cadence
+  is unchanged, unfocused and saver pacing is capped, and minimized or
+  DWM-cloaked windows stop presenting. Details and measurement fields are
+  in [windows.md](windows.md#power-and-battery).
 
 ### Updater
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -143,6 +143,11 @@ and lands incrementally.
   `ghostty-org/ghostty`.
 - Crash capture is local-only, and some hard-abort paths may still
   terminate before Windows can produce a dump.
+- Power- and visibility-aware render pacing has not been exercised on a
+  machine with a battery, and the DWM cloak/uncloak WinEvent path has not
+  been observed across a real virtual-desktop switch. Both are argued from
+  the documented Win32 contracts and covered by unit tests over the pure
+  policy and event-filter functions only.
 
 ## Out of scope
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -52,6 +52,7 @@ Last reviewed: 2026-08-12.
 | Universal palette                                                                 | One blended, fuzzy-ranked command surface. See [universal palette notes](#universal-palette).                              |
 | Native settings                                                                   | A native settings window with staged, source-preserving saves. See [native settings notes](#native-settings).              |
 | Tab dragging                                                                      | Same-window reorder and exact-pane drag-to-split. See [tab dragging notes](#tab-dragging).                                 |
+| Power-aware rendering                                                             | `unfocused-render-fps` caps visible background presentation; `power-saver-rendering` controls saver pacing; minimized and DWM-cloaked windows do not present. See [power and battery](windows.md#power-and-battery). |
 
 ## Notes
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -127,10 +127,27 @@ and defaults to `30`. Values below `1` are treated as `1`; values above
 often than every 8 ms.
 `power-saver-rendering` accepts `auto`, `on`, or `off` and defaults to
 `auto`: `auto` follows Windows Battery Saver or Energy Saver, `on` forces
-saver pacing, and `off` disables it. Focused surfaces retain their normal
-cadence when saver pacing is inactive. Saver pacing caps presentation at
-about 30 fps. Minimized and DWM-cloaked host windows do not present until
-they become visible again.
+saver pacing, and `off` disables it. `auto` deliberately does **not** key
+off battery power alone: running unplugged with saver off keeps the normal
+cadence, because throttling a focused terminal merely because a laptop is
+unplugged is a far more aggressive default than following the saver signal
+the user actually opted into. Focused surfaces retain their normal cadence
+when saver pacing is inactive. Saver pacing caps presentation at about
+30 fps. Minimized and DWM-cloaked host windows do not present until they
+become visible again.
+
+Cloak and uncloak have no window message, so noctty hooks the documented
+`EVENT_OBJECT_CLOAKED` / `EVENT_OBJECT_UNCLOAKED` WinEvents with a single
+`SetWinEventHook` scoped to this process and the UI thread. Without it, a
+virtual-desktop switch that uncloaks a background window need not send
+`WM_ACTIVATE`, `WM_SHOWWINDOW`, or `WM_WINDOWPOSCHANGED`, and since hidden
+surfaces skip rendering entirely there would be no self-healing path back
+to visible. The window messages above remain as a fallback for a missed
+event or a failed hook registration, which degrades to the previous
+behaviour rather than failing window creation. This hook path is argued
+from the Win32 contract and covered by unit tests over the pure event
+filter; it has not been observed on hardware -- see the status caveat
+below.
 
 Focus here is **per surface, not per window**. In a split, only the pane
 with keyboard focus presents at the full rate; the other panes are

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -109,6 +109,32 @@ Terminal progress reports are mapped to Windows taskbar progress for the
 active surface in each host window. Terminal apps can also set
 in-terminal progress state through Ghostty's shared VT/OSC support.
 
+## Power and battery
+
+noctty reads AC/battery and saver state from `GetSystemPowerStatus`.
+Windows power-setting notifications cover modern Energy Saver and the
+legacy Battery Saver signal; a fallback query runs at most once every 30
+seconds.
+
+`unfocused-render-fps` caps presentation for visible, unfocused surfaces
+and defaults to `30`. Values below `1` are treated as `1`; values above
+`125` have no additional effect, since the renderer never presents more
+often than every 8 ms.
+`power-saver-rendering` accepts `auto`, `on`, or `off` and defaults to
+`auto`: `auto` follows Windows battery or energy saver, `on` forces saver pacing,
+and `off` disables it. Focused surfaces retain their normal cadence when
+saver pacing is inactive. Saver pacing caps presentation at about 30
+fps and lengthens draw and cursor-blink timer cadences. Minimized and
+DWM-cloaked host windows do not present until they become visible again.
+
+Set `NOCTTY_RENDER_TRACE_FILE` to an absolute output path to write a JSON
+render trace when the first traced surface is destroyed. Presented fps
+can be derived as
+`(swap_buffers_count - 1) * 1000 / (last_swap_at_ms - first_swap_at_ms)`
+when at least two swaps are present and the time difference is positive.
+Debug builds also log one `presented fps` sample per surface per second,
+with the frame count and sample interval.
+
 ## Windows, tabs, and splits
 
 noctty uses a native Win32 host window with:

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -117,8 +117,13 @@ subscribes to Windows power-setting notifications for the power source
 It additionally registers for Windows 11 Energy Saver
 (`GUID_ENERGY_SAVER_STATUS`), which can engage while plugged in; Microsoft
 currently documents that GUID as prerelease, so registration is best-effort
-and simply does not take effect on Windows builds that lack it. A fallback
-query runs at most once every 30 seconds. This has not yet been verified on
+and simply does not take effect on Windows builds that lack it. Battery
+Saver and Energy Saver are tracked as two independent flags and combined
+with OR only when pacing is decided, so one turning off cannot cancel
+pacing that the other still requires. `GetSystemPowerStatus` reports only
+Battery Saver, so the fallback query carries the last notified Energy Saver
+value forward instead of clearing it. A fallback query runs at most once
+every 30 seconds. This has not yet been verified on
 a machine with a battery -- see the status caveat below.
 
 `unfocused-render-fps` caps presentation for visible, unfocused surfaces
@@ -144,10 +149,15 @@ virtual-desktop switch that uncloaks a background window need not send
 surfaces skip rendering entirely there would be no self-healing path back
 to visible. The window messages above remain as a fallback for a missed
 event or a failed hook registration, which degrades to the previous
-behaviour rather than failing window creation. This hook path is argued
-from the Win32 contract and covered by unit tests over the pure event
-filter; it has not been observed on hardware -- see the status caveat
-below.
+behaviour rather than failing window creation. The callback forwards which
+of the two events fired: the refresh it triggers re-queries
+`DwmGetWindowAttribute(DWMWA_CLOAKED)`, and if that query fails the
+observed transition is used instead of the last known cloak state, because
+preserving a stale "cloaked" across an uncloak would leave the window
+hidden with nothing left to re-query it. This hook path is argued from the
+Win32 contract and covered by unit tests over the pure event filter and the
+pure cloak-resolution policy; it has not been observed on hardware -- see
+the status caveat below.
 
 Focus here is **per surface, not per window**. In a split, only the pane
 with keyboard focus presents at the full rate; the other panes are

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -111,29 +111,39 @@ in-terminal progress state through Ghostty's shared VT/OSC support.
 
 ## Power and battery
 
-noctty reads AC/battery and saver state from `GetSystemPowerStatus`.
-Windows power-setting notifications cover modern Energy Saver and the
-legacy Battery Saver signal; a fallback query runs at most once every 30
-seconds.
+noctty reads AC/battery and saver state from `GetSystemPowerStatus`, and
+subscribes to Windows power-setting notifications for the power source
+(`GUID_ACDC_POWER_SOURCE`) and Battery Saver (`GUID_POWER_SAVING_STATUS`).
+It additionally registers for Windows 11 Energy Saver
+(`GUID_ENERGY_SAVER_STATUS`), which can engage while plugged in; Microsoft
+currently documents that GUID as prerelease, so registration is best-effort
+and simply does not take effect on Windows builds that lack it. A fallback
+query runs at most once every 30 seconds. This has not yet been verified on
+a machine with a battery -- see the status caveat below.
 
 `unfocused-render-fps` caps presentation for visible, unfocused surfaces
 and defaults to `30`. Values below `1` are treated as `1`; values above
 `125` have no additional effect, since the renderer never presents more
 often than every 8 ms.
 `power-saver-rendering` accepts `auto`, `on`, or `off` and defaults to
-`auto`: `auto` follows Windows battery or energy saver, `on` forces saver pacing,
-and `off` disables it. Focused surfaces retain their normal cadence when
-saver pacing is inactive. Saver pacing caps presentation at about 30
-fps and lengthens draw and cursor-blink timer cadences. Minimized and
-DWM-cloaked host windows do not present until they become visible again.
+`auto`: `auto` follows Windows Battery Saver or Energy Saver, `on` forces
+saver pacing, and `off` disables it. Focused surfaces retain their normal
+cadence when saver pacing is inactive. Saver pacing caps presentation at
+about 30 fps. Minimized and DWM-cloaked host windows do not present until
+they become visible again.
+
+Focus here is **per surface, not per window**. In a split, only the pane
+with keyboard focus presents at the full rate; the other panes are
+"unfocused" even though you can see them, so a split tailing fast output
+side by side with your active pane is capped at `unfocused-render-fps`
+(30 by default). Raise that value if you watch live output in a background
+split.
 
 Set `NOCTTY_RENDER_TRACE_FILE` to an absolute output path to write a JSON
 render trace when the first traced surface is destroyed. Presented fps
 can be derived as
 `(swap_buffers_count - 1) * 1000 / (last_swap_at_ms - first_swap_at_ms)`
 when at least two swaps are present and the time difference is positive.
-Debug builds also log one `presented fps` sample per surface per second,
-with the frame count and sample interval.
 
 ## Windows, tabs, and splits
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1570,6 +1570,10 @@ pub const App = struct {
             .launcher_profile_target = detectDefaultProfileTarget(core_app.alloc),
             .startup_profile_picker = detectStartupProfilePicker(core_app.alloc),
         };
+        // Install before any host window exists, so the very first
+        // SetWinEventHook registration already has somewhere to deliver.
+        cloak_event_app = self;
+        win32_power.setCloakEventHandler(&onHostCloakEvent);
         // Snapshot the CLI --config-file override BEFORE any code has
         // a chance to chdir. See the field comment above.
         self.cli_config_override_path = cliConfigFileOverride(core_app.alloc) catch null;
@@ -1887,6 +1891,10 @@ pub const App = struct {
             self.shell_compositor.deinit();
             self.shell_compositor_initialized = false;
         }
+        // After destroyAllWindows: every Host has released its cloak-hook
+        // reference by now, so no further callback can reach a freed App.
+        win32_power.setCloakEventHandler(null);
+        cloak_event_app = null;
         self.hosts.deinit(self.core_app.alloc);
         self.windows.deinit(self.core_app.alloc);
         self.global_hotkeys.deinit(self.core_app.alloc);
@@ -17620,6 +17628,29 @@ fn getHost(hwnd: HWND) ?*Host {
     return windowData(Host, hwnd);
 }
 
+/// Target of the DWM cloak/uncloak WinEvent hook. Set for the lifetime of the
+/// App so the callback can resolve an HWND without a global `getHost`, which
+/// would be unsafe here: other window classes in this apprt store unrelated
+/// payloads in `GWLP_USERDATA`, and the hook sees every window on this thread.
+var cloak_event_app: ?*App = null;
+
+/// Runs on the UI thread (WINEVENT_OUTOFCONTEXT delivers through our own
+/// message pump), so it may touch host state directly.
+///
+/// A cloak transition has no window message, so without this a virtual-desktop
+/// switch that uncloaks a background window would leave `surfaces_visible`
+/// false; hidden surfaces skip rendering entirely, so nothing would repair it
+/// until an unrelated message arrived.
+fn onHostCloakEvent(hwnd: HWND) void {
+    const app = cloak_event_app orelse return;
+    for (app.hosts.items) |host| {
+        const host_hwnd = host.hwnd orelse continue;
+        if (host_hwnd != hwnd) continue;
+        host.refreshSurfaceVisibility();
+        return;
+    }
+}
+
 fn refocusActiveSurface(host: *Host) void {
     if (host.activeSurface()) |surface| {
         if (surface.hwnd) |surface_hwnd| _ = sys.SetFocus(surface_hwnd);
@@ -18394,12 +18425,12 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
         },
         c.WM_ACTIVATE => {
             // Cloak/uncloak (virtual-desktop switches, shell animations)
-            // has NO documented window message -- the documented signal is
-            // the EVENT_OBJECT_CLOAKED/UNCLOAKED WinEvent, which would need
-            // a SetWinEventHook and is the principled fix. Until then, a
-            // cloaked host renders nothing, so refresh on activation and on
-            // show/hide as well to guarantee a self-healing path back to
-            // visible rather than a permanently frozen window.
+            // has NO window message -- the documented signal is the
+            // EVENT_OBJECT_CLOAKED/UNCLOAKED WinEvent, which
+            // `win32_power.Notifications` now hooks. This refresh is the
+            // belt-and-braces path for a missed or unavailable hook: a
+            // cloaked host renders nothing, so a stale `surfaces_visible`
+            // would otherwise mean a permanently frozen window.
             if (host) |v| v.refreshSurfaceVisibility();
             if ((wParam & 0xFFFF) == c.WA_INACTIVE) {
                 if (host) |v| {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4483,7 +4483,8 @@ pub const App = struct {
         try self.ensureScrollbarClass();
 
         const host = try self.core_app.alloc.create(Host);
-        errdefer self.core_app.alloc.destroy(host);
+        var host_registered = false;
+        errdefer if (!host_registered) self.core_app.alloc.destroy(host);
         host.* = .{
             .app = self,
             .id = self.allocateHostId(),
@@ -4528,6 +4529,8 @@ pub const App = struct {
         self.attachShellCompositorWindow(hwnd);
 
         try self.hosts.append(self.core_app.alloc, host);
+        host_registered = true;
+        errdefer self.removeHost(host);
         if (clone_state_from) |source| {
             if (source.host) |existing| try self.inheritHostWindowState(host, existing);
         }
@@ -5112,14 +5115,9 @@ pub const App = struct {
     }
 
     fn removeHost(self: *App, host: *Host) void {
-        for (self.hosts.items, 0..) |item, i| {
-            if (item == host) {
-                _ = self.hosts.swapRemove(i);
-                host.deinit();
-                self.core_app.alloc.destroy(host);
-                break;
-            }
-        }
+        if (!detachHostReference(&self.hosts, host)) return;
+        host.deinit();
+        self.core_app.alloc.destroy(host);
     }
 
     fn windowDestroyed(self: *App, surface: *Surface) void {
@@ -6335,6 +6333,15 @@ pub const App = struct {
         return true;
     }
 };
+
+fn detachHostReference(hosts: *std.ArrayListUnmanaged(*Host), host: *Host) bool {
+    for (hosts.items, 0..) |item, i| {
+        if (item != host) continue;
+        _ = hosts.swapRemove(i);
+        return true;
+    }
+    return false;
+}
 
 fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
     const alloc = request.alloc;
@@ -27121,6 +27128,26 @@ test "win32 effectiveHostWindowStyle preserves clipchildren for hosted surfaces"
     try std.testing.expect((effectiveHostWindowStyle(false, false, true) & c.WS_CLIPCHILDREN) != 0);
     try std.testing.expect((effectiveHostWindowStyle(true, true, true) & c.WS_CLIPCHILDREN) != 0);
     try std.testing.expect((effectiveHostWindowStyle(true, false, false) & c.WS_CLIPCHILDREN) == 0);
+}
+
+test "win32 failed cloned-host registration detaches the host reference" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var first: Host = undefined;
+    var failed_clone: Host = undefined;
+    var last: Host = undefined;
+    var hosts: std.ArrayListUnmanaged(*Host) = .empty;
+    defer hosts.deinit(std.testing.allocator);
+    try hosts.append(std.testing.allocator, &first);
+    try hosts.append(std.testing.allocator, &failed_clone);
+    try hosts.append(std.testing.allocator, &last);
+
+    try std.testing.expect(detachHostReference(&hosts, &failed_clone));
+    try std.testing.expectEqual(@as(usize, 2), hosts.items.len);
+    try std.testing.expect(std.mem.indexOfScalar(*Host, hosts.items, &failed_clone) == null);
+    try std.testing.expect(std.mem.indexOfScalar(*Host, hosts.items, &first) != null);
+    try std.testing.expect(std.mem.indexOfScalar(*Host, hosts.items, &last) != null);
+    try std.testing.expect(!detachHostReference(&hosts, &failed_clone));
 }
 
 test "win32 sharesHostWindowState only for same-host clones" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4524,13 +4524,24 @@ pub const App = struct {
         if (host.current_dpi == 0) host.current_dpi = 96;
         host.chrome_font = host.createChromeFont();
         host.recreateTitlebarIconFonts();
-        errdefer _ = sys.DestroyWindow(hwnd);
+        errdefer if (!host_registered) {
+            _ = sys.DestroyWindow(hwnd);
+        };
 
         self.attachShellCompositorWindow(hwnd);
 
         try self.hosts.append(self.core_app.alloc, host);
         host_registered = true;
-        errdefer self.removeHost(host);
+        errdefer {
+            // Keep the registered Host and its GWLP_USERDATA alive through
+            // WM_DESTROY so the normal compositor-detach path can find it.
+            if (sys.DestroyWindow(hwnd) == 0) {
+                // If teardown itself fails, WM_DESTROY did not provide the
+                // normal detach. Do it explicitly before host deinit.
+                self.detachShellCompositorWindow(hwnd);
+            }
+            self.removeHost(host);
+        }
         if (clone_state_from) |source| {
             if (source.host) |existing| try self.inheritHostWindowState(host, existing);
         }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -18393,6 +18393,14 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
             return 0;
         },
         c.WM_ACTIVATE => {
+            // Cloak/uncloak (virtual-desktop switches, shell animations)
+            // has NO documented window message -- the documented signal is
+            // the EVENT_OBJECT_CLOAKED/UNCLOAKED WinEvent, which would need
+            // a SetWinEventHook and is the principled fix. Until then, a
+            // cloaked host renders nothing, so refresh on activation and on
+            // show/hide as well to guarantee a self-healing path back to
+            // visible rather than a permanently frozen window.
+            if (host) |v| v.refreshSurfaceVisibility();
             if ((wParam & 0xFFFF) == c.WA_INACTIVE) {
                 if (host) |v| {
                     if (v.app.config.@"quick-terminal-autohide") {
@@ -18923,12 +18931,20 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
             return 1;
         },
 
+        c.WM_SHOWWINDOW => {
+            const result = sys.DefWindowProcW(hwnd, msg, wParam, lParam);
+            if (host) |v| v.refreshSurfaceVisibility();
+            return result;
+        },
+
         c.WM_WINDOWPOSCHANGED => {
             const result = sys.DefWindowProcW(hwnd, msg, wParam, lParam);
-            // This fires once per mouse-move during a drag-move/resize, and
-            // the visibility query costs a DWM round-trip. A window being
-            // dragged is by definition visible, so skip it until the drag
-            // ends; WM_EXITSIZEMOVE produces a final WM_WINDOWPOSCHANGED.
+            // This fires once per mouse-move during a drag-move/resize and
+            // the visibility query costs a DWM round-trip, so skip it while
+            // a drag is in flight -- a window being dragged is by definition
+            // visible. The drag loop emits its last WM_WINDOWPOSCHANGED just
+            // BEFORE WM_EXITSIZEMOVE, so that one is skipped too and the
+            // WM_EXITSIZEMOVE arm does the catch-up refresh.
             if (host) |v| {
                 if (!v.is_live_resize.load(.acquire)) v.refreshSurfaceVisibility();
             }
@@ -18955,6 +18971,9 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
                 v.startResizeSettleRepaints();
                 v.forceVisibleSurfaceRepaintsNow();
                 v.forceHostCompositionPaint();
+                // The last WM_WINDOWPOSCHANGED of the drag was skipped by
+                // the live-resize guard, so re-check here.
+                v.refreshSurfaceVisibility();
             }
             return sys.DefWindowProcW(hwnd, msg, wParam, lParam);
         },
@@ -19988,9 +20007,6 @@ pub const Surface = struct {
     live_resize_repaint_deferred: bool = false,
     renderer_repaint_requested: std.atomic.Value(bool) = .init(false),
     renderer_repaint_retry_pending: std.atomic.Value(bool) = .init(false),
-    presented_frame_count: u64 = 0,
-    presented_fps_last_tick_ms: u64 = 0,
-    presented_fps_last_frame_count: u64 = 0,
     draw_in_progress: bool = false,
     ime_composing: bool = false,
     deferred_char: DeferredCharState = .{},
@@ -21166,36 +21182,7 @@ pub const Surface = struct {
             const err = windows.kernel32.GetLastError();
             return windows.unexpectedError(err);
         }
-        self.notePresentedFrame();
         self.render_trace.noteSwapBuffers();
-    }
-
-    /// Sample presented frames per second for this surface. `RenderTrace`
-    /// carries the same signal for the benchmark suite; this is the
-    /// no-trace-file path, so it compiles away entirely unless debug
-    /// logging is on. `swapGLBuffers` runs on the app thread, so the
-    /// bookkeeping needs no synchronization.
-    fn notePresentedFrame(self: *Surface) void {
-        if (comptime !std.log.logEnabled(.debug, .win32)) return;
-
-        self.presented_frame_count += 1;
-        const now_ms = sys.GetTickCount64();
-        if (self.presented_fps_last_tick_ms == 0) {
-            self.presented_fps_last_tick_ms = now_ms;
-            self.presented_fps_last_frame_count = self.presented_frame_count;
-            return;
-        }
-
-        const elapsed_ms = now_ms -| self.presented_fps_last_tick_ms;
-        if (elapsed_ms < std.time.ms_per_s) return;
-
-        const frames = self.presented_frame_count -| self.presented_fps_last_frame_count;
-        self.presented_fps_last_tick_ms = now_ms;
-        self.presented_fps_last_frame_count = self.presented_frame_count;
-        log.debug(
-            "presented fps surface_id={} fps={} frames={} interval_ms={}",
-            .{ self.core_surface.id, frames *| std.time.ms_per_s / elapsed_ms, frames, elapsed_ms },
-        );
     }
 
     fn setTitle(self: *Surface, title: []const u8) !void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -20,6 +20,7 @@ const updatepkg = @import("../update/github_releases.zig");
 const SplitTree = @import("../datastruct/split_tree.zig").SplitTree;
 
 const win32_theme = @import("win32_theme.zig");
+const win32_power = @import("win32_power.zig");
 const win32_tween = @import("win32_tween.zig");
 const win32_uia = @import("win32_uia/mod.zig");
 const win32_terminal_accessibility = @import("win32_terminal_accessibility.zig");
@@ -4523,6 +4524,8 @@ pub const App = struct {
             if (source.host) |existing| try self.inheritHostWindowState(host, existing);
         }
 
+        host.power_notifications = win32_power.Notifications.init(hwnd);
+
         // Passive first-show for quick-terminal-keyboard-interactivity
         // = none: `SW_SHOWNOACTIVATE` makes the window visible but
         // does NOT bring it to the foreground, so the user's current
@@ -6921,6 +6924,9 @@ const Host = struct {
     id: u32,
     shell_id: ?win32_shell.model.WindowId = null,
     hwnd: ?HWND = null,
+    power_notifications: win32_power.Notifications = .{},
+    surfaces_visible: bool = true,
+    dwm_cloaked: bool = false,
     cached_decorations_visible: bool = true,
     tabs: std.ArrayListUnmanaged(Tab) = .empty,
     active_tab: usize = 0,
@@ -9378,6 +9384,7 @@ const Host = struct {
     }
 
     fn deinit(self: *Host) void {
+        self.power_notifications.deinit();
         // Stop the tween heartbeat timer before we tear down the
         // scheduler — leaving a SetTimer bound to a destroyed HWND
         // would panic the next time it fired.
@@ -10360,6 +10367,19 @@ const Host = struct {
             }
         }
         _ = sys.ShowWindow(hwnd, if (visible) c.SW_SHOW else c.SW_HIDE);
+        self.refreshSurfaceVisibility();
+    }
+
+    fn refreshSurfaceVisibility(self: *Host) void {
+        const hwnd = self.hwnd orelse return;
+        const state = win32_power.queryHostVisibility(hwnd, self.dwm_cloaked);
+        self.dwm_cloaked = state.cloaked;
+        if (self.surfaces_visible == state.visible) return;
+        self.surfaces_visible = state.visible;
+        for (self.tabs.items) |*tab| {
+            var it = tab.tree.iterator();
+            while (it.next()) |entry| entry.view.syncOcclusion();
+        }
     }
 
     fn present(self: *Host) void {
@@ -10371,6 +10391,7 @@ const Host = struct {
         )) |show_cmd| {
             _ = sys.ShowWindow(hwnd, show_cmd);
         }
+        self.refreshSurfaceVisibility();
         _ = sys.SetForegroundWindow(hwnd);
         _ = sys.SetFocus(hwnd);
     }
@@ -18891,6 +18912,29 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
             return sys.DefWindowProcW(hwnd, msg, wParam, lParam);
         },
 
+        win32_power.WM_POWERBROADCAST => {
+            // Only the power-setting notifications we registered for are
+            // ours. Suspend/resume and the legacy APM query messages must
+            // keep reaching DefWindowProcW.
+            if (wParam != win32_power.PBT_POWERSETTINGCHANGE) {
+                return sys.DefWindowProcW(hwnd, msg, wParam, lParam);
+            }
+            _ = win32_power.handlePowerSettingChange(lParam);
+            return 1;
+        },
+
+        c.WM_WINDOWPOSCHANGED => {
+            const result = sys.DefWindowProcW(hwnd, msg, wParam, lParam);
+            // This fires once per mouse-move during a drag-move/resize, and
+            // the visibility query costs a DWM round-trip. A window being
+            // dragged is by definition visible, so skip it until the drag
+            // ends; WM_EXITSIZEMOVE produces a final WM_WINDOWPOSCHANGED.
+            if (host) |v| {
+                if (!v.is_live_resize.load(.acquire)) v.refreshSurfaceVisibility();
+            }
+            return result;
+        },
+
         c.WM_ENTERSIZEMOVE => {
             // User started a drag-resize or drag-move. We don't know
             // which yet, but setting the flag on both is harmless —
@@ -18997,6 +19041,7 @@ fn hostWindowProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callcon
         c.WM_DESTROY => {
             if (host) |v| {
                 v.app.detachShellCompositorWindow(hwnd);
+                v.power_notifications.deinit();
                 v.hwnd = null;
             }
             return 0;
@@ -19943,6 +19988,9 @@ pub const Surface = struct {
     live_resize_repaint_deferred: bool = false,
     renderer_repaint_requested: std.atomic.Value(bool) = .init(false),
     renderer_repaint_retry_pending: std.atomic.Value(bool) = .init(false),
+    presented_frame_count: u64 = 0,
+    presented_fps_last_tick_ms: u64 = 0,
+    presented_fps_last_frame_count: u64 = 0,
     draw_in_progress: bool = false,
     ime_composing: bool = false,
     deferred_char: DeferredCharState = .{},
@@ -21118,7 +21166,36 @@ pub const Surface = struct {
             const err = windows.kernel32.GetLastError();
             return windows.unexpectedError(err);
         }
+        self.notePresentedFrame();
         self.render_trace.noteSwapBuffers();
+    }
+
+    /// Sample presented frames per second for this surface. `RenderTrace`
+    /// carries the same signal for the benchmark suite; this is the
+    /// no-trace-file path, so it compiles away entirely unless debug
+    /// logging is on. `swapGLBuffers` runs on the app thread, so the
+    /// bookkeeping needs no synchronization.
+    fn notePresentedFrame(self: *Surface) void {
+        if (comptime !std.log.logEnabled(.debug, .win32)) return;
+
+        self.presented_frame_count += 1;
+        const now_ms = sys.GetTickCount64();
+        if (self.presented_fps_last_tick_ms == 0) {
+            self.presented_fps_last_tick_ms = now_ms;
+            self.presented_fps_last_frame_count = self.presented_frame_count;
+            return;
+        }
+
+        const elapsed_ms = now_ms -| self.presented_fps_last_tick_ms;
+        if (elapsed_ms < std.time.ms_per_s) return;
+
+        const frames = self.presented_frame_count -| self.presented_fps_last_frame_count;
+        self.presented_fps_last_tick_ms = now_ms;
+        self.presented_fps_last_frame_count = self.presented_frame_count;
+        log.debug(
+            "presented fps surface_id={} fps={} frames={} interval_ms={}",
+            .{ self.core_surface.id, frames *| std.time.ms_per_s / elapsed_ms, frames, elapsed_ms },
+        );
     }
 
     fn setTitle(self: *Surface, title: []const u8) !void {
@@ -23438,7 +23515,13 @@ pub const Surface = struct {
             };
         }
 
+        self.syncOcclusion();
+    }
+
+    fn syncOcclusion(self: *Surface) void {
         if (!self.core_initialized) return;
+        const visible = self.window_visible and
+            (if (self.host) |host| host.surfaces_visible else true);
         if (!shouldDispatchOcclusion(self.occlusion_visible, visible)) return;
         self.occlusion_visible = visible;
         self.core_surface.occlusionCallback(visible) catch |err| {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -10379,8 +10379,20 @@ const Host = struct {
     }
 
     fn refreshSurfaceVisibility(self: *Host) void {
+        self.refreshSurfaceVisibilityObserving(null);
+    }
+
+    /// `observed_cloaked` is the transition a DWM cloak WinEvent just
+    /// reported, or `null` for message-driven refreshes that observed no
+    /// transition. Passing it through is what lets an uncloak recover when
+    /// `DwmGetWindowAttribute` fails; see `win32_power.resolveCloaked`.
+    fn refreshSurfaceVisibilityObserving(self: *Host, observed_cloaked: ?bool) void {
         const hwnd = self.hwnd orelse return;
-        const state = win32_power.queryHostVisibility(hwnd, self.dwm_cloaked);
+        const state = win32_power.queryHostVisibility(
+            hwnd,
+            self.dwm_cloaked,
+            observed_cloaked,
+        );
         self.dwm_cloaked = state.cloaked;
         if (self.surfaces_visible == state.visible) return;
         self.surfaces_visible = state.visible;
@@ -17641,12 +17653,17 @@ var cloak_event_app: ?*App = null;
 /// switch that uncloaks a background window would leave `surfaces_visible`
 /// false; hidden surfaces skip rendering entirely, so nothing would repair it
 /// until an unrelated message arrived.
-fn onHostCloakEvent(hwnd: HWND) void {
+///
+/// `cloaked` is the transition the event carried. It must reach the refresh:
+/// if it were dropped and the refresh's `DwmGetWindowAttribute` query then
+/// failed, the previous `cloaked = true` would be preserved and this very
+/// recovery path would be the thing that fails to recover.
+fn onHostCloakEvent(hwnd: HWND, cloaked: bool) void {
     const app = cloak_event_app orelse return;
     for (app.hosts.items) |host| {
         const host_hwnd = host.hwnd orelse continue;
         if (host_hwnd != hwnd) continue;
-        host.refreshSurfaceVisibility();
+        host.refreshSurfaceVisibilityObserving(cloaked);
         return;
     }
 }

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -113,6 +113,7 @@ pub const WM_SETCURSOR = 0x0020;
 pub const WM_SETFOCUS = 0x0007;
 pub const WM_SETTINGCHANGE = 0x001A;
 pub const WM_SIZE = 0x0005;
+pub const WM_WINDOWPOSCHANGED = 0x0047;
 pub const WM_ENTERSIZEMOVE = 0x0231;
 pub const WM_EXITSIZEMOVE = 0x0232;
 pub const SIZE_MAXIMIZED: u32 = 2;

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -113,6 +113,7 @@ pub const WM_SETCURSOR = 0x0020;
 pub const WM_SETFOCUS = 0x0007;
 pub const WM_SETTINGCHANGE = 0x001A;
 pub const WM_SIZE = 0x0005;
+pub const WM_SHOWWINDOW = 0x0018;
 pub const WM_WINDOWPOSCHANGED = 0x0047;
 pub const WM_ENTERSIZEMOVE = 0x0231;
 pub const WM_EXITSIZEMOVE = 0x0232;

--- a/src/apprt/win32/render_trace.zig
+++ b/src/apprt/win32/render_trace.zig
@@ -281,6 +281,10 @@ pub const RenderTrace = struct {
             .first_renderer_update_at_ms = self.first_renderer_update_at_ms.load(.acquire),
             .first_paint_at_ms = self.first_paint_at_ms.load(.acquire),
             .first_swap_at_ms = self.first_swap_at_ms.load(.acquire),
+            .last_swap_at_ms = elapsedTraceMs(
+                self.start_tick_ms,
+                self.last_swap_tick_ms.load(.acquire),
+            ),
         }, .{})}) catch return;
         stream.flush() catch return;
     }

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -1,0 +1,483 @@
+//! Win32 power-state sampling, notifications, and render pacing policy.
+
+const std = @import("std");
+const configpkg = @import("../config.zig");
+
+const log = std.log.scoped(.win32_power);
+const windows = std.os.windows;
+
+const BOOL = windows.BOOL;
+const BYTE = windows.BYTE;
+const DWORD = windows.DWORD;
+const GUID = windows.GUID;
+const HANDLE = windows.HANDLE;
+const HRESULT = windows.HRESULT;
+const HWND = windows.HWND;
+
+pub const WM_POWERBROADCAST: windows.UINT = 0x0218;
+pub const PBT_POWERSETTINGCHANGE: windows.WPARAM = 0x8013;
+
+const DEVICE_NOTIFY_WINDOW_HANDLE: DWORD = 0;
+const DWMWA_CLOAKED: DWORD = 14;
+const POLL_INTERVAL_MS: u64 = 30 * std.time.ms_per_s;
+/// Focused, non-saver surfaces keep this cadence, which must stay equal to
+/// the renderer thread's DRAW_INTERVAL (asserted there at comptime).
+pub const DEFAULT_PRESENT_INTERVAL_MS: u64 = 8;
+const SAVER_PRESENT_INTERVAL_MS: u64 = 34;
+
+const GUID_ACDC_POWER_SOURCE = GUID.parse("{5D3E9A59-E9D5-4B00-A6BD-FF34FF516548}");
+const GUID_POWER_SAVING_STATUS = GUID.parse("{E00958C0-C213-4ACE-AC77-FECCED2EEEA5}");
+
+pub const SYSTEM_POWER_STATUS = extern struct {
+    ACLineStatus: BYTE,
+    BatteryFlag: BYTE,
+    BatteryLifePercent: BYTE,
+    SystemStatusFlag: BYTE,
+    BatteryLifeTime: DWORD,
+    BatteryFullLifeTime: DWORD,
+};
+
+const POWERBROADCAST_SETTING = extern struct {
+    PowerSetting: GUID,
+    DataLength: DWORD,
+    Data: [1]BYTE,
+};
+
+comptime {
+    std.debug.assert(@sizeOf(SYSTEM_POWER_STATUS) == 12);
+    std.debug.assert(@offsetOf(POWERBROADCAST_SETTING, "Data") == 20);
+    std.debug.assert(@sizeOf(POWERBROADCAST_SETTING) == 24);
+}
+
+extern "kernel32" fn GetSystemPowerStatus(status: *SYSTEM_POWER_STATUS) callconv(.winapi) BOOL;
+extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
+extern "user32" fn RegisterPowerSettingNotification(
+    recipient: HANDLE,
+    power_setting_guid: *const GUID,
+    flags: DWORD,
+) callconv(.winapi) ?HANDLE;
+extern "user32" fn UnregisterPowerSettingNotification(handle: HANDLE) callconv(.winapi) BOOL;
+extern "user32" fn IsWindowVisible(hwnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn IsIconic(hwnd: HWND) callconv(.winapi) BOOL;
+extern "dwmapi" fn DwmGetWindowAttribute(
+    hwnd: HWND,
+    attribute: DWORD,
+    value: *anyopaque,
+    value_size: DWORD,
+) callconv(.winapi) HRESULT;
+
+const on_battery_bit: u8 = 1 << 0;
+const saver_bit: u8 = 1 << 1;
+
+var snapshot_bits = std.atomic.Value(u8).init(0);
+var last_poll_tick_ms = std.atomic.Value(u64).init(0);
+
+/// Process-wide power state. This is packed into one atomic byte so renderer
+/// threads read a coherent, lock-free snapshot.
+pub const Snapshot = struct {
+    on_battery: bool = false,
+    is_saver: bool = false,
+};
+
+pub const PolicyConfig = struct {
+    unfocused_render_fps: u32,
+    power_saver_rendering: configpkg.PowerSaverRendering,
+};
+
+pub const SettingUpdate = union(enum) {
+    on_battery: bool,
+    is_saver: bool,
+};
+
+pub const HostVisibility = struct {
+    visible: bool,
+    cloaked: bool,
+};
+
+/// Owns the two notification registrations associated with one host HWND.
+pub const Notifications = struct {
+    acdc: ?HANDLE = null,
+    saver: ?HANDLE = null,
+
+    pub fn init(hwnd: HWND) Notifications {
+        pollIfStale();
+
+        const acdc = RegisterPowerSettingNotification(
+            @ptrCast(hwnd),
+            &GUID_ACDC_POWER_SOURCE,
+            DEVICE_NOTIFY_WINDOW_HANDLE,
+        );
+        if (acdc == null) {
+            log.warn("AC/DC power notifications unavailable err={}", .{windows.kernel32.GetLastError()});
+        }
+
+        const saver = RegisterPowerSettingNotification(
+            @ptrCast(hwnd),
+            &GUID_POWER_SAVING_STATUS,
+            DEVICE_NOTIFY_WINDOW_HANDLE,
+        );
+        if (saver == null) {
+            log.warn("power-saver notifications unavailable err={}", .{windows.kernel32.GetLastError()});
+        }
+
+        return .{ .acdc = acdc, .saver = saver };
+    }
+
+    pub fn deinit(self: *Notifications) void {
+        if (self.acdc) |handle| {
+            if (UnregisterPowerSettingNotification(handle) == 0) {
+                log.warn("failed to unregister AC/DC power notification err={}", .{windows.kernel32.GetLastError()});
+            }
+        }
+        if (self.saver) |handle| {
+            if (UnregisterPowerSettingNotification(handle) == 0) {
+                log.warn("failed to unregister power-saver notification err={}", .{windows.kernel32.GetLastError()});
+            }
+        }
+        self.* = .{};
+    }
+};
+
+/// Convert the raw Win32 status structure without performing I/O. Unknown AC
+/// state preserves the last known source while the saver flag follows the
+/// documented exact `SystemStatusFlag == 1` contract.
+pub fn parseSystemPowerStatus(raw: SYSTEM_POWER_STATUS, previous: Snapshot) Snapshot {
+    return .{
+        .on_battery = switch (raw.ACLineStatus) {
+            0, 2 => true,
+            1 => false,
+            else => previous.on_battery,
+        },
+        .is_saver = raw.SystemStatusFlag == 1,
+    };
+}
+
+/// Parse the variable-length payload delivered with
+/// `PBT_POWERSETTINGCHANGE`. Both settings used here carry one DWORD.
+pub fn parsePowerSettingNotification(payload: []const u8) ?SettingUpdate {
+    const length_offset = @offsetOf(POWERBROADCAST_SETTING, "DataLength");
+    const data_offset = @offsetOf(POWERBROADCAST_SETTING, "Data");
+    const value_size = @sizeOf(DWORD);
+    if (payload.len < data_offset + value_size) return null;
+    const declared_len = std.mem.readInt(DWORD, payload[length_offset..][0..@sizeOf(DWORD)], .little);
+    if (declared_len != value_size) return null;
+
+    const value = std.mem.readInt(DWORD, payload[data_offset..][0..value_size], .little);
+    const guid_bytes = payload[@offsetOf(POWERBROADCAST_SETTING, "PowerSetting")..][0..@sizeOf(GUID)];
+    if (std.mem.eql(u8, guid_bytes, std.mem.asBytes(&GUID_ACDC_POWER_SOURCE))) {
+        return .{ .on_battery = switch (value) {
+            0 => false,
+            1, 2 => true,
+            else => return null,
+        } };
+    }
+    if (std.mem.eql(u8, guid_bytes, std.mem.asBytes(&GUID_POWER_SAVING_STATUS))) {
+        return .{ .is_saver = switch (value) {
+            0 => false,
+            1 => true,
+            else => return null,
+        } };
+    }
+    return null;
+}
+
+/// Apply a power-setting message to the process snapshot. The message payload
+/// is borrowed only for the duration of the window-procedure call.
+pub fn handlePowerSettingChange(l_param: windows.LPARAM) bool {
+    if (l_param == 0) return false;
+    const payload: *const [@sizeOf(POWERBROADCAST_SETTING)]u8 =
+        @ptrFromInt(@as(usize, @bitCast(l_param)));
+    const update = parsePowerSettingNotification(payload) orelse return false;
+    publishSetting(update);
+    return true;
+}
+
+/// Return the current process power state with one atomic load.
+pub fn snapshot() Snapshot {
+    return unpackSnapshot(snapshot_bits.load(.acquire));
+}
+
+/// Opportunistic fallback for systems where notifications are unavailable or
+/// missed. The atomic claim ensures calls cannot query more often than once per
+/// 30 seconds across all renderer threads.
+pub fn pollIfStale() void {
+    const now = GetTickCount64();
+    var previous = last_poll_tick_ms.load(.acquire);
+    if (previous != 0 and now -| previous < POLL_INTERVAL_MS) return;
+    while (true) {
+        if (last_poll_tick_ms.cmpxchgWeak(previous, now, .acq_rel, .acquire)) |observed| {
+            previous = observed;
+            if (previous != 0 and now -| previous < POLL_INTERVAL_MS) return;
+            continue;
+        }
+        break;
+    }
+
+    var raw: SYSTEM_POWER_STATUS = undefined;
+    if (GetSystemPowerStatus(&raw) == 0) return;
+    publishSnapshot(parseSystemPowerStatus(raw, snapshot()));
+}
+
+/// Monotonic millisecond clock shared with Win32 notification and visibility
+/// code. Renderer pacing uses this only when throttling is active.
+pub fn tickCountMs() u64 {
+    return GetTickCount64();
+}
+
+/// Whether saver-specific pacing is active for the current configuration.
+pub fn saverRenderingActive(mode: configpkg.PowerSaverRendering, state: Snapshot) bool {
+    return switch (mode) {
+        .auto => state.is_saver,
+        .on => true,
+        .off => false,
+    };
+}
+
+/// Pure render-pacing policy. `null` means the surface must not present.
+/// Focused, visible, non-saver surfaces retain the existing 8 ms cadence.
+pub fn minimumPresentIntervalMs(
+    focused: bool,
+    visible: bool,
+    state: Snapshot,
+    config: PolicyConfig,
+) ?u64 {
+    if (!visible) return null;
+
+    const saver_active = saverRenderingActive(config.power_saver_rendering, state);
+    if (focused and !saver_active) return DEFAULT_PRESENT_INTERVAL_MS;
+
+    const unfocused_interval = fpsIntervalMs(config.unfocused_render_fps);
+    if (!focused and !saver_active) return unfocused_interval;
+
+    return if (focused)
+        SAVER_PRESENT_INTERVAL_MS
+    else
+        @max(SAVER_PRESENT_INTERVAL_MS, unfocused_interval);
+}
+
+/// Pure host-window visibility decision. A host presents only while its
+/// window is shown, not minimized, and not DWM-cloaked. Logical tab/split
+/// visibility is tracked separately per surface and ANDed with this.
+pub fn hostVisible(window_visible: bool, minimized: bool, cloaked: bool) bool {
+    return window_visible and !minimized and !cloaked;
+}
+
+/// Query host visibility while preserving the last cloak result if DWM cannot
+/// answer transiently.
+pub fn queryHostVisibility(hwnd: HWND, previous_cloaked: bool) HostVisibility {
+    var cloak_reason: DWORD = 0;
+    const result = DwmGetWindowAttribute(
+        hwnd,
+        DWMWA_CLOAKED,
+        &cloak_reason,
+        @sizeOf(DWORD),
+    );
+    const cloaked = if (result >= 0) cloak_reason != 0 else previous_cloaked;
+    return .{
+        .visible = hostVisible(
+            IsWindowVisible(hwnd) != 0,
+            IsIconic(hwnd) != 0,
+            cloaked,
+        ),
+        .cloaked = cloaked,
+    };
+}
+
+fn fpsIntervalMs(fps: u32) u64 {
+    const normalized: u64 = @max(1, @as(u64, fps));
+    return @max(
+        DEFAULT_PRESENT_INTERVAL_MS,
+        (std.time.ms_per_s + normalized - 1) / normalized,
+    );
+}
+
+fn packSnapshot(value: Snapshot) u8 {
+    return @as(u8, @intFromBool(value.on_battery)) * on_battery_bit |
+        @as(u8, @intFromBool(value.is_saver)) * saver_bit;
+}
+
+fn unpackSnapshot(bits: u8) Snapshot {
+    return .{
+        .on_battery = bits & on_battery_bit != 0,
+        .is_saver = bits & saver_bit != 0,
+    };
+}
+
+fn publishSnapshot(value: Snapshot) void {
+    snapshot_bits.store(packSnapshot(value), .release);
+}
+
+fn publishSetting(update: SettingUpdate) void {
+    var current = snapshot_bits.load(.acquire);
+    while (true) {
+        var next = current;
+        switch (update) {
+            .on_battery => |value| {
+                if (value) next |= on_battery_bit else next &= ~on_battery_bit;
+            },
+            .is_saver => |value| {
+                if (value) next |= saver_bit else next &= ~saver_bit;
+            },
+        }
+        current = snapshot_bits.cmpxchgWeak(current, next, .acq_rel, .acquire) orelse return;
+    }
+}
+
+fn settingPayload(guid: GUID, value: DWORD) [@sizeOf(POWERBROADCAST_SETTING)]u8 {
+    var payload = [_]u8{0} ** @sizeOf(POWERBROADCAST_SETTING);
+    @memcpy(
+        payload[@offsetOf(POWERBROADCAST_SETTING, "PowerSetting")..][0..@sizeOf(GUID)],
+        std.mem.asBytes(&guid),
+    );
+    std.mem.writeInt(
+        DWORD,
+        payload[@offsetOf(POWERBROADCAST_SETTING, "DataLength")..][0..@sizeOf(DWORD)],
+        @sizeOf(DWORD),
+        .little,
+    );
+    std.mem.writeInt(
+        DWORD,
+        payload[@offsetOf(POWERBROADCAST_SETTING, "Data")..][0..@sizeOf(DWORD)],
+        value,
+        .little,
+    );
+    return payload;
+}
+
+test "power status parsing preserves unknown AC state" {
+    const previous: Snapshot = .{ .on_battery = true, .is_saver = false };
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = false, .is_saver = true },
+        parseSystemPowerStatus(.{
+            .ACLineStatus = 1,
+            .BatteryFlag = 0,
+            .BatteryLifePercent = 80,
+            .SystemStatusFlag = 1,
+            .BatteryLifeTime = 0,
+            .BatteryFullLifeTime = 0,
+        }, previous),
+    );
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = true, .is_saver = false },
+        parseSystemPowerStatus(.{
+            .ACLineStatus = 0xff,
+            .BatteryFlag = 0xff,
+            .BatteryLifePercent = 0xff,
+            .SystemStatusFlag = 2,
+            .BatteryLifeTime = 0xffff_ffff,
+            .BatteryFullLifeTime = 0xffff_ffff,
+        }, previous),
+    );
+}
+
+test "power notification parsing accepts registered settings" {
+    const acdc = settingPayload(GUID_ACDC_POWER_SOURCE, 1);
+    try std.testing.expectEqual(
+        SettingUpdate{ .on_battery = true },
+        parsePowerSettingNotification(&acdc).?,
+    );
+
+    const saver = settingPayload(GUID_POWER_SAVING_STATUS, 0);
+    try std.testing.expectEqual(
+        SettingUpdate{ .is_saver = false },
+        parsePowerSettingNotification(&saver).?,
+    );
+
+    const saver_on = settingPayload(GUID_POWER_SAVING_STATUS, 1);
+    try std.testing.expectEqual(
+        SettingUpdate{ .is_saver = true },
+        parsePowerSettingNotification(&saver_on).?,
+    );
+
+    var malformed = settingPayload(GUID_POWER_SAVING_STATUS, 1);
+    std.mem.writeInt(
+        DWORD,
+        malformed[@offsetOf(POWERBROADCAST_SETTING, "DataLength")..][0..@sizeOf(DWORD)],
+        8,
+        .little,
+    );
+    try std.testing.expect(parsePowerSettingNotification(&malformed) == null);
+}
+
+test "power render policy preserves focused non-saver pacing" {
+    const config: PolicyConfig = .{
+        .unfocused_render_fps = 30,
+        .power_saver_rendering = .auto,
+    };
+    try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
+        true,
+        true,
+        .{ .on_battery = false, .is_saver = false },
+        config,
+    ));
+    try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
+        true,
+        true,
+        .{ .on_battery = true, .is_saver = false },
+        config,
+    ));
+    try std.testing.expectEqual(@as(?u64, null), minimumPresentIntervalMs(
+        true,
+        false,
+        .{ .on_battery = true, .is_saver = true },
+        config,
+    ));
+}
+
+test "power render policy caps saver and unfocused surfaces" {
+    const sixty_fps: PolicyConfig = .{
+        .unfocused_render_fps = 60,
+        .power_saver_rendering = .auto,
+    };
+    try std.testing.expectEqual(@as(?u64, 17), minimumPresentIntervalMs(
+        false,
+        true,
+        .{},
+        sixty_fps,
+    ));
+    var uncapped = sixty_fps;
+    uncapped.unfocused_render_fps = 1000;
+    try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
+        false,
+        true,
+        .{},
+        uncapped,
+    ));
+    try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
+        true,
+        true,
+        .{ .on_battery = true, .is_saver = true },
+        sixty_fps,
+    ));
+    try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
+        false,
+        true,
+        .{ .on_battery = true, .is_saver = true },
+        sixty_fps,
+    ));
+
+    var forced = sixty_fps;
+    forced.power_saver_rendering = .on;
+    try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
+        true,
+        true,
+        .{},
+        forced,
+    ));
+
+    forced.power_saver_rendering = .off;
+    try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
+        true,
+        true,
+        .{ .is_saver = true },
+        forced,
+    ));
+}
+
+test "power visibility policy rejects hidden minimized and cloaked hosts" {
+    try std.testing.expect(hostVisible(true, false, false));
+    try std.testing.expect(!hostVisible(false, false, false));
+    try std.testing.expect(!hostVisible(true, true, false));
+    try std.testing.expect(!hostVisible(true, false, true));
+    try std.testing.expect(!hostVisible(true, true, true));
+}

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -28,6 +28,18 @@ const SAVER_PRESENT_INTERVAL_MS: u64 = 34;
 
 const GUID_ACDC_POWER_SOURCE = GUID.parse("{5D3E9A59-E9D5-4B00-A6BD-FF34FF516548}");
 const GUID_POWER_SAVING_STATUS = GUID.parse("{E00958C0-C213-4ACE-AC77-FECCED2EEEA5}");
+/// Windows 11 "Energy Saver", which unlike legacy battery saver can engage
+/// while plugged in. Microsoft documents this GUID on the Power Setting GUIDs
+/// (WinNT.h) page with exactly this value -- it happens to coincide with the
+/// RFC 4122 example UUID -- but marks it PRERELEASE, so it may change.
+/// Registration simply fails on builds that predate it, which is why that
+/// failure is logged at debug rather than warn.
+const GUID_ENERGY_SAVER_STATUS = GUID.parse("{550E8400-E29B-41D4-A716-446655440000}");
+
+/// ENERGY_SAVER_STATUS, the Data payload of GUID_ENERGY_SAVER_STATUS.
+const ENERGY_SAVER_OFF: DWORD = 0;
+const ENERGY_SAVER_STANDARD: DWORD = 1;
+const ENERGY_SAVER_HIGH_SAVINGS: DWORD = 2;
 
 pub const SYSTEM_POWER_STATUS = extern struct {
     ACLineStatus: BYTE,
@@ -69,6 +81,9 @@ const saver_bit: u8 = 1 << 1;
 
 var snapshot_bits = std.atomic.Value(u8).init(0);
 var last_poll_tick_ms = std.atomic.Value(u64).init(0);
+/// Bumped by every notification-driven update so a slower poll can detect
+/// that it raced a push and is therefore stale.
+var push_generation = std.atomic.Value(u32).init(0);
 
 /// Process-wide power state. This is packed into one atomic byte so renderer
 /// threads read a coherent, lock-free snapshot.
@@ -96,6 +111,7 @@ pub const HostVisibility = struct {
 pub const Notifications = struct {
     acdc: ?HANDLE = null,
     saver: ?HANDLE = null,
+    energy_saver: ?HANDLE = null,
 
     pub fn init(hwnd: HWND) Notifications {
         pollIfStale();
@@ -115,10 +131,21 @@ pub const Notifications = struct {
             DEVICE_NOTIFY_WINDOW_HANDLE,
         );
         if (saver == null) {
-            log.warn("power-saver notifications unavailable err={}", .{windows.kernel32.GetLastError()});
+            log.warn("battery-saver notifications unavailable err={}", .{windows.kernel32.GetLastError()});
         }
 
-        return .{ .acdc = acdc, .saver = saver };
+        // Expected to fail on Windows builds without Energy Saver. Battery
+        // saver above still covers those, so this is not a warning.
+        const energy_saver = RegisterPowerSettingNotification(
+            @ptrCast(hwnd),
+            &GUID_ENERGY_SAVER_STATUS,
+            DEVICE_NOTIFY_WINDOW_HANDLE,
+        );
+        if (energy_saver == null) {
+            log.debug("energy-saver notifications unavailable err={}", .{windows.kernel32.GetLastError()});
+        }
+
+        return .{ .acdc = acdc, .saver = saver, .energy_saver = energy_saver };
     }
 
     pub fn deinit(self: *Notifications) void {
@@ -129,7 +156,12 @@ pub const Notifications = struct {
         }
         if (self.saver) |handle| {
             if (UnregisterPowerSettingNotification(handle) == 0) {
-                log.warn("failed to unregister power-saver notification err={}", .{windows.kernel32.GetLastError()});
+                log.warn("failed to unregister battery-saver notification err={}", .{windows.kernel32.GetLastError()});
+            }
+        }
+        if (self.energy_saver) |handle| {
+            if (UnregisterPowerSettingNotification(handle) == 0) {
+                log.warn("failed to unregister energy-saver notification err={}", .{windows.kernel32.GetLastError()});
             }
         }
         self.* = .{};
@@ -180,6 +212,16 @@ pub fn parsePowerSettingNotification(payload: []const u8) ?SettingUpdate {
             else => return null,
         } };
     }
+    if (std.mem.eql(u8, guid_bytes, std.mem.asBytes(&GUID_ENERGY_SAVER_STATUS))) {
+        // Both saving modes throttle. STANDARD asks for savings where the
+        // user-experience cost is minimal, which capping an unfocused or
+        // idle terminal present rate satisfies.
+        return .{ .is_saver = switch (value) {
+            ENERGY_SAVER_OFF => false,
+            ENERGY_SAVER_STANDARD, ENERGY_SAVER_HIGH_SAVINGS => true,
+            else => return null,
+        } };
+    }
     return null;
 }
 
@@ -215,9 +257,22 @@ pub fn pollIfStale() void {
         break;
     }
 
+    // Claiming the slot up front keeps concurrent renderer threads from
+    // stampeding the syscall, but a failed query should not cost us the
+    // next 30 seconds of fallback, so hand the slot back on failure.
+    const generation = push_generation.load(.acquire);
     var raw: SYSTEM_POWER_STATUS = undefined;
-    if (GetSystemPowerStatus(&raw) == 0) return;
-    publishSnapshot(parseSystemPowerStatus(raw, snapshot()));
+    if (GetSystemPowerStatus(&raw) == 0) {
+        last_poll_tick_ms.store(previous, .release);
+        return;
+    }
+
+    // A WM_POWERBROADCAST push that landed while we were inside the
+    // syscall is strictly fresher than what we just read. Drop the poll
+    // rather than overwrite it; the next poll or push corrects us anyway.
+    const value = parseSystemPowerStatus(raw, snapshot());
+    if (push_generation.load(.acquire) != generation) return;
+    publishSnapshot(value);
 }
 
 /// Monotonic millisecond clock shared with Win32 notification and visibility
@@ -310,6 +365,11 @@ fn publishSnapshot(value: Snapshot) void {
 }
 
 fn publishSetting(update: SettingUpdate) void {
+    // Bump before the store so a poll that started earlier and is about to
+    // publish observes the change and backs off. Bumping after would leave a
+    // window where the poll sees the old generation and clobbers this update.
+    _ = push_generation.fetchAdd(1, .acq_rel);
+
     var current = snapshot_bits.load(.acquire);
     while (true) {
         var next = current;
@@ -390,6 +450,26 @@ test "power notification parsing accepts registered settings" {
         SettingUpdate{ .is_saver = true },
         parsePowerSettingNotification(&saver_on).?,
     );
+
+    // Energy Saver (prerelease GUID) maps its three-state enum onto the same
+    // saver flag: off is off, both savings modes throttle.
+    const energy_off = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_OFF);
+    try std.testing.expectEqual(
+        SettingUpdate{ .is_saver = false },
+        parsePowerSettingNotification(&energy_off).?,
+    );
+    const energy_standard = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_STANDARD);
+    try std.testing.expectEqual(
+        SettingUpdate{ .is_saver = true },
+        parsePowerSettingNotification(&energy_standard).?,
+    );
+    const energy_high = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_HIGH_SAVINGS);
+    try std.testing.expectEqual(
+        SettingUpdate{ .is_saver = true },
+        parsePowerSettingNotification(&energy_high).?,
+    );
+    const energy_bogus = settingPayload(GUID_ENERGY_SAVER_STATUS, 7);
+    try std.testing.expect(parsePowerSettingNotification(&energy_bogus) == null);
 
     var malformed = settingPayload(GUID_POWER_SAVING_STATUS, 1);
     std.mem.writeInt(

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const configpkg = @import("../config.zig");
+const sys = @import("win32/sys.zig");
 
 const log = std.log.scoped(.win32_power);
 const windows = std.os.windows;
@@ -50,15 +51,12 @@ comptime {
 }
 
 extern "kernel32" fn GetSystemPowerStatus(status: *SYSTEM_POWER_STATUS) callconv(.winapi) BOOL;
-extern "kernel32" fn GetTickCount64() callconv(.winapi) u64;
 extern "user32" fn RegisterPowerSettingNotification(
     recipient: HANDLE,
     power_setting_guid: *const GUID,
     flags: DWORD,
 ) callconv(.winapi) ?HANDLE;
 extern "user32" fn UnregisterPowerSettingNotification(handle: HANDLE) callconv(.winapi) BOOL;
-extern "user32" fn IsWindowVisible(hwnd: HWND) callconv(.winapi) BOOL;
-extern "user32" fn IsIconic(hwnd: HWND) callconv(.winapi) BOOL;
 extern "dwmapi" fn DwmGetWindowAttribute(
     hwnd: HWND,
     attribute: DWORD,
@@ -144,8 +142,12 @@ pub const Notifications = struct {
 pub fn parseSystemPowerStatus(raw: SYSTEM_POWER_STATUS, previous: Snapshot) Snapshot {
     return .{
         .on_battery = switch (raw.ACLineStatus) {
-            0, 2 => true,
+            0 => true,
             1 => false,
+            // 255 is "unknown"; anything else is undocumented. Keep the last
+            // known source rather than guessing. (The value 2 means
+            // "short term / UPS" in the GUID_ACDC_POWER_SOURCE notification
+            // payload, not here — see parsePowerSettingNotification.)
             else => previous.on_battery,
         },
         .is_saver = raw.SystemStatusFlag == 1,
@@ -201,7 +203,7 @@ pub fn snapshot() Snapshot {
 /// missed. The atomic claim ensures calls cannot query more often than once per
 /// 30 seconds across all renderer threads.
 pub fn pollIfStale() void {
-    const now = GetTickCount64();
+    const now = sys.GetTickCount64();
     var previous = last_poll_tick_ms.load(.acquire);
     if (previous != 0 and now -| previous < POLL_INTERVAL_MS) return;
     while (true) {
@@ -221,7 +223,7 @@ pub fn pollIfStale() void {
 /// Monotonic millisecond clock shared with Win32 notification and visibility
 /// code. Renderer pacing uses this only when throttling is active.
 pub fn tickCountMs() u64 {
-    return GetTickCount64();
+    return sys.GetTickCount64();
 }
 
 /// Whether saver-specific pacing is active for the current configuration.
@@ -275,8 +277,8 @@ pub fn queryHostVisibility(hwnd: HWND, previous_cloaked: bool) HostVisibility {
     const cloaked = if (result >= 0) cloak_reason != 0 else previous_cloaked;
     return .{
         .visible = hostVisible(
-            IsWindowVisible(hwnd) != 0,
-            IsIconic(hwnd) != 0,
+            sys.IsWindowVisible(hwnd) != 0,
+            sys.IsIconic(hwnd) != 0,
             cloaked,
         ),
         .cloaked = cloaked,

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -109,7 +109,12 @@ extern "user32" fn SetWinEventHook(
 extern "user32" fn UnhookWinEvent(hook: HANDLE) callconv(.winapi) BOOL;
 
 const on_battery_bit: u8 = 1 << 0;
-const saver_bit: u8 = 1 << 1;
+/// Legacy "Battery Saver" (GUID_POWER_SAVING_STATUS and the
+/// `SYSTEM_POWER_STATUS.SystemStatusFlag` poll fallback).
+const battery_saver_bit: u8 = 1 << 1;
+/// Windows 11 "Energy Saver" (GUID_ENERGY_SAVER_STATUS). Independent of the
+/// bit above: either source alone means saver pacing applies.
+const energy_saver_bit: u8 = 1 << 2;
 
 var snapshot_bits = std.atomic.Value(u8).init(0);
 var last_poll_tick_ms = std.atomic.Value(u64).init(0);
@@ -121,7 +126,27 @@ var push_generation = std.atomic.Value(u32).init(0);
 /// threads read a coherent, lock-free snapshot.
 pub const Snapshot = struct {
     on_battery: bool = false,
-    is_saver: bool = false,
+    /// Legacy Battery Saver. Reported by GUID_POWER_SAVING_STATUS and by
+    /// `SYSTEM_POWER_STATUS.SystemStatusFlag`.
+    battery_saver: bool = false,
+    /// Windows 11 Energy Saver. Reported only by GUID_ENERGY_SAVER_STATUS;
+    /// there is no `GetSystemPowerStatus` field for it.
+    energy_saver: bool = false,
+
+    /// Effective saver state: the union of the two independent sources.
+    ///
+    /// They must stay separate in storage. Windows reports them through
+    /// different notifications that can disagree, so folding them into one
+    /// flag at write time lets whichever notification arrives last erase the
+    /// other -- e.g. Energy Saver turning OFF would clear saver pacing while
+    /// Battery Saver is still on.
+    ///
+    /// `on_battery` is deliberately NOT a source here: `auto` follows the
+    /// saver signals only, never plain battery power. See `Config.zig` and
+    /// `docs/windows.md`.
+    pub fn isSaver(self: Snapshot) bool {
+        return self.battery_saver or self.energy_saver;
+    }
 };
 
 pub const PolicyConfig = struct {
@@ -129,9 +154,12 @@ pub const PolicyConfig = struct {
     power_saver_rendering: configpkg.PowerSaverRendering,
 };
 
+/// A single-source update. Each variant writes only its own bit, so one
+/// source can never clear another.
 pub const SettingUpdate = union(enum) {
     on_battery: bool,
-    is_saver: bool,
+    battery_saver: bool,
+    energy_saver: bool,
 };
 
 pub const HostVisibility = struct {
@@ -142,7 +170,11 @@ pub const HostVisibility = struct {
 /// Called on the UI thread when DWM reports that one of our own top-level
 /// windows was cloaked or uncloaked. Installed by the apprt, which owns the
 /// HWND -> host mapping this module deliberately knows nothing about.
-pub const CloakEventHandler = *const fn (hwnd: HWND) void;
+///
+/// `cloaked` is the transition the event itself carried, and must be passed
+/// through rather than discarded: it is the only recovery path when the
+/// follow-up `DwmGetWindowAttribute` query fails. See `resolveCloaked`.
+pub const CloakEventHandler = *const fn (hwnd: HWND, cloaked: bool) void;
 
 /// All of the following are touched only from the UI/pump thread: hosts are
 /// created and destroyed there, and `WINEVENT_OUTOFCONTEXT` callbacks are
@@ -184,7 +216,10 @@ fn cloakWinEventProc(
     // thread, so Windows delivers this from inside our own message pump.
     // We are on the UI thread and may touch host state directly; nothing
     // here may be moved to another thread.
-    handler(target);
+    //
+    // Forward WHICH transition fired. `isHostCloakEvent` has already
+    // narrowed `event` to exactly one of the two.
+    handler(target, event == EVENT_OBJECT_CLOAKED);
 }
 
 /// Reference-counted because one thread-scoped hook already covers every host
@@ -314,7 +349,11 @@ pub fn parseSystemPowerStatus(raw: SYSTEM_POWER_STATUS, previous: Snapshot) Snap
             // payload, not here — see parsePowerSettingNotification.)
             else => previous.on_battery,
         },
-        .is_saver = raw.SystemStatusFlag == 1,
+        // SystemStatusFlag is the legacy Battery Saver indicator only.
+        .battery_saver = raw.SystemStatusFlag == 1,
+        // `GetSystemPowerStatus` has no Energy Saver field, so a poll must
+        // carry the last notified value forward instead of clearing it.
+        .energy_saver = previous.energy_saver,
     };
 }
 
@@ -338,7 +377,7 @@ pub fn parsePowerSettingNotification(payload: []const u8) ?SettingUpdate {
         } };
     }
     if (std.mem.eql(u8, guid_bytes, std.mem.asBytes(&GUID_POWER_SAVING_STATUS))) {
-        return .{ .is_saver = switch (value) {
+        return .{ .battery_saver = switch (value) {
             0 => false,
             1 => true,
             else => return null,
@@ -348,7 +387,7 @@ pub fn parsePowerSettingNotification(payload: []const u8) ?SettingUpdate {
         // Both saving modes throttle. STANDARD asks for savings where the
         // user-experience cost is minimal, which capping an unfocused or
         // idle terminal present rate satisfies.
-        return .{ .is_saver = switch (value) {
+        return .{ .energy_saver = switch (value) {
             ENERGY_SAVER_OFF => false,
             ENERGY_SAVER_STANDARD, ENERGY_SAVER_HIGH_SAVINGS => true,
             else => return null,
@@ -425,7 +464,8 @@ pub fn tickCountMs() u64 {
 /// Whether saver-specific pacing is active for the current configuration.
 pub fn saverRenderingActive(mode: configpkg.PowerSaverRendering, state: Snapshot) bool {
     return switch (mode) {
-        .auto => state.is_saver,
+        // `auto` follows Battery Saver OR Energy Saver, never plain battery.
+        .auto => state.isSaver(),
         .on => true,
         .off => false,
     };
@@ -460,9 +500,41 @@ pub fn hostVisible(window_visible: bool, minimized: bool, cloaked: bool) bool {
     return window_visible and !minimized and !cloaked;
 }
 
-/// Query host visibility while preserving the last cloak result if DWM cannot
-/// answer transiently.
-pub fn queryHostVisibility(hwnd: HWND, previous_cloaked: bool) HostVisibility {
+/// Pure cloak-resolution policy.
+///
+/// `query` is the `DwmGetWindowAttribute(DWMWA_CLOAKED)` result, or `null`
+/// when DWM could not answer. `observed` is the transition a WinEvent just
+/// reported, or `null` for a refresh not driven by a cloak event.
+///
+/// Precedence, and why:
+///
+///  1. A successful query wins. It is the current truth and may be newer
+///     than the event that triggered this refresh.
+///  2. Otherwise the observed transition wins. Windows documents
+///     EVENT_OBJECT_UNCLOAKED as being raised after the window has been
+///     uncloaked, so the event is a valid statement about cloak state on its
+///     own and does not need the query to succeed.
+///  3. Only with neither do we preserve the previous value.
+///
+/// Rule 2 exists because falling back to `previous` on an UNCLOAKED event is
+/// unrecoverable rather than merely stale: a preserved `cloaked = true`
+/// leaves the host's surfaces hidden, hidden surfaces do no renderer work,
+/// and no further cloak event is coming for a window that is already
+/// uncloaked -- so nothing would ever re-query and the terminal stays frozen
+/// until an unrelated window message happens to arrive. The failure mode of
+/// guessing wrong in the other direction is bounded: a spuriously visible
+/// host merely presents until the next refresh corrects it.
+///
+/// NOTE: this precedence is argued from the documented WinEvent contract and
+/// from the code paths above, not from an observed repro. No desktop session
+/// was available to this change; the covering test below exercises the
+/// policy, not DWM itself.
+pub fn resolveCloaked(query: ?bool, observed: ?bool, previous: bool) bool {
+    return query orelse observed orelse previous;
+}
+
+/// Raw DWM cloak query. `null` means DWM could not answer transiently.
+fn queryCloaked(hwnd: HWND) ?bool {
     var cloak_reason: DWORD = 0;
     const result = DwmGetWindowAttribute(
         hwnd,
@@ -470,7 +542,22 @@ pub fn queryHostVisibility(hwnd: HWND, previous_cloaked: bool) HostVisibility {
         &cloak_reason,
         @sizeOf(DWORD),
     );
-    const cloaked = if (result >= 0) cloak_reason != 0 else previous_cloaked;
+    return if (result >= 0) cloak_reason != 0 else null;
+}
+
+/// Query host visibility. `observed_cloaked` carries the transition from a
+/// cloak WinEvent when this refresh was triggered by one; see
+/// `resolveCloaked` for how a failed DWM query is resolved.
+pub fn queryHostVisibility(
+    hwnd: HWND,
+    previous_cloaked: bool,
+    observed_cloaked: ?bool,
+) HostVisibility {
+    const cloaked = resolveCloaked(
+        queryCloaked(hwnd),
+        observed_cloaked,
+        previous_cloaked,
+    );
     return .{
         .visible = hostVisible(
             sys.IsWindowVisible(hwnd) != 0,
@@ -491,13 +578,15 @@ fn fpsIntervalMs(fps: u32) u64 {
 
 fn packSnapshot(value: Snapshot) u8 {
     return @as(u8, @intFromBool(value.on_battery)) * on_battery_bit |
-        @as(u8, @intFromBool(value.is_saver)) * saver_bit;
+        @as(u8, @intFromBool(value.battery_saver)) * battery_saver_bit |
+        @as(u8, @intFromBool(value.energy_saver)) * energy_saver_bit;
 }
 
 fn unpackSnapshot(bits: u8) Snapshot {
     return .{
         .on_battery = bits & on_battery_bit != 0,
-        .is_saver = bits & saver_bit != 0,
+        .battery_saver = bits & battery_saver_bit != 0,
+        .energy_saver = bits & energy_saver_bit != 0,
     };
 }
 
@@ -535,8 +624,13 @@ fn publishSetting(update: SettingUpdate) void {
             .on_battery => |value| {
                 if (value) next |= on_battery_bit else next &= ~on_battery_bit;
             },
-            .is_saver => |value| {
-                if (value) next |= saver_bit else next &= ~saver_bit;
+            // Each source owns exactly one bit, so a read-modify-write here
+            // leaves the other source untouched.
+            .battery_saver => |value| {
+                if (value) next |= battery_saver_bit else next &= ~battery_saver_bit;
+            },
+            .energy_saver => |value| {
+                if (value) next |= energy_saver_bit else next &= ~energy_saver_bit;
             },
         }
         current = snapshot_bits.cmpxchgWeak(current, next, .acq_rel, .acquire) orelse return;
@@ -565,9 +659,9 @@ fn settingPayload(guid: GUID, value: DWORD) [@sizeOf(POWERBROADCAST_SETTING)]u8 
 }
 
 test "power status parsing preserves unknown AC state" {
-    const previous: Snapshot = .{ .on_battery = true, .is_saver = false };
+    const previous: Snapshot = .{ .on_battery = true, .battery_saver = false };
     try std.testing.expectEqual(
-        Snapshot{ .on_battery = false, .is_saver = true },
+        Snapshot{ .on_battery = false, .battery_saver = true },
         parseSystemPowerStatus(.{
             .ACLineStatus = 1,
             .BatteryFlag = 0,
@@ -578,7 +672,7 @@ test "power status parsing preserves unknown AC state" {
         }, previous),
     );
     try std.testing.expectEqual(
-        Snapshot{ .on_battery = true, .is_saver = false },
+        Snapshot{ .on_battery = true, .battery_saver = false },
         parseSystemPowerStatus(.{
             .ACLineStatus = 0xff,
             .BatteryFlag = 0xff,
@@ -587,6 +681,21 @@ test "power status parsing preserves unknown AC state" {
             .BatteryLifeTime = 0xffff_ffff,
             .BatteryFullLifeTime = 0xffff_ffff,
         }, previous),
+    );
+
+    // `GetSystemPowerStatus` cannot see Energy Saver, so a poll must carry
+    // the last notified value through rather than clearing it. Without this
+    // the 30 s fallback poll would silently cancel Energy Saver pacing.
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = false, .battery_saver = false, .energy_saver = true },
+        parseSystemPowerStatus(.{
+            .ACLineStatus = 1,
+            .BatteryFlag = 0,
+            .BatteryLifePercent = 80,
+            .SystemStatusFlag = 0,
+            .BatteryLifeTime = 0,
+            .BatteryFullLifeTime = 0,
+        }, .{ .energy_saver = true }),
     );
 }
 
@@ -599,31 +708,32 @@ test "power notification parsing accepts registered settings" {
 
     const saver = settingPayload(GUID_POWER_SAVING_STATUS, 0);
     try std.testing.expectEqual(
-        SettingUpdate{ .is_saver = false },
+        SettingUpdate{ .battery_saver = false },
         parsePowerSettingNotification(&saver).?,
     );
 
     const saver_on = settingPayload(GUID_POWER_SAVING_STATUS, 1);
     try std.testing.expectEqual(
-        SettingUpdate{ .is_saver = true },
+        SettingUpdate{ .battery_saver = true },
         parsePowerSettingNotification(&saver_on).?,
     );
 
-    // Energy Saver (prerelease GUID) maps its three-state enum onto the same
-    // saver flag: off is off, both savings modes throttle.
+    // Energy Saver (prerelease GUID) maps its three-state enum onto its OWN
+    // flag: off is off, both savings modes throttle. It must not share a
+    // field with Battery Saver above -- see the union test below.
     const energy_off = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_OFF);
     try std.testing.expectEqual(
-        SettingUpdate{ .is_saver = false },
+        SettingUpdate{ .energy_saver = false },
         parsePowerSettingNotification(&energy_off).?,
     );
     const energy_standard = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_STANDARD);
     try std.testing.expectEqual(
-        SettingUpdate{ .is_saver = true },
+        SettingUpdate{ .energy_saver = true },
         parsePowerSettingNotification(&energy_standard).?,
     );
     const energy_high = settingPayload(GUID_ENERGY_SAVER_STATUS, ENERGY_SAVER_HIGH_SAVINGS);
     try std.testing.expectEqual(
-        SettingUpdate{ .is_saver = true },
+        SettingUpdate{ .energy_saver = true },
         parsePowerSettingNotification(&energy_high).?,
     );
     const energy_bogus = settingPayload(GUID_ENERGY_SAVER_STATUS, 7);
@@ -647,7 +757,7 @@ test "power render policy preserves focused non-saver pacing" {
     try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
         true,
         true,
-        .{ .on_battery = false, .is_saver = false },
+        .{ .on_battery = false },
         config,
     ));
     // Battery alone is NOT a saver trigger. `auto` is documented in
@@ -657,7 +767,7 @@ test "power render policy preserves focused non-saver pacing" {
     try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
         true,
         true,
-        .{ .on_battery = true, .is_saver = false },
+        .{ .on_battery = true },
         config,
     ));
     // 60 fps here so the expected value distinguishes the unfocused cap (17)
@@ -667,15 +777,17 @@ test "power render policy preserves focused non-saver pacing" {
     try std.testing.expectEqual(@as(?u64, 17), minimumPresentIntervalMs(
         false,
         true,
-        .{ .on_battery = true, .is_saver = false },
+        .{ .on_battery = true },
         sixty,
     ));
-    try std.testing.expect(!saverRenderingActive(.auto, .{ .on_battery = true, .is_saver = false }));
-    try std.testing.expect(saverRenderingActive(.auto, .{ .on_battery = false, .is_saver = true }));
+    try std.testing.expect(!saverRenderingActive(.auto, .{ .on_battery = true }));
+    // Either saver source alone drives `auto`.
+    try std.testing.expect(saverRenderingActive(.auto, .{ .battery_saver = true }));
+    try std.testing.expect(saverRenderingActive(.auto, .{ .energy_saver = true }));
     try std.testing.expectEqual(@as(?u64, null), minimumPresentIntervalMs(
         true,
         false,
-        .{ .on_battery = true, .is_saver = true },
+        .{ .on_battery = true, .battery_saver = true },
         config,
     ));
 }
@@ -702,13 +814,21 @@ test "power render policy caps saver and unfocused surfaces" {
     try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
         true,
         true,
-        .{ .on_battery = true, .is_saver = true },
+        .{ .on_battery = true, .battery_saver = true },
         sixty_fps,
     ));
     try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
         false,
         true,
-        .{ .on_battery = true, .is_saver = true },
+        .{ .on_battery = true, .battery_saver = true },
+        sixty_fps,
+    ));
+    // Energy Saver on AC power paces identically; the source does not matter
+    // once either is set.
+    try std.testing.expectEqual(@as(?u64, 34), minimumPresentIntervalMs(
+        true,
+        true,
+        .{ .on_battery = false, .energy_saver = true },
         sixty_fps,
     ));
 
@@ -725,9 +845,52 @@ test "power render policy caps saver and unfocused surfaces" {
     try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
         true,
         true,
-        .{ .is_saver = true },
+        .{ .battery_saver = true, .energy_saver = true },
         forced,
     ));
+}
+
+test "power saver sources do not erase each other in either order" {
+    resetPowerGlobalsForTest();
+    defer resetPowerGlobalsForTest();
+
+    // Battery Saver on, then Energy Saver reports OFF. Energy Saver was
+    // never on; its "off" must not cancel Battery Saver's pacing.
+    publishSetting(.{ .battery_saver = true });
+    publishSetting(.{ .energy_saver = false });
+    try std.testing.expectEqual(
+        Snapshot{ .battery_saver = true, .energy_saver = false },
+        snapshot(),
+    );
+    try std.testing.expect(snapshot().isSaver());
+    try std.testing.expect(saverRenderingActive(.auto, snapshot()));
+
+    // ...and the reverse ordering: Energy Saver on, then Battery Saver OFF.
+    resetPowerGlobalsForTest();
+    publishSetting(.{ .energy_saver = true });
+    publishSetting(.{ .battery_saver = false });
+    try std.testing.expectEqual(
+        Snapshot{ .battery_saver = false, .energy_saver = true },
+        snapshot(),
+    );
+    try std.testing.expect(snapshot().isSaver());
+    try std.testing.expect(saverRenderingActive(.auto, snapshot()));
+
+    // Both on, then only one clears: still saver.
+    resetPowerGlobalsForTest();
+    publishSetting(.{ .battery_saver = true });
+    publishSetting(.{ .energy_saver = true });
+    publishSetting(.{ .battery_saver = false });
+    try std.testing.expect(snapshot().isSaver());
+
+    // Only when the last remaining source clears does pacing release.
+    publishSetting(.{ .energy_saver = false });
+    try std.testing.expect(!snapshot().isSaver());
+
+    // `on_battery` is not a saver source and never contributes.
+    publishSetting(.{ .on_battery = true });
+    try std.testing.expect(!snapshot().isSaver());
+    try std.testing.expect(!saverRenderingActive(.auto, snapshot()));
 }
 
 fn resetPowerGlobalsForTest() void {
@@ -776,7 +939,7 @@ test "power poll claims the 30 s slot only on a successful read" {
     try std.testing.expectEqual(@as(usize, 1), readers.calls);
     try std.testing.expectEqual(@as(u64, 1_001), last_poll_tick_ms.load(.acquire));
     try std.testing.expectEqual(
-        Snapshot{ .on_battery = true, .is_saver = true },
+        Snapshot{ .on_battery = true, .battery_saver = true },
         snapshot(),
     );
 
@@ -795,20 +958,60 @@ test "power poll publication yields to a notification that raced it" {
     // The push lands while the poll is still inside the status syscall: it
     // bumps the generation and wins the byte, and the poll must not undo it.
     const raced = push_generation.load(.acquire);
-    publishSetting(.{ .is_saver = true });
-    publishPolledSnapshot(.{ .on_battery = true, .is_saver = false }, raced);
+    publishSetting(.{ .battery_saver = true });
+    publishPolledSnapshot(.{ .on_battery = true, .battery_saver = false }, raced);
     try std.testing.expectEqual(
-        Snapshot{ .on_battery = false, .is_saver = true },
+        Snapshot{ .on_battery = false, .battery_saver = true },
         snapshot(),
     );
 
     // With no racing push the poll publishes normally.
     const quiet = push_generation.load(.acquire);
-    publishPolledSnapshot(.{ .on_battery = true, .is_saver = false }, quiet);
+    publishPolledSnapshot(.{ .on_battery = true, .battery_saver = false }, quiet);
     try std.testing.expectEqual(
-        Snapshot{ .on_battery = true, .is_saver = false },
+        Snapshot{ .on_battery = true, .battery_saver = false },
         snapshot(),
     );
+
+    // Widening the snapshot to a third bit must not have broken the CAS: an
+    // Energy Saver push still wins the byte against a stale poll that only
+    // knows about the two GetSystemPowerStatus-visible fields.
+    const raced_energy = push_generation.load(.acquire);
+    publishSetting(.{ .energy_saver = true });
+    publishPolledSnapshot(.{ .on_battery = true, .battery_saver = true }, raced_energy);
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = true, .battery_saver = false, .energy_saver = true },
+        snapshot(),
+    );
+}
+
+test "power cloak resolution recovers from a failed query on uncloak" {
+    // The window was cloaked; DWM then raises EVENT_OBJECT_UNCLOAKED but the
+    // follow-up DwmGetWindowAttribute query fails. Preserving `previous`
+    // here is unrecoverable -- hidden surfaces do no renderer work and no
+    // second uncloak event is coming -- so the observed transition wins.
+    try std.testing.expectEqual(false, resolveCloaked(null, false, true));
+    try std.testing.expect(hostVisible(true, false, resolveCloaked(null, false, true)));
+
+    // The symmetric case: a failed query on CLOAKED adopts cloaked. This
+    // direction is safe either way (a stale visible host merely presents
+    // until the next refresh), but the event is still the better answer.
+    try std.testing.expectEqual(true, resolveCloaked(null, true, false));
+
+    // A successful query is the current truth and outranks the event that
+    // triggered the refresh, including when they disagree because the window
+    // was re-cloaked between the two.
+    try std.testing.expectEqual(true, resolveCloaked(true, false, false));
+    try std.testing.expectEqual(false, resolveCloaked(false, true, true));
+
+    // Message-driven refreshes observe no transition. With a working query
+    // they follow it; with a failed query they preserve the last known value,
+    // which is the pre-existing behaviour and stays correct because some
+    // other window message will drive the next refresh.
+    try std.testing.expectEqual(true, resolveCloaked(true, null, false));
+    try std.testing.expectEqual(false, resolveCloaked(false, null, true));
+    try std.testing.expectEqual(true, resolveCloaked(null, null, true));
+    try std.testing.expectEqual(false, resolveCloaked(null, null, false));
 }
 
 test "power cloak winevent filter accepts only window-level cloak transitions" {

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -14,12 +14,23 @@ const GUID = windows.GUID;
 const HANDLE = windows.HANDLE;
 const HRESULT = windows.HRESULT;
 const HWND = windows.HWND;
+const LONG = windows.LONG;
 
 pub const WM_POWERBROADCAST: windows.UINT = 0x0218;
 pub const PBT_POWERSETTINGCHANGE: windows.WPARAM = 0x8013;
 
 const DEVICE_NOTIFY_WINDOW_HANDLE: DWORD = 0;
 const DWMWA_CLOAKED: DWORD = 14;
+
+/// DWM cloak transitions (virtual-desktop switches, shell show/hide
+/// animations, suspended UWP hosts) have NO window message. The documented
+/// signal is this WinEvent pair, so a cloak-aware presenter has to hook it.
+const EVENT_OBJECT_CLOAKED: DWORD = 0x8017;
+const EVENT_OBJECT_UNCLOAKED: DWORD = 0x8018;
+const WINEVENT_OUTOFCONTEXT: DWORD = 0x0000;
+const OBJID_WINDOW: LONG = 0;
+const CHILDID_SELF: LONG = 0;
+
 const POLL_INTERVAL_MS: u64 = 30 * std.time.ms_per_s;
 /// Focused, non-saver surfaces keep this cadence, which must stay equal to
 /// the renderer thread's DRAW_INTERVAL (asserted there at comptime).
@@ -76,6 +87,27 @@ extern "dwmapi" fn DwmGetWindowAttribute(
     value_size: DWORD,
 ) callconv(.winapi) HRESULT;
 
+const WinEventProc = *const fn (
+    hook: ?HANDLE,
+    event: DWORD,
+    hwnd: ?HWND,
+    id_object: LONG,
+    id_child: LONG,
+    event_thread: DWORD,
+    event_time_ms: DWORD,
+) callconv(.winapi) void;
+
+extern "user32" fn SetWinEventHook(
+    event_min: DWORD,
+    event_max: DWORD,
+    module: ?HANDLE,
+    callback: WinEventProc,
+    process_id: DWORD,
+    thread_id: DWORD,
+    flags: DWORD,
+) callconv(.winapi) ?HANDLE;
+extern "user32" fn UnhookWinEvent(hook: HANDLE) callconv(.winapi) BOOL;
+
 const on_battery_bit: u8 = 1 << 0;
 const saver_bit: u8 = 1 << 1;
 
@@ -107,14 +139,108 @@ pub const HostVisibility = struct {
     cloaked: bool,
 };
 
-/// Owns the two notification registrations associated with one host HWND.
+/// Called on the UI thread when DWM reports that one of our own top-level
+/// windows was cloaked or uncloaked. Installed by the apprt, which owns the
+/// HWND -> host mapping this module deliberately knows nothing about.
+pub const CloakEventHandler = *const fn (hwnd: HWND) void;
+
+/// All of the following are touched only from the UI/pump thread: hosts are
+/// created and destroyed there, and `WINEVENT_OUTOFCONTEXT` callbacks are
+/// delivered through that same thread's message queue. Plain (non-atomic)
+/// state is therefore correct here; see `cloakWinEventProc`.
+var cloak_handler: ?CloakEventHandler = null;
+var cloak_hook: ?HANDLE = null;
+var cloak_hook_refs: usize = 0;
+
+/// Install (or clear) the cloak handler. Safe to call before any host exists;
+/// events that arrive with no handler installed are dropped.
+pub fn setCloakEventHandler(handler: ?CloakEventHandler) void {
+    cloak_handler = handler;
+}
+
+/// Pure WinEvent filter. The hook range also carries events for accessible
+/// child objects, which are not window cloak transitions and must be ignored.
+pub fn isHostCloakEvent(event: DWORD, id_object: LONG, id_child: LONG) bool {
+    if (event != EVENT_OBJECT_CLOAKED and event != EVENT_OBJECT_UNCLOAKED) return false;
+    return id_object == OBJID_WINDOW and id_child == CHILDID_SELF;
+}
+
+fn cloakWinEventProc(
+    hook: ?HANDLE,
+    event: DWORD,
+    hwnd: ?HWND,
+    id_object: LONG,
+    id_child: LONG,
+    event_thread: DWORD,
+    event_time_ms: DWORD,
+) callconv(.winapi) void {
+    _ = hook;
+    _ = event_thread;
+    _ = event_time_ms;
+    if (!isHostCloakEvent(event, id_object, id_child)) return;
+    const target = hwnd orelse return;
+    const handler = cloak_handler orelse return;
+    // The hook is registered WINEVENT_OUTOFCONTEXT and scoped to this
+    // thread, so Windows delivers this from inside our own message pump.
+    // We are on the UI thread and may touch host state directly; nothing
+    // here may be moved to another thread.
+    handler(target);
+}
+
+/// Reference-counted because one thread-scoped hook already covers every host
+/// window on the pump thread; registering one per host would multiply every
+/// callback by the window count.
+fn acquireCloakHook() void {
+    cloak_hook_refs += 1;
+    if (cloak_hook != null or cloak_hook_refs != 1) return;
+    cloak_hook = SetWinEventHook(
+        EVENT_OBJECT_CLOAKED,
+        EVENT_OBJECT_UNCLOAKED,
+        null,
+        cloakWinEventProc,
+        sys.GetCurrentProcessId(),
+        sys.GetCurrentThreadId(),
+        WINEVENT_OUTOFCONTEXT,
+    );
+    if (cloak_hook == null) {
+        // Degrade to the message-driven refreshes (WM_ACTIVATE,
+        // WM_SHOWWINDOW, WM_WINDOWPOSCHANGED, WM_EXITSIZEMOVE) rather than
+        // failing window creation.
+        log.warn(
+            "DWM cloak notifications unavailable err={}",
+            .{windows.kernel32.GetLastError()},
+        );
+    }
+}
+
+fn releaseCloakHook() void {
+    if (cloak_hook_refs == 0) return;
+    cloak_hook_refs -= 1;
+    if (cloak_hook_refs != 0) return;
+    if (cloak_hook) |hook| {
+        if (UnhookWinEvent(hook) == 0) {
+            log.warn(
+                "failed to unhook DWM cloak notifications err={}",
+                .{windows.kernel32.GetLastError()},
+            );
+        }
+        cloak_hook = null;
+    }
+}
+
+/// Owns the power notification registrations and the shared cloak WinEvent
+/// reference associated with one host HWND.
 pub const Notifications = struct {
     acdc: ?HANDLE = null,
     saver: ?HANDLE = null,
     energy_saver: ?HANDLE = null,
+    /// Guards against the second `deinit` (WM_DESTROY plus Host.deinit)
+    /// dropping a reference twice, matching the handle fields' reset below.
+    cloak_hook_held: bool = false,
 
     pub fn init(hwnd: HWND) Notifications {
         pollIfStale();
+        acquireCloakHook();
 
         const acdc = RegisterPowerSettingNotification(
             @ptrCast(hwnd),
@@ -145,10 +271,16 @@ pub const Notifications = struct {
             log.debug("energy-saver notifications unavailable err={}", .{windows.kernel32.GetLastError()});
         }
 
-        return .{ .acdc = acdc, .saver = saver, .energy_saver = energy_saver };
+        return .{
+            .acdc = acdc,
+            .saver = saver,
+            .energy_saver = energy_saver,
+            .cloak_hook_held = true,
+        };
     }
 
     pub fn deinit(self: *Notifications) void {
+        if (self.cloak_hook_held) releaseCloakHook();
         if (self.acdc) |handle| {
             if (UnregisterPowerSettingNotification(handle) == 0) {
                 log.warn("failed to unregister AC/DC power notification err={}", .{windows.kernel32.GetLastError()});
@@ -245,7 +377,18 @@ pub fn snapshot() Snapshot {
 /// missed. The atomic claim ensures calls cannot query more often than once per
 /// 30 seconds across all renderer threads.
 pub fn pollIfStale() void {
-    const now = sys.GetTickCount64();
+    pollIfStaleWith(sys.GetTickCount64(), readSystemPowerStatus);
+}
+
+/// Reader indirection so the slot-accounting policy above can be tested
+/// without a real `GetSystemPowerStatus`.
+const PowerStatusReader = *const fn (status: *SYSTEM_POWER_STATUS) bool;
+
+fn readSystemPowerStatus(status: *SYSTEM_POWER_STATUS) bool {
+    return GetSystemPowerStatus(status) != 0;
+}
+
+fn pollIfStaleWith(now: u64, read: PowerStatusReader) void {
     var previous = last_poll_tick_ms.load(.acquire);
     if (previous != 0 and now -| previous < POLL_INTERVAL_MS) return;
     while (true) {
@@ -262,7 +405,7 @@ pub fn pollIfStale() void {
     // next 30 seconds of fallback, so hand the slot back on failure.
     const generation = push_generation.load(.acquire);
     var raw: SYSTEM_POWER_STATUS = undefined;
-    if (GetSystemPowerStatus(&raw) == 0) {
+    if (!read(&raw)) {
         last_poll_tick_ms.store(previous, .release);
         return;
     }
@@ -270,9 +413,7 @@ pub fn pollIfStale() void {
     // A WM_POWERBROADCAST push that landed while we were inside the
     // syscall is strictly fresher than what we just read. Drop the poll
     // rather than overwrite it; the next poll or push corrects us anyway.
-    const value = parseSystemPowerStatus(raw, snapshot());
-    if (push_generation.load(.acquire) != generation) return;
-    publishSnapshot(value);
+    publishPolledSnapshot(parseSystemPowerStatus(raw, snapshot()), generation);
 }
 
 /// Monotonic millisecond clock shared with Win32 notification and visibility
@@ -360,8 +501,25 @@ fn unpackSnapshot(bits: u8) Snapshot {
     };
 }
 
-fn publishSnapshot(value: Snapshot) void {
-    snapshot_bits.store(packSnapshot(value), .release);
+/// Publish a polled snapshot only if no notification landed since the caller
+/// sampled `generation`.
+///
+/// A plain store guarded by a preceding generation load is NOT enough: a push
+/// can bump the generation and complete its own update in the window between
+/// that load and the store, and the full-byte store would then erase it. The
+/// compare-exchange closes that window. `publishSetting` bumps the generation
+/// BEFORE it mutates the byte, so any push whose write could land after ours
+/// has already made the generation check below fail, and any push that lands
+/// between our load and our exchange makes the exchange itself fail and sends
+/// us back through that check.
+fn publishPolledSnapshot(value: Snapshot, generation: u32) void {
+    const next = packSnapshot(value);
+    var current = snapshot_bits.load(.acquire);
+    while (true) {
+        if (push_generation.load(.acquire) != generation) return;
+        if (current == next) return;
+        current = snapshot_bits.cmpxchgWeak(current, next, .acq_rel, .acquire) orelse return;
+    }
 }
 
 fn publishSetting(update: SettingUpdate) void {
@@ -492,12 +650,28 @@ test "power render policy preserves focused non-saver pacing" {
         .{ .on_battery = false, .is_saver = false },
         config,
     ));
+    // Battery alone is NOT a saver trigger. `auto` is documented in
+    // Config.zig ("Battery Saver is active, or ... Energy Saver is active")
+    // and docs/windows.md as following the saver signals only, so an
+    // unplugged laptop with saver off keeps its full cadence, focused or not.
     try std.testing.expectEqual(@as(?u64, 8), minimumPresentIntervalMs(
         true,
         true,
         .{ .on_battery = true, .is_saver = false },
         config,
     ));
+    // 60 fps here so the expected value distinguishes the unfocused cap (17)
+    // from saver pacing (34) instead of colliding with it at 30 fps.
+    var sixty = config;
+    sixty.unfocused_render_fps = 60;
+    try std.testing.expectEqual(@as(?u64, 17), minimumPresentIntervalMs(
+        false,
+        true,
+        .{ .on_battery = true, .is_saver = false },
+        sixty,
+    ));
+    try std.testing.expect(!saverRenderingActive(.auto, .{ .on_battery = true, .is_saver = false }));
+    try std.testing.expect(saverRenderingActive(.auto, .{ .on_battery = false, .is_saver = true }));
     try std.testing.expectEqual(@as(?u64, null), minimumPresentIntervalMs(
         true,
         false,
@@ -554,6 +728,98 @@ test "power render policy caps saver and unfocused surfaces" {
         .{ .is_saver = true },
         forced,
     ));
+}
+
+fn resetPowerGlobalsForTest() void {
+    last_poll_tick_ms.store(0, .release);
+    snapshot_bits.store(0, .release);
+    push_generation.store(0, .release);
+}
+
+test "power poll claims the 30 s slot only on a successful read" {
+    const readers = struct {
+        var calls: usize = 0;
+
+        fn fail(status: *SYSTEM_POWER_STATUS) bool {
+            calls += 1;
+            status.* = std.mem.zeroes(SYSTEM_POWER_STATUS);
+            return false;
+        }
+
+        fn ok(status: *SYSTEM_POWER_STATUS) bool {
+            calls += 1;
+            status.* = .{
+                .ACLineStatus = 0,
+                .BatteryFlag = 1,
+                .BatteryLifePercent = 50,
+                .SystemStatusFlag = 1,
+                .BatteryLifeTime = 0,
+                .BatteryFullLifeTime = 0,
+            };
+            return true;
+        }
+    };
+
+    resetPowerGlobalsForTest();
+    defer resetPowerGlobalsForTest();
+
+    // A failed query must hand the slot back instead of costing the next
+    // 30 seconds of fallback coverage.
+    readers.calls = 0;
+    pollIfStaleWith(1_000, readers.fail);
+    try std.testing.expectEqual(@as(usize, 1), readers.calls);
+    try std.testing.expectEqual(@as(u64, 0), last_poll_tick_ms.load(.acquire));
+
+    // ...so the very next caller still gets to poll.
+    readers.calls = 0;
+    pollIfStaleWith(1_001, readers.ok);
+    try std.testing.expectEqual(@as(usize, 1), readers.calls);
+    try std.testing.expectEqual(@as(u64, 1_001), last_poll_tick_ms.load(.acquire));
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = true, .is_saver = true },
+        snapshot(),
+    );
+
+    // A successful query does hold the slot for the whole interval.
+    readers.calls = 0;
+    pollIfStaleWith(1_002, readers.ok);
+    try std.testing.expectEqual(@as(usize, 0), readers.calls);
+    pollIfStaleWith(1_001 + POLL_INTERVAL_MS, readers.ok);
+    try std.testing.expectEqual(@as(usize, 1), readers.calls);
+}
+
+test "power poll publication yields to a notification that raced it" {
+    resetPowerGlobalsForTest();
+    defer resetPowerGlobalsForTest();
+
+    // The push lands while the poll is still inside the status syscall: it
+    // bumps the generation and wins the byte, and the poll must not undo it.
+    const raced = push_generation.load(.acquire);
+    publishSetting(.{ .is_saver = true });
+    publishPolledSnapshot(.{ .on_battery = true, .is_saver = false }, raced);
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = false, .is_saver = true },
+        snapshot(),
+    );
+
+    // With no racing push the poll publishes normally.
+    const quiet = push_generation.load(.acquire);
+    publishPolledSnapshot(.{ .on_battery = true, .is_saver = false }, quiet);
+    try std.testing.expectEqual(
+        Snapshot{ .on_battery = true, .is_saver = false },
+        snapshot(),
+    );
+}
+
+test "power cloak winevent filter accepts only window-level cloak transitions" {
+    try std.testing.expect(isHostCloakEvent(EVENT_OBJECT_CLOAKED, OBJID_WINDOW, CHILDID_SELF));
+    try std.testing.expect(isHostCloakEvent(EVENT_OBJECT_UNCLOAKED, OBJID_WINDOW, CHILDID_SELF));
+    // Accessible child/sub-objects share the hooked event range.
+    try std.testing.expect(!isHostCloakEvent(EVENT_OBJECT_UNCLOAKED, OBJID_WINDOW, 3));
+    try std.testing.expect(!isHostCloakEvent(EVENT_OBJECT_CLOAKED, -4, CHILDID_SELF));
+    // Neighbouring EVENT_OBJECT_* values must not refresh visibility.
+    try std.testing.expect(!isHostCloakEvent(EVENT_OBJECT_CLOAKED - 1, OBJID_WINDOW, CHILDID_SELF));
+    try std.testing.expect(!isHostCloakEvent(EVENT_OBJECT_UNCLOAKED + 1, OBJID_WINDOW, CHILDID_SELF));
 }
 
 test "power visibility policy rejects hidden minimized and cloaked hosts" {

--- a/src/apprt/win32_power.zig
+++ b/src/apprt/win32_power.zig
@@ -118,8 +118,9 @@ const energy_saver_bit: u8 = 1 << 2;
 
 var snapshot_bits = std.atomic.Value(u8).init(0);
 var last_poll_tick_ms = std.atomic.Value(u64).init(0);
-/// Bumped by every notification-driven update so a slower poll can detect
-/// that it raced a push and is therefore stale.
+/// Notification publication sequence. Even values are stable; odd values mean
+/// a notification has claimed publication but has not finished updating the
+/// snapshot yet. Pollers may publish only against an unchanged even value.
 var push_generation = std.atomic.Value(u32).init(0);
 
 /// Process-wide power state. This is packed into one atomic byte so renderer
@@ -443,6 +444,10 @@ fn pollIfStaleWith(now: u64, read: PowerStatusReader) void {
     // stampeding the syscall, but a failed query should not cost us the
     // next 30 seconds of fallback, so hand the slot back on failure.
     const generation = push_generation.load(.acquire);
+    if (generation & 1 != 0) {
+        last_poll_tick_ms.store(previous, .release);
+        return;
+    }
     var raw: SYSTEM_POWER_STATUS = undefined;
     if (!read(&raw)) {
         last_poll_tick_ms.store(previous, .release);
@@ -591,17 +596,17 @@ fn unpackSnapshot(bits: u8) Snapshot {
 }
 
 /// Publish a polled snapshot only if no notification landed since the caller
-/// sampled `generation`.
+/// sampled a stable `generation`.
 ///
 /// A plain store guarded by a preceding generation load is NOT enough: a push
 /// can bump the generation and complete its own update in the window between
 /// that load and the store, and the full-byte store would then erase it. The
-/// compare-exchange closes that window. `publishSetting` bumps the generation
-/// BEFORE it mutates the byte, so any push whose write could land after ours
-/// has already made the generation check below fail, and any push that lands
-/// between our load and our exchange makes the exchange itself fail and sends
-/// us back through that check.
+/// compare-exchange closes that window. `publishSetting` makes the generation
+/// odd BEFORE it mutates the byte and even again only after the mutation. A
+/// poll therefore rejects both an update that completed while it was reading
+/// and one whose publication is still in flight.
 fn publishPolledSnapshot(value: Snapshot, generation: u32) void {
+    if (generation & 1 != 0) return;
     const next = packSnapshot(value);
     var current = snapshot_bits.load(.acquire);
     while (true) {
@@ -611,12 +616,29 @@ fn publishPolledSnapshot(value: Snapshot, generation: u32) void {
     }
 }
 
-fn publishSetting(update: SettingUpdate) void {
-    // Bump before the store so a poll that started earlier and is about to
-    // publish observes the change and backs off. Bumping after would leave a
-    // window where the poll sees the old generation and clobbers this update.
-    _ = push_generation.fetchAdd(1, .acq_rel);
+fn beginPushPublication() void {
+    var generation = push_generation.load(.acquire);
+    while (true) {
+        if (generation & 1 != 0) {
+            std.atomic.spinLoopHint();
+            generation = push_generation.load(.acquire);
+            continue;
+        }
+        generation = push_generation.cmpxchgWeak(
+            generation,
+            generation +% 1,
+            .acq_rel,
+            .acquire,
+        ) orelse return;
+    }
+}
 
+fn endPushPublication() void {
+    const previous = push_generation.fetchAdd(1, .release);
+    std.debug.assert(previous & 1 != 0);
+}
+
+fn applySetting(update: SettingUpdate) void {
     var current = snapshot_bits.load(.acquire);
     while (true) {
         var next = current;
@@ -635,6 +657,14 @@ fn publishSetting(update: SettingUpdate) void {
         }
         current = snapshot_bits.cmpxchgWeak(current, next, .acq_rel, .acquire) orelse return;
     }
+}
+
+fn publishSetting(update: SettingUpdate) void {
+    // Claim an odd sequence before touching the snapshot. A poll that samples
+    // us in this window must not mistake the old byte for the new generation.
+    beginPushPublication();
+    defer endPushPublication();
+    applySetting(update);
 }
 
 fn settingPayload(guid: GUID, value: DWORD) [@sizeOf(POWERBROADCAST_SETTING)]u8 {
@@ -983,6 +1013,27 @@ test "power poll publication yields to a notification that raced it" {
         Snapshot{ .on_battery = true, .battery_saver = false, .energy_saver = true },
         snapshot(),
     );
+}
+
+test "power poll rejects an in-flight notification generation" {
+    resetPowerGlobalsForTest();
+    defer resetPowerGlobalsForTest();
+
+    // Reproduce the publication window deterministically: the notification
+    // has claimed the next (odd) generation but has not changed the byte yet.
+    beginPushPublication();
+    const in_flight = push_generation.load(.acquire);
+    try std.testing.expect(in_flight & 1 != 0);
+
+    publishPolledSnapshot(.{ .on_battery = true }, in_flight);
+    try std.testing.expectEqual(Snapshot{}, snapshot());
+
+    // Finish the notification. The stale poll must remain unable to replace
+    // it, even if publication completed without another generation change.
+    applySetting(.{ .battery_saver = true });
+    endPushPublication();
+    publishPolledSnapshot(.{ .on_battery = true }, in_flight);
+    try std.testing.expectEqual(Snapshot{ .battery_saver = true }, snapshot());
 }
 
 test "power cloak resolution recovers from a failed query on uncloak" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -25,6 +25,7 @@ pub const ConfirmCloseSurface = Config.ConfirmCloseSurface;
 pub const CopyOnSelect = Config.CopyOnSelect;
 pub const RightClickAction = Config.RightClickAction;
 pub const CustomShaderAnimation = Config.CustomShaderAnimation;
+pub const PowerSaverRendering = Config.PowerSaverRendering;
 pub const FontSyntheticStyle = Config.FontSyntheticStyle;
 pub const FontShapingBreak = Config.FontShapingBreak;
 pub const FontStyle = Config.FontStyle;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1978,6 +1978,11 @@ keybind: Keybinds = .{},
 /// Limit visible, unfocused terminal surfaces to this many rendered frames
 /// per second while output remains active.
 ///
+/// Focus is per surface, not per window: in a split, every pane except the
+/// one with keyboard focus is "unfocused" even while visible, so a background
+/// split tailing fast output is capped by this value. Raise it if you watch
+/// live output side by side with your active pane.
+///
 /// Lower values reduce CPU, GPU, and power use at the cost of less fluid
 /// background updates. Values below 1 are treated as 1, and values above
 /// 125 have no additional effect because the renderer never presents more
@@ -1990,8 +1995,10 @@ keybind: Keybinds = .{},
 ///
 /// Valid values:
 ///
-/// * `auto` - Enable power-saving behavior when Windows reports that battery
-///   or energy saver is active.
+/// * `auto` - Enable power-saving behavior when Windows reports that Battery
+///   Saver is active, or that Windows 11 Energy Saver is active (the latter
+///   uses a GUID Microsoft still documents as prerelease, so it is
+///   best-effort and inert on Windows builds that lack it).
 /// * `on` - Always enable power-saving behavior.
 /// * `off` - Never enable power-saving behavior.
 ///

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1975,6 +1975,31 @@ keybind: Keybinds = .{},
 /// Changing this value at runtime will only affect new terminals.
 @"window-vsync": bool = true,
 
+/// Limit visible, unfocused terminal surfaces to this many rendered frames
+/// per second while output remains active.
+///
+/// Lower values reduce CPU, GPU, and power use at the cost of less fluid
+/// background updates. Values below 1 are treated as 1, and values above
+/// 125 have no additional effect because the renderer never presents more
+/// often than every 8 ms. The default is `30`.
+///
+/// This can be changed at runtime and affects all open terminals.
+@"unfocused-render-fps": u32 = 30,
+
+/// Control whether power-saving render scheduling is enabled.
+///
+/// Valid values:
+///
+/// * `auto` - Enable power-saving behavior when Windows reports that battery
+///   or energy saver is active.
+/// * `on` - Always enable power-saving behavior.
+/// * `off` - Never enable power-saving behavior.
+///
+/// The default is `auto`.
+///
+/// This can be changed at runtime and affects all open terminals.
+@"power-saver-rendering": PowerSaverRendering = .auto,
+
 /// If true, new windows will inherit the working directory of the
 /// previously focused window. If no window was previously focused, the default
 /// working directory will be used (the `working-directory` option).
@@ -4628,6 +4653,13 @@ pub const CustomShaderAnimation = enum(c_int) {
     false,
     true,
     always,
+};
+
+/// See power-saver-rendering.
+pub const PowerSaverRendering = enum {
+    auto,
+    on,
+    off,
 };
 
 /// Valid values for fullscreen config option

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -312,7 +312,7 @@ fn threadMain_(self: *Thread) !void {
     self.cursor_h.run(
         &self.loop,
         &self.cursor_c,
-        self.cursorBlinkInterval(),
+        cursorBlinkInterval(),
         Thread,
         self,
         cursorTimerCallback,
@@ -506,7 +506,7 @@ fn drainMailbox(self: *Thread) !bool {
                     // active, its callback owns the eventual rearm.
                     self.flags.cursor_blink_visible = true;
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
-                    self.armCursorTimerIfDead(self.cursorBlinkInterval());
+                    self.armCursorTimerIfDead(cursorBlinkInterval());
                 }
             },
 
@@ -514,7 +514,7 @@ fn drainMailbox(self: *Thread) !bool {
                 self.flags.cursor_blink_visible = true;
                 if (self.flags.focused) {
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
-                    self.armCursorTimerIfDead(self.cursorBlinkInterval());
+                    self.armCursorTimerIfDead(cursorBlinkInterval());
                 }
             },
 
@@ -642,7 +642,14 @@ fn notePresentRequest(self: *Thread, interval_ms: u64) void {
 /// just trigger a draw/paint.
 fn drawFrame(self: *Thread, now: bool) void {
     const interval_ms = self.minimumPresentIntervalMs() orelse return;
-    if (self.presentWaitMs(interval_ms) > 0) return;
+
+    // `now` is the forced, vsync-bypassing path (`drawNowCallback`): a
+    // resize, a damage event, something the user is looking at right this
+    // moment. Dropping it would leave visible artifacts on screen for up to a
+    // full interval — a whole second at `unfocused-render-fps = 1` — so
+    // pacing does not apply. Forced draws are event-driven, not timer-driven,
+    // so this cannot become a busy loop.
+    if (!now and self.presentWaitMs(interval_ms) > 0) return;
 
     // If the renderer is managing a vsync on its own, we only draw
     // when we're forced to via `now`.
@@ -887,7 +894,7 @@ fn cursorTimerCallback(
         null;
     switch (cursorBlinkTimerDecision(
         t.flags.focused,
-        t.cursorBlinkInterval(),
+        cursorBlinkInterval(),
         reset_elapsed_ns,
     )) {
         .disarm => {
@@ -907,7 +914,7 @@ fn cursorTimerCallback(
     t.flags.cursor_blink_visible = !t.flags.cursor_blink_visible;
     t.wakeup.notify() catch {};
 
-    t.armCursorTimerIfDead(t.cursorBlinkInterval());
+    t.armCursorTimerIfDead(cursorBlinkInterval());
     return .disarm;
 }
 
@@ -929,7 +936,7 @@ fn stopCallback(
 }
 
 /// Returns the interval for the blinking cursor in milliseconds.
-fn cursorBlinkInterval(self: *const Thread) u64 {
+fn cursorBlinkInterval() u64 {
     var interval: u64 = CURSOR_BLINK_INTERVAL;
     if (std.valgrind.runningOnValgrind() > 0) {
         // If we're running under Valgrind, the cursor blink adds enough
@@ -940,13 +947,6 @@ fn cursorBlinkInterval(self: *const Thread) u64 {
         // logic to be more efficient:
         // https://github.com/ghostty-org/ghostty/issues/8003
         interval *= 5;
-    }
-
-    if (apprt.runtime == apprt.win32 and win32_power.saverRenderingActive(
-        self.config.power_saver_rendering,
-        self.powerSnapshot(),
-    )) {
-        interval *= 2;
     }
 
     return interval;

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -842,7 +842,13 @@ fn drawCallback(
     _: *xev.Completion,
     r: xev.Timer.RunError!void,
 ) xev.CallbackAction {
-    _ = r catch unreachable;
+    _ = r catch |err| switch (err) {
+        // `Timer.reset` cancels the previous completion before rearming it.
+        // The replacement timer is already scheduled; this callback belongs
+        // only to the canceled run.
+        error.Canceled => return .disarm,
+        else => unreachable,
+    };
     const t: *Thread = self_ orelse {
         // This shouldn't happen so we log it.
         log.warn("render callback fired without data set", .{});

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -103,7 +103,10 @@ stop_c: xev.Completion = .{},
 /// The timer used for rendering
 render_h: xev.Timer,
 render_c: xev.Completion = .{},
+render_reset_c: xev.Completion = .{},
 render_followup_pending: bool = false,
+/// Absolute Win32 tick when the active render follow-up should fire.
+render_timer_due_ms: u64 = 0,
 last_present_request_ms: u64 = 0,
 
 /// The timer used for draw calls. Draw calls don't update from the
@@ -401,7 +404,7 @@ fn syncDrawTimer(self: *Thread) void {
         if (apprt.runtime != apprt.win32) return;
 
         const now_ms = win32_power.tickCountMs();
-        if (!drawTimerNeedsReset(now_ms, self.draw_timer_due_ms, delay_ms)) return;
+        if (!timerNeedsEarlierDeadline(now_ms, self.draw_timer_due_ms, delay_ms)) return;
         self.draw_h.reset(
             &self.loop,
             &self.draw_c,
@@ -429,7 +432,7 @@ fn syncDrawTimer(self: *Thread) void {
     }
 }
 
-fn drawTimerNeedsReset(now_ms: u64, due_ms: u64, next_delay_ms: u64) bool {
+fn timerNeedsEarlierDeadline(now_ms: u64, due_ms: u64, next_delay_ms: u64) bool {
     if (due_ms == 0) return true;
     return next_delay_ms < due_ms -| now_ms;
 }
@@ -711,8 +714,26 @@ fn drawFrame(self: *Thread, now: bool) void {
 }
 
 fn scheduleRenderFollowup(self: *Thread) void {
-    if (self.render_followup_pending) return;
     const delay_ms = self.nextPresentTimerDelayMs() orelse return;
+
+    if (self.render_followup_pending) {
+        if (apprt.runtime != apprt.win32) return;
+
+        const now_ms = win32_power.tickCountMs();
+        if (!timerNeedsEarlierDeadline(now_ms, self.render_timer_due_ms, delay_ms)) return;
+        self.render_h.reset(
+            &self.loop,
+            &self.render_c,
+            &self.render_reset_c,
+            delay_ms,
+            Thread,
+            self,
+            renderCallback,
+        );
+        self.render_timer_due_ms = now_ms +| delay_ms;
+        return;
+    }
+
     self.render_followup_pending = true;
     self.render_h.run(
         &self.loop,
@@ -722,6 +743,9 @@ fn scheduleRenderFollowup(self: *Thread) void {
         self,
         renderCallback,
     );
+    if (apprt.runtime == apprt.win32) {
+        self.render_timer_due_ms = win32_power.tickCountMs() +| delay_ms;
+    }
 }
 
 /// Arm the cursor's one-shot timer only when libxev no longer owns the
@@ -875,10 +899,19 @@ fn drawCallback(
 }
 
 test "draw timer shortens an active slow interval" {
-    try std.testing.expect(drawTimerNeedsReset(100, 1100, 8));
-    try std.testing.expect(!drawTimerNeedsReset(1095, 1100, 8));
-    try std.testing.expect(!drawTimerNeedsReset(100, 108, 8));
-    try std.testing.expect(drawTimerNeedsReset(100, 0, 8));
+    try std.testing.expect(timerNeedsEarlierDeadline(100, 1100, 8));
+    try std.testing.expect(!timerNeedsEarlierDeadline(1095, 1100, 8));
+    try std.testing.expect(!timerNeedsEarlierDeadline(100, 108, 8));
+    try std.testing.expect(timerNeedsEarlierDeadline(100, 0, 8));
+}
+
+test "render follow-up timer shortens an active slow interval" {
+    // A focus/config change from 1 fps to focused cadence must replace the
+    // pending one-second follow-up with an 8 ms deadline.
+    try std.testing.expect(timerNeedsEarlierDeadline(200, 1200, DRAW_INTERVAL));
+    // Never postpone an already-earlier follow-up or reset an equal deadline.
+    try std.testing.expect(!timerNeedsEarlierDeadline(200, 208, 1000));
+    try std.testing.expect(!timerNeedsEarlierDeadline(200, 208, DRAW_INTERVAL));
 }
 
 fn renderCallback(
@@ -887,13 +920,19 @@ fn renderCallback(
     _: *xev.Completion,
     r: xev.Timer.RunError!void,
 ) xev.CallbackAction {
-    _ = r catch unreachable;
+    _ = r catch |err| switch (err) {
+        // A reset has already armed the replacement follow-up. Leave its
+        // pending flag and deadline intact when the canceled run reports back.
+        error.Canceled => return .disarm,
+        else => unreachable,
+    };
     const t: *Thread = self_ orelse {
         // This shouldn't happen so we log it.
         log.warn("render callback fired without data set", .{});
         return .disarm;
     };
     t.render_followup_pending = false;
+    t.render_timer_due_ms = 0;
     if (comptime @hasDecl(apprt.Surface, "noteRendererFollowupCallback")) {
         t.surface.noteRendererFollowupCallback();
     }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -461,10 +461,16 @@ fn drainMailbox(self: *Thread) !bool {
                 // Visibility affects our QoS class
                 self.setQosClass();
 
-                // If we became visible then we immediately trigger a draw.
-                // `drawFrame` applies the present-pacing policy itself, so a
-                // throttled surface still draws as soon as its interval is up.
-                if (v) self.drawFrame(false);
+                // Becoming visible used to draw immediately here, on the
+                // assumption that frame data kept updating while hidden.
+                // It no longer does — hidden surfaces skip `updateFrame`
+                // entirely — so drawing now would present a stale frame AND
+                // start the throttle clock, deferring the real repaint by a
+                // full interval. `drainMailbox` is only ever called from
+                // `renderOnce`, which does `updateFrame` + `drawFrame` right
+                // after this, so the first visible frame is both fresh and
+                // immediate.
+                if (v) self.last_present_request_ms = 0;
 
                 // Notify the renderer so it can update any state.
                 self.renderer.setVisible(v);

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -111,7 +111,11 @@ last_present_request_ms: u64 = 0,
 /// and are paused when the terminal is not focused.
 draw_h: xev.Timer,
 draw_c: xev.Completion = .{},
+draw_reset_c: xev.Completion = .{},
 draw_active: bool = false,
+/// Absolute Win32 tick when the active draw timer should fire. This lets a
+/// focus or power-policy change shorten an already-queued slow interval.
+draw_timer_due_ms: u64 = 0,
 
 /// This async is used to force a draw immediately. This does not
 /// coalesce like the wakeup does.
@@ -388,14 +392,30 @@ fn syncDrawTimer(self: *Thread) void {
     // even checking the active state in case we have a pending shutdown.
     self.draw_active = true;
 
-    // If our draw timer is already active, then we don't have to do anything.
-    if (self.draw_c.state() == .active) return;
-
-    // Start the timer which loops
     const delay_ms = self.nextPresentTimerDelayMs() orelse {
         self.draw_active = false;
         return;
     };
+
+    if (self.draw_c.state() == .active) {
+        if (apprt.runtime != apprt.win32) return;
+
+        const now_ms = win32_power.tickCountMs();
+        if (!drawTimerNeedsReset(now_ms, self.draw_timer_due_ms, delay_ms)) return;
+        self.draw_h.reset(
+            &self.loop,
+            &self.draw_c,
+            &self.draw_reset_c,
+            delay_ms,
+            Thread,
+            self,
+            drawCallback,
+        );
+        self.draw_timer_due_ms = now_ms +| delay_ms;
+        return;
+    }
+
+    // Start the timer which loops.
     self.draw_h.run(
         &self.loop,
         &self.draw_c,
@@ -404,6 +424,14 @@ fn syncDrawTimer(self: *Thread) void {
         self,
         drawCallback,
     );
+    if (apprt.runtime == apprt.win32) {
+        self.draw_timer_due_ms = win32_power.tickCountMs() +| delay_ms;
+    }
+}
+
+fn drawTimerNeedsReset(now_ms: u64, due_ms: u64, next_delay_ms: u64) bool {
+    if (due_ms == 0) return true;
+    return next_delay_ms < due_ms -| now_ms;
 }
 
 /// Enqueue a message and wake the renderer to process it.
@@ -820,6 +848,7 @@ fn drawCallback(
         log.warn("render callback fired without data set", .{});
         return .disarm;
     };
+    t.draw_timer_due_ms = 0;
 
     // Draw
     t.drawFrame(false);
@@ -828,12 +857,22 @@ fn drawCallback(
     if (t.draw_active) {
         if (t.nextPresentTimerDelayMs()) |delay_ms| {
             t.draw_h.run(&t.loop, &t.draw_c, delay_ms, Thread, t, drawCallback);
+            if (apprt.runtime == apprt.win32) {
+                t.draw_timer_due_ms = win32_power.tickCountMs() +| delay_ms;
+            }
         } else {
             t.draw_active = false;
         }
     }
 
     return .disarm;
+}
+
+test "draw timer shortens an active slow interval" {
+    try std.testing.expect(drawTimerNeedsReset(100, 1100, 8));
+    try std.testing.expect(!drawTimerNeedsReset(1095, 1100, 8));
+    try std.testing.expect(!drawTimerNeedsReset(100, 108, 8));
+    try std.testing.expect(drawTimerNeedsReset(100, 0, 8));
 }
 
 fn renderCallback(

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -14,6 +14,7 @@ const BlockingQueue = @import("../datastruct/main.zig").BlockingQueue;
 const App = @import("../App.zig");
 const terminalpkg = @import("../terminal/main.zig");
 const terminal_render_dirty = @import("../terminal/render_dirty.zig");
+const win32_power = @import("../apprt/win32_power.zig");
 
 const Allocator = std.mem.Allocator;
 const log = std.log.scoped(.renderer_thread);
@@ -60,6 +61,13 @@ const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;
 const RENDER_FOLLOWUP_BURST_MS = 128;
 
+comptime {
+    // The power policy returns this same interval for focused, non-saver
+    // surfaces so their pacing stays exactly what it was before adaptive
+    // rendering existed. Keep the two constants in lockstep.
+    std.debug.assert(DRAW_INTERVAL == win32_power.DEFAULT_PRESENT_INTERVAL_MS);
+}
+
 /// Whether calls to `drawFrame` must be done from the app thread.
 ///
 /// If this is `true` then we send a `redraw_surface` message to the apprt
@@ -96,6 +104,7 @@ stop_c: xev.Completion = .{},
 render_h: xev.Timer,
 render_c: xev.Completion = .{},
 render_followup_pending: bool = false,
+last_present_request_ms: u64 = 0,
 
 /// The timer used for draw calls. Draw calls don't update from the
 /// terminal state so they're much cheaper. They're used for animation
@@ -161,10 +170,14 @@ flags: packed struct {
 
 pub const DerivedConfig = struct {
     custom_shader_animation: configpkg.CustomShaderAnimation,
+    unfocused_render_fps: u32,
+    power_saver_rendering: configpkg.PowerSaverRendering,
 
     pub fn init(config: *const configpkg.Config) DerivedConfig {
         return .{
             .custom_shader_animation = config.@"custom-shader-animation",
+            .unfocused_render_fps = config.@"unfocused-render-fps",
+            .power_saver_rendering = config.@"power-saver-rendering",
         };
     }
 };
@@ -299,7 +312,7 @@ fn threadMain_(self: *Thread) !void {
     self.cursor_h.run(
         &self.loop,
         &self.cursor_c,
-        cursorBlinkInterval(),
+        self.cursorBlinkInterval(),
         Thread,
         self,
         cursorTimerCallback,
@@ -379,10 +392,14 @@ fn syncDrawTimer(self: *Thread) void {
     if (self.draw_c.state() == .active) return;
 
     // Start the timer which loops
+    const delay_ms = self.nextPresentTimerDelayMs() orelse {
+        self.draw_active = false;
+        return;
+    };
     self.draw_h.run(
         &self.loop,
         &self.draw_c,
-        DRAW_INTERVAL,
+        delay_ms,
         Thread,
         self,
         drawCallback,
@@ -445,8 +462,8 @@ fn drainMailbox(self: *Thread) !bool {
                 self.setQosClass();
 
                 // If we became visible then we immediately trigger a draw.
-                // We don't need to update frame data because that should
-                // still be happening.
+                // `drawFrame` applies the present-pacing policy itself, so a
+                // throttled surface still draws as soon as its interval is up.
                 if (v) self.drawFrame(false);
 
                 // Notify the renderer so it can update any state.
@@ -483,7 +500,7 @@ fn drainMailbox(self: *Thread) !bool {
                     // active, its callback owns the eventual rearm.
                     self.flags.cursor_blink_visible = true;
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
-                    self.armCursorTimerIfDead(cursorBlinkInterval());
+                    self.armCursorTimerIfDead(self.cursorBlinkInterval());
                 }
             },
 
@@ -491,7 +508,7 @@ fn drainMailbox(self: *Thread) !bool {
                 self.flags.cursor_blink_visible = true;
                 if (self.flags.focused) {
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
-                    self.armCursorTimerIfDead(cursorBlinkInterval());
+                    self.armCursorTimerIfDead(self.cursorBlinkInterval());
                 }
             },
 
@@ -573,11 +590,53 @@ fn shouldAcceptSearchGeneration(self: *const Thread, generation: u64) bool {
     return self.search_generation.load(.acquire) == generation;
 }
 
+fn powerSnapshot(self: *const Thread) win32_power.Snapshot {
+    _ = self;
+    if (apprt.runtime != apprt.win32) return .{};
+    win32_power.pollIfStale();
+    return win32_power.snapshot();
+}
+
+fn minimumPresentIntervalMs(self: *const Thread) ?u64 {
+    if (apprt.runtime != apprt.win32) {
+        return if (self.flags.visible) DRAW_INTERVAL else null;
+    }
+    return win32_power.minimumPresentIntervalMs(
+        self.flags.focused,
+        self.flags.visible,
+        self.powerSnapshot(),
+        .{
+            .unfocused_render_fps = self.config.unfocused_render_fps,
+            .power_saver_rendering = self.config.power_saver_rendering,
+        },
+    );
+}
+
+fn presentWaitMs(self: *const Thread, interval_ms: u64) u64 {
+    if (interval_ms <= DRAW_INTERVAL or self.last_present_request_ms == 0) return 0;
+    const elapsed_ms = win32_power.tickCountMs() -| self.last_present_request_ms;
+    return interval_ms -| elapsed_ms;
+}
+
+fn nextPresentTimerDelayMs(self: *const Thread) ?u64 {
+    const interval_ms = self.minimumPresentIntervalMs() orelse return null;
+    const wait_ms = self.presentWaitMs(interval_ms);
+    return if (wait_ms > 0) wait_ms else interval_ms;
+}
+
+fn notePresentRequest(self: *Thread, interval_ms: u64) void {
+    if (interval_ms <= DRAW_INTERVAL) {
+        self.last_present_request_ms = 0;
+        return;
+    }
+    self.last_present_request_ms = win32_power.tickCountMs();
+}
+
 /// Trigger a draw. This will not update frame data or anything, it will
 /// just trigger a draw/paint.
 fn drawFrame(self: *Thread, now: bool) void {
-    // If we're invisible, we do not draw.
-    if (!self.flags.visible) return;
+    const interval_ms = self.minimumPresentIntervalMs() orelse return;
+    if (self.presentWaitMs(interval_ms) > 0) return;
 
     // If the renderer is managing a vsync on its own, we only draw
     // when we're forced to via `now`.
@@ -598,20 +657,26 @@ fn drawFrame(self: *Thread, now: bool) void {
             if (comptime @hasDecl(apprt.Surface, "cancelRendererRepaintRequest")) {
                 self.surface.cancelRendererRepaintRequest();
             }
+        } else {
+            self.notePresentRequest(interval_ms);
         }
     } else {
-        self.renderer.drawFrame(false) catch |err|
+        self.renderer.drawFrame(false) catch |err| {
             log.warn("error drawing err={}", .{err});
+            return;
+        };
+        self.notePresentRequest(interval_ms);
     }
 }
 
 fn scheduleRenderFollowup(self: *Thread) void {
     if (self.render_followup_pending) return;
+    const delay_ms = self.nextPresentTimerDelayMs() orelse return;
     self.render_followup_pending = true;
     self.render_h.run(
         &self.loop,
         &self.render_c,
-        DRAW_INTERVAL,
+        delay_ms,
         Thread,
         self,
         renderCallback,
@@ -659,6 +724,13 @@ fn renderOnce(self: *Thread, from_wakeup: bool) bool {
         log.err("error draining mailbox err={}", .{err});
         return false;
     };
+
+    // Invisible surfaces retain terminal state but do no renderer work. A
+    // throttled surface defers both updateFrame and presentation through the
+    // existing follow-up timer so background output cannot burn CPU at the
+    // uncapped wakeup rate.
+    const interval_ms = self.minimumPresentIntervalMs() orelse return false;
+    if (self.presentWaitMs(interval_ms) > 0) return true;
 
     // Update our frame data.
     if (comptime @hasDecl(apprt.Surface, "noteRendererUpdateFrame")) {
@@ -741,7 +813,11 @@ fn drawCallback(
 
     // Only continue if we're still active
     if (t.draw_active) {
-        t.draw_h.run(&t.loop, &t.draw_c, DRAW_INTERVAL, Thread, t, drawCallback);
+        if (t.nextPresentTimerDelayMs()) |delay_ms| {
+            t.draw_h.run(&t.loop, &t.draw_c, delay_ms, Thread, t, drawCallback);
+        } else {
+            t.draw_active = false;
+        }
     }
 
     return .disarm;
@@ -805,7 +881,7 @@ fn cursorTimerCallback(
         null;
     switch (cursorBlinkTimerDecision(
         t.flags.focused,
-        cursorBlinkInterval(),
+        t.cursorBlinkInterval(),
         reset_elapsed_ns,
     )) {
         .disarm => {
@@ -825,7 +901,7 @@ fn cursorTimerCallback(
     t.flags.cursor_blink_visible = !t.flags.cursor_blink_visible;
     t.wakeup.notify() catch {};
 
-    t.armCursorTimerIfDead(cursorBlinkInterval());
+    t.armCursorTimerIfDead(t.cursorBlinkInterval());
     return .disarm;
 }
 
@@ -847,7 +923,8 @@ fn stopCallback(
 }
 
 /// Returns the interval for the blinking cursor in milliseconds.
-fn cursorBlinkInterval() u64 {
+fn cursorBlinkInterval(self: *const Thread) u64 {
+    var interval: u64 = CURSOR_BLINK_INTERVAL;
     if (std.valgrind.runningOnValgrind() > 0) {
         // If we're running under Valgrind, the cursor blink adds enough
         // churn that it makes some stalls annoying unless you're on a
@@ -856,10 +933,17 @@ fn cursorBlinkInterval() u64 {
         // This is a hack, we should change some of our cursor timer
         // logic to be more efficient:
         // https://github.com/ghostty-org/ghostty/issues/8003
-        return CURSOR_BLINK_INTERVAL * 5;
+        interval *= 5;
     }
 
-    return CURSOR_BLINK_INTERVAL;
+    if (apprt.runtime == apprt.win32 and win32_power.saverRenderingActive(
+        self.config.power_saver_rendering,
+        self.powerSnapshot(),
+    )) {
+        interval *= 2;
+    }
+
+    return interval;
 }
 
 fn cursorBlinkRemainingMs(interval_ms: u64, elapsed_ns: u64) u64 {


### PR DESCRIPTION
## Summary

Makes rendering power- and visibility-aware on Win32 so idle, unfocused, and invisible surfaces stop burning GPU/CPU, which is the enabling half of the idle budget in PRODUCT.md ("Idle: effectively 0% GPU/CPU with no timer wake churn").

Focused, non-power-saver pacing is deliberately unchanged: the policy returns the existing 8 ms interval, `RENDER_FOLLOWUP_BURST_MS` stays 128 ms, and `scheduleRenderFollowup` remains the only site that arms `render_c` (the AGENTS.md 2026-04-29 streaming-TUI invariants). A comptime assert pins `DRAW_INTERVAL` to the policy's default so the two cannot drift.

Refs #134

## Changes

- **`src/apprt/win32_power.zig` (new)** — samples AC/battery and saver state via `GetSystemPowerStatus`, takes push updates from `RegisterPowerSettingNotification` on `GUID_ACDC_POWER_SOURCE`, `GUID_POWER_SAVING_STATUS` (Battery Saver) and `GUID_ENERGY_SAVER_STATUS` (Windows 11 Energy Saver, which Microsoft still documents as prerelease — registration is best-effort and inert on builds that lack it), and falls back to a poll at most once per 30 s. State is one atomic byte so the renderer thread reads it lock-free. Contains the pure `minimumPresentIntervalMs` policy and the pure `hostVisible` decision, both unit-tested.
- **`src/renderer/Thread.zig`** — the policy drives the *existing* draw, render-followup, and cursor timers; no new xev handle or Win32 timer. Visible unfocused surfaces are capped by `unfocused-render-fps`; saver pacing caps at ~30 fps; invisible/occluded surfaces skip `updateFrame` and presentation entirely. Forced draws (`drawFrame(now=true)`, the vsync-bypass path) are exempt from pacing so a resize or damage event is never held back.
- **`src/apprt/win32.zig`** — host visibility now folds in minimize (`IsIconic`) and DWM cloak (`DWMWA_CLOAKED`), fanning out through the existing per-surface occlusion dispatch (`shouldDispatchOcclusion` → `occlusionCallback`) rather than a new mechanism. Refreshed on `WM_WINDOWPOSCHANGED`, `WM_ACTIVATE`, `WM_SHOWWINDOW` and `WM_EXITSIZEMOVE`; the query is skipped during live resize, since a window being dragged is by definition visible.
- **Measurement for #121** — `render_trace.zig` gains `last_swap_at_ms` so presented fps is derivable from `swap_buffers_count`.
- **Config (2 new keys)** — `unfocused-render-fps` (default `30`) and `power-saver-rendering = auto|on|off` (default `auto`), both with doc comments.
- **Docs** — new "Power and battery" section in `docs/windows.md`, a `docs/status.md` bullet, a capability-matrix row, and a pointer from the PRODUCT.md idle budget.

## Behavior change worth knowing

Focus is **per surface, not per window**. In a split, every pane except the keyboard-focused one is "unfocused" even while visible, so a background split tailing fast output is capped at `unfocused-render-fps` (30 by default) rather than ~120. This is the most user-visible consequence of the PR; it is called out in `docs/windows.md` and in the config doc comment.

## Validation

Run on this branch (rebased onto `main` @ 5220df49e, which had since extracted `RenderTrace` and the Win32 constants into `src/apprt/win32/`):

- `zig build -Demit-exe=true` — exit 0
- `zig build test -Dtest-filter=power --summary all` — 114/115 tests passed, 1 pre-existing skip
- `zig build test -Dtest-filter=occlusion --summary all` — 67/68 passed, 1 pre-existing skip
- `zig build test -Dtest-filter=cursor --summary all` — 194/195 passed, 1 pre-existing skip
- `pwsh -NoProfile -File scripts/check-zig-format.ps1` — passed (671 tracked sources)
- `pwsh -NoProfile -File scripts/check-source-format.ps1` — passed
- Full CI green: Windows Build And Tests, Native Windows ARM64 Tests, Windows x64 Portable Package Smoke.

Note: bare `zig fmt --check src` exits 1 on the unmodified generated `src/build/uucode_tables.zig`; that is a repo baseline exception and the reason `check-zig-format.ps1` is the real gate.

## Review history

Two independent review rounds, both incorporated (see PR comments for the full findings). Round 2 verified every Windows constant, GUID, struct layout and field offset in the new module against primary Microsoft documentation.

One correction worth recording: I removed `GUID_ENERGY_SAVER_STATUS` during round 1 believing `550E8400-E29B-41D4-A716-446655440000` was fabricated, because it is the RFC 4122 example UUID. It is not fabricated — Microsoft's Power Setting GUIDs (WinNT.h) page really does define Energy Saver with that exact value, marked prerelease. It has been restored with its `ENERGY_SAVER_STATUS` payload mapping and tests.

## Residuals / user steps

- **Not measured on hardware.** No idle CPU/GPU sampling, no `Get-Counter` evidence, and no interactive harness run (`interactive-win11-resize.ps1` / `-progress.ps1` / `-shaders.ps1`) — the Codex account that owns interactive/desktop validation in this campaign hit its usage limit (resets 2026-09-03). Every performance claim here is argued from code paths and unit tests, not observed. **This must be measured before the PR leaves draft.**
- This machine has no battery, so a real AC↔DC transition, a real Battery Saver toggle, and Energy Saver behavior on 24H2 were never exercised; only the parsers are unit-tested. `powercfg /setdcvalueindex` cannot fake battery saver on AC — use `power-saver-rendering = on` to exercise saver pacing.
- Cloak/uncloak detection is best-effort. No documented window message signals a `DWMWA_CLOAKED` transition; the principled fix is a `SetWinEventHook` for `EVENT_OBJECT_CLOAKED`/`UNCLOAKED`. This PR instead refreshes on four messages that bracket every transition we know of, so a stuck-invisible host always has a path back. Worth confirming on hardware with virtual-desktop switching.
- Occlusion covers minimized and DWM-cloaked windows only. A window fully covered by another window still presents; Win32 has no cheap equivalent of the macOS occlusion signal.
- The full suite (`zig build test -Demit-test-exe=true`) has not been run locally; only targeted filters plus CI.

## Summary by Sourcery

Make Win32 rendering aware of power-saving and host visibility so idle and background surfaces reduce resource usage without changing focused non-saver pacing.

New Features:
- Add Win32 power- and visibility-aware render pacing, including configurable unfocused-surface and power-saver limits.
- Stop rendering and presenting minimized or DWM-cloaked surfaces until they become visible again.
- Track AC, Battery Saver, and Windows 11 Energy Saver state through notifications with periodic fallback polling.

Bug Fixes:
- Prevent stale visibility state from leaving cloaked windows permanently frozen after they are uncloaked.
- Preserve independent Battery Saver and Energy Saver state when updates arrive or polling races notifications.
- Improve host cleanup when cloned-window creation fails.

Enhancements:
- Keep focused, non-saver rendering at the existing cadence while adapting draw, follow-up, and cursor scheduling for slower policies.
- Extend render tracing with the timestamp of the last buffer swap for presented-FPS measurement.

Documentation:
- Document Windows power and battery behavior, configuration options, split-surface focus semantics, measurement fields, and validation caveats.

Tests:
- Add unit coverage for power-state parsing, notification handling, pacing and visibility policies, cloak-event filtering, polling races, and timer deadline updates.