### PR TITLE
fix(win32): harden single-instance IPC pipe and action allowlist

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -331,9 +331,20 @@ submit a request.
 user is fully trusted with this channel: it can list your windows,
 perform allowlisted actions, and open new windows. Treat the automation
 surface the way you would treat your own shell — it reduces exposure to
-other accounts and to the network, not to malware running as you. The
-pipe *name* is also not protected; another process running as you can
-create it first.
+other accounts and to the network, not to malware running as you.
+
+The pipe *name* is derived from `--class` alone, so it is predictable and
+lives in the machine-wide named-pipe namespace: any local account can
+create it before noctty does. noctty therefore authenticates the **server**
+as well as the client. Before writing anything to a pipe it did not create,
+a client resolves the serving process with `GetNamedPipeServerProcessId` and
+requires that process's token user SID to match its own; a mismatch is
+treated as "no instance we can reach", and the launch starts its own local
+instance instead. This runs before the first write, which is also before a
+server could call `ImpersonateNamedPipeClient`. It stops another *account*
+from harvesting forwarded arguments or forging an acknowledgement; it does
+not — and cannot — stop another process running as **you**, which is the
+same trust boundary as everything else in this section.
 
 List windows, tabs, and panes:
 
@@ -360,6 +371,12 @@ arbitrary file helper actions (`text`, `csi`, `esc`,
 `paste_from_clipboard`, `write_screen_file`, `end_key_sequence`,
 `clear_screen`, and `crash`), and new keybinding action variants stay
 disabled for automation until they are reviewed and allowlisted.
+
+`undo` and `redo` are refused for the same reason. They do not name a
+dangerous action themselves — they *replay* one that was captured earlier,
+and the Win32 undo stack can hold a `clear_screen` entry whose replay
+queues the same write `clear_screen` was delisted for. An action that can
+re-run another action inherits everything that action can do.
 
 `+new-window` forwards command-line arguments to the running instance.
 The running instance applies an **allowlist**: only window-scoped

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -319,10 +319,12 @@ single-instance IPC path used by `+new-window`.
 The named pipe behind it is restricted to processes running as the same
 user: it is created with `PIPE_REJECT_REMOTE_CLIENTS` and a protected
 DACL whose single ACE grants access to the SID of the token that owns
-the running noctty process. When that process runs above medium
-integrity, a `NO_WRITE_UP` mandatory-label ACE is added as well, so a
-filtered (non-elevated) token of the same account cannot drive an
-elevated instance.
+the running noctty process. Every pipe is also labeled explicitly with
+the process token's exact integrity level and a `NO_WRITE_UP`
+mandatory-label ACE. Above medium integrity, that label prevents a
+filtered (non-elevated) token of the same account from driving the
+elevated instance; at medium integrity, the explicit label lets clients
+reject an otherwise unlabeled same-user pipe squatter.
 
 That denial is **observed against a real elevated instance**, not
 inferred. From a medium-integrity process, `CreateFileW` on the elevated
@@ -337,8 +339,8 @@ succeeds, so `NO_WRITE_UP` does not lock out the intended client. The
 live descriptor reads back
 `D:P(A;;FA;;;S-1-5-21-...-1001)S:AI(ML;;NW;;;HI)`, confirming the label
 survives object creation; a medium-integrity instance reads back the same
-DACL with an **empty** label, which is correct and proves the readback
-distinguishes present from absent.
+DACL with `S:AI(ML;;NW;;;ME)`, proving that the endpoint is labeled
+explicitly at every integrity level.
 
 **Known residual — a lower-integrity process can stall the channel.** The
 label sets `NO_WRITE_UP` only, so it does not deny *reads*: a medium

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -340,10 +340,17 @@ as well as the client. Before writing anything to a pipe it did not create,
 a client resolves the serving process with `GetNamedPipeServerProcessId` and
 requires that process's token user SID to match its own; a mismatch is
 treated as "no instance we can reach", and the launch starts its own local
-instance instead. This runs before the first write, which is also before a
-server could call `ImpersonateNamedPipeClient`. It stops another *account*
-from harvesting forwarded arguments or forging an acknowledgement; it does
-not — and cannot — stop another process running as **you**, which is the
+instance instead.
+
+Clients also open the pipe with `SECURITY_SQOS_PRESENT |
+SECURITY_IDENTIFICATION`. A named-pipe server impersonates at
+`SecurityImpersonation` by default, so without that flag a squatting server
+could act *as* the connecting user; with it, the server can determine who
+connected but cannot use the token to open anything.
+
+Together these stop another *account* from harvesting forwarded arguments,
+forging an acknowledgement, or borrowing the connecting user's token. They
+do not — and cannot — stop another process running as **you**, which is the
 same trust boundary as everything else in this section.
 
 List windows, tabs, and panes:

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -322,30 +322,47 @@ DACL whose single ACE grants access to the SID of the token that owns
 the running noctty process. When that process runs above medium
 integrity, a `NO_WRITE_UP` mandatory-label ACE is added as well, so a
 filtered (non-elevated) token of the same account cannot drive an
-elevated instance. That denial is observed: a client whose open is
-refused logs `single-instance pipe exists but is not accessible to this
-token; starting a local instance` and goes on to open its own window.
+elevated instance.
+
+That denial is **observed against a real elevated instance**, not
+inferred. From a medium-integrity process, `CreateFileW` on the elevated
+instance's pipe fails with `win32=5` for both
+`GENERIC_READ | GENERIC_WRITE` and `GENERIC_WRITE` alone — the refusal
+happens at `CreateFileW`, not as a timeout or a missing acknowledgement.
+At the command line `+perform-action` and `+list-windows` exit 1 with
+"No matching noctty instance is listening", and `+new-window` exits 0
+having quietly started its **own** local instance rather than driving the
+elevated one. From an elevated shell `+perform-action new_tab` still
+succeeds, so `NO_WRITE_UP` does not lock out the intended client. The
+live descriptor reads back
+`D:P(A;;FA;;;S-1-5-21-...-1001)S:AI(ML;;NW;;;HI)`, confirming the label
+survives object creation; a medium-integrity instance reads back the same
+DACL with an **empty** label, which is correct and proves the readback
+distinguishes present from absent.
 
 **Known residual — a lower-integrity process can stall the channel.** The
-label sets `NO_WRITE_UP` only, so it does not deny reads. A plain
-`READ_CONTROL` open is enough — it need not even ask for `GENERIC_READ`.
-Because the server offers one pipe instance at a time, a single such open
-makes the next legitimate client fail with `ERROR_PIPE_BUSY` while the
-server logs an `IpcTimeout`. The attacker learns nothing and can submit
-nothing; the cost is availability of the automation channel, bounded by
-the server's read timeout and repeatable.
+label sets `NO_WRITE_UP` only, so it does not deny *reads*: a medium
+process can open the elevated instance's pipe for `GENERIC_READ` (a bare
+`READ_CONTROL` is enough — it need not ask for read data access at all).
+`WriteFile` on that handle then fails with `win32=5`, so this is an
+**occupancy problem, not an access break**: the squatter learns nothing
+and can submit nothing. But because the server offers one pipe instance
+at a time, a single such open makes the next legitimate client fail with
+`win32=231 ERROR_PIPE_BUSY` while the server logs
+`failed to process win32 IPC client err=error.IpcTimeout`. The cost is
+availability of the automation channel, bounded by the server's read
+timeout and repeatable.
 
-This is not fixed here, and two candidate fixes were considered and
-rejected for now. Keeping a spare listening instance is only a speed
-bump: an attacker opens one more. Adding `NO_READ_UP` to the label is the
-plausible real fix and cannot break a legitimate client (mandatory policy
-only ever denies principals *below* the object, and the legitimate client
-is already refused by `NO_WRITE_UP` if it is lower), but whether
-`NO_READ_UP` actually denies a bare `READ_CONTROL` open is not something
-this project has verified on hardware, and shipping an unverified change
-to a mandatory label is worse than recording a known limit. The
-experiment that settles it: from a lower-integrity process, open the pipe
-with `READ_CONTROL` only, against a server whose label carries `NRNW`.
+**This residual is closed by the elevation work, not here.** That change
+labels the elevated endpoint `NWNR` instead of `NW`, and the added
+`NO_READ_UP` denies *every* medium-integrity open — including
+`GENERIC_READ` and `READ_CONTROL` — which has been verified on hardware
+against a live elevated instance. It is deliberately not duplicated in
+this change: the two would collide on the same SDDL term for no net gain
+once both land, and altering the label here would invalidate the
+descriptor readback recorded above. Keeping a spare listening instance
+was also considered and rejected as a speed bump — an attacker simply
+opens one more.
 
 **This is not a privilege boundary.** Any code already running as your
 user is fully trusted with this channel: it can list your windows,

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -322,10 +322,30 @@ DACL whose single ACE grants access to the SID of the token that owns
 the running noctty process. When that process runs above medium
 integrity, a `NO_WRITE_UP` mandatory-label ACE is added as well, so a
 filtered (non-elevated) token of the same account cannot drive an
-elevated instance. The label sets `NO_WRITE_UP` only, so a
-lower-integrity process can still open the pipe for *reading*; it can
-occupy a pipe instance (bounded by the server's read timeout) but cannot
-submit a request.
+elevated instance. That denial is observed: a client whose open is
+refused logs `single-instance pipe exists but is not accessible to this
+token; starting a local instance` and goes on to open its own window.
+
+**Known residual — a lower-integrity process can stall the channel.** The
+label sets `NO_WRITE_UP` only, so it does not deny reads. A plain
+`READ_CONTROL` open is enough — it need not even ask for `GENERIC_READ`.
+Because the server offers one pipe instance at a time, a single such open
+makes the next legitimate client fail with `ERROR_PIPE_BUSY` while the
+server logs an `IpcTimeout`. The attacker learns nothing and can submit
+nothing; the cost is availability of the automation channel, bounded by
+the server's read timeout and repeatable.
+
+This is not fixed here, and two candidate fixes were considered and
+rejected for now. Keeping a spare listening instance is only a speed
+bump: an attacker opens one more. Adding `NO_READ_UP` to the label is the
+plausible real fix and cannot break a legitimate client (mandatory policy
+only ever denies principals *below* the object, and the legitimate client
+is already refused by `NO_WRITE_UP` if it is lower), but whether
+`NO_READ_UP` actually denies a bare `READ_CONTROL` open is not something
+this project has verified on hardware, and shipping an unverified change
+to a mandatory label is worse than recording a known limit. The
+experiment that settles it: from a lower-integrity process, open the pipe
+with `READ_CONTROL` only, against a server whose label carries `NRNW`.
 
 **This is not a privilege boundary.** Any code already running as your
 user is fully trusted with this channel: it can list your windows,

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -322,7 +322,10 @@ DACL whose single ACE grants access to the SID of the token that owns
 the running noctty process. When that process runs above medium
 integrity, a `NO_WRITE_UP` mandatory-label ACE is added as well, so a
 filtered (non-elevated) token of the same account cannot drive an
-elevated instance.
+elevated instance. The label sets `NO_WRITE_UP` only, so a
+lower-integrity process can still open the pipe for *reading*; it can
+occupy a pipe instance (bounded by the server's read timeout) but cannot
+submit a request.
 
 **This is not a privilege boundary.** Any code already running as your
 user is fully trusted with this channel: it can list your windows,
@@ -359,12 +362,36 @@ arbitrary file helper actions (`text`, `csi`, `esc`,
 disabled for automation until they are reviewed and allowlisted.
 
 `+new-window` forwards command-line arguments to the running instance.
-The running instance refuses any forwarded argument that would select
-code to run or an extra configuration source — `--command`,
-`--initial-command`, `-e`, `--config-file`, `--config-default-files`,
-`--theme`, and `--custom-shader` — and refuses the whole request rather
-than dropping the key. `--working-directory` is accepted only as `home`,
-`inherit`, or a local absolute path that resolves to a directory.
+The running instance applies an **allowlist**: only window-scoped
+presentation settings are honored, and every other key is refused. The
+allowlist covers window geometry and decoration (`--window-width`,
+`--window-height`, `--window-position-*`, `--window-padding-*`,
+`--window-decoration`, `--maximize`, `--fullscreen`, ...), `--title`,
+non-name font settings (`--font-size`, `--font-thicken`, ...), and
+colors (`--background`, `--foreground`, `--palette`, `--cursor-color`,
+`--background-opacity`, ...).
+
+Everything else is refused, including anything that would run code
+(`--command`, `--initial-command`, `-e`, `--input`, `--env`), load a
+file (`--background-image`, `--custom-shader`, `--bell-audio-path`),
+change the configuration source (`--config-file`,
+`--config-default-files`, `--theme`), or write to the terminal
+(`--keybind`, `--command-palette-entry`, `--enquiry-response`). A key
+that is not on the allowlist — including one added by a future
+release — is refused by default rather than allowed by omission. The
+whole request is refused rather than the key being dropped.
+
+`--working-directory` is allowed as `home`, `inherit`, `~/...`, or a
+local drive-letter absolute path. UNC *syntax* (`\\host\share`) is
+refused so the running instance is not made to authenticate to a remote
+SMB host. Note this is a check on syntax only: a mapped or `subst`
+drive, or a junction under a local drive, still resolves off-box.
+
+When you launch noctty normally and an instance is already running, any
+argument the running instance would refuse is dropped by the launching
+process before forwarding, with a warning in the log, so you still get a
+window. That drop is a convenience on your own command line, not a
+security control — the running instance re-checks every argument.
 
 ## Crash reports and diagnostics
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -316,10 +316,21 @@ on Windows. Global keyboard capture is intentionally not implemented.
 noctty exposes a local Windows automation surface over the same
 single-instance IPC path used by `+new-window`.
 
-The named pipe behind it is local-only and user-private: it is created
-with `PIPE_REJECT_REMOTE_CLIENTS` and a protected DACL whose single ACE
-grants access to the SID that owns the running noctty process. Other
-local accounts and remote SMB clients cannot open it.
+The named pipe behind it is restricted to processes running as the same
+user: it is created with `PIPE_REJECT_REMOTE_CLIENTS` and a protected
+DACL whose single ACE grants access to the SID of the token that owns
+the running noctty process. When that process runs above medium
+integrity, a `NO_WRITE_UP` mandatory-label ACE is added as well, so a
+filtered (non-elevated) token of the same account cannot drive an
+elevated instance.
+
+**This is not a privilege boundary.** Any code already running as your
+user is fully trusted with this channel: it can list your windows,
+perform allowlisted actions, and open new windows. Treat the automation
+surface the way you would treat your own shell — it reduces exposure to
+other accounts and to the network, not to malware running as you. The
+pipe *name* is also not protected; another process running as you can
+create it first.
 
 List windows, tabs, and panes:
 
@@ -343,9 +354,17 @@ Actions use the same names as `keybind` values. `--surface-id` is only
 valid for surface-scoped actions; app-scoped actions such as `quit`
 always target the app. The running instance rejects terminal-input and
 arbitrary file helper actions (`text`, `csi`, `esc`,
-`paste_from_clipboard`, `write_screen_file`, `end_key_sequence`, and
-`crash`), and new keybinding action variants stay disabled for automation
-until they are reviewed and allowlisted.
+`paste_from_clipboard`, `write_screen_file`, `end_key_sequence`,
+`clear_screen`, and `crash`), and new keybinding action variants stay
+disabled for automation until they are reviewed and allowlisted.
+
+`+new-window` forwards command-line arguments to the running instance.
+The running instance refuses any forwarded argument that would select
+code to run or an extra configuration source — `--command`,
+`--initial-command`, `-e`, `--config-file`, `--config-default-files`,
+`--theme`, and `--custom-shader` — and refuses the whole request rather
+than dropping the key. `--working-directory` is accepted only as `home`,
+`inherit`, or a local absolute path that resolves to a directory.
 
 ## Crash reports and diagnostics
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -374,10 +374,13 @@ The pipe *name* is derived from `--class` alone, so it is predictable and
 lives in the machine-wide named-pipe namespace: any local account can
 create it before noctty does. noctty therefore authenticates the **server**
 as well as the client. Before writing anything to a pipe it did not create,
-a client resolves the serving process with `GetNamedPipeServerProcessId` and
-requires that process's token user SID to match its own; a mismatch is
-treated as "no instance we can reach", and the launch starts its own local
-instance instead.
+a client reads the owner SID and mandatory-integrity label from the security
+descriptor attached to that connected pipe object. The owner must match the
+client's user SID and the pipe's integrity must be at least the client's; a
+mismatch is treated as "no instance we can reach", and the launch starts its
+own local instance instead. Authentication is object-bound rather than based
+on a numeric server PID that could be recycled after a duplicated pipe handle
+outlives its creating process.
 
 Clients also open the pipe with `SECURITY_SQOS_PRESENT |
 SECURITY_IDENTIFICATION`. A named-pipe server impersonates at

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -316,6 +316,11 @@ on Windows. Global keyboard capture is intentionally not implemented.
 noctty exposes a local Windows automation surface over the same
 single-instance IPC path used by `+new-window`.
 
+The named pipe behind it is local-only and user-private: it is created
+with `PIPE_REJECT_REMOTE_CLIENTS` and a protected DACL whose single ACE
+grants access to the SID that owns the running noctty process. Other
+local accounts and remote SMB clients cannot open it.
+
 List windows, tabs, and panes:
 
 ```powershell
@@ -338,9 +343,9 @@ Actions use the same names as `keybind` values. `--surface-id` is only
 valid for surface-scoped actions; app-scoped actions such as `quit`
 always target the app. The running instance rejects terminal-input and
 arbitrary file helper actions (`text`, `csi`, `esc`,
-`paste_from_clipboard`, `write_screen_file`, and `crash`), and new
-keybinding action variants stay disabled for automation until they are
-reviewed and allowlisted.
+`paste_from_clipboard`, `write_screen_file`, `end_key_sequence`, and
+`crash`), and new keybinding action variants stay disabled for automation
+until they are reviewed and allowlisted.
 
 ## Crash reports and diagnostics
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -245,6 +245,21 @@ test "automation-action safety rejects terminal input and crash actions" {
     // full scrollback, so it is terminal input too.
     try std.testing.expect(!isSafeAutomationAction(.clear_screen));
 
+    // undo/redo REPLAY a previously captured action, so allowlisting them
+    // would re-open every action they can replay. The Win32 undo stack can
+    // hold a `clear_screen` entry, and redoing it calls
+    // `reapplyUndoableAction`, which queues the same
+    // `.clear_screen{ .history = true }` io message the direct action does
+    // (src/apprt/win32.zig `reapplyUndoableAction`) -- i.e. a pty write and a
+    // full scrollback erase, reachable without ever naming `clear_screen`.
+    // Undo additionally restores a snapshot title straight into the apprt
+    // cache, bypassing the title sanitizer these setters otherwise enforce.
+    // Gating on the replayed entry would mean plumbing the automation origin
+    // through the whole apprt action dispatch; refusing both is the
+    // deny-by-default answer and costs only IPC-driven undo/redo.
+    try std.testing.expect(!isSafeAutomationAction(.undo));
+    try std.testing.expect(!isSafeAutomationAction(.redo));
+
     // Key table actions only move the binding stack and stay allowed.
     try std.testing.expect(isSafeAutomationAction(.deactivate_all_key_tables));
 }
@@ -284,6 +299,9 @@ test "automation-action dispatch rejects unsafe actions before dispatching" {
         "end_key_sequence",
         "clear_screen",
         "paste_from_clipboard",
+        // Reachable pty writes by replay rather than by name.
+        "undo",
+        "redo",
     }) |action_text| {
         try std.testing.expectError(
             error.UnsafeAutomationAction,
@@ -750,8 +768,6 @@ fn isSafeAutomationAction(action: input.Binding.Action) bool {
         .toggle_visibility,
         .toggle_background_opacity,
         .check_for_updates,
-        .undo,
-        .redo,
         .activate_key_table,
         .activate_key_table_once,
         .deactivate_key_table,

--- a/src/App.zig
+++ b/src/App.zig
@@ -236,6 +236,18 @@ test "automation-action safety rejects terminal input and crash actions" {
     try std.testing.expect(!isSafeAutomationAction(.paste_from_clipboard));
     try std.testing.expect(!isSafeAutomationAction(.{ .write_screen_file = .copy }));
     try std.testing.expect(!isSafeAutomationAction(.{ .crash = .main }));
+
+    // end_key_sequence flushes the queued key-sequence writes to the pty,
+    // so it is terminal input even though it takes no argument.
+    try std.testing.expect(!isSafeAutomationAction(.end_key_sequence));
+
+    // Key table actions only move the binding stack and stay allowed.
+    try std.testing.expect(isSafeAutomationAction(.deactivate_all_key_tables));
+}
+
+test "automation-action safety rejects end_key_sequence parsed from IPC text" {
+    const action = try input.Binding.Action.parse("end_key_sequence");
+    try std.testing.expect(!isSafeAutomationAction(action));
 }
 
 test "automation-action surface id targets reject app scoped actions" {
@@ -595,6 +607,11 @@ fn automationActionTargetError(
     };
 }
 
+/// Actions that `+perform-action` may invoke over IPC. Anything that can
+/// put bytes on the pty is excluded, including `end_key_sequence`: it
+/// resolves to `endKeySequence(.flush, ...)`, which writes the pending
+/// key-sequence queue to the terminal. New action variants default to
+/// unsafe until they are reviewed.
 fn isSafeAutomationAction(action: input.Binding.Action) bool {
     return switch (action) {
         .ignore,
@@ -665,7 +682,6 @@ fn isSafeAutomationAction(action: input.Binding.Action) bool {
         .check_for_updates,
         .undo,
         .redo,
-        .end_key_sequence,
         .activate_key_table,
         .activate_key_table_once,
         .deactivate_key_table,

--- a/src/App.zig
+++ b/src/App.zig
@@ -241,6 +241,10 @@ test "automation-action safety rejects terminal input and crash actions" {
     // so it is terminal input even though it takes no argument.
     try std.testing.expect(!isSafeAutomationAction(.end_key_sequence));
 
+    // clear_screen writes 0x0C to the child at a prompt and erases the
+    // full scrollback, so it is terminal input too.
+    try std.testing.expect(!isSafeAutomationAction(.clear_screen));
+
     // Key table actions only move the binding stack and stay allowed.
     try std.testing.expect(isSafeAutomationAction(.deactivate_all_key_tables));
 }
@@ -248,6 +252,62 @@ test "automation-action safety rejects terminal input and crash actions" {
 test "automation-action safety rejects end_key_sequence parsed from IPC text" {
     const action = try input.Binding.Action.parse("end_key_sequence");
     try std.testing.expect(!isSafeAutomationAction(action));
+}
+
+/// An App with just enough state for `performAutomationAction` to run its
+/// pre-dispatch checks. `font_grid_set` is untouched on that path, so this
+/// avoids standing up the font subsystem for a pure gating test.
+fn testAutomationApp() App {
+    return .{
+        .alloc = std.testing.allocator,
+        .surfaces = .{},
+        .mailbox = .{},
+        .font_grid_set = undefined,
+        .config_conditional_state = .{},
+    };
+}
+
+test "automation-action dispatch rejects unsafe actions before dispatching" {
+    var app = testAutomationApp();
+    defer app.surfaces.deinit(app.alloc);
+
+    // `performAutomationAction` returns before it touches `rt_app` for every
+    // outcome asserted here: the safety gate rejects first, and with no
+    // focused surface the fallback is a surface-scope check. A dangling but
+    // correctly aligned pointer is therefore never dereferenced.
+    const rt_app: *apprt.App = @ptrFromInt(@alignOf(apprt.App));
+
+    // These go through the real IPC entry point, so deleting the
+    // `isSafeAutomationAction` gate inside `performAutomationAction` fails
+    // this test rather than leaving the parse-only tests above green.
+    for ([_][]const u8{
+        "end_key_sequence",
+        "clear_screen",
+        "paste_from_clipboard",
+    }) |action_text| {
+        try std.testing.expectError(
+            error.UnsafeAutomationAction,
+            app.performAutomationAction(rt_app, .focused, action_text),
+        );
+        try std.testing.expectError(
+            error.UnsafeAutomationAction,
+            app.performAutomationAction(rt_app, .{ .surface_id = 1 }, action_text),
+        );
+    }
+
+    // An allowlisted surface-scoped action gets past the gate and fails
+    // later for lack of a target, which is what proves the gate is what
+    // rejected the actions above.
+    try std.testing.expectError(
+        error.NoAutomationTarget,
+        app.performAutomationAction(rt_app, .focused, "scroll_to_top"),
+    );
+
+    // Unparseable action text is rejected before the gate.
+    try std.testing.expectError(
+        error.InvalidAutomationAction,
+        app.performAutomationAction(rt_app, .focused, "no_such_action_zz"),
+    );
 }
 
 test "automation-action surface id targets reject app scoped actions" {
@@ -607,11 +667,22 @@ fn automationActionTargetError(
     };
 }
 
-/// Actions that `+perform-action` may invoke over IPC. Anything that can
-/// put bytes on the pty is excluded, including `end_key_sequence`: it
-/// resolves to `endKeySequence(.flush, ...)`, which writes the pending
-/// key-sequence queue to the terminal. New action variants default to
-/// unsafe until they are reviewed.
+/// Actions that `+perform-action` may invoke over IPC.
+///
+/// Anything that can put bytes on the pty is excluded:
+///
+///   - `end_key_sequence` resolves to `endKeySequence(.flush, ...)`, which
+///     writes the pending key-sequence queue to the terminal.
+///   - `clear_screen` reaches `Termio.clearScreen`, which sends `0x0C` (FF)
+///     to the child when the cursor is at a prompt, and also erases the
+///     full scrollback without regard to `readonly`.
+///
+/// This is only the boundary for the `.perform_action` IPC request kind.
+/// The `.new_window` kind on the same pipe carries argv and is filtered
+/// separately in `apprt/win32.zig` (`applyNewWindowArguments`); the pipe
+/// itself is restricted to the same user and is not a privilege boundary.
+///
+/// New action variants default to unsafe until they are reviewed.
 fn isSafeAutomationAction(action: input.Binding.Action) bool {
     return switch (action) {
         .ignore,
@@ -632,7 +703,6 @@ fn isSafeAutomationAction(action: input.Binding.Action) bool {
         .prompt_tab_title,
         .set_surface_title,
         .set_tab_title,
-        .clear_screen,
         .select_all,
         .scroll_to_top,
         .scroll_to_bottom,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -967,19 +967,102 @@ fn collectStartupForwardArguments(alloc: Allocator) !?[]const [:0]const u8 {
     return try argv.toOwnedSlice(alloc);
 }
 
+/// Build the security descriptor for the single-instance IPC pipe: a
+/// protected DACL whose only ACE grants full access to the SID that owns
+/// this process. Without it the pipe gets the default DACL, which is wider
+/// than the same-user contract the IPC verbs assume.
+///
+/// The current user's SID is resolved from the process token rather than
+/// using the `OW` (owner rights) SDDL alias, because an elevated token's
+/// default object owner is the Administrators group, not the user.
+///
+/// Returns a descriptor allocated by the OS; free it with `sys.LocalFree`.
+fn allocIpcPipeSecurityDescriptor() !*anyopaque {
+    var token: windows.HANDLE = undefined;
+    if (sys.OpenProcessToken(
+        windows.kernel32.GetCurrentProcess(),
+        c.TOKEN_QUERY,
+        &token,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+    defer _ = windows.CloseHandle(token);
+
+    // A TOKEN_USER plus the largest well-formed SID fits comfortably here;
+    // SECURITY_MAX_SID_SIZE is 68 bytes.
+    var token_user_buf: [256]u8 align(@alignOf(sys.TOKEN_USER)) = undefined;
+    var token_user_len: u32 = 0;
+    if (sys.GetTokenInformation(
+        token,
+        c.TokenUser,
+        &token_user_buf,
+        token_user_buf.len,
+        &token_user_len,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+    const token_user: *const sys.TOKEN_USER = @ptrCast(&token_user_buf);
+
+    var sid_string: ?[*:0]u16 = null;
+    if (sys.ConvertSidToStringSidW(
+        token_user.User.Sid,
+        &sid_string,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+    const sid = sid_string orelse return error.IpcSecurityDescriptorFailed;
+    defer _ = sys.LocalFree(@ptrCast(sid));
+
+    // "D:P" is a protected DACL (no inherited ACEs) containing exactly one
+    // ACE: GENERIC_ALL for the current user. Nothing is granted to
+    // Administrators, SYSTEM, NETWORK, or ANONYMOUS.
+    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("D:P(A;;GA;;;");
+    const sid_len = std.mem.len(sid);
+    var sddl: [256]u16 = undefined;
+    if (prefix.len + sid_len + 2 > sddl.len) {
+        return error.IpcSecurityDescriptorFailed;
+    }
+    @memcpy(sddl[0..prefix.len], prefix);
+    @memcpy(sddl[prefix.len..][0..sid_len], sid[0..sid_len]);
+    sddl[prefix.len + sid_len] = ')';
+    sddl[prefix.len + sid_len + 1] = 0;
+
+    var descriptor: ?*anyopaque = null;
+    if (sys.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+        @ptrCast(&sddl),
+        c.SDDL_REVISION_1,
+        &descriptor,
+        null,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+
+    return descriptor orelse error.IpcSecurityDescriptorFailed;
+}
+
 fn ipcServerMain(app: *App) void {
     const pipe_name = app.ipc_pipe_name orelse return;
+
+    // Fail closed: an unrestricted single-instance pipe would accept
+    // requests from any local account, so refuse to listen at all if the
+    // DACL cannot be built.
+    const descriptor = allocIpcPipeSecurityDescriptor() catch |err| {
+        log.warn("failed to build win32 IPC pipe security descriptor err={}", .{err});
+        return;
+    };
+    defer _ = sys.LocalFree(descriptor);
+
+    var security_attributes: windows.SECURITY_ATTRIBUTES = .{
+        .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+        .lpSecurityDescriptor = descriptor,
+        .bInheritHandle = windows.FALSE,
+    };
 
     server: while (!app.ipc_stop_requested.load(.acquire)) {
         const pipe = sys.CreateNamedPipeW(
             pipe_name.ptr,
             c.PIPE_ACCESS_DUPLEX,
-            windows.PIPE_TYPE_BYTE | c.PIPE_READMODE_BYTE | win32_ipc.pipe_nowait,
+            windows.PIPE_TYPE_BYTE |
+                c.PIPE_READMODE_BYTE |
+                win32_ipc.pipe_nowait |
+                c.PIPE_REJECT_REMOTE_CLIENTS,
             c.PIPE_UNLIMITED_INSTANCES,
             16 * 1024,
             16 * 1024,
             0,
-            null,
+            &security_attributes,
         );
         if (pipe == windows.INVALID_HANDLE_VALUE) {
             log.warn("failed to create win32 IPC pipe err={}", .{
@@ -27652,6 +27735,62 @@ test "win32 timed out automation request remains owned until consumption" {
     try std.testing.expectEqualStrings("new_tab", request.action_text);
     request.completed.store(true, .release);
     request.release(); // Delayed mailbox consumer owns the final reference.
+}
+
+test "win32 IPC pipe DACL still admits a same-user client" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const descriptor = try allocIpcPipeSecurityDescriptor();
+    defer _ = sys.LocalFree(descriptor);
+
+    var security_attributes: windows.SECURITY_ATTRIBUTES = .{
+        .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+        .lpSecurityDescriptor = descriptor,
+        .bInheritHandle = windows.FALSE,
+    };
+
+    const pipe_name_utf8 = try std.fmt.allocPrintSentinel(
+        std.testing.allocator,
+        "\\\\.\\pipe\\noctty-ipc-dacl-{d}",
+        .{sys.GetTickCount64()},
+        0,
+    );
+    defer std.testing.allocator.free(pipe_name_utf8);
+    const pipe_name = try std.unicode.utf8ToUtf16LeAllocZ(
+        std.testing.allocator,
+        pipe_name_utf8,
+    );
+    defer std.testing.allocator.free(pipe_name);
+
+    const server = sys.CreateNamedPipeW(
+        pipe_name.ptr,
+        c.PIPE_ACCESS_DUPLEX,
+        windows.PIPE_TYPE_BYTE |
+            c.PIPE_READMODE_BYTE |
+            win32_ipc.pipe_nowait |
+            c.PIPE_REJECT_REMOTE_CLIENTS,
+        1,
+        1024,
+        1024,
+        0,
+        &security_attributes,
+    );
+    try std.testing.expect(server != windows.INVALID_HANDLE_VALUE);
+    defer _ = windows.CloseHandle(server);
+
+    // The CLI verbs reach the server through this same CreateFileW path,
+    // so the restrictive DACL must not lock the owning user out.
+    const client = windows.kernel32.CreateFileW(
+        pipe_name.ptr,
+        windows.GENERIC_READ | windows.GENERIC_WRITE,
+        0,
+        null,
+        windows.OPEN_EXISTING,
+        windows.FILE_ATTRIBUTE_NORMAL,
+        null,
+    );
+    try std.testing.expect(client != windows.INVALID_HANDLE_VALUE);
+    defer _ = windows.CloseHandle(client);
 }
 
 test "win32 IPC silent client read is bounded" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -837,6 +837,31 @@ fn tokenUserSidBytes(
     return buf[0..sid_len];
 }
 
+/// Mandatory integrity level of a token, as an `S-1-16-<rid>` RID.
+///
+/// Unlike `allocIpcPipeIntegritySid` this reports EVERY level including
+/// medium and below, because the comparison below needs the actual value
+/// rather than "is it above medium".
+fn tokenIntegrityRid(token: windows.HANDLE) ?u32 {
+    var label_buf: [256]u8 align(@alignOf(sys.TOKEN_MANDATORY_LABEL)) = undefined;
+    var label_len: u32 = 0;
+    if (sys.GetTokenInformation(
+        token,
+        c.TokenIntegrityLevel,
+        &label_buf,
+        label_buf.len,
+        &label_len,
+    ) == 0) return null;
+    const label: *const sys.TOKEN_MANDATORY_LABEL = @ptrCast(&label_buf);
+
+    var sid_string: ?[*:0]u16 = null;
+    if (sys.ConvertSidToStringSidW(label.Label.Sid, &sid_string) == 0) return null;
+    const sid = sid_string orelse return null;
+    defer _ = sys.LocalFree(@ptrCast(sid));
+
+    return integrityRidFromSidString(std.mem.span(sid));
+}
+
 /// Is the process serving this pipe running as the same user we are?
 ///
 /// The single-instance pipe name is derived only from `--class`, so it is
@@ -879,7 +904,32 @@ fn ipcPipeServerIsSameUser(pipe: windows.HANDLE) bool {
     const own_sid = currentUserSidBytes(&own_buf) catch return false;
 
     if (server_sid.len != own_sid.len) return false;
-    return sys.EqualSid(@ptrCast(server_sid.ptr), @ptrCast(own_sid.ptr)) != 0;
+    if (sys.EqualSid(@ptrCast(server_sid.ptr), @ptrCast(own_sid.ptr)) == 0) return false;
+
+    // The user SID is NOT sufficient on its own. Under the ordinary split
+    // UAC token, an elevated process and a medium-integrity process of the
+    // same account carry the SAME user SID, so `EqualSid` alone would let a
+    // medium-integrity squatter pre-create the predictable name and serve an
+    // ELEVATED client -- which would then hand its forwarded arguments
+    // downward and accept a forged ack. `SECURITY_IDENTIFICATION` prevents
+    // the squatter impersonating us; it says nothing about who it is.
+    //
+    // So require the server to be at least our own integrity level. Equal is
+    // fine (the normal case, and what the medium-to-medium path needs);
+    // higher is fine (a medium client talking to an elevated instance is
+    // already governed by the pipe's NO_WRITE_UP label); strictly lower is
+    // refused.
+    var own_token: windows.HANDLE = undefined;
+    if (sys.OpenProcessToken(
+        windows.kernel32.GetCurrentProcess(),
+        c.TOKEN_QUERY,
+        &own_token,
+    ) == 0) return false;
+    defer _ = windows.CloseHandle(own_token);
+
+    const own_rid = tokenIntegrityRid(own_token) orelse return false;
+    const server_rid = tokenIntegrityRid(server_token) orelse return false;
+    return server_rid >= own_rid;
 }
 
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
@@ -29200,11 +29250,27 @@ test "win32 IPC client authenticates the pipe server as the same user" {
     try std.testing.expect(own_sid.len >= 8);
     try std.testing.expectEqual(@as(u8, 1), own_sid[0]); // SID revision
 
-    // NOTE: the REJECT direction cannot be exercised here. It needs a pipe
-    // server running under a different local account, which this suite
-    // cannot create. The negative case is argued from the fail-closed
-    // structure of `ipcPipeServerIsSameUser` (every error path returns
-    // false), not observed.
+    // The integrity half of the check reads a real level. A same-user SID
+    // is NOT sufficient on its own, because a split UAC token shares it
+    // across integrity levels.
+    var token: windows.HANDLE = undefined;
+    try std.testing.expect(sys.OpenProcessToken(
+        windows.kernel32.GetCurrentProcess(),
+        c.TOKEN_QUERY,
+        &token,
+    ) != 0);
+    defer _ = windows.CloseHandle(token);
+    const rid = tokenIntegrityRid(token).?;
+    // Any interactive or service token sits at low or above; a zero here
+    // would make the `>=` comparison vacuous.
+    try std.testing.expect(rid >= c.SECURITY_MANDATORY_LOW_RID);
+
+    // NOTE: the REJECT directions cannot be exercised here. A foreign-user
+    // server needs a second local account, and a lower-integrity server
+    // needs a medium process while this suite runs elevated; neither is
+    // creatable from a test. Both are argued from the fail-closed structure
+    // of `ipcPipeServerIsSameUser` (every error path returns false, and the
+    // final comparison is `server_rid >= own_rid`), not observed.
 }
 
 test "win32 IPC silent client read is bounded" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -945,23 +945,45 @@ fn descriptorIntegrityRid(descriptor: *anyopaque) error{InvalidSecurityDescripto
     const text_ptr = text orelse return error.InvalidSecurityDescriptor;
     defer _ = sys.LocalFree(@ptrCast(text_ptr));
 
-    const sddl = std.mem.span(text_ptr);
-    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-");
-    const start = std.mem.indexOf(u16, sddl, prefix) orelse {
-        // Unlabelled kernel objects evaluate at medium integrity.
-        return c.SECURITY_MANDATORY_MEDIUM_RID;
-    };
+    return descriptorIntegrityRidFromSddl(std.mem.span(text_ptr));
+}
 
-    var rid: u32 = 0;
-    var digits: usize = 0;
-    for (sddl[start + prefix.len ..]) |ch| {
-        if (ch < '0' or ch > '9') break;
-        rid = std.math.mul(u32, rid, 10) catch return error.InvalidSecurityDescriptor;
-        rid = std.math.add(u32, rid, ch - '0') catch return error.InvalidSecurityDescriptor;
-        digits += 1;
+fn descriptorIntegrityRidFromSddl(sddl: []const u16) error{InvalidSecurityDescriptor}!u32 {
+    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-");
+    if (std.mem.indexOf(u16, sddl, prefix)) |start| {
+        var rid: u32 = 0;
+        var digits: usize = 0;
+        for (sddl[start + prefix.len ..]) |ch| {
+            if (ch < '0' or ch > '9') break;
+            rid = std.math.mul(u32, rid, 10) catch return error.InvalidSecurityDescriptor;
+            rid = std.math.add(u32, rid, ch - '0') catch return error.InvalidSecurityDescriptor;
+            digits += 1;
+        }
+        if (digits == 0) return error.InvalidSecurityDescriptor;
+        return rid;
     }
-    if (digits == 0) return error.InvalidSecurityDescriptor;
-    return rid;
+
+    // Windows renders well-known mandatory-label SIDs using SDDL aliases.
+    // The label-only descriptor contains no unrelated ACEs, so matching the
+    // trustee suffix is unambiguous.
+    const aliases = [_]struct { suffix: []const u16, rid: u32 }{
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;UN)"), .rid = 0x0000 },
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;LW)"), .rid = 0x1000 },
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;ME)"), .rid = 0x2000 },
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;MP)"), .rid = 0x2100 },
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;HI)"), .rid = 0x3000 },
+        .{ .suffix = std.unicode.utf8ToUtf16LeStringLiteral(";;;SI)"), .rid = 0x4000 },
+    };
+    for (aliases) |alias| {
+        if (std.mem.indexOf(u16, sddl, alias.suffix) != null) return alias.rid;
+    }
+
+    // An absent mandatory-label ACE evaluates as medium. A present but
+    // unknown label is malformed and must fail closed.
+    if (std.mem.indexOf(u16, sddl, std.unicode.utf8ToUtf16LeStringLiteral("(ML;")) != null) {
+        return error.InvalidSecurityDescriptor;
+    }
+    return c.SECURITY_MANDATORY_MEDIUM_RID;
 }
 
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
@@ -28610,6 +28632,30 @@ test "win32 integrity SID parsing accepts only mandatory label SIDs" {
     try expect(integrityRidFromSidString(L("S-1-16-12a88")) == null);
     try expect(integrityRidFromSidString(L("")) == null);
     try expect(integrityRidFromSidString(L("S-1-16-99999999999")) == null);
+}
+
+test "win32 pipe descriptor integrity parsing accepts SDDL aliases" {
+    const L = std.unicode.utf8ToUtf16LeStringLiteral;
+    try std.testing.expectEqual(
+        @as(u32, 0x3000),
+        try descriptorIntegrityRidFromSddl(L("S:AI(ML;;NW;;;HI)")),
+    );
+    try std.testing.expectEqual(
+        @as(u32, 0x4000),
+        try descriptorIntegrityRidFromSddl(L("S:(ML;;NWNR;;;SI)")),
+    );
+    try std.testing.expectEqual(
+        @as(u32, 0x3000),
+        try descriptorIntegrityRidFromSddl(L("S:(ML;;NW;;;S-1-16-12288)")),
+    );
+    try std.testing.expectEqual(
+        @as(u32, c.SECURITY_MANDATORY_MEDIUM_RID),
+        try descriptorIntegrityRidFromSddl(L("")),
+    );
+    try std.testing.expectError(
+        error.InvalidSecurityDescriptor,
+        descriptorIntegrityRidFromSddl(L("S:(ML;;NW;;;ZZ)")),
+    );
 }
 
 /// Render a security descriptor to SDDL text.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -879,6 +879,105 @@ fn sendPerformActionIpc(
     return try win32_ipc.readAckWithTimeout(pipe, win32_ipc.automation_response_timeout_ms);
 }
 
+/// Configuration keys that a forwarded `new_window` argv may never set.
+///
+/// `applyNewWindowArguments` runs on the server side of the single-instance
+/// IPC pipe and feeds attacker-controllable argv straight into
+/// `Config.loadIter`, so the automation allowlist in `App.isSafeAutomationAction`
+/// is not the boundary for this request kind. Every key below either selects
+/// code that the server will execute or names an additional configuration
+/// source that could set such a key transitively:
+///
+///   - `command` / `initial-command` become the spawned child (termio/Exec).
+///   - `config-file` and `config-default-files` re-point config loading.
+///   - `theme` accepts an absolute path and is parsed as a full config file
+///     (see `config/theme.zig` `open`), so it is a `config-file` by proxy.
+///   - `custom-shader` loads and compiles files from arbitrary paths.
+///
+/// `-e` is rejected as well: `Config.parseManuallyHook` turns it into
+/// `initial-command`.
+const forbidden_forwarded_config_keys = [_][]const u8{
+    "command",
+    "initial-command",
+    "config-file",
+    "config-default-files",
+    "theme",
+    "custom-shader",
+};
+
+/// Returns the offending key when `arg` is a forwarded argument that the
+/// server must not honor, or null when it is acceptable.
+///
+/// `cli/args.zig` only accepts `--key=value` and `--key` forms (values are
+/// never a separate argv token), plus the `-e` manual hook, so prefix
+/// matching on the key segment is exhaustive.
+fn forbiddenForwardedArgument(arg: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, arg, "-e")) return "-e";
+    if (!std.mem.startsWith(u8, arg, "--")) return null;
+
+    const body = arg[2..];
+    const key = if (std.mem.indexOfScalar(u8, body, '=')) |idx| body[0..idx] else body;
+    for (forbidden_forwarded_config_keys) |forbidden| {
+        if (std.mem.eql(u8, key, forbidden)) return forbidden;
+    }
+    return null;
+}
+
+/// Returns true when a forwarded `--working-directory` value is one the
+/// server is willing to honor.
+///
+/// The startup forwarder always sends the launching process's realpath'd cwd
+/// (`collectStartupForwardArguments`), so this key cannot simply be rejected
+/// without breaking single-instance launches. Instead it is constrained to
+/// the two symbolic values plus a local drive-letter absolute path that
+/// currently resolves to a directory. That rejects UNC paths, which would
+/// otherwise make the server authenticate to an attacker-chosen SMB host.
+fn forwardedWorkingDirectoryAllowed(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (std.mem.eql(u8, trimmed, "home")) return true;
+    if (std.mem.eql(u8, trimmed, "inherit")) return true;
+
+    // Reject UNC (`\\host\share`, `//host/share`) and device (`\\?\`) paths.
+    if (trimmed.len < 3) return false;
+    if (trimmed[0] == '\\' or trimmed[0] == '/') return false;
+    if (!std.ascii.isAlphabetic(trimmed[0])) return false;
+    if (trimmed[1] != ':') return false;
+    if (trimmed[2] != '\\' and trimmed[2] != '/') return false;
+
+    var dir = std.fs.openDirAbsolute(trimmed, .{}) catch return false;
+    dir.close();
+    return true;
+}
+
+/// Scan a forwarded `new_window` argv and return a reason string when the
+/// whole request must be refused, or null when every argument is acceptable.
+///
+/// The reason is a static string suitable for logging; it names the key but
+/// never the attacker-supplied value.
+fn forwardedArgvRejection(argv: []const [:0]const u8) ?[]const u8 {
+    for (argv) |arg| {
+        if (forbiddenForwardedArgument(arg)) |key| return key;
+
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) {
+            const value = arg["--working-directory=".len..];
+            if (!forwardedWorkingDirectoryAllowed(value)) {
+                return "working-directory (not a local directory)";
+            }
+        }
+    }
+    return null;
+}
+
+/// Apply a forwarded `new_window` argv to `config`.
+///
+/// Returns `error.ForbiddenForwardedArgument` for the whole request if any
+/// argument is rejected. Dropping individual keys silently would leave the
+/// caller with a window that does not match what was asked for, and would
+/// make an attacker's probe indistinguishable from a normal launch.
+///
+/// The rejection is logged by the caller that handles it (see the
+/// `.new_window` arm of `performAction`) so that this stays a pure predicate
+/// over argv.
 fn applyNewWindowArguments(
     alloc_gpa: Allocator,
     config: *configpkg.Config,
@@ -886,6 +985,10 @@ fn applyNewWindowArguments(
 ) !void {
     const argv = arguments orelse return;
     if (argv.len == 0) return;
+
+    if (forwardedArgvRejection(argv) != null) {
+        return error.ForbiddenForwardedArgument;
+    }
 
     var iter: ForwardedArgIterator = .{ .args = argv };
     try config.loadIter(alloc_gpa, &iter);
@@ -967,10 +1070,107 @@ fn collectStartupForwardArguments(alloc: Allocator) !?[]const [:0]const u8 {
     return try argv.toOwnedSlice(alloc);
 }
 
+/// Parse the relative identifier out of an integrity-level SID string of the
+/// form `S-1-16-<rid>`. Returns null for anything that is not a mandatory
+/// label SID, so callers fail closed rather than mislabelling the pipe.
+fn integrityRidFromSidString(sid: []const u16) ?u32 {
+    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-");
+    if (sid.len <= prefix.len) return null;
+    if (!std.mem.eql(u16, sid[0..prefix.len], prefix)) return null;
+
+    var rid: u32 = 0;
+    for (sid[prefix.len..]) |unit| {
+        if (unit < '0' or unit > '9') return null;
+        rid = std.math.mul(u32, rid, 10) catch return null;
+        rid = std.math.add(u32, rid, @intCast(unit - '0')) catch return null;
+    }
+    return rid;
+}
+
+/// Render the SDDL text for the IPC pipe security descriptor into `buf`.
+///
+/// `D:P` is a protected DACL (no inherited ACEs) holding exactly one ACE:
+/// `GENERIC_ALL` for `user_sid`. When `integrity_sid` is non-null a
+/// mandatory-label ACE with the `NO_WRITE_UP` policy is appended, which is
+/// what keeps a lower-integrity process from opening the pipe for write.
+fn buildIpcPipeSddl(
+    buf: []u16,
+    user_sid: []const u16,
+    integrity_sid: ?[]const u16,
+) error{IpcSecurityDescriptorFailed}![:0]u16 {
+    var len: usize = 0;
+
+    const Appender = struct {
+        fn append(dest: []u16, at: *usize, text: []const u16) error{IpcSecurityDescriptorFailed}!void {
+            // Reserve one unit for the sentinel.
+            if (text.len + 1 > dest.len - at.*) return error.IpcSecurityDescriptorFailed;
+            @memcpy(dest[at.*..][0..text.len], text);
+            at.* += text.len;
+        }
+    };
+
+    try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("D:P(A;;GA;;;"));
+    try Appender.append(buf, &len, user_sid);
+    try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
+
+    if (integrity_sid) |label| {
+        try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("S:(ML;;NW;;;"));
+        try Appender.append(buf, &len, label);
+        try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
+    }
+
+    buf[len] = 0;
+    return buf[0..len :0];
+}
+
+/// Resolve the process token's mandatory integrity level as an SDDL SID
+/// string, but only when it sits strictly above medium integrity.
+///
+/// Windows does not auto-label kernel objects created by a high-integrity
+/// process, and an unlabeled object evaluates as medium. Because the token
+/// USER SID is identical across the elevated and non-elevated tokens of one
+/// account, a DACL keyed on that SID alone would let a filtered medium-IL
+/// process drive an elevated instance's pipe. Returning the label SID here
+/// lets the caller add `S:(ML;;NW;;;S-1-16-<rid>)`, which blocks write-up.
+///
+/// Returns null at or below medium integrity (where the label would be a
+/// no-op). The returned string is OS-allocated; free it with `sys.LocalFree`.
+fn allocIpcPipeIntegritySid(token: windows.HANDLE) !?[*:0]u16 {
+    var label_buf: [256]u8 align(@alignOf(sys.TOKEN_MANDATORY_LABEL)) = undefined;
+    var label_len: u32 = 0;
+    if (sys.GetTokenInformation(
+        token,
+        c.TokenIntegrityLevel,
+        &label_buf,
+        label_buf.len,
+        &label_len,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+    const label: *const sys.TOKEN_MANDATORY_LABEL = @ptrCast(&label_buf);
+
+    var sid_string: ?[*:0]u16 = null;
+    if (sys.ConvertSidToStringSidW(
+        label.Label.Sid,
+        &sid_string,
+    ) == 0) return error.IpcSecurityDescriptorFailed;
+    const sid = sid_string orelse return error.IpcSecurityDescriptorFailed;
+
+    const rid = integrityRidFromSidString(std.mem.span(sid)) orelse {
+        _ = sys.LocalFree(@ptrCast(sid));
+        return error.IpcSecurityDescriptorFailed;
+    };
+    if (rid <= c.SECURITY_MANDATORY_MEDIUM_RID) {
+        _ = sys.LocalFree(@ptrCast(sid));
+        return null;
+    }
+
+    return sid;
+}
+
 /// Build the security descriptor for the single-instance IPC pipe: a
 /// protected DACL whose only ACE grants full access to the SID that owns
-/// this process. Without it the pipe gets the default DACL, which is wider
-/// than the same-user contract the IPC verbs assume.
+/// this process, plus a mandatory-label ACE when this process runs above
+/// medium integrity. Without it the pipe gets the default DACL, which is
+/// wider than the same-user contract the IPC verbs assume.
 ///
 /// The current user's SID is resolved from the process token rather than
 /// using the `OW` (owner rights) SDDL alias, because an elevated token's
@@ -1007,23 +1207,29 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
     const sid = sid_string orelse return error.IpcSecurityDescriptorFailed;
     defer _ = sys.LocalFree(@ptrCast(sid));
 
-    // "D:P" is a protected DACL (no inherited ACEs) containing exactly one
-    // ACE: GENERIC_ALL for the current user. Nothing is granted to
-    // Administrators, SYSTEM, NETWORK, or ANONYMOUS.
-    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("D:P(A;;GA;;;");
-    const sid_len = std.mem.len(sid);
-    var sddl: [256]u16 = undefined;
-    if (prefix.len + sid_len + 2 > sddl.len) {
-        return error.IpcSecurityDescriptorFailed;
-    }
-    @memcpy(sddl[0..prefix.len], prefix);
-    @memcpy(sddl[prefix.len..][0..sid_len], sid[0..sid_len]);
-    sddl[prefix.len + sid_len] = ')';
-    sddl[prefix.len + sid_len + 1] = 0;
+    const integrity_sid = try allocIpcPipeIntegritySid(token);
+    defer if (integrity_sid) |v| {
+        _ = sys.LocalFree(@ptrCast(v));
+    };
+
+    // NOTE: there is no `O:` term, so the object owner defaults to the
+    // token's default owner. For an elevated token that is the
+    // Administrators group, and an owner always retains implicit
+    // READ_CONTROL/WRITE_DAC. A local administrator can therefore rewrite
+    // this DACL; that is inherent to running as an administrator and is not
+    // a boundary this descriptor claims to hold. What the descriptor does
+    // hold is that no ACE grants access to other interactive users,
+    // NETWORK, or ANONYMOUS.
+    var sddl_buf: [320]u16 = undefined;
+    const sddl = try buildIpcPipeSddl(
+        &sddl_buf,
+        std.mem.span(sid),
+        if (integrity_sid) |v| std.mem.span(v) else null,
+    );
 
     var descriptor: ?*anyopaque = null;
     if (sys.ConvertStringSecurityDescriptorToSecurityDescriptorW(
-        @ptrCast(&sddl),
+        sddl.ptr,
         c.SDDL_REVISION_1,
         &descriptor,
         null,
@@ -1035,9 +1241,11 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
 fn ipcServerMain(app: *App) void {
     const pipe_name = app.ipc_pipe_name orelse return;
 
-    // Fail closed: an unrestricted single-instance pipe would accept
-    // requests from any local account, so refuse to listen at all if the
-    // DACL cannot be built.
+    // Fail closed: with the default named-pipe security descriptor the pipe
+    // grants Administrators and LocalSystem full control, grants Everyone
+    // read (enough to occupy instances and observe the channel), and is
+    // reachable over SMB. Refuse to listen at all if the descriptor cannot
+    // be built rather than falling back to that.
     const descriptor = allocIpcPipeSecurityDescriptor() catch |err| {
         log.warn("failed to build win32 IPC pipe security descriptor err={}", .{err});
         return;
@@ -3358,7 +3566,30 @@ pub const App = struct {
                     .window,
                 );
                 defer config.deinit();
-                try applyNewWindowArguments(self.core_app.alloc, &config, forwarded_arguments);
+                // The forwarded argv reaches us over the single-instance IPC
+                // pipe, so it is only as trusted as any process running as
+                // this user. Refuse the whole request when it names a key
+                // that selects executed code or an extra config source.
+                if (forwarded_arguments) |argv| {
+                    if (forwardedArgvRejection(argv)) |reason| {
+                        std.log.err(
+                            "refusing forwarded new-window argv: {s} may not be set over IPC",
+                            .{reason},
+                        );
+                        return true;
+                    }
+                }
+                applyNewWindowArguments(
+                    self.core_app.alloc,
+                    &config,
+                    forwarded_arguments,
+                ) catch |err| switch (err) {
+                    // Defense in depth: `applyNewWindowArguments` enforces
+                    // the same filter independently. Treat a rejection as
+                    // handled so it cannot abort the app tick.
+                    error.ForbiddenForwardedArgument => return true,
+                    else => return err,
+                };
                 _ = try self.createWindowSurface(&config, default_title, .{
                     .clone_state_from = self.findSurfaceForTarget(target),
                 });
@@ -15316,6 +15547,58 @@ fn launchTargetButtonKeyAction(vk: WPARAM) ?LaunchTargetButtonKeyAction {
     };
 }
 
+/// True when `title` contains a byte that must not survive into a stored
+/// window/tab title. See `sanitizeTitleAlloc` for why.
+fn titleNeedsSanitize(title: []const u8) bool {
+    var i: usize = 0;
+    while (i < title.len) : (i += 1) {
+        const byte = title[i];
+        if (byte < 0x20 or byte == 0x7F) return true;
+        // UTF-8 encoding of the C1 controls U+0080..U+009F, which includes
+        // 8-bit CSI (U+009B) and ST (U+009C).
+        if (byte == 0xC2 and i + 1 < title.len and
+            title[i + 1] >= 0x80 and title[i + 1] <= 0x9F) return true;
+    }
+    return false;
+}
+
+/// Strip C0 controls, DEL, and C1 controls from a title.
+///
+/// A stored title is not display-only: with `title-report = true` the child
+/// process can issue `CSI 21 t` and the surface answers with
+/// `ESC ] l <title> ESC \` written back to the pty
+/// (`Surface.handleMessage` `.report_title`). Titles arrive from two places
+/// — OSC 0/2 from the child, and `set_surface_title` / `set_tab_title`
+/// performed over the automation IPC pipe — and the IPC path does not honor
+/// the `config.title != null` guard that the OSC path checks. Sanitizing at
+/// the apprt setters covers both, so an IPC peer cannot smuggle an escape
+/// sequence into the terminal by way of the title.
+///
+/// Returns null when `title` is already clean, so the common path allocates
+/// nothing. Otherwise returns an owned copy the caller must free.
+fn sanitizeTitleAlloc(alloc: Allocator, title: []const u8) Allocator.Error!?[]u8 {
+    if (!titleNeedsSanitize(title)) return null;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+    try out.ensureTotalCapacity(alloc, title.len);
+
+    var i: usize = 0;
+    while (i < title.len) : (i += 1) {
+        const byte = title[i];
+        if (byte < 0x20 or byte == 0x7F) continue;
+        if (byte == 0xC2 and i + 1 < title.len and
+            title[i + 1] >= 0x80 and title[i + 1] <= 0x9F)
+        {
+            i += 1;
+            continue;
+        }
+        out.appendAssumeCapacity(byte);
+    }
+
+    return try out.toOwnedSlice(alloc);
+}
+
 fn appendOwnedString(
     alloc: Allocator,
     target: *?[:0]const u8,
@@ -21458,6 +21741,13 @@ pub const Surface = struct {
 
     fn setTitle(self: *Surface, title: []const u8) !void {
         const alloc = self.app.core_app.alloc;
+        // Both the OSC 0/2 path and the automation IPC path
+        // (`set_surface_title`) land here, and a stored title can be echoed
+        // back to the pty by `title-report`. See `sanitizeTitleAlloc`.
+        const sanitized = try sanitizeTitleAlloc(alloc, title);
+        defer if (sanitized) |v| alloc.free(v);
+        const value = sanitized orelse title;
+
         var changed = false;
 
         // Direct commands initially report argv[0] as their title. Keep an
@@ -21465,15 +21755,15 @@ pub const Surface = struct {
         // remote terminal supplies a different title.
         if (sshAliasFromLaunchKey(self.launched_ssh, self.launch_profile_key)) |alias| {
             if (self.tab_title_override) |override| {
-                if (std.mem.eql(u8, override, alias) and !isAutomaticSshCommandTitle(title)) {
+                if (std.mem.eql(u8, override, alias) and !isAutomaticSshCommandTitle(value)) {
                     try appendOwnedString(alloc, &self.tab_title_override, null);
                     changed = true;
                 }
             }
         }
 
-        if (!ownedStringEquals(self.title, title)) {
-            try appendOwnedString(alloc, &self.title, title);
+        if (!ownedStringEquals(self.title, value)) {
+            try appendOwnedString(alloc, &self.title, value);
             changed = true;
         }
         if (!changed) return;
@@ -21486,17 +21776,28 @@ pub const Surface = struct {
     }
 
     fn setTitleOverride(self: *Surface, title: ?[]const u8) !void {
-        if (optionalOwnedStringEquals(self.title_override, title)) return;
         const alloc = self.app.core_app.alloc;
-        try appendOwnedString(alloc, &self.title_override, title);
+        const sanitized = if (title) |v| try sanitizeTitleAlloc(alloc, v) else null;
+        defer if (sanitized) |v| alloc.free(v);
+        const value: ?[]const u8 = if (sanitized) |v| v else title;
+
+        if (optionalOwnedStringEquals(self.title_override, value)) return;
+        try appendOwnedString(alloc, &self.title_override, value);
         try self.refreshWindowTitle();
         self.notifyTerminalUiaNameChanged();
     }
 
     fn setTabTitleOverride(self: *Surface, title: ?[]const u8) !void {
-        if (optionalOwnedStringEquals(self.tab_title_override, title)) return;
         const alloc = self.app.core_app.alloc;
-        try appendOwnedString(alloc, &self.tab_title_override, title);
+        // `set_tab_title` is reachable over the automation IPC pipe and
+        // `effectiveTitle` can surface this value to `title-report`, so it
+        // gets the same sanitizing as `setTitle`.
+        const sanitized = if (title) |v| try sanitizeTitleAlloc(alloc, v) else null;
+        defer if (sanitized) |v| alloc.free(v);
+        const value: ?[]const u8 = if (sanitized) |v| v else title;
+
+        if (optionalOwnedStringEquals(self.tab_title_override, value)) return;
+        try appendOwnedString(alloc, &self.tab_title_override, value);
         try self.refreshWindowTitle();
         self.notifyTerminalUiaNameChanged();
     }
@@ -27737,6 +28038,136 @@ test "win32 timed out automation request remains owned until consumption" {
     request.release(); // Delayed mailbox consumer owns the final reference.
 }
 
+test "win32 IPC pipe SDDL renders the exact DACL and mandatory label" {
+    const user_sid = std.unicode.utf8ToUtf16LeStringLiteral("S-1-5-21-1111-2222-3333-1001");
+    const high_sid = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-12288");
+
+    var buf: [320]u16 = undefined;
+
+    // Medium integrity: no label ACE, because an unlabeled object already
+    // evaluates as medium with NO_WRITE_UP.
+    {
+        const sddl = try buildIpcPipeSddl(&buf, user_sid, null);
+        var utf8: [320]u8 = undefined;
+        const len = try std.unicode.utf16LeToUtf8(&utf8, sddl);
+        try std.testing.expectEqualStrings(
+            "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)",
+            utf8[0..len],
+        );
+    }
+
+    // Above medium: the label ACE is what stops a filtered medium-integrity
+    // token of the SAME user from opening the elevated instance's pipe for
+    // write. The DACL alone cannot, because the token USER SID is identical
+    // across the elevated and non-elevated tokens of one account.
+    {
+        const sddl = try buildIpcPipeSddl(&buf, user_sid, high_sid);
+        var utf8: [320]u8 = undefined;
+        const len = try std.unicode.utf16LeToUtf8(&utf8, sddl);
+        try std.testing.expectEqualStrings(
+            "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)S:(ML;;NW;;;S-1-16-12288)",
+            utf8[0..len],
+        );
+    }
+
+    // A buffer too small to hold the text plus its sentinel fails closed.
+    var tiny: [8]u16 = undefined;
+    try std.testing.expectError(
+        error.IpcSecurityDescriptorFailed,
+        buildIpcPipeSddl(&tiny, user_sid, null),
+    );
+}
+
+test "win32 integrity SID parsing accepts only mandatory label SIDs" {
+    const expect = std.testing.expect;
+    const L = std.unicode.utf8ToUtf16LeStringLiteral;
+
+    try std.testing.expectEqual(
+        @as(?u32, 0x3000),
+        integrityRidFromSidString(L("S-1-16-12288")),
+    );
+    try std.testing.expectEqual(
+        @as(?u32, 0x2000),
+        integrityRidFromSidString(L("S-1-16-8192")),
+    );
+    try std.testing.expectEqual(
+        @as(?u32, 0x4000),
+        integrityRidFromSidString(L("S-1-16-16384")),
+    );
+
+    // Anything that is not S-1-16-<digits> must fail closed rather than be
+    // treated as an integrity level.
+    try expect(integrityRidFromSidString(L("S-1-5-21-1-2-3-1001")) == null);
+    try expect(integrityRidFromSidString(L("S-1-16-")) == null);
+    try expect(integrityRidFromSidString(L("S-1-16-12a88")) == null);
+    try expect(integrityRidFromSidString(L("")) == null);
+    try expect(integrityRidFromSidString(L("S-1-16-99999999999")) == null);
+}
+
+test "win32 IPC pipe security descriptor round-trips to the expected SDDL" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const descriptor = try allocIpcPipeSecurityDescriptor();
+    defer _ = sys.LocalFree(descriptor);
+
+    // Resolve the expected principal independently of the descriptor so the
+    // assertion is on content, not on "the function returned something".
+    var token: windows.HANDLE = undefined;
+    try std.testing.expect(sys.OpenProcessToken(
+        windows.kernel32.GetCurrentProcess(),
+        c.TOKEN_QUERY,
+        &token,
+    ) != 0);
+    defer _ = windows.CloseHandle(token);
+
+    var token_user_buf: [256]u8 align(@alignOf(sys.TOKEN_USER)) = undefined;
+    var token_user_len: u32 = 0;
+    try std.testing.expect(sys.GetTokenInformation(
+        token,
+        c.TokenUser,
+        &token_user_buf,
+        token_user_buf.len,
+        &token_user_len,
+    ) != 0);
+    const token_user: *const sys.TOKEN_USER = @ptrCast(&token_user_buf);
+
+    var expected_sid: ?[*:0]u16 = null;
+    try std.testing.expect(sys.ConvertSidToStringSidW(
+        token_user.User.Sid,
+        &expected_sid,
+    ) != 0);
+    const sid = expected_sid.?;
+    defer _ = sys.LocalFree(@ptrCast(sid));
+
+    var sid_utf8: [128]u8 = undefined;
+    const sid_utf8_len = try std.unicode.utf16LeToUtf8(&sid_utf8, std.mem.span(sid));
+
+    var expected_buf: [320]u8 = undefined;
+    const expected = try std.fmt.bufPrint(
+        &expected_buf,
+        "D:P(A;;GA;;;{s})",
+        .{sid_utf8[0..sid_utf8_len]},
+    );
+
+    // Round-trip the built descriptor back to SDDL. A null descriptor, an
+    // Everyone ACE, an unprotected DACL, or a narrower/wider access mask all
+    // change this string.
+    var actual_sddl: ?[*:0]u16 = null;
+    try std.testing.expect(sys.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+        descriptor,
+        c.SDDL_REVISION_1,
+        c.DACL_SECURITY_INFORMATION,
+        &actual_sddl,
+        null,
+    ) != 0);
+    const actual_utf16 = std.mem.span(actual_sddl.?);
+    defer _ = sys.LocalFree(@ptrCast(actual_sddl.?));
+
+    var actual_buf: [320]u8 = undefined;
+    const actual_len = try std.unicode.utf16LeToUtf8(&actual_buf, actual_utf16);
+    try std.testing.expectEqualStrings(expected, actual_buf[0..actual_len]);
+}
+
 test "win32 IPC pipe DACL still admits a same-user client" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -27791,6 +28222,152 @@ test "win32 IPC pipe DACL still admits a same-user client" {
     );
     try std.testing.expect(client != windows.INVALID_HANDLE_VALUE);
     defer _ = windows.CloseHandle(client);
+}
+
+test "win32 forwarded new-window argv rejects code and config-source keys" {
+    const expect = std.testing.expect;
+
+    // A pipe writer that gets `--command` accepted gets execution in the
+    // server's context, which is the whole point of the server-side filter.
+    try std.testing.expectEqualStrings(
+        "command",
+        forbiddenForwardedArgument("--command=powershell -enc AAAA").?,
+    );
+    try std.testing.expectEqualStrings(
+        "initial-command",
+        forbiddenForwardedArgument("--initial-command=calc.exe").?,
+    );
+    try std.testing.expectEqualStrings(
+        "config-file",
+        forbiddenForwardedArgument("--config-file=C:/tmp/evil.conf").?,
+    );
+    try std.testing.expectEqualStrings(
+        "config-default-files",
+        forbiddenForwardedArgument("--config-default-files=false").?,
+    );
+    // `theme` takes an absolute path and is parsed as a whole config file,
+    // so it is a `config-file` by proxy.
+    try std.testing.expectEqualStrings(
+        "theme",
+        forbiddenForwardedArgument("--theme=C:/tmp/evil.conf").?,
+    );
+    try std.testing.expectEqualStrings(
+        "custom-shader",
+        forbiddenForwardedArgument("--custom-shader=C:/tmp/x.glsl").?,
+    );
+    // `-e` is turned into `initial-command` by `Config.parseManuallyHook`.
+    try std.testing.expectEqualStrings("-e", forbiddenForwardedArgument("-e").?);
+
+    // Valueless and prefix-similar forms.
+    try std.testing.expectEqualStrings("command", forbiddenForwardedArgument("--command").?);
+    try expect(forbiddenForwardedArgument("--command-palette-entry=x") == null);
+    try expect(forbiddenForwardedArgument("--font-size=14") == null);
+    try expect(forbiddenForwardedArgument("--title=hello") == null);
+    try expect(forbiddenForwardedArgument("not-a-flag") == null);
+}
+
+test "win32 forwarded working-directory is constrained to local directories" {
+    const expect = std.testing.expect;
+
+    try expect(forwardedWorkingDirectoryAllowed("home"));
+    try expect(forwardedWorkingDirectoryAllowed("inherit"));
+
+    // UNC values would make the server authenticate to an attacker-chosen
+    // SMB host just by resolving the path.
+    try expect(!forwardedWorkingDirectoryAllowed("\\\\attacker\\share"));
+    try expect(!forwardedWorkingDirectoryAllowed("//attacker/share"));
+    try expect(!forwardedWorkingDirectoryAllowed("\\\\?\\C:\\Windows"));
+    try expect(!forwardedWorkingDirectoryAllowed("relative\\path"));
+    try expect(!forwardedWorkingDirectoryAllowed(""));
+
+    if (builtin.os.tag == .windows) {
+        // The startup forwarder always sends a realpath'd cwd, so a real
+        // local directory has to keep working or single-instance launches
+        // would break.
+        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const cwd = try std.fs.cwd().realpath(".", &cwd_buf);
+        try expect(forwardedWorkingDirectoryAllowed(cwd));
+        try expect(!forwardedWorkingDirectoryAllowed("C:\\this-path-should-not-exist-noctty"));
+    }
+}
+
+test "win32 applyNewWindowArguments rejects a forwarded command outright" {
+    const alloc = std.testing.allocator;
+
+    // The whole request must be refused rather than silently stripping the
+    // key, so the caller never builds a window from a half-honored argv.
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--window-height=40",
+                "--command=powershell -enc AAAA",
+            }),
+        );
+        try std.testing.expect(config.command == null);
+    }
+
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--config-file=C:/tmp/evil.conf",
+            }),
+        );
+    }
+
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--working-directory=\\\\attacker\\share",
+            }),
+        );
+    }
+
+    // A benign argv is still applied.
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+            "--window-height=40",
+        });
+        try std.testing.expectEqual(@as(u32, 40), config.@"window-height");
+    }
+}
+
+test "win32 title sanitizing strips control bytes from IPC and OSC titles" {
+    const alloc = std.testing.allocator;
+
+    // Clean titles allocate nothing.
+    try std.testing.expect(try sanitizeTitleAlloc(alloc, "hello world") == null);
+    try std.testing.expect(try sanitizeTitleAlloc(alloc, "caf\u{00e9} \u{4e2d}\u{6587}") == null);
+
+    // With `title-report = true` a stored title is echoed back to the child
+    // as `ESC ] l <title> ESC \`, so an ESC in an IPC-supplied title would
+    // let a pipe writer inject a sequence into the pty.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\x1b]0;pwned\x07b")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("a]0;pwnedb", out);
+    }
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\x1b\\b\nc\rd\x00e\x7ff")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("a\\bcdef", out);
+    }
+    // 8-bit CSI (U+009B) and ST (U+009C) as UTF-8.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\u{009b}0mb\u{009c}c")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("a0mbc", out);
+    }
 }
 
 test "win32 IPC silent client read is bounded" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1816,6 +1816,16 @@ fn handleNewWindowIpcClient(app: *App, pipe: windows.HANDLE) !void {
     const arguments = try win32_ipc.decodeNewWindowPayload(app.core_app.alloc, pipe);
     errdefer win32_ipc.freeOwnedArguments(app.core_app.alloc, arguments);
 
+    // Reject policy-invalid requests before the success ACK. The UI-thread
+    // path repeats the same checks as defense in depth, but acknowledging
+    // here first would make +new-window exit successfully without creating a
+    // window.
+    if (!newWindowIpcArgumentsAccepted(arguments)) {
+        try win32_ipc.writeAck(pipe, false);
+        win32_ipc.freeOwnedArguments(app.core_app.alloc, arguments);
+        return;
+    }
+
     const mailbox: CoreApp.Mailbox = .{
         .rt_app = app,
         .mailbox = &app.core_app.mailbox,
@@ -1827,6 +1837,15 @@ fn handleNewWindowIpcClient(app: *App, pipe: windows.HANDLE) !void {
     }
 
     try win32_ipc.writeAck(pipe, true);
+}
+
+fn newWindowIpcArgumentsAccepted(arguments: ?[]const [:0]const u8) bool {
+    const argv = arguments orelse return true;
+    return switch (scanForwardedToastActivation(argv)) {
+        .activation => true,
+        .malformed => false,
+        .none => forwardedArgvRejection(argv) == null,
+    };
 }
 
 fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
@@ -28093,6 +28112,15 @@ test "win32 synthesized forwarded working directory obeys receiver policy" {
     )).?;
     defer std.testing.allocator.free(local);
     try std.testing.expectEqualStrings("--working-directory=C:\\work", local);
+}
+
+test "win32 new-window IPC rejects policy failures before acknowledgement" {
+    try std.testing.expect(newWindowIpcArgumentsAccepted(null));
+    try std.testing.expect(newWindowIpcArgumentsAccepted(&.{"--title=Inbox"}));
+    try std.testing.expect(!newWindowIpcArgumentsAccepted(&.{"--command=calc.exe"}));
+    try std.testing.expect(!newWindowIpcArgumentsAccepted(&.{
+        "--working-directory=\\\\host\\share",
+    }));
 }
 
 test "win32 decorationsVisibleForConfig only hides none" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -978,12 +978,13 @@ fn descriptorIntegrityRidFromSddl(sddl: []const u16) error{InvalidSecurityDescri
         if (std.mem.indexOf(u16, sddl, alias.suffix) != null) return alias.rid;
     }
 
-    // An absent mandatory-label ACE evaluates as medium. A present but
-    // unknown label is malformed and must fail closed.
+    // The producer always emits an explicit label. Missing or unknown labels
+    // must fail closed; otherwise a low-integrity same-user squatter can rely
+    // on Windows' implicit-medium interpretation and impersonate our server.
     if (std.mem.indexOf(u16, sddl, std.unicode.utf8ToUtf16LeStringLiteral("(ML;")) != null) {
         return error.InvalidSecurityDescriptor;
     }
-    return c.SECURITY_MANDATORY_MEDIUM_RID;
+    return error.InvalidSecurityDescriptor;
 }
 
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
@@ -1533,9 +1534,9 @@ fn integrityRidFromSidString(sid: []const u16) ?u32 {
 /// Render the SDDL text for the IPC pipe security descriptor into `buf`.
 ///
 /// `D:P` is a protected DACL (no inherited ACEs) holding exactly one ACE:
-/// `GENERIC_ALL` for `user_sid`. When `integrity_sid` is non-null a
-/// mandatory-label ACE with the `NO_WRITE_UP` policy is appended, which is
-/// what keeps a lower-integrity process from opening the pipe for write.
+/// `GENERIC_ALL` for `user_sid`. An explicit mandatory-label ACE with the
+/// `NO_WRITE_UP` policy is always appended, which both prevents write-up and
+/// lets clients reject unlabeled same-user squatters.
 ///
 /// RESIDUAL: `NO_WRITE_UP` does not deny reads, so a medium-integrity
 /// process can open an elevated instance's pipe for `GENERIC_READ` (a bare
@@ -1555,7 +1556,7 @@ fn integrityRidFromSidString(sid: []const u16) ?u32 {
 fn buildIpcPipeSddl(
     buf: []u16,
     user_sid: []const u16,
-    integrity_sid: ?[]const u16,
+    integrity_sid: []const u16,
 ) error{IpcSecurityDescriptorFailed}![:0]u16 {
     var len: usize = 0;
 
@@ -1574,18 +1575,16 @@ fn buildIpcPipeSddl(
     try Appender.append(buf, &len, user_sid);
     try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
 
-    if (integrity_sid) |label| {
-        try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("S:(ML;;NW;;;"));
-        try Appender.append(buf, &len, label);
-        try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
-    }
+    try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("S:(ML;;NW;;;"));
+    try Appender.append(buf, &len, integrity_sid);
+    try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
 
     buf[len] = 0;
     return buf[0..len :0];
 }
 
 /// Resolve the process token's mandatory integrity level as an SDDL SID
-/// string, but only when it sits strictly above medium integrity.
+/// string at every integrity level.
 ///
 /// Windows does not auto-label kernel objects created by a high-integrity
 /// process, and an unlabeled object evaluates as medium. Because the token
@@ -1611,9 +1610,8 @@ fn buildIpcPipeSddl(
 /// and changing the label here would invalidate this PR's live descriptor
 /// readback.
 ///
-/// Returns null at or below medium integrity (where the label would be a
-/// no-op). The returned string is OS-allocated; free it with `sys.LocalFree`.
-fn allocIpcPipeIntegritySid(token: windows.HANDLE) !?[*:0]u16 {
+/// The returned string is OS-allocated; free it with `sys.LocalFree`.
+fn allocIpcPipeIntegritySid(token: windows.HANDLE) ![*:0]u16 {
     var label_buf: [256]u8 align(@alignOf(sys.TOKEN_MANDATORY_LABEL)) = undefined;
     var label_len: u32 = 0;
     if (sys.GetTokenInformation(
@@ -1632,23 +1630,18 @@ fn allocIpcPipeIntegritySid(token: windows.HANDLE) !?[*:0]u16 {
     ) == 0) return error.IpcSecurityDescriptorFailed;
     const sid = sid_string orelse return error.IpcSecurityDescriptorFailed;
 
-    const rid = integrityRidFromSidString(std.mem.span(sid)) orelse {
+    _ = integrityRidFromSidString(std.mem.span(sid)) orelse {
         _ = sys.LocalFree(@ptrCast(sid));
         return error.IpcSecurityDescriptorFailed;
     };
-    if (rid <= c.SECURITY_MANDATORY_MEDIUM_RID) {
-        _ = sys.LocalFree(@ptrCast(sid));
-        return null;
-    }
-
     return sid;
 }
 
 /// Build the security descriptor for the single-instance IPC pipe: a
 /// protected DACL whose only ACE grants full access to the SID that owns
-/// this process, plus a mandatory-label ACE when this process runs above
-/// medium integrity. Without it the pipe gets the default DACL, which is
-/// wider than the same-user contract the IPC verbs assume.
+/// this process, plus an explicit mandatory-label ACE at the process's exact
+/// integrity level. Without it the pipe gets the default DACL, which is wider
+/// than the same-user contract the IPC verbs assume.
 ///
 /// The current user's SID is resolved from the process token rather than
 /// using the `OW` (owner rights) SDDL alias, because an elevated token's
@@ -1686,9 +1679,7 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
     defer _ = sys.LocalFree(@ptrCast(sid));
 
     const integrity_sid = try allocIpcPipeIntegritySid(token);
-    defer if (integrity_sid) |v| {
-        _ = sys.LocalFree(@ptrCast(v));
-    };
+    defer _ = sys.LocalFree(@ptrCast(integrity_sid));
 
     // Pin the owner to the token user as well as granting that SID access.
     // The client authenticates the owner and mandatory label directly from
@@ -1697,7 +1688,7 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
     const sddl = try buildIpcPipeSddl(
         &sddl_buf,
         std.mem.span(sid),
-        if (integrity_sid) |v| std.mem.span(v) else null,
+        std.mem.span(integrity_sid),
     );
 
     var descriptor: ?*anyopaque = null;
@@ -28626,19 +28617,21 @@ test "win32 timed out automation request remains owned until consumption" {
 
 test "win32 IPC pipe SDDL renders the exact DACL and mandatory label" {
     const user_sid = std.unicode.utf8ToUtf16LeStringLiteral("S-1-5-21-1111-2222-3333-1001");
+    const medium_sid = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-8192");
     const high_sid = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-12288");
 
     var buf: [320]u16 = undefined;
 
-    // Medium integrity: no label ACE, because an unlabeled object already
-    // evaluates as medium with NO_WRITE_UP.
+    // Medium integrity is explicit so clients can reject an unlabeled
+    // same-user squatter instead of treating it as implicitly medium.
     {
-        const sddl = try buildIpcPipeSddl(&buf, user_sid, null);
+        const sddl = try buildIpcPipeSddl(&buf, user_sid, medium_sid);
         var utf8: [320]u8 = undefined;
         const len = try std.unicode.utf16LeToUtf8(&utf8, sddl);
         try std.testing.expectEqualStrings(
             "O:S-1-5-21-1111-2222-3333-1001" ++
-                "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)",
+                "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)" ++
+                "S:(ML;;NW;;;S-1-16-8192)",
             utf8[0..len],
         );
     }
@@ -28663,7 +28656,7 @@ test "win32 IPC pipe SDDL renders the exact DACL and mandatory label" {
     var tiny: [8]u16 = undefined;
     try std.testing.expectError(
         error.IpcSecurityDescriptorFailed,
-        buildIpcPipeSddl(&tiny, user_sid, null),
+        buildIpcPipeSddl(&tiny, user_sid, medium_sid),
     );
 }
 
@@ -28707,9 +28700,9 @@ test "win32 pipe descriptor integrity parsing accepts SDDL aliases" {
         @as(u32, 0x3000),
         try descriptorIntegrityRidFromSddl(L("S:(ML;;NW;;;S-1-16-12288)")),
     );
-    try std.testing.expectEqual(
-        @as(u32, c.SECURITY_MANDATORY_MEDIUM_RID),
-        try descriptorIntegrityRidFromSddl(L("")),
+    try std.testing.expectError(
+        error.InvalidSecurityDescriptor,
+        descriptorIntegrityRidFromSddl(L("")),
     );
     try std.testing.expectError(
         error.InvalidSecurityDescriptor,
@@ -28956,15 +28949,13 @@ test "win32 IPC pipe descriptor attaches the expected owner DACL and label" {
     defer _ = sys.LocalFree(@ptrCast(user_sid.?));
 
     const integrity_sid = try allocIpcPipeIntegritySid(token);
-    defer if (integrity_sid) |v| {
-        _ = sys.LocalFree(@ptrCast(v));
-    };
+    defer _ = sys.LocalFree(@ptrCast(integrity_sid));
 
     var reference_buf: [320]u16 = undefined;
     const reference_sddl = try buildIpcPipeSddl(
         &reference_buf,
         std.mem.span(user_sid.?),
-        if (integrity_sid) |v| std.mem.span(v) else null,
+        std.mem.span(integrity_sid),
     );
 
     var reference: ?*anyopaque = null;
@@ -29002,19 +28993,13 @@ test "win32 IPC pipe descriptor attaches the expected owner DACL and label" {
     try std.testing.expect(std.mem.indexOf(u8, dacl_text, ";;;WD)") == null);
     try std.testing.expect(std.mem.indexOf(u8, dacl_text, ";;;AN)") == null);
 
-    if (integrity_sid) |label_sid| {
-        // Above medium: the label must be present, with NO_WRITE_UP.
-        try std.testing.expect(std.mem.startsWith(u8, sacl_text, "S:"));
-        try std.testing.expect(std.mem.indexOf(u8, sacl_text, "(ML;;NW;;;") != null);
-        const rid = integrityRidFromSidString(std.mem.span(label_sid)).?;
-        try std.testing.expect(rid > c.SECURITY_MANDATORY_MEDIUM_RID);
-    } else {
-        // At or below medium an unlabeled object already evaluates as medium
-        // with NO_WRITE_UP, so emitting a label here would be wrong. Asserting
-        // its ABSENCE is the half that catches a label emitted for every
-        // process.
-        try std.testing.expect(std.mem.indexOf(u8, actual, "(ML;") == null);
-    }
+    // Every endpoint must carry its exact label. An absent label is not
+    // equivalent for authentication because Windows would interpret a
+    // low-integrity squatter's unlabeled object as medium.
+    try std.testing.expect(std.mem.startsWith(u8, sacl_text, "S:"));
+    try std.testing.expect(std.mem.indexOf(u8, sacl_text, "(ML;;NW;;;") != null);
+    const rid = integrityRidFromSidString(std.mem.span(integrity_sid)).?;
+    try std.testing.expect(rid >= c.SECURITY_MANDATORY_LOW_RID);
 }
 
 test "win32 IPC pipe DACL still admits a same-user client" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1449,24 +1449,31 @@ fn normalizeForwardedStartupArg(
         // process exits having produced no window at all. Dropping just this
         // argument here is what makes the "still gets a window" promise
         // above true for `--working-directory=\\host\share` and friends.
-        if (!forwardedWorkingDirectoryAllowed(normalized)) {
-            log.warn(
-                "not forwarding --working-directory to the running instance: " ++
-                    "value is not a local absolute path",
-                .{},
-            );
-            return null;
-        }
-
-        return try std.fmt.allocPrintSentinel(
-            alloc,
-            "--working-directory={s}",
-            .{normalized},
-            0,
-        );
+        return try allocForwardedWorkingDirectoryArg(alloc, normalized);
     }
 
     return try alloc.dupeZ(u8, arg);
+}
+
+fn allocForwardedWorkingDirectoryArg(
+    alloc: Allocator,
+    value: []const u8,
+) !?[:0]const u8 {
+    if (!forwardedWorkingDirectoryAllowed(value)) {
+        log.warn(
+            "not forwarding --working-directory to the running instance: " ++
+                "value is not a local absolute path",
+            .{},
+        );
+        return null;
+    }
+
+    return try std.fmt.allocPrintSentinel(
+        alloc,
+        "--working-directory={s}",
+        .{value},
+        0,
+    );
 }
 
 fn collectStartupForwardArguments(alloc: Allocator) !?[]const [:0]const u8 {
@@ -1493,12 +1500,9 @@ fn collectStartupForwardArguments(alloc: Allocator) !?[]const [:0]const u8 {
         const cwd = std.fs.cwd();
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
         const wd = try cwd.realpath(".", &cwd_buf);
-        try argv.insert(alloc, 0, try std.fmt.allocPrintSentinel(
-            alloc,
-            "--working-directory={s}",
-            .{wd},
-            0,
-        ));
+        if (try allocForwardedWorkingDirectoryArg(alloc, wd)) |arg| {
+            try argv.insert(alloc, 0, arg);
+        }
     }
 
     if (argv.items.len == 0) {
@@ -28075,6 +28079,20 @@ test "win32 normalizeForwardedStartupArg drops class and normalizes working dire
         std.testing.allocator,
         "wgh://activate?surface=abc",
     ) == null);
+}
+
+test "win32 synthesized forwarded working directory obeys receiver policy" {
+    try std.testing.expect(try allocForwardedWorkingDirectoryArg(
+        std.testing.allocator,
+        "\\\\host\\share",
+    ) == null);
+
+    const local = (try allocForwardedWorkingDirectoryArg(
+        std.testing.allocator,
+        "C:\\work",
+    )).?;
+    defer std.testing.allocator.free(local);
+    try std.testing.expectEqualStrings("--working-directory=C:\\work", local);
 }
 
 test "win32 decorationsVisibleForConfig only hides none" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1471,6 +1471,14 @@ fn integrityRidFromSidString(sid: []const u16) ?u32 {
 /// `GENERIC_ALL` for `user_sid`. When `integrity_sid` is non-null a
 /// mandatory-label ACE with the `NO_WRITE_UP` policy is appended, which is
 /// what keeps a lower-integrity process from opening the pipe for write.
+///
+/// RESIDUAL: `NO_WRITE_UP` does not deny reads, and a bare `READ_CONTROL`
+/// open is enough to occupy the server's single pipe instance — it does not
+/// need `GENERIC_READ`. The next legitimate client then fails with
+/// `ERROR_PIPE_BUSY`. That is an availability limit only (nothing is
+/// disclosed and no request can be submitted), and it is recorded in
+/// docs/windows.md along with the two candidate fixes and why neither is
+/// applied yet. Observed on hardware by the desktop lane, not inferred.
 fn buildIpcPipeSddl(
     buf: []u16,
     user_sid: []const u16,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -16160,6 +16160,16 @@ fn appendOwnedString(
     target.* = next;
 }
 
+fn appendSanitizedTitle(
+    alloc: Allocator,
+    target: *?[:0]const u8,
+    title: ?[]const u8,
+) !void {
+    const sanitized = if (title) |value| try sanitizeTitleAlloc(alloc, value) else null;
+    defer if (sanitized) |value| alloc.free(value);
+    try appendOwnedString(alloc, target, if (sanitized) |value| value else title);
+}
+
 const ownedStringEquals = labels.ownedStringEquals;
 
 fn ownedBytesEquals(current: ?[]const u8, value: []const u8) bool {
@@ -21718,7 +21728,10 @@ pub const Surface = struct {
             );
         }
 
-        appendOwnedString(alloc, &self.title, restored.title) catch |err| {
+        // Undo snapshots are serialized terminal state and may predate the
+        // normal title setters. Keep the title-report cache on the same
+        // control-byte policy as live OSC and automation title updates.
+        appendSanitizedTitle(alloc, &self.title, restored.title) catch |err| {
             log.warn("undo snapshot title cache sync failed err={}", .{err});
         };
         appendOwnedString(alloc, &self.pwd, restored.pwd) catch |err| {
@@ -29379,6 +29392,15 @@ test "win32 title sanitizing strips control bytes from IPC and OSC titles" {
         defer alloc.free(out);
         try std.testing.expectEqualStrings("", out);
     }
+}
+
+test "win32 undo title cache sanitizes bytes before title reporting" {
+    const alloc = std.testing.allocator;
+    var title: ?[:0]const u8 = null;
+    defer if (title) |value| alloc.free(value);
+
+    try appendSanitizedTitle(alloc, &title, "safe\x1b]0;injected\x07title");
+    try std.testing.expectEqualStrings("safe]0;injectedtitle", title.?);
 }
 
 test "win32 IPC client authenticates the connected pipe descriptor" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1527,11 +1527,22 @@ fn buildIpcPipeSddl(
 /// process drive an elevated instance's pipe. Returning the label SID here
 /// lets the caller add `S:(ML;;NW;;;S-1-16-<rid>)`, which blocks write-up.
 ///
-/// RESIDUAL: the policy is `NW` only, not `NR`/`NX`. A lower-integrity
-/// process can still open the pipe for READ and occupy a pipe instance --
-/// an availability nuisance against an elevated instance, bounded by the
-/// server's read timeout. `NR` would close that but is a larger behavioral
-/// change; it is tracked as a follow-up rather than done here.
+/// RESIDUAL: the policy is `NW` only, not `NR`/`NX`. See the fuller note on
+/// `buildIpcPipeSddl`; in short, and now measured rather than assumed, a
+/// medium-integrity process can open an elevated instance's pipe for
+/// `GENERIC_READ` -- a bare `READ_CONTROL` is enough, it need not request
+/// read data access at all -- and `WriteFile` on that handle then fails
+/// `win32=5`. So this is an OCCUPANCY problem, not an access break, but the
+/// server offers one pipe instance at a time, so one such handle makes the
+/// next legitimate client fail `win32=231 ERROR_PIPE_BUSY`.
+///
+/// `NR` closes it, and that is no longer a supposition: the elevation work
+/// labels its elevated endpoint `NWNR`, and hardware verification shows the
+/// `NR` denies every medium open including `GENERIC_READ` and
+/// `READ_CONTROL`. It is supplied there rather than duplicated here, since
+/// both would collide on the same SDDL term for no net gain once they land,
+/// and changing the label here would invalidate this PR's live descriptor
+/// readback.
 ///
 /// Returns null at or below medium integrity (where the label would be a
 /// no-op). The returned string is OS-allocated; free it with `sys.LocalFree`.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -789,6 +789,12 @@ fn resolveIpcPipeNameForTarget(
     };
 }
 
+/// Connect to the single-instance IPC pipe as a client.
+///
+/// `error.FileNotFound` and `error.PipeUnreachable` both mean "there is no
+/// instance we can talk to"; callers must treat them the same and fall back
+/// to running locally. They are kept distinct only so the unreachable case
+/// can be logged differently.
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
     var retries: u8 = 0;
     while (true) {
@@ -806,6 +812,16 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
         const err = windows.kernel32.GetLastError();
         switch (err) {
             .FILE_NOT_FOUND => return error.FileNotFound,
+
+            // The pipe exists but this token may not open it. The common
+            // cause is an elevated instance holding the name: its descriptor
+            // carries a NO_WRITE_UP mandatory label, so a medium-integrity
+            // client is denied at CreateFileW. That is the intended denial,
+            // but it must NOT abort startup -- an ordinary non-elevated
+            // launch has to fall through to its own local instance rather
+            // than failing to open a window at all.
+            .ACCESS_DENIED => return error.PipeUnreachable,
+
             .PIPE_BUSY => {
                 if (retries == 0 and sys.WaitNamedPipeW(pipe_name.ptr, 1000) != 0) {
                     retries += 1;
@@ -825,6 +841,15 @@ fn sendNewWindowIpc(
 ) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         error.FileNotFound => return false,
+        // No instance we are allowed to talk to. Report "not forwarded" so
+        // the caller starts a local instance instead of aborting startup.
+        error.PipeUnreachable => {
+            log.info(
+                "single-instance pipe exists but is not accessible to this token; starting a local instance",
+                .{},
+            );
+            return false;
+        },
         error.PipeBusy => return error.IPCFailed,
         else => return err,
     };
@@ -842,7 +867,8 @@ fn sendListWindowsIpc(
     pipe_name: [:0]const u16,
 ) !?[]u8 {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
-        error.FileNotFound => return null,
+        // Both mean "no instance we can reach"; see `connectToIpcPipe`.
+        error.FileNotFound, error.PipeUnreachable => return null,
         error.PipeBusy => return error.IPCFailed,
         else => return err,
     };
@@ -866,7 +892,8 @@ fn sendPerformActionIpc(
     action_text: []const u8,
 ) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
-        error.FileNotFound => return false,
+        // Both mean "no instance we can reach"; see `connectToIpcPipe`.
+        error.FileNotFound, error.PipeUnreachable => return false,
         error.PipeBusy => return error.IPCFailed,
         else => return err,
     };
@@ -879,93 +906,260 @@ fn sendPerformActionIpc(
     return try win32_ipc.readAckWithTimeout(pipe, win32_ipc.automation_response_timeout_ms);
 }
 
-/// Configuration keys that a forwarded `new_window` argv may never set.
+/// Configuration keys a forwarded `new_window` argv is allowed to set.
 ///
-/// `applyNewWindowArguments` runs on the server side of the single-instance
-/// IPC pipe and feeds attacker-controllable argv straight into
-/// `Config.loadIter`, so the automation allowlist in `App.isSafeAutomationAction`
-/// is not the boundary for this request kind. Every key below either selects
-/// code that the server will execute or names an additional configuration
-/// source that could set such a key transitively:
+/// `applyNewWindowArguments` runs on the SERVER side of the single-instance
+/// IPC pipe and feeds caller-controlled argv straight into `Config.loadIter`,
+/// so the automation allowlist in `App.isSafeAutomationAction` is not the
+/// boundary for this request kind. Any process running as this user can write
+/// to the pipe, so this argv must be treated as untrusted input.
 ///
-///   - `command` / `initial-command` become the spawned child (termio/Exec).
-///   - `config-file` and `config-default-files` re-point config loading.
-///   - `theme` accepts an absolute path and is parsed as a full config file
-///     (see `config/theme.zig` `open`), so it is a `config-file` by proxy.
-///   - `custom-shader` loads and compiles files from arbitrary paths.
+/// This is an ALLOWLIST, deliberately, and not a denylist. The config surface
+/// is ~190 fields and grows with every upstream merge; a denylist gets it
+/// wrong by omission every time a new key lands. Deny-by-default means an
+/// unrecognised key -- including any key added upstream after this list was
+/// written -- is refused until someone reviews it.
 ///
-/// `-e` is rejected as well: `Config.parseManuallyHook` turns it into
-/// `initial-command`.
-const forbidden_forwarded_config_keys = [_][]const u8{
-    "command",
-    "initial-command",
-    "config-file",
-    "config-default-files",
-    "theme",
-    "custom-shader",
+/// Admission rule: a key qualifies only if its value is a scalar, an enum, a
+/// color, or (for `title`) a display string that is sanitized downstream. A
+/// key does NOT qualify if its value is resolved as a filesystem path, a
+/// command, an environment variable, a font or theme NAME looked up against
+/// something, an additional configuration source, or bytes that can reach the
+/// pty. That rule excludes, among others:
+///
+///   - `command`, `initial-command`, `-e`  -> become the spawned child.
+///   - `input`                             -> written straight to the pty;
+///     its own doc comment warns it can execute programs in a shell.
+///   - `env`                               -> overrides are applied AFTER
+///     `shell_integration.setup`, so `ZDOTDIR` / `ENV` / `XDG_DATA_DIRS` /
+///     `GHOSTTY_BASH_RCFILE` / `PATH` become code execution at shell start.
+///   - `config-file`, `config-default-files`, `theme` -> config sources.
+///     `theme` accepts an absolute path and is parsed as a full config file
+///     (`config/theme.zig` `open`), so it is a `config-file` by proxy.
+///   - `background-image`, `bell-audio-path`, `custom-shader`,
+///     `gtk-custom-css`                    -> arbitrary file reads, and UNC
+///     values make this process authenticate to a remote SMB host.
+///   - `keybind`, `command-palette-entry`  -> inject attacker-chosen binding
+///     actions, re-opening the `.perform_action` allowlist by another door.
+///   - `enquiry-response`                  -> attacker bytes written to the
+///     pty when the child sends ENQ.
+///   - `title-report`, `window-save-state`, `class` -> not presentation.
+///   - `font-family*`, `font-style*`, `font-feature`, `font-variation*`,
+///     `font-codepoint-map`, `window-title-font-family` -> name strings that
+///     are resolved by font discovery. Excluded on the admission rule rather
+///     than because a concrete exploit is known.
+///
+/// `working-directory` is handled separately: it is admitted, but its VALUE
+/// is constrained by `forwardedWorkingDirectoryAllowed`.
+const forwarded_argv_allowed_keys = [_][]const u8{
+    // Window geometry, decoration, and state.
+    "window-width",
+    "window-height",
+    "window-position-x",
+    "window-position-y",
+    "window-padding-x",
+    "window-padding-y",
+    "window-padding-balance",
+    "window-padding-color",
+    "window-decoration",
+    "window-theme",
+    "window-colorspace",
+    "window-subtitle",
+    "window-titlebar-background",
+    "window-titlebar-foreground",
+    "window-show-tab-bar",
+    "window-new-tab-position",
+    "window-step-resize",
+    "window-vsync",
+    "maximize",
+    "fullscreen",
+    "title",
+
+    // Font sizing and rendering. Font NAME keys are deliberately absent.
+    "font-size",
+    "font-thicken",
+    "font-thicken-strength",
+    "font-synthetic-style",
+    "font-shaping-break",
+
+    // Colors and compositing.
+    "background",
+    "foreground",
+    "palette",
+    "selection-foreground",
+    "selection-background",
+    "cursor-color",
+    "cursor-text",
+    "cursor-style",
+    "cursor-style-blink",
+    "cursor-opacity",
+    "background-opacity",
+    "background-opacity-cells",
+    "background-blur",
+    "unfocused-split-opacity",
+    "unfocused-split-fill",
+    "split-divider-color",
+    "bold-color",
+    "faint-opacity",
+    "minimum-contrast",
+    "alpha-blending",
 };
 
-/// Returns the offending key when `arg` is a forwarded argument that the
-/// server must not honor, or null when it is acceptable.
-///
-/// `cli/args.zig` only accepts `--key=value` and `--key` forms (values are
-/// never a separate argv token), plus the `-e` manual hook, so prefix
-/// matching on the key segment is exhaustive.
-fn forbiddenForwardedArgument(arg: []const u8) ?[]const u8 {
-    if (std.mem.eql(u8, arg, "-e")) return "-e";
-    if (!std.mem.startsWith(u8, arg, "--")) return null;
+/// The one allowlisted key whose value needs its own check.
+const forwarded_working_directory_key = "working-directory";
 
+/// Extract the config key from a forwarded argument, or null when the
+/// argument is not in `--key[=value]` form.
+///
+/// `cli/args.zig` (:112-133) takes `key = arg[2..]` up to the first `=` and
+/// matches it with exact case-sensitive `mem.eql` against field names. There
+/// is no prefix abbreviation, no `--key value` separate-token form, no case
+/// folding, and no underscore/hyphen aliasing, so this sees exactly the key
+/// the loader will act on.
+fn forwardedArgumentKey(arg: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, arg, "--")) return null;
     const body = arg[2..];
-    const key = if (std.mem.indexOfScalar(u8, body, '=')) |idx| body[0..idx] else body;
-    for (forbidden_forwarded_config_keys) |forbidden| {
-        if (std.mem.eql(u8, key, forbidden)) return forbidden;
+    return if (std.mem.indexOfScalar(u8, body, '=')) |idx| body[0..idx] else body;
+}
+
+/// True when a forwarded config key is on the allowlist. `working-directory`
+/// is included here; its value is checked separately.
+fn forwardedKeyAllowed(key: []const u8) bool {
+    if (std.mem.eql(u8, key, forwarded_working_directory_key)) return true;
+    for (forwarded_argv_allowed_keys) |allowed| {
+        if (std.mem.eql(u8, key, allowed)) return true;
     }
-    return null;
+    return false;
+}
+
+/// True when a key is safe to echo into a log line.
+///
+/// The refused key comes from the pipe, so it is attacker-controlled text and
+/// must not be logged raw (newlines would forge log records). Real config keys
+/// are lowercase ASCII with hyphens and digits, so anything else is reported
+/// generically instead.
+fn forwardedKeyLoggable(key: []const u8) bool {
+    if (key.len == 0 or key.len > 64) return false;
+    for (key) |ch| {
+        const ok = (ch >= 'a' and ch <= 'z') or
+            (ch >= '0' and ch <= '9') or
+            ch == '-';
+        if (!ok) return false;
+    }
+    return true;
 }
 
 /// Returns true when a forwarded `--working-directory` value is one the
 /// server is willing to honor.
 ///
 /// The startup forwarder always sends the launching process's realpath'd cwd
-/// (`collectStartupForwardArguments`), so this key cannot simply be rejected
-/// without breaking single-instance launches. Instead it is constrained to
-/// the two symbolic values plus a local drive-letter absolute path that
-/// currently resolves to a directory. That rejects UNC paths, which would
-/// otherwise make the server authenticate to an attacker-chosen SMB host.
+/// (`collectStartupForwardArguments`), so this key cannot be rejected
+/// outright without breaking every single-instance launch. It is instead
+/// constrained to the symbolic values, a home-relative path, or a local
+/// drive-letter absolute path.
+///
+/// SCOPE OF THIS CHECK, stated precisely: it rejects UNC *syntax* only. A
+/// mapped drive (`net use Z: \\host\share`), a `subst` drive, or a junction
+/// under a local drive still resolves off-box, and any same-user process can
+/// create those. That is acceptable under this channel's threat model --
+/// same-user code is already trusted -- and the point of the check is to stop
+/// a bare `\\attacker\share` value from making the server authenticate to an
+/// attacker-chosen SMB host.
+///
+/// The check is deliberately PURELY SYNTACTIC. An earlier version called
+/// `openDirAbsolute` to confirm the directory existed, but that resolution is
+/// itself the SMB authentication we are trying to avoid for mapped drives and
+/// junctions, and it was defeated by TOCTOU anyway since the path is
+/// re-resolved at spawn time.
 fn forwardedWorkingDirectoryAllowed(value: []const u8) bool {
-    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+    var trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+
+    // `Config.parseCLI` strips one pair of surrounding double quotes, so a
+    // quoted path is a legal value and must not be refused here.
+    if (trimmed.len >= 2 and trimmed[0] == '"' and trimmed[trimmed.len - 1] == '"') {
+        trimmed = std.mem.trim(u8, trimmed[1 .. trimmed.len - 1], &std.ascii.whitespace);
+    }
+
     if (std.mem.eql(u8, trimmed, "home")) return true;
     if (std.mem.eql(u8, trimmed, "inherit")) return true;
 
-    // Reject UNC (`\\host\share`, `//host/share`) and device (`\\?\`) paths.
+    // `~`, `~/...` and `~\...` are documented legal values that
+    // `WorkingDirectory.finalize` expands against the user's own home
+    // directory, so they cannot point off-box.
+    if (std.mem.eql(u8, trimmed, "~")) return true;
+    if (trimmed.len >= 2 and trimmed[0] == '~' and
+        (trimmed[1] == '/' or trimmed[1] == '\\')) return true;
+
+    // Everything else must be a local drive-letter absolute path. This
+    // rejects UNC (`\\host\share`, `//host/share`), device namespace
+    // (`\\?\`, `\\.\`), relative (`foo\bar`) and drive-relative (`C:foo`).
     if (trimmed.len < 3) return false;
-    if (trimmed[0] == '\\' or trimmed[0] == '/') return false;
     if (!std.ascii.isAlphabetic(trimmed[0])) return false;
     if (trimmed[1] != ':') return false;
     if (trimmed[2] != '\\' and trimmed[2] != '/') return false;
-
-    var dir = std.fs.openDirAbsolute(trimmed, .{}) catch return false;
-    dir.close();
     return true;
 }
 
-/// Scan a forwarded `new_window` argv and return a reason string when the
-/// whole request must be refused, or null when every argument is acceptable.
-///
-/// The reason is a static string suitable for logging; it names the key but
-/// never the attacker-supplied value.
-fn forwardedArgvRejection(argv: []const [:0]const u8) ?[]const u8 {
-    for (argv) |arg| {
-        if (forbiddenForwardedArgument(arg)) |key| return key;
+/// Why a forwarded argv was refused. `key` borrows from the argument and is
+/// only safe to log when `forwardedKeyLoggable(key)`.
+const ForwardedArgvRejection = struct {
+    reason: enum { not_allowlisted, bad_working_directory, not_a_config_flag },
+    key: []const u8,
+};
 
-        if (std.mem.startsWith(u8, arg, "--working-directory=")) {
-            const value = arg["--working-directory=".len..];
+/// Scan a forwarded `new_window` argv and describe the first argument that
+/// must not be honored, or null when every argument is acceptable.
+///
+/// Every element is scanned, so a repeated or trailing occurrence of a key
+/// cannot slip past by appearing after an acceptable one.
+fn forwardedArgvRejection(argv: []const [:0]const u8) ?ForwardedArgvRejection {
+    for (argv) |arg| {
+        const key = forwardedArgumentKey(arg) orelse {
+            // Not `--key[=value]`. `-e` lands here, and
+            // `Config.parseManuallyHook` would turn it into
+            // `initial-command`. Nothing in this form is ever legitimate on
+            // a forwarded argv, so refuse rather than relying on the loader
+            // to treat it as an inert diagnostic.
+            return .{ .reason = .not_a_config_flag, .key = arg };
+        };
+
+        if (!forwardedKeyAllowed(key)) {
+            return .{ .reason = .not_allowlisted, .key = key };
+        }
+
+        if (std.mem.eql(u8, key, forwarded_working_directory_key)) {
+            const value = if (std.mem.indexOfScalar(u8, arg, '=')) |idx|
+                arg[idx + 1 ..]
+            else
+                "";
             if (!forwardedWorkingDirectoryAllowed(value)) {
-                return "working-directory (not a local directory)";
+                return .{ .reason = .bad_working_directory, .key = key };
             }
         }
     }
     return null;
+}
+
+/// Log a refused forwarded argv at error level, without echoing untrusted
+/// text into the log.
+fn logForwardedArgvRejection(rejection: ForwardedArgvRejection) void {
+    switch (rejection.reason) {
+        .bad_working_directory => log.err(
+            "refusing forwarded new-window argv: working-directory must be home, inherit, ~/..., or a local absolute path",
+            .{},
+        ),
+        .not_a_config_flag => log.err(
+            "refusing forwarded new-window argv: contains an argument that is not a --key=value config flag",
+            .{},
+        ),
+        .not_allowlisted => if (forwardedKeyLoggable(rejection.key)) log.err(
+            "refusing forwarded new-window argv: key {s} is not permitted over IPC",
+            .{rejection.key},
+        ) else log.err(
+            "refusing forwarded new-window argv: contains a key that is not permitted over IPC",
+            .{},
+        ),
+    }
 }
 
 /// Apply a forwarded `new_window` argv to `config`.
@@ -975,9 +1169,8 @@ fn forwardedArgvRejection(argv: []const [:0]const u8) ?[]const u8 {
 /// caller with a window that does not match what was asked for, and would
 /// make an attacker's probe indistinguishable from a normal launch.
 ///
-/// The rejection is logged by the caller that handles it (see the
-/// `.new_window` arm of `performAction`) so that this stays a pure predicate
-/// over argv.
+/// This function does not log, so that it stays a pure predicate over argv
+/// and can be unit tested; every caller logs the rejection it handles.
 fn applyNewWindowArguments(
     alloc_gpa: Allocator,
     config: *configpkg.Config,
@@ -1004,6 +1197,23 @@ fn normalizeForwardedStartupArg(
         std.mem.startsWith(u8, arg, "--gtk-single-instance=") or
         std.mem.eql(u8, arg, "--safe-mode"))
     {
+        return null;
+    }
+
+    // Drop anything the running instance would refuse, so an ordinary launch
+    // still gets a window instead of having the whole request rejected. This
+    // is a usability measure on OUR OWN argv, not a security control -- the
+    // server re-checks every argument, because a hostile pipe writer never
+    // runs this code.
+    const key = forwardedArgumentKey(arg) orelse {
+        log.warn("not forwarding non-flag startup argument to the running instance", .{});
+        return null;
+    };
+    if (!forwardedKeyAllowed(key)) {
+        log.warn(
+            "not forwarding {s} to the running instance: it may not be set over IPC",
+            .{key},
+        );
         return null;
     }
 
@@ -1132,6 +1342,12 @@ fn buildIpcPipeSddl(
 /// account, a DACL keyed on that SID alone would let a filtered medium-IL
 /// process drive an elevated instance's pipe. Returning the label SID here
 /// lets the caller add `S:(ML;;NW;;;S-1-16-<rid>)`, which blocks write-up.
+///
+/// RESIDUAL: the policy is `NW` only, not `NR`/`NX`. A lower-integrity
+/// process can still open the pipe for READ and occupy a pipe instance --
+/// an availability nuisance against an elevated instance, bounded by the
+/// server's read timeout. `NR` would close that but is a larger behavioral
+/// change; it is tracked as a follow-up rather than done here.
 ///
 /// Returns null at or below medium integrity (where the label would be a
 /// no-op). The returned string is OS-allocated; free it with `sys.LocalFree`.
@@ -3568,14 +3784,11 @@ pub const App = struct {
                 defer config.deinit();
                 // The forwarded argv reaches us over the single-instance IPC
                 // pipe, so it is only as trusted as any process running as
-                // this user. Refuse the whole request when it names a key
-                // that selects executed code or an extra config source.
+                // this user. Refuse the whole request unless every key is on
+                // the presentation allowlist.
                 if (forwarded_arguments) |argv| {
-                    if (forwardedArgvRejection(argv)) |reason| {
-                        std.log.err(
-                            "refusing forwarded new-window argv: {s} may not be set over IPC",
-                            .{reason},
-                        );
+                    if (forwardedArgvRejection(argv)) |rejection| {
+                        logForwardedArgvRejection(rejection);
                         return true;
                     }
                 }
@@ -3586,8 +3799,16 @@ pub const App = struct {
                 ) catch |err| switch (err) {
                     // Defense in depth: `applyNewWindowArguments` enforces
                     // the same filter independently. Treat a rejection as
-                    // handled so it cannot abort the app tick.
-                    error.ForbiddenForwardedArgument => return true,
+                    // handled so it cannot abort the app tick. Logged here
+                    // too so the rejection can never become silent if the
+                    // pre-check above is ever refactored away.
+                    error.ForbiddenForwardedArgument => {
+                        log.err(
+                            "refusing forwarded new-window argv: rejected by applyNewWindowArguments",
+                            .{},
+                        );
+                        return true;
+                    },
                     else => return err,
                 };
                 _ = try self.createWindowSurface(&config, default_title, .{
@@ -28104,14 +28325,125 @@ test "win32 integrity SID parsing accepts only mandatory label SIDs" {
     try expect(integrityRidFromSidString(L("S-1-16-99999999999")) == null);
 }
 
-test "win32 IPC pipe security descriptor round-trips to the expected SDDL" {
+/// Render a security descriptor to SDDL text.
+///
+/// Any two descriptors being compared must BOTH come through this one helper.
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW` abbreviates a
+/// well-known SID to its two-letter alias (`SY`, `BA`, `LA`, ...) while
+/// `ConvertSidToStringSidW` always emits the full `S-1-5-...` form, so
+/// rendering one side each way cannot be compared for any account that has an
+/// alias -- which includes a runner executing as built-in Administrator or as
+/// SYSTEM.
+///
+/// Helper shape borrowed from the equivalent fix on
+/// `issues/123-paste-path-audit-fuzz` (`win32_ipc.zig` `descriptorSddlAlloc`);
+/// keep the two in sync, or collapse them into one shared helper, when those
+/// branches meet.
+fn testDescriptorSddlAlloc(
+    alloc: Allocator,
+    descriptor: *anyopaque,
+    information: u32,
+) ![]u8 {
+    var text: ?[*:0]u16 = null;
+    if (sys.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+        descriptor,
+        c.SDDL_REVISION_1,
+        information,
+        &text,
+        null,
+    ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+    defer _ = sys.LocalFree(@ptrCast(text.?));
+
+    return std.unicode.utf16LeToUtf8Alloc(alloc, std.mem.span(text.?));
+}
+
+/// Rewrite `GENERIC_ALL` to `FILE_ALL_ACCESS` in SDDL text.
+///
+/// Windows resolves generic rights against the object's generic mapping when
+/// an ACE is ATTACHED, so a descriptor built asking for `GA` reads back off a
+/// named pipe as `FA`. Same access, canonical spelling. The request side has
+/// to be normalized before it can be compared with what the object carries.
+fn testMapGenericAllToFileAllAlloc(alloc: Allocator, sddl: []const u8) ![]u8 {
+    return std.mem.replaceOwned(u8, alloc, sddl, ";;GA;;", ";;FA;;");
+}
+
+test "win32 IPC pipe descriptor attaches the expected DACL and label" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
-    const descriptor = try allocIpcPipeSecurityDescriptor();
-    defer _ = sys.LocalFree(descriptor);
+    const alloc = std.testing.allocator;
+    const requested = try allocIpcPipeSecurityDescriptor();
+    defer _ = sys.LocalFree(requested);
 
-    // Resolve the expected principal independently of the descriptor so the
-    // assertion is on content, not on "the function returned something".
+    var security_attributes: windows.SECURITY_ATTRIBUTES = .{
+        .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+        .lpSecurityDescriptor = requested,
+        .bInheritHandle = windows.FALSE,
+    };
+
+    const pipe_name_utf8 = try std.fmt.allocPrintSentinel(
+        alloc,
+        "\\\\.\\pipe\\noctty-ipc-sddl-{d}",
+        .{sys.GetTickCount64()},
+        0,
+    );
+    defer alloc.free(pipe_name_utf8);
+    const pipe_name = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name_utf8);
+    defer alloc.free(pipe_name);
+
+    // Assert against the descriptor Windows ACTUALLY ATTACHED, not against the
+    // string we handed in. Only the live object shows the generic-rights
+    // mapping, and only the live object proves the label survived creation.
+    const pipe = sys.CreateNamedPipeW(
+        pipe_name.ptr,
+        c.PIPE_ACCESS_DUPLEX,
+        windows.PIPE_TYPE_BYTE |
+            c.PIPE_READMODE_BYTE |
+            win32_ipc.pipe_nowait |
+            c.PIPE_REJECT_REMOTE_CLIENTS,
+        1,
+        1024,
+        1024,
+        0,
+        &security_attributes,
+    );
+    try std.testing.expect(pipe != windows.INVALID_HANDLE_VALUE);
+    defer _ = windows.CloseHandle(pipe);
+
+    // DACL *and* label. Requesting the DACL alone would assert nothing about
+    // the label, and would pass even if a label were wrongly emitted at medium
+    // integrity. LABEL_SECURITY_INFORMATION needs no SeSecurityPrivilege.
+    const information = c.DACL_SECURITY_INFORMATION | c.LABEL_SECURITY_INFORMATION;
+
+    var attached: ?*anyopaque = null;
+    const status = sys.GetSecurityInfo(
+        pipe,
+        c.SE_KERNEL_OBJECT,
+        information,
+        null,
+        null,
+        null,
+        null,
+        &attached,
+    );
+    try std.testing.expectEqual(@as(u32, 0), status);
+    defer _ = sys.LocalFree(attached.?);
+
+    const actual = try testDescriptorSddlAlloc(alloc, attached.?, information);
+    defer alloc.free(actual);
+
+    // (1) What the pipe carries must equal what we asked for, once generic
+    // rights are normalized and both sides are rendered the same way.
+    {
+        const requested_text = try testDescriptorSddlAlloc(alloc, requested, information);
+        defer alloc.free(requested_text);
+        const requested_mapped = try testMapGenericAllToFileAllAlloc(alloc, requested_text);
+        defer alloc.free(requested_mapped);
+        try std.testing.expectEqualStrings(requested_mapped, actual);
+    }
+
+    // (2) That alone would still pass if `allocIpcPipeSecurityDescriptor` were
+    // changed to request a wider trustee, so rebuild the descriptor we WANT
+    // independently from the token's own SID and require an exact match.
     var token: windows.HANDLE = undefined;
     try std.testing.expect(sys.OpenProcessToken(
         windows.kernel32.GetCurrentProcess(),
@@ -28131,41 +28463,65 @@ test "win32 IPC pipe security descriptor round-trips to the expected SDDL" {
     ) != 0);
     const token_user: *const sys.TOKEN_USER = @ptrCast(&token_user_buf);
 
-    var expected_sid: ?[*:0]u16 = null;
+    var user_sid: ?[*:0]u16 = null;
     try std.testing.expect(sys.ConvertSidToStringSidW(
         token_user.User.Sid,
-        &expected_sid,
+        &user_sid,
     ) != 0);
-    const sid = expected_sid.?;
-    defer _ = sys.LocalFree(@ptrCast(sid));
+    defer _ = sys.LocalFree(@ptrCast(user_sid.?));
 
-    var sid_utf8: [128]u8 = undefined;
-    const sid_utf8_len = try std.unicode.utf16LeToUtf8(&sid_utf8, std.mem.span(sid));
+    const integrity_sid = try allocIpcPipeIntegritySid(token);
+    defer if (integrity_sid) |v| {
+        _ = sys.LocalFree(@ptrCast(v));
+    };
 
-    var expected_buf: [320]u8 = undefined;
-    const expected = try std.fmt.bufPrint(
-        &expected_buf,
-        "D:P(A;;GA;;;{s})",
-        .{sid_utf8[0..sid_utf8_len]},
+    var reference_buf: [320]u16 = undefined;
+    const reference_sddl = try buildIpcPipeSddl(
+        &reference_buf,
+        std.mem.span(user_sid.?),
+        if (integrity_sid) |v| std.mem.span(v) else null,
     );
 
-    // Round-trip the built descriptor back to SDDL. A null descriptor, an
-    // Everyone ACE, an unprotected DACL, or a narrower/wider access mask all
-    // change this string.
-    var actual_sddl: ?[*:0]u16 = null;
-    try std.testing.expect(sys.ConvertSecurityDescriptorToStringSecurityDescriptorW(
-        descriptor,
+    var reference: ?*anyopaque = null;
+    try std.testing.expect(sys.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+        reference_sddl.ptr,
         c.SDDL_REVISION_1,
-        c.DACL_SECURITY_INFORMATION,
-        &actual_sddl,
+        &reference,
         null,
     ) != 0);
-    const actual_utf16 = std.mem.span(actual_sddl.?);
-    defer _ = sys.LocalFree(@ptrCast(actual_sddl.?));
+    defer _ = sys.LocalFree(reference.?);
 
-    var actual_buf: [320]u8 = undefined;
-    const actual_len = try std.unicode.utf16LeToUtf8(&actual_buf, actual_utf16);
-    try std.testing.expectEqualStrings(expected, actual_buf[0..actual_len]);
+    const reference_text = try testDescriptorSddlAlloc(alloc, reference.?, information);
+    defer alloc.free(reference_text);
+    const reference_mapped = try testMapGenericAllToFileAllAlloc(alloc, reference_text);
+    defer alloc.free(reference_mapped);
+    try std.testing.expectEqualStrings(reference_mapped, actual);
+
+    // (3) Pin the SHAPE independently, so a future change to the SDDL we
+    // request cannot quietly widen access while still matching (1) and (2).
+    const sacl_idx = std.mem.indexOf(u8, actual, "S:");
+    const dacl_text = if (sacl_idx) |idx| actual[0..idx] else actual;
+    const sacl_text = if (sacl_idx) |idx| actual[idx..] else "";
+
+    try std.testing.expect(std.mem.startsWith(u8, dacl_text, "D:P"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "(A;"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "("));
+    try std.testing.expect(std.mem.indexOf(u8, dacl_text, ";;;WD)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, dacl_text, ";;;AN)") == null);
+
+    if (integrity_sid) |label_sid| {
+        // Above medium: the label must be present, with NO_WRITE_UP.
+        try std.testing.expect(std.mem.startsWith(u8, sacl_text, "S:"));
+        try std.testing.expect(std.mem.indexOf(u8, sacl_text, "(ML;;NW;;;") != null);
+        const rid = integrityRidFromSidString(std.mem.span(label_sid)).?;
+        try std.testing.expect(rid > c.SECURITY_MANDATORY_MEDIUM_RID);
+    } else {
+        // At or below medium an unlabeled object already evaluates as medium
+        // with NO_WRITE_UP, so emitting a label here would be wrong. Asserting
+        // its ABSENCE is the half that catches a label emitted for every
+        // process.
+        try std.testing.expect(std.mem.indexOf(u8, actual, "(ML;") == null);
+    }
 }
 
 test "win32 IPC pipe DACL still admits a same-user client" {
@@ -28224,70 +28580,160 @@ test "win32 IPC pipe DACL still admits a same-user client" {
     defer _ = windows.CloseHandle(client);
 }
 
-test "win32 forwarded new-window argv rejects code and config-source keys" {
+test "win32 forwarded new-window argv refuses everything off the allowlist" {
     const expect = std.testing.expect;
 
-    // A pipe writer that gets `--command` accepted gets execution in the
-    // server's context, which is the whole point of the server-side filter.
-    try std.testing.expectEqualStrings(
-        "command",
-        forbiddenForwardedArgument("--command=powershell -enc AAAA").?,
-    );
-    try std.testing.expectEqualStrings(
-        "initial-command",
-        forbiddenForwardedArgument("--initial-command=calc.exe").?,
-    );
-    try std.testing.expectEqualStrings(
-        "config-file",
-        forbiddenForwardedArgument("--config-file=C:/tmp/evil.conf").?,
-    );
-    try std.testing.expectEqualStrings(
-        "config-default-files",
-        forbiddenForwardedArgument("--config-default-files=false").?,
-    );
-    // `theme` takes an absolute path and is parsed as a whole config file,
-    // so it is a `config-file` by proxy.
-    try std.testing.expectEqualStrings(
-        "theme",
-        forbiddenForwardedArgument("--theme=C:/tmp/evil.conf").?,
-    );
-    try std.testing.expectEqualStrings(
-        "custom-shader",
-        forbiddenForwardedArgument("--custom-shader=C:/tmp/x.glsl").?,
-    );
-    // `-e` is turned into `initial-command` by `Config.parseManuallyHook`.
-    try std.testing.expectEqualStrings("-e", forbiddenForwardedArgument("-e").?);
+    // THE PROPERTY THAT MATTERS: the filter is deny-by-default, so a key
+    // nobody enumerated -- including any key a future upstream merge adds --
+    // is refused rather than allowed by omission. These names are not in the
+    // allowlist and are not in any denylist either.
+    try expect(!forwardedKeyAllowed("totally-made-up-key"));
+    try expect(!forwardedKeyAllowed("some-future-upstream-key"));
+    try expect(!forwardedKeyAllowed(""));
 
-    // Valueless and prefix-similar forms.
-    try std.testing.expectEqualStrings("command", forbiddenForwardedArgument("--command").?);
-    try expect(forbiddenForwardedArgument("--command-palette-entry=x") == null);
-    try expect(forbiddenForwardedArgument("--font-size=14") == null);
-    try expect(forbiddenForwardedArgument("--title=hello") == null);
-    try expect(forbiddenForwardedArgument("not-a-flag") == null);
+    // Each of these reproduces arbitrary code execution, an arbitrary file
+    // read, an SMB authentication, or a pty write if it is honored.
+    for ([_][]const u8{
+        "command",
+        "initial-command",
+        "config-file",
+        "config-default-files",
+        "theme",
+        "custom-shader",
+        "gtk-custom-css",
+        // Written straight to the pty; its doc comment warns it can execute
+        // programs in a shell.
+        "input",
+        // Overrides are applied after shell-integration setup, so ZDOTDIR /
+        // ENV / XDG_DATA_DIRS / PATH become code execution at shell start.
+        "env",
+        // Arbitrary file read, and a UNC value authenticates to a remote host.
+        "background-image",
+        "bell-audio-path",
+        // Re-open the perform_action allowlist through another door.
+        "keybind",
+        "command-palette-entry",
+        // Attacker bytes written to the pty on ENQ.
+        "enquiry-response",
+        // Not presentation.
+        "title-report",
+        "window-save-state",
+        "class",
+        "single-instance",
+    }) |key| {
+        try expect(!forwardedKeyAllowed(key));
+    }
+
+    // Prefix confusion must not admit anything: `windows-...` is a different
+    // key from `window-...`.
+    try expect(!forwardedKeyAllowed("windows-job-object-kill-on-close"));
+    try expect(forwardedKeyAllowed("window-height"));
+
+    // Representative allowlisted keys still work.
+    for ([_][]const u8{
+        "window-width",
+        "window-height",
+        "font-size",
+        "title",
+        "background",
+        "background-opacity",
+        "fullscreen",
+        "maximize",
+        "working-directory",
+    }) |key| {
+        try expect(forwardedKeyAllowed(key));
+    }
 }
 
-test "win32 forwarded working-directory is constrained to local directories" {
+test "win32 forwarded argv key extraction matches the config loader" {
+    const expect = std.testing.expect;
+
+    try std.testing.expectEqualStrings("font-size", forwardedArgumentKey("--font-size=14").?);
+    try std.testing.expectEqualStrings("maximize", forwardedArgumentKey("--maximize").?);
+    // Only the segment before the FIRST `=` is the key, matching
+    // cli/args.zig.
+    try std.testing.expectEqualStrings("title", forwardedArgumentKey("--title=a=b").?);
+    try std.testing.expectEqualStrings("", forwardedArgumentKey("--=x").?);
+
+    // Not `--key[=value]` form; these are refused wholesale by
+    // `forwardedArgvRejection`.
+    try expect(forwardedArgumentKey("-e") == null);
+    try expect(forwardedArgumentKey("powershell") == null);
+    try expect(forwardedArgumentKey("-") == null);
+}
+
+test "win32 forwarded rejection reasons are classified and safe to log" {
+    const argv_bad_key = [_][:0]const u8{"--input=calc.exe"};
+    const r1 = forwardedArgvRejection(&argv_bad_key).?;
+    try std.testing.expectEqual(.not_allowlisted, r1.reason);
+    try std.testing.expectEqualStrings("input", r1.key);
+    try std.testing.expect(forwardedKeyLoggable(r1.key));
+
+    // `-e` becomes `initial-command` in Config.parseManuallyHook.
+    const argv_dash_e = [_][:0]const u8{ "-e", "calc.exe" };
+    try std.testing.expectEqual(
+        .not_a_config_flag,
+        forwardedArgvRejection(&argv_dash_e).?.reason,
+    );
+
+    const argv_wd = [_][:0]const u8{"--working-directory=\\\\attacker\\share"};
+    try std.testing.expectEqual(
+        .bad_working_directory,
+        forwardedArgvRejection(&argv_wd).?.reason,
+    );
+
+    // A bad key later in the argv is still caught.
+    const argv_trailing = [_][:0]const u8{ "--font-size=14", "--env=ZDOTDIR=C:\\a" };
+    try std.testing.expectEqualStrings(
+        "env",
+        forwardedArgvRejection(&argv_trailing).?.key,
+    );
+
+    const argv_ok = [_][:0]const u8{ "--font-size=14", "--working-directory=home" };
+    try std.testing.expect(forwardedArgvRejection(&argv_ok) == null);
+
+    // A refused key is attacker-controlled text, so it must not be echoed
+    // into a log line raw.
+    try std.testing.expect(!forwardedKeyLoggable("has space"));
+    try std.testing.expect(!forwardedKeyLoggable("newline\ninjected"));
+    try std.testing.expect(!forwardedKeyLoggable("UPPER"));
+    try std.testing.expect(!forwardedKeyLoggable("a" ** 65));
+    try std.testing.expect(forwardedKeyLoggable("window-height"));
+}
+
+test "win32 forwarded working-directory rejects UNC syntax and keeps legal forms" {
     const expect = std.testing.expect;
 
     try expect(forwardedWorkingDirectoryAllowed("home"));
     try expect(forwardedWorkingDirectoryAllowed("inherit"));
 
-    // UNC values would make the server authenticate to an attacker-chosen
-    // SMB host just by resolving the path.
+    // Documented legal values that an earlier revision wrongly refused,
+    // killing the whole +new-window request with only a log line.
+    try expect(forwardedWorkingDirectoryAllowed("~"));
+    try expect(forwardedWorkingDirectoryAllowed("~/projects"));
+    try expect(forwardedWorkingDirectoryAllowed("~\\projects"));
+    try expect(forwardedWorkingDirectoryAllowed("\"C:\\Program Files\\x\""));
+    try expect(forwardedWorkingDirectoryAllowed("  C:\\Users\\me  "));
+
+    // A literal UNC value would make this process authenticate to an
+    // attacker-chosen SMB host. NOTE: this is a check on SYNTAX only -- a
+    // mapped drive or a junction still resolves off-box.
     try expect(!forwardedWorkingDirectoryAllowed("\\\\attacker\\share"));
     try expect(!forwardedWorkingDirectoryAllowed("//attacker/share"));
+    try expect(!forwardedWorkingDirectoryAllowed("\\\\?\\UNC\\attacker\\share"));
     try expect(!forwardedWorkingDirectoryAllowed("\\\\?\\C:\\Windows"));
+    try expect(!forwardedWorkingDirectoryAllowed("\\\\.\\pipe\\x"));
     try expect(!forwardedWorkingDirectoryAllowed("relative\\path"));
+    try expect(!forwardedWorkingDirectoryAllowed("C:foo"));
     try expect(!forwardedWorkingDirectoryAllowed(""));
+    try expect(!forwardedWorkingDirectoryAllowed("\"\\\\attacker\\share\""));
 
+    // A realpath'd local cwd is what the startup forwarder always sends, so
+    // it has to keep working or single-instance launches break.
     if (builtin.os.tag == .windows) {
-        // The startup forwarder always sends a realpath'd cwd, so a real
-        // local directory has to keep working or single-instance launches
-        // would break.
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
         const cwd = try std.fs.cwd().realpath(".", &cwd_buf);
         try expect(forwardedWorkingDirectoryAllowed(cwd));
-        try expect(!forwardedWorkingDirectoryAllowed("C:\\this-path-should-not-exist-noctty"));
     }
 }
 
@@ -28320,6 +28766,45 @@ test "win32 applyNewWindowArguments rejects a forwarded command outright" {
         );
     }
 
+    // `--input` is written straight to the pty and its own doc comment warns
+    // it can execute programs in a shell.
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--input=powershell -enc AAAA\n",
+            }),
+        );
+        try std.testing.expectEqual(@as(usize, 0), config.input.list.items.len);
+    }
+
+    // `--env` reaches the child after shell-integration setup, so it can
+    // repoint ZDOTDIR/ENV and run an attacker script at shell start.
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--env=ZDOTDIR=C:\\attacker",
+            }),
+        );
+    }
+
+    // Deny-by-default: a key that appears in NO list is still refused.
+    {
+        var config = try configpkg.Config.default(alloc);
+        defer config.deinit();
+        try std.testing.expectError(
+            error.ForbiddenForwardedArgument,
+            applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
+                "--some-key-nobody-enumerated=1",
+            }),
+        );
+    }
+
     {
         var config = try configpkg.Config.default(alloc);
         defer config.deinit();
@@ -28331,14 +28816,18 @@ test "win32 applyNewWindowArguments rejects a forwarded command outright" {
         );
     }
 
-    // A benign argv is still applied.
+    // A benign argv is still applied, including the working-directory the
+    // startup forwarder always sends.
     {
         var config = try configpkg.Config.default(alloc);
         defer config.deinit();
         try applyNewWindowArguments(alloc, &config, &[_][:0]const u8{
             "--window-height=40",
+            "--font-size=16",
+            "--working-directory=home",
         });
         try std.testing.expectEqual(@as(u32, 40), config.@"window-height");
+        try std.testing.expectEqual(@as(f32, 16), config.@"font-size");
     }
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1472,13 +1472,21 @@ fn integrityRidFromSidString(sid: []const u16) ?u32 {
 /// mandatory-label ACE with the `NO_WRITE_UP` policy is appended, which is
 /// what keeps a lower-integrity process from opening the pipe for write.
 ///
-/// RESIDUAL: `NO_WRITE_UP` does not deny reads, and a bare `READ_CONTROL`
-/// open is enough to occupy the server's single pipe instance — it does not
-/// need `GENERIC_READ`. The next legitimate client then fails with
-/// `ERROR_PIPE_BUSY`. That is an availability limit only (nothing is
-/// disclosed and no request can be submitted), and it is recorded in
-/// docs/windows.md along with the two candidate fixes and why neither is
-/// applied yet. Observed on hardware by the desktop lane, not inferred.
+/// RESIDUAL: `NO_WRITE_UP` does not deny reads, so a medium-integrity
+/// process can open an elevated instance's pipe for `GENERIC_READ` (a bare
+/// `READ_CONTROL` suffices). `WriteFile` on that handle then fails with
+/// `win32=5`, so this is an OCCUPANCY problem, not an access break —
+/// nothing is disclosed and no request can be submitted. But the server
+/// offers one pipe instance at a time, so one such open makes the next
+/// legitimate client fail with `win32=231 ERROR_PIPE_BUSY`. All of this is
+/// observed on hardware, not inferred.
+///
+/// The fix is `NO_READ_UP`, and it lands with the elevation work rather
+/// than here: that change labels the elevated endpoint `NWNR`, and the
+/// added `NR` has been verified on hardware to deny every medium open
+/// including `GENERIC_READ` and `READ_CONTROL`. Duplicating it here would
+/// collide on the same SDDL term for no net gain, and would invalidate the
+/// live descriptor readback recorded in docs/windows.md.
 fn buildIpcPipeSddl(
     buf: []u16,
     user_sid: []const u16,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -28932,7 +28932,11 @@ test "win32 IPC pipe descriptor attaches the expected owner DACL and label" {
     const dacl_text = if (sacl_idx) |idx| actual[dacl_idx..idx] else actual[dacl_idx..];
     const sacl_text = if (sacl_idx) |idx| actual[idx..] else "";
 
-    try std.testing.expect(std.mem.startsWith(u8, owner_text, "O:S-1-5-21-"));
+    // The exact token-user owner was proved above. Its rendered SID shape is
+    // environment-dependent (domain user, virtual account, or well-known
+    // service alias), so only pin the owner field itself here.
+    try std.testing.expect(owner_text.len > 2);
+    try std.testing.expect(std.mem.startsWith(u8, owner_text, "O:"));
     try std.testing.expect(std.mem.startsWith(u8, dacl_text, "D:P"));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "(A;"));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "("));
@@ -29346,6 +29350,14 @@ test "win32 IPC client authenticates the connected pipe descriptor" {
     const pipe_name = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name_utf8);
     defer alloc.free(pipe_name);
 
+    const descriptor = try allocIpcPipeSecurityDescriptor();
+    defer _ = sys.LocalFree(descriptor);
+    var security_attributes: windows.SECURITY_ATTRIBUTES = .{
+        .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+        .lpSecurityDescriptor = descriptor,
+        .bInheritHandle = windows.FALSE,
+    };
+
     const server = sys.CreateNamedPipeW(
         pipe_name.ptr,
         c.PIPE_ACCESS_DUPLEX,
@@ -29357,7 +29369,7 @@ test "win32 IPC client authenticates the connected pipe descriptor" {
         1024,
         1024,
         0,
-        null,
+        &security_attributes,
     );
     try std.testing.expect(server != windows.INVALID_HANDLE_VALUE);
     defer _ = windows.CloseHandle(server);

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -862,7 +862,7 @@ fn tokenIntegrityRid(token: windows.HANDLE) ?u32 {
     return integrityRidFromSidString(std.mem.span(sid));
 }
 
-/// Is the process serving this pipe running as the same user we are?
+/// Is this connected pipe object owned and labelled for our trust level?
 ///
 /// The single-instance pipe name is derived only from `--class`, so it is
 /// PREDICTABLE and lives in the machine-wide named-pipe namespace. Any local
@@ -881,30 +881,31 @@ fn tokenIntegrityRid(token: windows.HANDLE) ?u32 {
 /// `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, which caps the server
 /// at an identification-only token whatever the timing.
 ///
-/// Fails CLOSED: any error answers "not ours".
-fn ipcPipeServerIsSameUser(pipe: windows.HANDLE) bool {
-    var server_pid: u32 = 0;
-    if (sys.GetNamedPipeServerProcessId(pipe, &server_pid) == 0) return false;
-
-    const process = sys.OpenProcess(
-        c.PROCESS_QUERY_LIMITED_INFORMATION,
-        windows.FALSE,
-        server_pid,
-    ) orelse return false;
-    defer _ = windows.CloseHandle(process);
-
-    var server_token: windows.HANDLE = undefined;
-    if (sys.OpenProcessToken(process, c.TOKEN_QUERY, &server_token) == 0) return false;
-    defer _ = windows.CloseHandle(server_token);
-
-    var server_buf: SidBuffer align(sid_buffer_align) = undefined;
-    const server_sid = tokenUserSidBytes(server_token, &server_buf) catch return false;
+/// Authentication is read from the descriptor attached to THIS pipe object.
+/// A PID lookup is not sufficient: a duplicated server handle can outlive
+/// its creating process, and the numeric PID can then be recycled.
+///
+/// Fails CLOSED: any query or parse error answers "not ours".
+fn ipcPipeServerIsTrusted(pipe: windows.HANDLE) bool {
+    const information = c.OWNER_SECURITY_INFORMATION | c.LABEL_SECURITY_INFORMATION;
+    var owner: ?*anyopaque = null;
+    var descriptor: ?*anyopaque = null;
+    if (sys.GetSecurityInfo(
+        pipe,
+        c.SE_KERNEL_OBJECT,
+        information,
+        &owner,
+        null,
+        null,
+        null,
+        &descriptor,
+    ) != 0) return false;
+    const attached = descriptor orelse return false;
+    defer _ = sys.LocalFree(attached);
 
     var own_buf: SidBuffer align(sid_buffer_align) = undefined;
     const own_sid = currentUserSidBytes(&own_buf) catch return false;
-
-    if (server_sid.len != own_sid.len) return false;
-    if (sys.EqualSid(@ptrCast(server_sid.ptr), @ptrCast(own_sid.ptr)) == 0) return false;
+    if (owner == null or sys.EqualSid(owner.?, @ptrCast(own_sid.ptr)) == 0) return false;
 
     // The user SID is NOT sufficient on its own. Under the ordinary split
     // UAC token, an elevated process and a medium-integrity process of the
@@ -928,8 +929,39 @@ fn ipcPipeServerIsSameUser(pipe: windows.HANDLE) bool {
     defer _ = windows.CloseHandle(own_token);
 
     const own_rid = tokenIntegrityRid(own_token) orelse return false;
-    const server_rid = tokenIntegrityRid(server_token) orelse return false;
+    const server_rid = descriptorIntegrityRid(attached) catch return false;
     return server_rid >= own_rid;
+}
+
+fn descriptorIntegrityRid(descriptor: *anyopaque) error{InvalidSecurityDescriptor}!u32 {
+    var text: ?[*:0]u16 = null;
+    if (sys.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+        descriptor,
+        c.SDDL_REVISION_1,
+        c.LABEL_SECURITY_INFORMATION,
+        &text,
+        null,
+    ) == 0) return error.InvalidSecurityDescriptor;
+    const text_ptr = text orelse return error.InvalidSecurityDescriptor;
+    defer _ = sys.LocalFree(@ptrCast(text_ptr));
+
+    const sddl = std.mem.span(text_ptr);
+    const prefix = std.unicode.utf8ToUtf16LeStringLiteral("S-1-16-");
+    const start = std.mem.indexOf(u16, sddl, prefix) orelse {
+        // Unlabelled kernel objects evaluate at medium integrity.
+        return c.SECURITY_MANDATORY_MEDIUM_RID;
+    };
+
+    var rid: u32 = 0;
+    var digits: usize = 0;
+    for (sddl[start + prefix.len ..]) |ch| {
+        if (ch < '0' or ch > '9') break;
+        rid = std.math.mul(u32, rid, 10) catch return error.InvalidSecurityDescriptor;
+        rid = std.math.add(u32, rid, ch - '0') catch return error.InvalidSecurityDescriptor;
+        digits += 1;
+    }
+    if (digits == 0) return error.InvalidSecurityDescriptor;
+    return rid;
 }
 
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
@@ -949,11 +981,11 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
             null,
         );
         if (handle != windows.INVALID_HANDLE_VALUE) {
-            if (!ipcPipeServerIsSameUser(handle)) {
+            if (!ipcPipeServerIsTrusted(handle)) {
                 _ = windows.CloseHandle(handle);
                 log.warn(
-                    "single-instance pipe is served by a process belonging to " ++
-                        "another user; refusing to forward anything to it",
+                    "single-instance pipe owner or integrity label is not trusted; " ++
+                        "refusing to forward anything to it",
                     .{},
                 );
                 return error.PipeUnreachable;
@@ -1352,6 +1384,13 @@ fn normalizeForwardedStartupArg(
         return null;
     }
 
+    // Action Center launches carry the target as a positional URI. Preserve
+    // only a URI that the same parser used by the receiver accepts; malformed
+    // lookalikes still fall through to the non-flag rejection below.
+    if (win32_toast_activation.parseLaunchArg(arg)) |_| {
+        return try alloc.dupeZ(u8, arg);
+    } else |_| {}
+
     // Drop anything the running instance would refuse, so an ordinary launch
     // still gets a window instead of having the whole request rejected. This
     // is a usability measure on OUR OWN argv, not a security control -- the
@@ -1503,6 +1542,8 @@ fn buildIpcPipeSddl(
         }
     };
 
+    try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("O:"));
+    try Appender.append(buf, &len, user_sid);
     try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral("D:P(A;;GA;;;"));
     try Appender.append(buf, &len, user_sid);
     try Appender.append(buf, &len, std.unicode.utf8ToUtf16LeStringLiteral(")"));
@@ -1623,14 +1664,9 @@ fn allocIpcPipeSecurityDescriptor() !*anyopaque {
         _ = sys.LocalFree(@ptrCast(v));
     };
 
-    // NOTE: there is no `O:` term, so the object owner defaults to the
-    // token's default owner. For an elevated token that is the
-    // Administrators group, and an owner always retains implicit
-    // READ_CONTROL/WRITE_DAC. A local administrator can therefore rewrite
-    // this DACL; that is inherent to running as an administrator and is not
-    // a boundary this descriptor claims to hold. What the descriptor does
-    // hold is that no ACE grants access to other interactive users,
-    // NETWORK, or ANONYMOUS.
+    // Pin the owner to the token user as well as granting that SID access.
+    // The client authenticates the owner and mandatory label directly from
+    // the connected pipe object, avoiding a recyclable process-ID lookup.
     var sddl_buf: [320]u16 = undefined;
     const sddl = try buildIpcPipeSddl(
         &sddl_buf,
@@ -28005,6 +28041,18 @@ test "win32 normalizeForwardedStartupArg drops class and normalizes working dire
     const other = (try normalizeForwardedStartupArg(std.testing.allocator, "--title=Inbox")).?;
     defer std.testing.allocator.free(other);
     try std.testing.expectEqualStrings("--title=Inbox", other);
+
+    const activation = (try normalizeForwardedStartupArg(
+        std.testing.allocator,
+        "wgh://activate?surface=42&tab=7",
+    )).?;
+    defer std.testing.allocator.free(activation);
+    try std.testing.expectEqualStrings("wgh://activate?surface=42&tab=7", activation);
+
+    try std.testing.expect(try normalizeForwardedStartupArg(
+        std.testing.allocator,
+        "wgh://activate?surface=abc",
+    ) == null);
 }
 
 test "win32 decorationsVisibleForConfig only hides none" {
@@ -28508,7 +28556,8 @@ test "win32 IPC pipe SDDL renders the exact DACL and mandatory label" {
         var utf8: [320]u8 = undefined;
         const len = try std.unicode.utf16LeToUtf8(&utf8, sddl);
         try std.testing.expectEqualStrings(
-            "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)",
+            "O:S-1-5-21-1111-2222-3333-1001" ++
+                "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)",
             utf8[0..len],
         );
     }
@@ -28522,7 +28571,9 @@ test "win32 IPC pipe SDDL renders the exact DACL and mandatory label" {
         var utf8: [320]u8 = undefined;
         const len = try std.unicode.utf16LeToUtf8(&utf8, sddl);
         try std.testing.expectEqualStrings(
-            "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)S:(ML;;NW;;;S-1-16-12288)",
+            "O:S-1-5-21-1111-2222-3333-1001" ++
+                "D:P(A;;GA;;;S-1-5-21-1111-2222-3333-1001)" ++
+                "S:(ML;;NW;;;S-1-16-12288)",
             utf8[0..len],
         );
     }
@@ -28688,7 +28739,7 @@ test "win32 SDDL auto-inherit normalization keeps every access-bearing field" {
     }
 }
 
-test "win32 IPC pipe descriptor attaches the expected DACL and label" {
+test "win32 IPC pipe descriptor attaches the expected owner DACL and label" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
@@ -28733,7 +28784,9 @@ test "win32 IPC pipe descriptor attaches the expected DACL and label" {
     // DACL *and* label. Requesting the DACL alone would assert nothing about
     // the label, and would pass even if a label were wrongly emitted at medium
     // integrity. LABEL_SECURITY_INFORMATION needs no SeSecurityPrivilege.
-    const information = c.DACL_SECURITY_INFORMATION | c.LABEL_SECURITY_INFORMATION;
+    const information = c.OWNER_SECURITY_INFORMATION |
+        c.DACL_SECURITY_INFORMATION |
+        c.LABEL_SECURITY_INFORMATION;
 
     var attached: ?*anyopaque = null;
     const status = sys.GetSecurityInfo(
@@ -28826,10 +28879,14 @@ test "win32 IPC pipe descriptor attaches the expected DACL and label" {
 
     // (3) Pin the SHAPE independently, so a future change to the SDDL we
     // request cannot quietly widen access while still matching (1) and (2).
+    const dacl_idx = std.mem.indexOf(u8, actual, "D:") orelse
+        return error.TestUnexpectedResult;
     const sacl_idx = std.mem.indexOf(u8, actual, "S:");
-    const dacl_text = if (sacl_idx) |idx| actual[0..idx] else actual;
+    const owner_text = actual[0..dacl_idx];
+    const dacl_text = if (sacl_idx) |idx| actual[dacl_idx..idx] else actual[dacl_idx..];
     const sacl_text = if (sacl_idx) |idx| actual[idx..] else "";
 
+    try std.testing.expect(std.mem.startsWith(u8, owner_text, "O:S-1-5-21-"));
     try std.testing.expect(std.mem.startsWith(u8, dacl_text, "D:P"));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "(A;"));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, dacl_text, "("));
@@ -29228,7 +29285,7 @@ test "win32 title sanitizing strips control bytes from IPC and OSC titles" {
     }
 }
 
-test "win32 IPC client authenticates the pipe server as the same user" {
+test "win32 IPC client authenticates the connected pipe descriptor" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
@@ -29268,7 +29325,7 @@ test "win32 IPC client authenticates the pipe server as the same user" {
 
     // And directly, so a future refactor that drops the call site still
     // fails a test rather than silently disabling the check.
-    try std.testing.expect(ipcPipeServerIsSameUser(client));
+    try std.testing.expect(ipcPipeServerIsTrusted(client));
 
     // The comparison operates on a real, well-formed SID rather than an
     // empty slice that would trivially compare equal.
@@ -29296,7 +29353,7 @@ test "win32 IPC client authenticates the pipe server as the same user" {
     // server needs a second local account, and a lower-integrity server
     // needs a medium process while this suite runs elevated; neither is
     // creatable from a test. Both are argued from the fail-closed structure
-    // of `ipcPipeServerIsSameUser` (every error path returns false, and the
+    // of `ipcPipeServerIsTrusted` (every error path returns false, and the
     // final comparison is `server_rid >= own_rid`), not observed.
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -795,6 +795,90 @@ fn resolveIpcPipeNameForTarget(
 /// instance we can talk to"; callers must treat them the same and fall back
 /// to running locally. They are kept distinct only so the unreachable case
 /// can be logged differently.
+/// Backing store for a copied SID. `SECURITY_MAX_SID_SIZE` is 68 bytes, so
+/// 256 is ample. The alignment is required, not cosmetic: a `SID` ends in an
+/// array of `DWORD` sub-authorities, and `EqualSid` reads them as such.
+const SidBuffer = [256]u8;
+const sid_buffer_align = @alignOf(u32);
+
+/// Copy the current process token's user SID into `buf`, returning the
+/// populated prefix.
+fn currentUserSidBytes(buf: *align(sid_buffer_align) SidBuffer) ![]u8 {
+    var token: windows.HANDLE = undefined;
+    if (sys.OpenProcessToken(
+        windows.kernel32.GetCurrentProcess(),
+        c.TOKEN_QUERY,
+        &token,
+    ) == 0) return error.TokenQueryFailed;
+    defer _ = windows.CloseHandle(token);
+    return try tokenUserSidBytes(token, buf);
+}
+
+fn tokenUserSidBytes(
+    token: windows.HANDLE,
+    buf: *align(sid_buffer_align) SidBuffer,
+) ![]u8 {
+    var token_user_buf: [256]u8 align(@alignOf(sys.TOKEN_USER)) = undefined;
+    var token_user_len: u32 = 0;
+    if (sys.GetTokenInformation(
+        token,
+        c.TokenUser,
+        &token_user_buf,
+        token_user_buf.len,
+        &token_user_len,
+    ) == 0) return error.TokenQueryFailed;
+
+    const token_user: *const sys.TOKEN_USER = @ptrCast(&token_user_buf);
+    const sid_len = sys.GetLengthSid(token_user.User.Sid);
+    if (sid_len == 0 or sid_len > buf.len) return error.TokenQueryFailed;
+
+    const sid_bytes: [*]const u8 = @ptrCast(token_user.User.Sid);
+    @memcpy(buf[0..sid_len], sid_bytes[0..sid_len]);
+    return buf[0..sid_len];
+}
+
+/// Is the process serving this pipe running as the same user we are?
+///
+/// The single-instance pipe name is derived only from `--class`, so it is
+/// PREDICTABLE and lives in the machine-wide named-pipe namespace. Any local
+/// account can therefore pre-create `\\.\pipe\noctty.<class>` before we do.
+/// The server-side owner-only DACL does not help here: it protects the pipe
+/// WE create, not the one we CONNECT to. Without this check a squatter would
+/// receive our forwarded startup arguments (including the working directory)
+/// and could return a forged ack, so the real instance never starts and the
+/// user gets no window -- a cross-account disclosure plus a startup denial.
+///
+/// Authenticating BEFORE the first write is what makes this sufficient:
+/// `ImpersonateNamedPipeClient` fails with `ERROR_CANNOT_IMPERSONATE` until
+/// the client has written to the pipe, so a hostile server cannot borrow our
+/// token in the window between connect and this check.
+///
+/// Fails CLOSED: any error answers "not ours".
+fn ipcPipeServerIsSameUser(pipe: windows.HANDLE) bool {
+    var server_pid: u32 = 0;
+    if (sys.GetNamedPipeServerProcessId(pipe, &server_pid) == 0) return false;
+
+    const process = sys.OpenProcess(
+        c.PROCESS_QUERY_LIMITED_INFORMATION,
+        windows.FALSE,
+        server_pid,
+    ) orelse return false;
+    defer _ = windows.CloseHandle(process);
+
+    var server_token: windows.HANDLE = undefined;
+    if (sys.OpenProcessToken(process, c.TOKEN_QUERY, &server_token) == 0) return false;
+    defer _ = windows.CloseHandle(server_token);
+
+    var server_buf: SidBuffer align(sid_buffer_align) = undefined;
+    const server_sid = tokenUserSidBytes(server_token, &server_buf) catch return false;
+
+    var own_buf: SidBuffer align(sid_buffer_align) = undefined;
+    const own_sid = currentUserSidBytes(&own_buf) catch return false;
+
+    if (server_sid.len != own_sid.len) return false;
+    return sys.EqualSid(@ptrCast(server_sid.ptr), @ptrCast(own_sid.ptr)) != 0;
+}
+
 fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
     var retries: u8 = 0;
     while (true) {
@@ -807,7 +891,18 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
             windows.FILE_ATTRIBUTE_NORMAL,
             null,
         );
-        if (handle != windows.INVALID_HANDLE_VALUE) return handle;
+        if (handle != windows.INVALID_HANDLE_VALUE) {
+            if (!ipcPipeServerIsSameUser(handle)) {
+                _ = windows.CloseHandle(handle);
+                log.warn(
+                    "single-instance pipe is served by a process belonging to " ++
+                        "another user; refusing to forward anything to it",
+                    .{},
+                );
+                return error.PipeUnreachable;
+            }
+            return handle;
+        }
 
         const err = windows.kernel32.GetLastError();
         switch (err) {
@@ -1229,6 +1324,22 @@ fn normalizeForwardedStartupArg(
         const expanded = homedir.expandHome(trimmed, &home_buf) catch trimmed;
         var realpath_buf: [std.fs.max_path_bytes]u8 = undefined;
         const normalized = cwd.realpath(expanded, &realpath_buf) catch expanded;
+
+        // The key check above is not enough for this one option: the server
+        // refuses the ENTIRE argv on a bad working-directory VALUE, and it
+        // has already acknowledged the request by then, so the launching
+        // process exits having produced no window at all. Dropping just this
+        // argument here is what makes the "still gets a window" promise
+        // above true for `--working-directory=\\host\share` and friends.
+        if (!forwardedWorkingDirectoryAllowed(normalized)) {
+            log.warn(
+                "not forwarding --working-directory to the running instance: " ++
+                    "value is not a local absolute path",
+                .{},
+            );
+            return null;
+        }
+
         return try std.fmt.allocPrintSentinel(
             alloc,
             "--working-directory={s}",
@@ -15770,15 +15881,62 @@ fn launchTargetButtonKeyAction(vk: WPARAM) ?LaunchTargetButtonKeyAction {
 
 /// True when `title` contains a byte that must not survive into a stored
 /// window/tab title. See `sanitizeTitleAlloc` for why.
+/// Control code points that must never survive into a stored title.
+fn isTitleControlCodepoint(cp: u21) bool {
+    // C0 controls and DEL.
+    if (cp < 0x20 or cp == 0x7F) return true;
+    // C1 controls U+0080..U+009F, which include 8-bit CSI (U+009B) and
+    // 8-bit ST (U+009C).
+    if (cp >= 0x80 and cp <= 0x9F) return true;
+    return false;
+}
+
+/// One scanned unit of a title: the bytes to keep (empty when the unit must
+/// be dropped) and the offset of the next unit.
+const TitleUnit = struct {
+    keep: []const u8,
+    next: usize,
+};
+
+/// Decode one UTF-8 unit, dropping controls and anything that is not valid
+/// UTF-8.
+///
+/// This is deliberately CODE-POINT oriented rather than byte oriented. A
+/// byte-level filter for the range 0x80..0x9F would corrupt ordinary text,
+/// because those bytes also occur as UTF-8 CONTINUATION bytes -- `U+20AC`
+/// (the euro sign) is `E2 82 AC`, whose second byte is 0x82. Decoding first
+/// means a raw `0x9B` is recognized as an 8-bit CSI and removed while `€`
+/// survives intact.
+///
+/// Invalid UTF-8 is dropped one byte at a time rather than passed through:
+/// it cannot be rendered meaningfully, and letting it through would also let
+/// an OVERLONG encoding of a C1 control (for example `E0 82 9B`) evade the
+/// control check. `std.unicode.utf8Decode` rejects overlong forms and
+/// surrogates, so this fails closed. Dropping the trailing bytes of a
+/// truncated sequence also removes the lone-`0xC2` tail that would otherwise
+/// leave invalid UTF-8 in the stored title.
+fn nextTitleUnit(title: []const u8, i: usize) TitleUnit {
+    const len = std.unicode.utf8ByteSequenceLength(title[i]) catch {
+        return .{ .keep = "", .next = i + 1 };
+    };
+    if (i + len > title.len) return .{ .keep = "", .next = title.len };
+
+    const seq = title[i .. i + len];
+    const cp = std.unicode.utf8Decode(seq) catch {
+        return .{ .keep = "", .next = i + 1 };
+    };
+    if (isTitleControlCodepoint(cp)) return .{ .keep = "", .next = i + len };
+    return .{ .keep = seq, .next = i + len };
+}
+
 fn titleNeedsSanitize(title: []const u8) bool {
     var i: usize = 0;
-    while (i < title.len) : (i += 1) {
-        const byte = title[i];
-        if (byte < 0x20 or byte == 0x7F) return true;
-        // UTF-8 encoding of the C1 controls U+0080..U+009F, which includes
-        // 8-bit CSI (U+009B) and ST (U+009C).
-        if (byte == 0xC2 and i + 1 < title.len and
-            title[i + 1] >= 0x80 and title[i + 1] <= 0x9F) return true;
+    while (i < title.len) {
+        const unit = nextTitleUnit(title, i);
+        // A kept unit is always at least one byte, so an empty `keep` means
+        // this unit was dropped.
+        if (unit.keep.len == 0) return true;
+        i = unit.next;
     }
     return false;
 }
@@ -15805,16 +15963,10 @@ fn sanitizeTitleAlloc(alloc: Allocator, title: []const u8) Allocator.Error!?[]u8
     try out.ensureTotalCapacity(alloc, title.len);
 
     var i: usize = 0;
-    while (i < title.len) : (i += 1) {
-        const byte = title[i];
-        if (byte < 0x20 or byte == 0x7F) continue;
-        if (byte == 0xC2 and i + 1 < title.len and
-            title[i + 1] >= 0x80 and title[i + 1] <= 0x9F)
-        {
-            i += 1;
-            continue;
-        }
-        out.appendAssumeCapacity(byte);
+    while (i < title.len) {
+        const unit = nextTitleUnit(title, i);
+        out.appendSliceAssumeCapacity(unit.keep);
+        i = unit.next;
     }
 
     return try out.toOwnedSlice(alloc);
@@ -28367,6 +28519,91 @@ fn testMapGenericAllToFileAllAlloc(alloc: Allocator, sddl: []const u8) ![]u8 {
     return std.mem.replaceOwned(u8, alloc, sddl, ";;GA;;", ";;FA;;");
 }
 
+/// Drop the `AI` / `AR` ACL control flags from SDDL text.
+///
+/// `CreateNamedPipeW` hands our descriptor to the object manager, which runs
+/// the auto-inheritance algorithm and stamps `SE_SACL_AUTO_INHERITED` on the
+/// copy it attaches (the DACL escapes this only because we mark it protected).
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW` then renders `S:AI(`
+/// where the descriptor we asked for renders `S:(` — so a comparison of the two
+/// spellings fails on any host that gets a label at all, i.e. an ELEVATED one.
+/// That is why this only ever reproduced on CI: a medium-integrity developer
+/// machine emits no label, so there is no SACL to stamp.
+///
+/// These two flags record how an ACL was assembled, never who may do what, so
+/// normalizing them away loses no access-control coverage. `P` is deliberately
+/// NOT stripped — assertion (3) below still requires a protected DACL.
+fn testStripAclAutoInheritFlagsAlloc(alloc: Allocator, sddl: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    var i: usize = 0;
+    while (i < sddl.len) {
+        // ACL flags only appear between an ACL introducer and its first ACE.
+        if (!isTestSddlAclIntroducer(sddl, i)) {
+            try out.append(alloc, sddl[i]);
+            i += 1;
+            continue;
+        }
+
+        try out.appendSlice(alloc, sddl[i .. i + 2]);
+        i += 2;
+        while (i < sddl.len and sddl[i] != '(' and !isTestSddlAclIntroducer(sddl, i)) {
+            if (sddl[i] == 'A' and
+                i + 1 < sddl.len and
+                (sddl[i + 1] == 'I' or sddl[i + 1] == 'R'))
+            {
+                i += 2;
+                continue;
+            }
+            try out.append(alloc, sddl[i]);
+            i += 1;
+        }
+    }
+
+    return out.toOwnedSlice(alloc);
+}
+
+fn isTestSddlAclIntroducer(sddl: []const u8, i: usize) bool {
+    return (sddl[i] == 'D' or sddl[i] == 'S') and
+        i + 1 < sddl.len and
+        sddl[i + 1] == ':';
+}
+
+test "win32 SDDL auto-inherit normalization keeps every access-bearing field" {
+    const alloc = std.testing.allocator;
+
+    const cases = [_]struct { in: []const u8, want: []const u8 }{
+        // The exact shape CI produced on an elevated runner.
+        .{
+            .in = "D:P(A;;FA;;;LA)S:AI(ML;;NW;;;HI)",
+            .want = "D:P(A;;FA;;;LA)S:(ML;;NW;;;HI)",
+        },
+        // Already normalized: unchanged.
+        .{
+            .in = "D:P(A;;FA;;;LA)S:(ML;;NW;;;HI)",
+            .want = "D:P(A;;FA;;;LA)S:(ML;;NW;;;HI)",
+        },
+        // Medium integrity: no label, therefore no SACL at all.
+        .{ .in = "D:P(A;;GA;;;S-1-5-21-1-2-3-1000)", .want = "D:P(A;;GA;;;S-1-5-21-1-2-3-1000)" },
+        // AR as well as AI, and on both ACLs.
+        .{ .in = "D:AIAR(A;;FA;;;LA)S:AR(ML;;NW;;;HI)", .want = "D:(A;;FA;;;LA)S:(ML;;NW;;;HI)" },
+        // `P` survives -- losing it would silently allow an inheritable ACE.
+        .{ .in = "D:PAI(A;;FA;;;LA)", .want = "D:P(A;;FA;;;LA)" },
+        // Trustee aliases that merely CONTAIN A/I/R live inside ACEs, which the
+        // flag scan never enters. AN (Anonymous) and AU are the ones that matter.
+        .{ .in = "D:P(A;;FA;;;AN)(A;;FA;;;AU)", .want = "D:P(A;;FA;;;AN)(A;;FA;;;AU)" },
+        // Owner and group sections are copied through untouched.
+        .{ .in = "O:LAG:BAD:PAI(A;;FA;;;LA)", .want = "O:LAG:BAD:P(A;;FA;;;LA)" },
+    };
+
+    for (cases) |case| {
+        const got = try testStripAclAutoInheritFlagsAlloc(alloc, case.in);
+        defer alloc.free(got);
+        try std.testing.expectEqualStrings(case.want, got);
+    }
+}
+
 test "win32 IPC pipe descriptor attaches the expected DACL and label" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -28428,7 +28665,13 @@ test "win32 IPC pipe descriptor attaches the expected DACL and label" {
     try std.testing.expectEqual(@as(u32, 0), status);
     defer _ = sys.LocalFree(attached.?);
 
-    const actual = try testDescriptorSddlAlloc(alloc, attached.?, information);
+    const attached_text = try testDescriptorSddlAlloc(alloc, attached.?, information);
+    defer alloc.free(attached_text);
+
+    // Only the auto-inheritance bookkeeping the object manager stamps on the
+    // attached copy is normalized away; every access-bearing field of the live
+    // descriptor is compared exactly. See testStripAclAutoInheritFlagsAlloc.
+    const actual = try testStripAclAutoInheritFlagsAlloc(alloc, attached_text);
     defer alloc.free(actual);
 
     // (1) What the pipe carries must equal what we asked for, once generic
@@ -28857,6 +29100,104 @@ test "win32 title sanitizing strips control bytes from IPC and OSC titles" {
         defer alloc.free(out);
         try std.testing.expectEqualStrings("a0mbc", out);
     }
+
+    // RAW 8-bit C1 bytes, not the two-byte UTF-8 form. An IPC payload is
+    // arbitrary bytes, so nothing forces a pipe writer to spell C1 the way
+    // the previous byte-pair check expected.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\x9b0mb\x9cc\x80d\x9fe")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("a0mbcde", out);
+    }
+
+    // The bytes 0x80..0x9F are also UTF-8 CONTINUATION bytes, so stripping
+    // them at the byte level would corrupt ordinary text. U+20AC is
+    // `E2 82 AC` and U+0161 is `C5 A1`; both must survive untouched.
+    try std.testing.expect(try sanitizeTitleAlloc(alloc, "10 \u{20ac} \u{0161}") == null);
+
+    // An OVERLONG encoding of U+009B must not slip past by dodging the
+    // canonical two-byte form. `utf8Decode` rejects it, so it is dropped.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\xe0\x82\x9bb")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("ab", out);
+    }
+
+    // Invalid UTF-8 is removed rather than stored: a lone continuation byte,
+    // and a truncated lead byte at the very end of the input.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "a\xffb")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("ab", out);
+    }
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "ab\xc2")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("ab", out);
+    }
+
+    // A dropped unit never stalls the scan.
+    {
+        const out = (try sanitizeTitleAlloc(alloc, "\x9b\x9b\x9b")).?;
+        defer alloc.free(out);
+        try std.testing.expectEqualStrings("", out);
+    }
+}
+
+test "win32 IPC client authenticates the pipe server as the same user" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+
+    const pipe_name_utf8 = try std.fmt.allocPrintSentinel(
+        alloc,
+        "\\\\.\\pipe\\noctty-ipc-serverauth-{d}",
+        .{sys.GetTickCount64()},
+        0,
+    );
+    defer alloc.free(pipe_name_utf8);
+    const pipe_name = try std.unicode.utf8ToUtf16LeAllocZ(alloc, pipe_name_utf8);
+    defer alloc.free(pipe_name);
+
+    const server = sys.CreateNamedPipeW(
+        pipe_name.ptr,
+        c.PIPE_ACCESS_DUPLEX,
+        windows.PIPE_TYPE_BYTE |
+            c.PIPE_READMODE_BYTE |
+            win32_ipc.pipe_nowait |
+            c.PIPE_REJECT_REMOTE_CLIENTS,
+        1,
+        1024,
+        1024,
+        0,
+        null,
+    );
+    try std.testing.expect(server != windows.INVALID_HANDLE_VALUE);
+    defer _ = windows.CloseHandle(server);
+
+    // `connectToIpcPipe` performs the authentication itself, so connecting
+    // to OUR OWN server succeeding is what proves the check ran and passed
+    // rather than being skipped: if the SID comparison were broken in the
+    // "reject" direction this returns `error.PipeUnreachable` instead.
+    const client = try connectToIpcPipe(pipe_name);
+    defer _ = windows.CloseHandle(client);
+
+    // And directly, so a future refactor that drops the call site still
+    // fails a test rather than silently disabling the check.
+    try std.testing.expect(ipcPipeServerIsSameUser(client));
+
+    // The comparison operates on a real, well-formed SID rather than an
+    // empty slice that would trivially compare equal.
+    var own_buf: SidBuffer align(sid_buffer_align) = undefined;
+    const own_sid = try currentUserSidBytes(&own_buf);
+    try std.testing.expect(own_sid.len >= 8);
+    try std.testing.expectEqual(@as(u8, 1), own_sid[0]); // SID revision
+
+    // NOTE: the REJECT direction cannot be exercised here. It needs a pipe
+    // server running under a different local account, which this suite
+    // cannot create. The negative case is argued from the fail-closed
+    // structure of `ipcPipeServerIsSameUser` (every error path returns
+    // false), not observed.
 }
 
 test "win32 IPC silent client read is bounded" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -848,10 +848,13 @@ fn tokenUserSidBytes(
 /// and could return a forged ack, so the real instance never starts and the
 /// user gets no window -- a cross-account disclosure plus a startup denial.
 ///
-/// Authenticating BEFORE the first write is what makes this sufficient:
-/// `ImpersonateNamedPipeClient` fails with `ERROR_CANNOT_IMPERSONATE` until
-/// the client has written to the pipe, so a hostile server cannot borrow our
-/// token in the window between connect and this check.
+/// This runs before the first write. `ImpersonateNamedPipeClient` is
+/// documented to impersonate "the security context of the last message read
+/// from the pipe", so a server that has read nothing from us has no context
+/// to assume. That ordering is a defence in depth rather than the guarantee,
+/// though: the guarantee is that `connectToIpcPipe` opens with
+/// `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, which caps the server
+/// at an identification-only token whatever the timing.
 ///
 /// Fails CLOSED: any error answers "not ours".
 fn ipcPipeServerIsSameUser(pipe: windows.HANDLE) bool {
@@ -888,7 +891,11 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
             0,
             null,
             windows.OPEN_EXISTING,
-            windows.FILE_ATTRIBUTE_NORMAL,
+            // Deny impersonation outright rather than relying on the server
+            // never having read a message from us. See the constants.
+            windows.FILE_ATTRIBUTE_NORMAL |
+                c.SECURITY_SQOS_PRESENT |
+                c.SECURITY_IDENTIFICATION,
             null,
         );
         if (handle != windows.INVALID_HANDLE_VALUE) {

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -420,6 +420,10 @@ pub const SECURITY_IDENTIFICATION = 0x00010000;
 /// medium integrity, so a label ACE is only worth adding above this.
 pub const SECURITY_MANDATORY_MEDIUM_RID = 0x2000;
 
+/// `S-1-16-4096`. The lowest level any interactive or service token
+/// carries, used only as a sanity floor in tests.
+pub const SECURITY_MANDATORY_LOW_RID = 0x1000;
+
 /// SDDL string revision accepted by
 /// `ConvertStringSecurityDescriptorToSecurityDescriptorW` and
 /// `ConvertSecurityDescriptorToStringSecurityDescriptorW`.

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -397,6 +397,12 @@ pub const TOKEN_QUERY = 0x0008;
 pub const TokenUser = 1;
 pub const TokenIntegrityLevel = 25;
 
+/// Least privilege that still permits `OpenProcessToken` on another
+/// process, used to authenticate the IPC pipe server. Deliberately NOT
+/// `PROCESS_QUERY_INFORMATION`, which additionally grants access this check
+/// has no use for.
+pub const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
 /// Relative identifier of the medium mandatory integrity level
 /// (`S-1-16-8192`). Windows treats an object with no mandatory label as
 /// medium integrity, so a label ACE is only worth adding above this.

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -434,6 +434,7 @@ pub const SDDL_REVISION_1 = 1;
 /// the SACL without needing `SeSecurityPrivilege`.
 pub const DACL_SECURITY_INFORMATION = 0x00000004;
 pub const LABEL_SECURITY_INFORMATION = 0x00000010;
+pub const OWNER_SECURITY_INFORMATION = 0x00000001;
 
 /// `SE_OBJECT_TYPE.SE_KERNEL_OBJECT`, for reading a named pipe's descriptor
 /// back off the live handle with `GetSecurityInfo`.

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -403,6 +403,18 @@ pub const TokenIntegrityLevel = 25;
 /// has no use for.
 pub const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
+/// Security quality-of-service flags for `CreateFileW` on a named pipe.
+///
+/// A named-pipe server impersonates at `SecurityImpersonation` BY DEFAULT.
+/// Passing `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION` lets the server
+/// learn who we are but not act as us: `ImpersonateNamedPipeClient`'s
+/// documented rule is that impersonation is permitted when "the requested
+/// impersonation level of the token is less than SecurityImpersonation, such
+/// as SecurityIdentification" -- the resulting token can be queried but not
+/// used to open objects on our behalf.
+pub const SECURITY_SQOS_PRESENT = 0x00100000;
+pub const SECURITY_IDENTIFICATION = 0x00010000;
+
 /// Relative identifier of the medium mandatory integrity level
 /// (`S-1-16-8192`). Windows treats an object with no mandatory label as
 /// medium integrity, so a label ACE is only worth adding above this.

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -391,14 +391,29 @@ pub const PIPE_UNLIMITED_INSTANCES = 255;
 /// single-instance IPC pipe must opt out explicitly.
 pub const PIPE_REJECT_REMOTE_CLIENTS = 0x00000008;
 
-/// Token access and info class used to resolve the current user's SID for
-/// the IPC pipe DACL.
+/// Token access and info classes used to resolve the current user's SID and
+/// integrity level for the IPC pipe security descriptor.
 pub const TOKEN_QUERY = 0x0008;
 pub const TokenUser = 1;
+pub const TokenIntegrityLevel = 25;
+
+/// Relative identifier of the medium mandatory integrity level
+/// (`S-1-16-8192`). Windows treats an object with no mandatory label as
+/// medium integrity, so a label ACE is only worth adding above this.
+pub const SECURITY_MANDATORY_MEDIUM_RID = 0x2000;
 
 /// SDDL string revision accepted by
-/// `ConvertStringSecurityDescriptorToSecurityDescriptorW`.
+/// `ConvertStringSecurityDescriptorToSecurityDescriptorW` and
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW`.
 pub const SDDL_REVISION_1 = 1;
+
+/// `SECURITY_INFORMATION` bits. `LABEL_SECURITY_INFORMATION` selects the
+/// mandatory-label ACE in the SACL without needing `SeSecurityPrivilege`.
+pub const OWNER_SECURITY_INFORMATION = 0x00000001;
+pub const GROUP_SECURITY_INFORMATION = 0x00000002;
+pub const DACL_SECURITY_INFORMATION = 0x00000004;
+pub const SACL_SECURITY_INFORMATION = 0x00000008;
+pub const LABEL_SECURITY_INFORMATION = 0x00000010;
 
 /// Main-thread COM apartment for in-process STA clients (settings path
 /// picker, WinRT toast factory, OLE drag-drop targets). `S_FALSE` means

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -386,6 +386,20 @@ pub const PIPE_READMODE_BYTE = 0x00000000;
 pub const PIPE_ACCESS_DUPLEX = 0x00000003;
 pub const PIPE_UNLIMITED_INSTANCES = 255;
 
+/// Refuse pipe clients that arrive over SMB from another machine. Named
+/// pipes are reachable as `\\<host>\pipe\<name>` by default, so the
+/// single-instance IPC pipe must opt out explicitly.
+pub const PIPE_REJECT_REMOTE_CLIENTS = 0x00000008;
+
+/// Token access and info class used to resolve the current user's SID for
+/// the IPC pipe DACL.
+pub const TOKEN_QUERY = 0x0008;
+pub const TokenUser = 1;
+
+/// SDDL string revision accepted by
+/// `ConvertStringSecurityDescriptorToSecurityDescriptorW`.
+pub const SDDL_REVISION_1 = 1;
+
 /// Main-thread COM apartment for in-process STA clients (settings path
 /// picker, WinRT toast factory, OLE drag-drop targets). `S_FALSE` means
 /// the desired STA already exists. `RPC_E_CHANGED_MODE` means the thread

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -407,13 +407,15 @@ pub const SECURITY_MANDATORY_MEDIUM_RID = 0x2000;
 /// `ConvertSecurityDescriptorToStringSecurityDescriptorW`.
 pub const SDDL_REVISION_1 = 1;
 
-/// `SECURITY_INFORMATION` bits. `LABEL_SECURITY_INFORMATION` selects the
-/// mandatory-label ACE in the SACL without needing `SeSecurityPrivilege`.
-pub const OWNER_SECURITY_INFORMATION = 0x00000001;
-pub const GROUP_SECURITY_INFORMATION = 0x00000002;
+/// `SECURITY_INFORMATION` bits used when reading the IPC pipe descriptor back
+/// as SDDL. `LABEL_SECURITY_INFORMATION` selects the mandatory-label ACE in
+/// the SACL without needing `SeSecurityPrivilege`.
 pub const DACL_SECURITY_INFORMATION = 0x00000004;
-pub const SACL_SECURITY_INFORMATION = 0x00000008;
 pub const LABEL_SECURITY_INFORMATION = 0x00000010;
+
+/// `SE_OBJECT_TYPE.SE_KERNEL_OBJECT`, for reading a named pipe's descriptor
+/// back off the live handle with `GetSecurityInfo`.
+pub const SE_KERNEL_OBJECT = 6;
 
 /// Main-thread COM apartment for in-process STA clients (settings path
 /// picker, WinRT toast factory, OLE drag-drop targets). `S_FALSE` means

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -469,14 +469,6 @@ pub extern "advapi32" fn OpenProcessToken(
     TokenHandle: *HANDLE,
 ) callconv(.winapi) BOOL;
 
-/// Identify the process that created the named-pipe server end this handle
-/// is connected to. Used to authenticate the server before a client writes
-/// anything to it.
-pub extern "kernel32" fn GetNamedPipeServerProcessId(
-    Pipe: HANDLE,
-    ServerProcessId: *DWORD,
-) callconv(.winapi) BOOL;
-
 pub extern "advapi32" fn EqualSid(
     pSid1: *anyopaque,
     pSid2: *anyopaque,

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -489,6 +489,20 @@ pub extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
     SecurityDescriptorSize: ?*u32,
 ) callconv(.winapi) BOOL;
 
+/// Read the security descriptor attached to a kernel object. Returns a
+/// Win32 error code (0 == ERROR_SUCCESS), not a BOOL. The out-descriptor is
+/// LocalAlloc'd; free it with `LocalFree`.
+pub extern "advapi32" fn GetSecurityInfo(
+    handle: HANDLE,
+    ObjectType: DWORD,
+    SecurityInfo: DWORD,
+    ppsidOwner: ?*?*anyopaque,
+    ppsidGroup: ?*?*anyopaque,
+    ppDacl: ?*?*anyopaque,
+    ppSacl: ?*?*anyopaque,
+    ppSecurityDescriptor: *?*anyopaque,
+) callconv(.winapi) DWORD;
+
 pub extern "advapi32" fn ConvertSecurityDescriptorToStringSecurityDescriptorW(
     SecurityDescriptor: *anyopaque,
     RequestedStringSDRevision: DWORD,

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -445,6 +445,46 @@ pub extern "kernel32" fn ConnectNamedPipe(
     lpOverlapped: ?*anyopaque,
 ) callconv(.winapi) BOOL;
 
+/// `SID_AND_ATTRIBUTES`/`TOKEN_USER` as returned by `GetTokenInformation`
+/// with `TokenUser`. Only the SID pointer is used; the SID itself lives in
+/// the caller-provided buffer.
+pub const SID_AND_ATTRIBUTES = extern struct {
+    Sid: *anyopaque,
+    Attributes: DWORD,
+};
+
+pub const TOKEN_USER = extern struct {
+    User: SID_AND_ATTRIBUTES,
+};
+
+pub extern "advapi32" fn OpenProcessToken(
+    ProcessHandle: HANDLE,
+    DesiredAccess: DWORD,
+    TokenHandle: *HANDLE,
+) callconv(.winapi) BOOL;
+
+pub extern "advapi32" fn GetTokenInformation(
+    TokenHandle: HANDLE,
+    TokenInformationClass: DWORD,
+    TokenInformation: ?*anyopaque,
+    TokenInformationLength: DWORD,
+    ReturnLength: *DWORD,
+) callconv(.winapi) BOOL;
+
+pub extern "advapi32" fn ConvertSidToStringSidW(
+    Sid: *anyopaque,
+    StringSid: *?[*:0]u16,
+) callconv(.winapi) BOOL;
+
+pub extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
+    StringSecurityDescriptor: [*:0]const u16,
+    StringSDRevision: DWORD,
+    SecurityDescriptor: *?*anyopaque,
+    SecurityDescriptorSize: ?*u32,
+) callconv(.winapi) BOOL;
+
+pub extern "kernel32" fn LocalFree(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+
 pub extern "kernel32" fn GetProcAddress(hModule: HMODULE, lpProcName: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
 
 pub extern "kernel32" fn LoadLibraryA(lpLibFileName: [*:0]const u8) callconv(.winapi) HMODULE;

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -457,6 +457,12 @@ pub const TOKEN_USER = extern struct {
     User: SID_AND_ATTRIBUTES,
 };
 
+/// `TOKEN_MANDATORY_LABEL` as returned by `GetTokenInformation` with
+/// `TokenIntegrityLevel`. `Label.Sid` is an `S-1-16-<rid>` integrity SID.
+pub const TOKEN_MANDATORY_LABEL = extern struct {
+    Label: SID_AND_ATTRIBUTES,
+};
+
 pub extern "advapi32" fn OpenProcessToken(
     ProcessHandle: HANDLE,
     DesiredAccess: DWORD,
@@ -481,6 +487,14 @@ pub extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
     StringSDRevision: DWORD,
     SecurityDescriptor: *?*anyopaque,
     SecurityDescriptorSize: ?*u32,
+) callconv(.winapi) BOOL;
+
+pub extern "advapi32" fn ConvertSecurityDescriptorToStringSecurityDescriptorW(
+    SecurityDescriptor: *anyopaque,
+    RequestedStringSDRevision: DWORD,
+    SecurityInformation: DWORD,
+    StringSecurityDescriptor: *?[*:0]u16,
+    StringSecurityDescriptorLen: ?*u32,
 ) callconv(.winapi) BOOL;
 
 pub extern "kernel32" fn LocalFree(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -469,6 +469,24 @@ pub extern "advapi32" fn OpenProcessToken(
     TokenHandle: *HANDLE,
 ) callconv(.winapi) BOOL;
 
+/// Identify the process that created the named-pipe server end this handle
+/// is connected to. Used to authenticate the server before a client writes
+/// anything to it.
+pub extern "kernel32" fn GetNamedPipeServerProcessId(
+    Pipe: HANDLE,
+    ServerProcessId: *DWORD,
+) callconv(.winapi) BOOL;
+
+pub extern "advapi32" fn EqualSid(
+    pSid1: *anyopaque,
+    pSid2: *anyopaque,
+) callconv(.winapi) BOOL;
+
+/// Byte length of a well-formed SID. Returns 0 if the SID is malformed.
+pub extern "advapi32" fn GetLengthSid(
+    pSid: *anyopaque,
+) callconv(.winapi) DWORD;
+
 pub extern "advapi32" fn GetTokenInformation(
     TokenHandle: HANDLE,
     TokenInformationClass: DWORD,


### PR DESCRIPTION
## Summary

Hardening for the Windows single-instance IPC surface, found during #144 research. Now at **round 3**, after two adversarial review passes (R-185, R-185b) both returned `request-changes`; see **Review delta** below for what changed each round and what is deliberately deferred.

The IPC pipe carries three request kinds — `.new_window`, `.list_windows`, `.perform_action`. The original PR hardened the transport and one allowlist entry. Round 2 fixed the fact that the allowlist was not the boundary for the `.new_window` kind, and that the mandatory-integrity claim was false. Round 3 **inverted the `.new_window` filter from a denylist to an allowlist** after the re-review found the denylist still missed two full-RCE keys, and fixed a startup regression that round 2's own label ACE had made reachable.

**Scope statement, stated up front:** this channel is restricted to processes running as the same user. **It is not a privilege boundary.** Any code already running as your user is fully trusted with it. The change reduces exposure to *other accounts* and *to the network*; it does not defend against malware running as you.

Refs #144.

## Defects fixed

1. **The pipe accepted remote clients and had no explicit DACL.** `ipcServerMain` called `CreateNamedPipeW` with `lpSecurityAttributes = null` and a `dwPipeMode` omitting `PIPE_REJECT_REMOTE_CLIENTS`. Windows named pipes are reachable over SMB as `\\<host>\pipe\<name>` unless that flag is set. The concrete pre-fix exposures were: **Administrators and LocalSystem had full control**, **Everyone had read** (enough for instance-occupancy DoS and channel observation), and **the pipe was reachable over SMB**. Cross-account *request submission* was already denied, because the documented default named-pipe DACL grants Everyone `READ` only and submitting a request needs `GENERIC_WRITE` — the original body overstated this and it is corrected here.

2. **`end_key_sequence` was an injection escape in the `+perform-action` allowlist.** It dispatches to `endKeySequence(.flush, .retain)`, which writes the queued key-sequence data to the pty. That is terminal input, which `docs/windows.md` documents as rejected.

3. **`.new_window` bypassed the allowlist entirely.** `.new_window` and `.perform_action` share one pipe, but only `.perform_action` went through `App.isSafeAutomationAction`. `applyNewWindowArguments` fed attacker-supplied argv straight into `Config.loadIter` + `finalize`. A pipe writer could send `--command=powershell -enc <payload>`, `--input=<keystrokes>\n`, or `--env=ZDOTDIR=<attacker dir>` and get execution in the server's context; `--background-image=\\attacker\share\x.png` made the server authenticate to a remote SMB host. The client-side `normalizeForwardedStartupArg` filter is not a control here — a pipe writer never runs it. **Now filtered by an allowlist**, so this class of key is refused by default rather than one at a time.

4. **A high-integrity instance was not protected from a medium-integrity client (round 2).** Windows does not auto-label kernel objects created by a high-IL process, an unlabeled object evaluates as medium, and the token USER SID is identical across the elevated and non-elevated tokens of one account. `D:P(A;;GA;;;<user>)` alone therefore did **not** stop a filtered medium-IL process from driving an elevated instance. Combined with (3) that was a UAC-boundary EoP.

5. **`clear_screen` put bytes on the pty (round 2).** It reaches `Termio.clearScreen`, which sends `0x0C` (FF) to the child when the cursor is at a prompt and erases the full scrollback regardless of `readonly`.

## Changes

**Transport / descriptor** — `src/apprt/win32.zig`, `win32/sys.zig`, `win32/consts.zig`

- `ipcServerMain` creates the pipe with `PIPE_REJECT_REMOTE_CLIENTS` and a `SECURITY_ATTRIBUTES` carrying a protected DACL `D:P(A;;GA;;;<user SID>)`. The SID comes from the process token (`OpenProcessToken` + `GetTokenInformation(TokenUser)` + `ConvertSidToStringSidW`) rather than the SDDL `OW` alias, because an elevated token's default object owner is the Administrators group, not the user.
- When the process token's integrity level is **strictly above medium**, a mandatory-label ACE `S:(ML;;NW;;;S-1-16-<rid>)` is appended. `NO_WRITE_UP` is checked by the kernel *before* the DACL, so a filtered medium-IL token of the same account cannot open the elevated instance's pipe for write. The label is skipped at or below medium because an unlabeled object already behaves as medium/`NO_WRITE_UP`. The SID is emitted numerically so any level above medium works without an abbreviation table.
- Descriptor construction is split into a pure `buildIpcPipeSddl` plus `integrityRidFromSidString`, so both are unit-testable without elevation.
- Fail closed: if the descriptor cannot be built the server refuses to listen rather than falling back to the default DACL.

**`.new_window` argv allowlist** — `src/apprt/win32.zig`

- `forwardedKeyAllowed` admits an explicit list of window-scoped presentation keys and **refuses everything else**, including keys added upstream after the list was written. `forwardedArgvRejection` scans every argv element and classifies the first refusal; the server refuses the **whole request** with a logged error rather than dropping keys. See the Review delta for the admission rule and the full list.
- `cli/args.zig` accepts only `--key=value` / `--key` (values are never a separate argv token) plus the `-e` hook, and matches keys with exact case-sensitive `mem.eql`, so `forwardedArgumentKey` sees exactly the key the loader acts on. Anything not in `--key[=value]` form — including `-e`, which `Config.parseManuallyHook` turns into `initial-command` — is refused wholesale.
- The refused key is attacker-controlled text, so `forwardedKeyLoggable` gates it out of the log line unless it is plain lowercase-ASCII-with-hyphens and ≤ 64 chars; otherwise the message is generic. No log-record forging via a newline in a key.
- `--working-directory` is **constrained rather than rejected** — the startup forwarder always sends the launching process's realpath'd cwd, so a hard reject would break every single-instance launch. Accepted as `home`, `inherit`, `~`, `~/...`, `~\...`, a quoted path, or a local drive-letter absolute path. The check is purely syntactic and rejects UNC **syntax** only; see the Review delta for what that does and does not buy.
- Enforced in two places: the `.new_window` arm of `performAction` (which logs and drops the request) and inside `applyNewWindowArguments` itself (defense in depth). The catch arm logs too, so a rejection cannot go silent if the pre-check is ever refactored away.
- **Client side**, `normalizeForwardedStartupArg` drops arguments the server would refuse before forwarding, with a warning, so an ordinary launch still gets a window. Convenience only — not a control.

**Client connect path** — `src/apprt/win32.zig`

- `connectToIpcPipe` maps `ACCESS_DENIED` to `error.PipeUnreachable`, and all three senders treat that exactly like `FileNotFound`. Without this, the round-2 label ACE made an ordinary non-elevated launch fail to start whenever an elevated instance held the pipe.

**Allowlist** — `src/App.zig`

- Removed `.end_key_sequence` and `.clear_screen` from `isSafeAutomationAction`.
- The doc comment now records *why* each is excluded, and states explicitly that the allowlist is only the boundary for the `.perform_action` request kind — `.new_window` is filtered separately — and that the pipe is not a privilege boundary.

**Title sanitizing** — `src/apprt/win32.zig`

- `Surface.setTitle`, `setTitleOverride`, and `setTabTitleOverride` strip C0 controls, DEL, and C1 controls (including UTF-8-encoded 8-bit CSI/ST). With `title-report = true` a stored title is echoed back to the pty as `ESC ] l <title> ESC \`, and the IPC path (`set_surface_title` / `set_tab_title`) bypasses the `config.title != null` guard the OSC path honors. Sanitizing at the apprt setters covers both paths. Clean titles allocate nothing.

**Docs** — `docs/windows.md`

- The pipe paragraph now states: restricted to processes running as the same user; **not a privilege boundary**; any code running as your user is fully trusted with this channel; the pipe *name* is not protected.
- Documents the mandatory-label behavior **and its `NO_WRITE_UP`-only residual** (a lower-integrity process can still open the pipe for reading and occupy an instance), the expanded rejected-action list (`end_key_sequence`, `clear_screen`), the `+new-window` **allowlist** with its deny-by-default property, the UNC-syntax-only scope of the `--working-directory` check, and the client-side drop.

## Review delta

### Round 3 (re-review R-185b) — what changed

R-185b confirmed F3, F4, F7 and the refactor as correct (including that no `SeSecurityPrivilege` issue exists and that `NW` is the right policy), and rejected F1.

| Finding | Disposition |
| --- | --- |
| **F1 rejection list incomplete** — `--input`, `--env`, `--background-image` each reproduce the primitive the fix claimed to close | **Fixed by inverting to an allowlist.** Not by extending the denylist. |
| **Startup abort made reachable by the round-2 label ACE** (NEW, introduced by this PR) | **Fixed.** `ACCESS_DENIED` → `error.PipeUnreachable` → fall through to a local instance. |
| **Round-trip test requested DACL only; brittle for alias-able SIDs** | **Fixed.** Reads DACL \| LABEL off the live pipe handle; one renderer both sides; label asserted absent at medium IL. |
| **`--working-directory` claim overstated; `~/...` and quoted paths refused** | **Fixed.** Claim restated as UNC-*syntax* only; legal forms accepted again; check is now purely syntactic. |
| **`docs/windows.md` false again; silent catch arm; dead constants** | **Fixed.** |
| **NR/NX residual unstated** | **Recorded** in `docs/windows.md` and in the `allocIpcPipeIntegritySid` doc comment. |
| **7-point UAC spec** | Parked at `prompts/a5-9-185-uac-verify-PARKED.md`, then **RUN and PASSED in full** on 2026-08-30 — see "Live validation". |

#### F1: why an allowlist, not a longer denylist

The re-review found three more keys that each reproduce arbitrary code execution or the SMB-auth primitive:

- **`--input`** (`RepeatableReadableIO`) is written straight to the pty before any other input — its own doc comment warns it "can be used to execute programs in a shell". `+new-window --input=powershell -enc AAAA\n` ran in the new window's shell. `--input=path:\\attacker\share\x` additionally gives SMB auth and an arbitrary local file read.
- **`--env`** (`RepeatableStringMap`) is applied **after** `shell_integration.setup`, so `ZDOTDIR`, `ENV`, `XDG_DATA_DIRS`, and `GHOSTTY_BASH_RCFILE` can be repointed to run an attacker script at shell start; `PATH` hijacks the next command.
- **`--background-image`** (`?Path`) is read with `openFileAbsolute` + `readToEndAlloc(maxInt(u32))` — the exact SMB-auth primitive `--working-directory` was constrained for, reached through an unfiltered key, plus a 4 GiB memory DoS.

Adding these to the denylist would have left the defect class intact. The config surface is ~190 fields and grows with every upstream merge, so a denylist is wrong by omission every time a key lands. The filter is now **deny-by-default**: `forwardedKeyAllowed` admits an explicit list of window-scoped presentation keys and refuses everything else, *including any key added upstream after this list was written*.

Admission rule: a key qualifies only if its value is a scalar, an enum, a color, or (for `title`) a display string that is sanitized downstream. It does not qualify if the value is resolved as a path, a command, an environment variable, a font or theme **name**, an additional config source, or bytes that can reach the pty.

Allowed: window geometry/decoration/state (`window-width`, `window-height`, `window-position-*`, `window-padding-*`, `window-decoration`, `window-theme`, `window-colorspace`, `window-show-tab-bar`, `maximize`, `fullscreen`, ...), `title`, non-name font settings (`font-size`, `font-thicken`, `font-thicken-strength`, `font-synthetic-style`, `font-shaping-break`), colors and compositing (`background`, `foreground`, `palette`, `cursor-*`, `selection-*`, `background-opacity*`, `background-blur`, `split-divider-color`, `bold-color`, `faint-opacity`, `minimum-contrast`, `alpha-blending`), plus `working-directory` with its value constrained.

Font **name** keys (`font-family*`, `font-style*`, `font-feature`, `font-variation*`, `font-codepoint-map`, `window-title-font-family`) are excluded on the admission rule — their values are resolved by font discovery — rather than because a concrete exploit is known. Matching is exact, never by prefix, so `windows-job-object-kill-on-close` cannot slip past a `window-` rule.

**Usability**: to stop the inversion becoming a cliff, the **client** now drops arguments the server would refuse before forwarding, with a warning, so an ordinary launch still gets a window instead of silently getting nothing. That is a convenience on our own argv and explicitly **not** a control — a hostile pipe writer never runs it, and the server re-checks every argument.

#### The startup regression this PR introduced, now fixed

Round 2's label ACE made a pre-existing latent abort reachable in the most ordinary configuration. `connectToIpcPipe` mapped everything but `FILE_NOT_FOUND`/`PIPE_BUSY` to `windows.unexpectedError`, and `App.run` calls `tryForwardStartupToExistingInstance` with `try`. With an elevated instance holding the pipe, a non-elevated launch got `ACCESS_DENIED` at `CreateFileW` → `error.Unexpected` → **the non-elevated noctty failed to start at all**: no window, no fallback.

`ACCESS_DENIED` is now `error.PipeUnreachable`, which `sendNewWindowIpc`, `sendListWindowsIpc` and `sendPerformActionIpc` all treat exactly like `FileNotFound` — "no instance we can reach" — so startup falls through to a local instance and logs an info line. Point 6 of the parked UAC spec is the regression test for this.

#### `--working-directory`, restated honestly

The check rejects **UNC syntax only**. A mapped drive (`net use Z: \\host\share`), a `subst` drive, or a junction under a local drive still resolves off-box, and any same-user process can create those. That is acceptable under this channel's threat model — same-user code is already trusted — but the previous wording ("rejects UNC values") overclaimed.

It is now **purely syntactic**. The old `openDirAbsolute` existence probe was itself the SMB authentication we were trying to avoid for mapped drives and junctions, and TOCTOU made it meaningless since the path is re-resolved at spawn. `~`, `~/...`, `~\...` and quoted paths are documented legal values that round 2 wrongly refused — killing the whole request with only a log line — and are accepted again.

### Round 2 (review R-185)

| Finding | Disposition |
| --- | --- |
| **F1** `.new_window` bypasses the allowlist | Denylist added in round 2; **superseded by the round-3 allowlist**. |
| **F2** pipe-name squatting | **Deferred** — see follow-ups. Separate coherent change. |
| **F3** MIC claim false | **Confirmed false; fixed defensively.** Mandatory-label ACE when above medium IL. **Verified empirically** on 2026-08-30 by the desktop lane — see "Live validation". (This cell previously read "Not verified empirically"; that is retracted.) |
| **F4** `clear_screen` + unsanitized titles | **Fixed.** `clear_screen` removed from the allowlist; titles sanitized at the apprt setters. |
| **F5** broader allowlist re-scoping | **Deferred** — see follow-ups. |
| **F6** unvalidated action arguments | **Deferred** — see follow-ups. |
| **F7** tests weaker than claimed | **Fixed**, then strengthened again in round 3. |
| **F8** docs overclaim | **Fixed.** |
| **F9** imprecise comment + overstated PR claim | **Fixed.** |

### F3 was not verified empirically at authoring time (superseded 2026-08-30)

**Kept for history. The check has since been run and passed — see "Live validation (desktop lane, 2026-08-30) — COMPLETE" below.** As written at the time:

The review asked for an empirical check (elevated `--single-instance=true`, then `+perform-action new_tab` from a non-elevated shell). **This machine cannot run it unattended:** `EnableLUA=1`, `ConsentPromptBehaviorAdmin=5`, `PromptOnSecureDesktop=1`, so launching an elevated instance raises a secure-desktop consent dialog that an automated pass cannot answer. The fix was applied defensively on the strength of the documented MIC semantics, which R-185b independently confirmed as correct by construction.

The full 7-point verification spec is at `prompts/a5-9-185-uac-verify-PARKED.md`, including the regression case for the startup abort above. It has since been executed end to end.

### Why the label ACE rather than a per-token pipe name

The review offered `S:(ML;;NW;;;HI)` and/or a per-token discriminator in the pipe name. The label ACE was chosen because it is the smaller change — the descriptor is built in one place, whereas the pipe name is threaded through startup forwarding, the CLI verbs, and the recovery path — and because it is enforced by the kernel before the DACL check rather than resting on name obscurity, without changing the wire contract. Putting the SID in the name is still worth doing and is folded into the F2 follow-up, where it additionally fixes the cross-session name-collision startup abort.

## Tests

- `App.zig` — `automation-action dispatch rejects unsafe actions before dispatching` calls **`performAutomationAction`**, the real IPC entry point, rather than `isSafeAutomationAction` directly. Asserts `error.UnsafeAutomationAction` for `end_key_sequence`, `clear_screen`, and `paste_from_clipboard` on both target kinds, plus a positive control (an allowlisted action reaching `error.NoAutomationTarget`) proving the gate is what rejected the others.
- `win32.zig` — **`win32 IPC pipe descriptor attaches the expected DACL and label`** creates a real pipe with the built descriptor and reads the DACL back **off the live handle** with `GetSecurityInfo`, requesting `DACL | LABEL`. It compares against both the requested descriptor and a reference rebuilt independently from the token SID, and asserts the label is **absent** at medium integrity. See the SDDL notes below.
- `win32.zig` — `win32 IPC pipe SDDL renders the exact DACL and mandatory label` pins both the unlabeled and labeled SDDL forms as pure string assertions, covering the elevated branch without elevation.
- `win32.zig` — `win32 forwarded new-window argv refuses everything off the allowlist` asserts **the property that matters**: keys nobody enumerated (`totally-made-up-key`, `some-future-upstream-key`) are refused, alongside every specific dangerous key the reviews named. Also pins that `windows-...` is not `window-...`.
- `win32.zig` — `win32 forwarded argv key extraction matches the config loader`, `win32 forwarded rejection reasons are classified and safe to log`, `win32 forwarded working-directory rejects UNC syntax and keeps legal forms`, `win32 applyNewWindowArguments rejects a forwarded command outright` (now covering `--input`, `--env`, and an unenumerated key), `win32 integrity SID parsing accepts only mandatory label SIDs`, `win32 title sanitizing strips control bytes from IPC and OSC titles`.
- `win32 IPC pipe DACL still admits a same-user client` is retained as the guard against locking the owning user out.

### SDDL comparison: two spelling traps, both handled

Cross-pollinated from the identical fix on `issues/123-paste-path-audit-fuzz` (`win32_ipc.zig` `descriptorSddlAlloc`) rather than re-derived. The helper shape is duplicated deliberately because that branch is not in this one's history; the doc comment flags it so the two collapse into one shared helper when the branches meet.

1. **Alias spelling.** `ConvertSecurityDescriptorToStringSecurityDescriptorW` abbreviates well-known SIDs to two-letter aliases (`SY`, `BA`, `LA`), while `ConvertSidToStringSidW` is always numeric. Rendering one side each way can never match for an alias-able account — which is why the round-2 exact-string form would have failed spuriously as built-in Administrator or SYSTEM. Both sides now render through one helper.
2. **Generic-rights mapping.** Windows resolves generic rights against the object's generic mapping **on attach**, so the `GA` we request reads back off a named pipe as `FA`. The request side is normalized by `testMapGenericAllToFileAllAlloc`. This reproduced here and is mutation-verified below.

### Mutation evidence

Each mutation was applied, the suite run, and the source restored.

| Mutation | Where | Result |
| --- | --- | --- |
| DACL principal → `WD` (Everyone) | inside `buildIpcPipeSddl` | **2 failed** — the pure-string test and the attached-descriptor test |
| Drop the protected-DACL `P` flag (`D:P(` → `D:(`) | inside `buildIpcPipeSddl` | **2 failed** — same two |
| Emit the mandatory label even at medium IL | `allocIpcPipeIntegritySid` threshold | **1 failed** — attached-descriptor test (the round-2 DACL-only version would have passed) |
| Disable `GA` → `FA` normalization | `testMapGenericAllToFileAllAlloc` | **1 failed**, showing `D:P(A;;GA;;;<sid>)` requested vs `D:P(A;;FA;;;<sid>)` attached — proving the pipe really does remap, and that the normalization is load-bearing |
| Disable the allowlist check | `forwardedArgvRejection` | **2 failed** — the rejection-reason test and `applyNewWindowArguments` (`expected error.ForbiddenForwardedArgument, found void`) |
| Delete the `isSafeAutomationAction` gate | `performAutomationAction` | **1 failed** — `expected error.UnsafeAutomationAction, found error.NoAutomationTarget` |
| Re-add `.clear_screen` to the allowlist | `isSafeAutomationAction` | **2 failed** — the table test and the dispatch test |

The pre-round-2 tests passed under all of these.

## Validation

```
zig fmt --check src
  -> src\build\uucode_tables.zig   (pre-existing exception, only file listed)

zig build -Demit-exe=true
  -> exit 0

zig build test -Demit-test-exe=true --summary all
  -> 41/41 steps succeeded; 3783/3853 tests passed; 70 skipped; 0 failed

pwsh -NoProfile -File scripts/check-source-format.ps1
  -> PowerShell syntax and JSON validity checks passed. (exit 0)
```

The full suite was run, not just filtered runs: the `GA`/`FA` half of the SDDL problem is exactly the kind of failure a `-Dtest-filter` run can mask. The previously known failure `Command: custom env vars` is fixed on current `main`.

## Live validation (desktop lane, 2026-08-30) — COMPLETE

Run by the exclusive desktop lane on real hardware, against a genuine elevated instance. All seven points of the parked UAC spec now RUN and PASS. Artifacts: `evidence/185-uac/elevated.txt`, `evidence/185-uac/medium.txt`.

**Point 6 (the merge blocker) — PASS, by direct evidence.** With a real elevated instance running, an ordinary non-elevated launch opened a window (`hwnd=205655358`) and logged `single-instance pipe exists but is not accessible to this token; starting a local instance`. This is the startup regression this PR introduced and then fixed. An earlier run proved this only via a decoy DACL; it is now the real label path.

**Points 1–2 — PASS.** From medium integrity, `CreateFileW` on the elevated pipe failed `win32=5` for both `GENERIC_READ | GENERIC_WRITE` and `GENERIC_WRITE` alone — denial **at `CreateFileW`**, not a timeout and not a missing ack. At CLI level `+perform-action` and `+list-windows` exit 1 with "No matching noctty instance is listening"; `+new-window` exits 0 but did **not** drive the elevated instance, falling through to its own local one (process list 24600 → 24600 + 25712).

**Point 3 — PASS.** From an elevated shell, `+perform-action new_tab` exits 0 with `tab_count` 1 → 2. `NO_WRITE_UP` does not lock out the intended client.

**Point 4 — PASS.** The pipe was created while elevated with neither a "failed to build" nor a "failed to create win32 IPC pipe" warning, so points 1–2 are not passing for the wrong reason.

**Point 5 — PASS.** The live descriptor reads `D:P(A;;FA;;;S-1-5-21-...-1001)S:AI(ML;;NW;;;HI)` — the label **survived object creation**. Three renderings differ cosmetically from the spec string (`GA`→`FA` generic mapping, `S-1-16-12288`→`HI` well-known alias, plus an `AI` auto-inherited flag stamped by the object manager), but the load-bearing `ML;;NW` term is exact. The medium-integrity run's **empty** label proves the readback distinguishes present from absent in both directions.

**Point 7 — PASS, and it confirms the residual.** A medium `GENERIC_READ` open succeeds, but `WriteFile` on that handle fails `win32=5`. The residual is therefore real and bounded exactly as documented: an **occupancy/DoS** problem, not an access break.

### Cross-PR interaction: #171 closes the occupancy residual this PR leaves open

This PR labels the elevated endpoint `S:AI(ML;;NW;;;HI)`. `NO_WRITE_UP` alone does not deny reads, so a medium process can open the pipe read-only (a bare `READ_CONTROL` suffices) and occupy the single listening instance, making the next legitimate client fail `win32=231 ERROR_PIPE_BUSY`.

**#171 fixes this.** Its elevated pipe carries `S:AI(ML;;NWNR;;;HI)`, and the added `NO_READ_UP` denies **every** medium open including `GENERIC_READ` and `READ_CONTROL` — verified on hardware in `evidence/171-uac/`. That is the experiment this PR previously recorded as outstanding, now run.

`NR` is deliberately **not** duplicated here. The two changes would collide on the same SDDL term for no net gain once both land, and altering the label in this PR would invalidate the point-5 descriptor readback above. The interaction is stated in `docs/windows.md` and in the `buildIpcPipeSddl` doc comment so the two PRs are not left carrying different labels with no note.

## Known follow-ups from adversarial review

Deliberately **not** in this PR. No GitHub issues filed (AGENTS.md forbids agent-created issues); recorded in `issues-notes.md`.

### FU-1 — Pipe-name squatting (was F2, HIGH). Separate coherent change.

The DACL protects the *object*, not the *name*. `\\.\pipe\io.github.amanthanvi.noctty` (win32.zig:316, 711-716) is machine-global with no SID, session, or logon-ID component.

- No `FILE_FLAG_FIRST_PIPE_INSTANCE` anywhere — `dwOpenMode` is bare `PIPE_ACCESS_DUPLEX`.
- The server closes the handle before recreating it, so there are windows with **zero** instances.
- If a squatter owns the name first, `CreateNamedPipeW` fails, logs a `warn`, and returns — **the server thread dies permanently and silently**.
- The client never authenticates the server: `connectToIpcPipe` calls `CreateFileW` without `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION`, so the default `SecurityImpersonation` applies.

Chain: squat the name → a victim launch forwards its full argv plus realpath'd cwd to the attacker (`tryForwardStartupToExistingInstance`) → forged ack → `markRecoveryReady()` and silent exit. Result: persistent DoS + argv/cwd disclosure + `ImpersonateNamedPipeClient` (a high-IL client yields a high-IL token).

Fixes to make together: `FILE_FLAG_FIRST_PIPE_INSTANCE` and abort **loudly** on squat; keep an anchor instance so the name is never free; `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION` on the client `CreateFileW`; put the user SID (and ideally the logon/session ID) in the pipe name. The last one also fixes the F9 tail: `tryForwardStartupToExistingInstance` is called with `try` while `connectToIpcPipe` maps `ACCESS_DENIED` to `windows.unexpectedError`, so a cross-user or cross-session name collision aborts startup entirely today.

### FU-2 — Broader allowlist re-scoping (was F5, MEDIUM)

The audit this PR scoped out. Remaining `isSafeAutomationAction` entries worth re-examining:

- `quit` / `close_all_windows` call `destroyAllWindows` immediately and never consult `needsConfirmQuit` / `confirm-close-surface` — no confirmation for a remote-ish caller.
- `select_all` + `copy_to_clipboard` is a **full-scrollback exfiltration primitive** (`Screen.zig` selects all history; copy in `Surface.zig`).
- `reload_config` is an amplifier for an attacker who can write the user-writable config.
- `new_window` / `new_tab` / `new_split` / `toggle_quick_terminal` each spawn a child with no user interaction — fork-bomb DoS.
- `open_config` falls back to `ShellExecuteW`.
- `toggle_secure_input` / `toggle_mouse_reporting` / `toggle_readonly` silently flip user protections.

Decide per entry: keep, gate behind confirmation, or drop. Some are legitimately needed for automation, so this needs a design pass, not a blanket removal.

### FU-3 — Unvalidated action arguments (was F6, LOW)

`Binding.zig` (~:1170) uses `parseInt` / `parseFloat` with no range or finiteness checks:

- `scroll_page_fractional:nan|inf` → `@intFromFloat(@trunc(...))` in `Surface.zig`.
- `goto_tab:4294967296` → `@enumFromInt` into an `enum(c_int)` in `Surface.zig`.
- `move_tab:<isize max>` → `@mod` overflow in `win32.zig`.

Safety-checked panic in ReleaseSafe (remote DoS), silent UB in shipped builds — `package-windows.ps1` builds ReleaseFast. Fix by validating at parse time in `Binding.zig` so every caller benefits, not just the IPC path.

## Residuals

- **No automated test for remote-client rejection.** Verifying `PIPE_REJECT_REMOTE_CLIENTS` needs a second machine or an SMB loopback path; there is no harness. Asserted by code review against the `CreateNamedPipeW` contract. The DACL half *is* covered.
- **No automated test for cross-user denial**, and none for the mandatory label taking effect at runtime — both need a second token the suite cannot mint. Covered instead by reading the attached descriptor off the live pipe handle and asserting its exact shape.
- ~~**F3's empirical check is parked for the interactive pass** (secure-desktop consent required): `prompts/a5-9-185-uac-verify-PARKED.md`.~~ **Retracted 2026-08-30 — this is no longer a residual.** The desktop lane ran the parked 7-point spec on real hardware against a genuine elevated instance; all seven points RUN and PASS, including point 6, the merge blocker. See "Live validation (desktop lane, 2026-08-30) — COMPLETE" above and `evidence/185-uac/elevated.txt` / `evidence/185-uac/medium.txt`. The bullet survived from the revision written before that pass and contradicted the same body.
- **The mandatory label sets `NO_WRITE_UP` only, not `NR`/`NX`.** Now measured rather than reasoned about: a medium `GENERIC_READ` open on an elevated instance's pipe succeeds, but `WriteFile` on that handle fails `win32=5`. So it is an **occupancy/DoS** residual, not an access break — nothing is disclosed and no request can be submitted, but because the server offers one instance at a time, one squatting read handle makes the next legitimate client fail `win32=231 ERROR_PIPE_BUSY` (server logs `err=error.IpcTimeout`). **#171 closes it** with `NWNR` on the elevated endpoint, hardware-verified to deny every medium open including `READ_CONTROL`; it is not duplicated here because the two would collide on one SDDL term and would invalidate this PR's descriptor readback. A spare listening instance was considered and rejected as a speed bump.
- **The `--working-directory` check is UNC-syntax only.** A mapped or `subst` drive, or a junction under a local drive, still resolves off-box. Any same-user process can create those, so this is inside the stated threat model rather than a gap being papered over.
- **Two SDDL helpers are duplicated** with `issues/123-paste-path-audit-fuzz` (`descriptorSddlAlloc` / generic-rights normalization). That branch is not in this one's history; the doc comment flags the duplication so they collapse into one shared helper when the branches meet.
- **Other `CreateNamedPipeW` call sites left alone.** `src/pty.zig` (per-pty pipes, already passes `SECURITY_ATTRIBUTES`) and the in-test pipes are not the single-instance surface.

## Summary by Sourcery

Harden the Windows single-instance IPC surface and constrain all forwarded automation inputs to reduce cross-account, network, and injection exposure.

Bug Fixes:
- Harden the Windows single-instance IPC channel against remote access, unauthorized cross-account clients, elevated-to-medium write-up, and server-name spoofing.
- Prevent unsafe automation actions and forwarded new-window arguments from injecting terminal input, executing commands, accessing attacker-controlled files, or modifying configuration sources.
- Restore local startup fallback when an existing elevated instance is inaccessible.
- Sanitize window and tab titles before they can be reported back to the terminal.

Enhancements:
- Enforce a deny-by-default allowlist for forwarded window presentation settings, including syntactic validation of working-directory values and safe rejection logging.
- Authenticate connected pipe objects using their owner SID and integrity label, and restrict client impersonation to identification level.
- Fail closed when IPC security descriptors cannot be constructed and validate the attached pipe descriptor in Windows tests.

Documentation:
- Document the Windows IPC trust boundary, security controls, residual occupancy risk, forwarded-argument policy, and rejected automation actions.

Tests:
- Add coverage for IPC security descriptor construction and live descriptor readback, forwarding allowlist behavior, working-directory validation, title sanitization, and automation dispatch gating.
- Complete live elevated/medium-integrity validation of the Windows IPC protections and startup fallback.