### PR TITLE
feat(win32): SSH host ingestion into profiles and palette (#143)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -51,6 +51,8 @@ Win32-validated VT protocol coverage is tracked in
 - Native right-click context menus.
 - In-app profile picker for detected shells: PowerShell 7, Windows
   PowerShell, `cmd`, Git Bash, and WSL distributions when WSL responds.
+- Concrete aliases from `%USERPROFILE%\.ssh\config` appear in the profile
+  picker and universal palette and launch through the system `ssh.exe`.
 - Per-monitor DPI scaling.
 - DWM dark title bar that follows the app theme.
 - High-contrast mode detection and palette switching.

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -53,6 +53,7 @@ Last reviewed: 2026-08-12.
 | Native settings                                                                   | A native settings window with staged, source-preserving saves. See [native settings notes](#native-settings).              |
 | Tab dragging                                                                      | Same-window reorder and exact-pane drag-to-split. See [tab dragging notes](#tab-dragging).                                 |
 | Power-aware rendering                                                             | `unfocused-render-fps` caps visible background presentation; `power-saver-rendering` controls saver pacing; minimized and DWM-cloaked windows do not present. See [power and battery](windows.md#power-and-battery). |
+| SSH host discovery                                                                | Concrete aliases from `%USERPROFILE%\.ssh\config` appear as system `ssh.exe` launch entries in the picker and palette.    |
 
 ## Notes
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -127,9 +127,10 @@ pane returns as the default shell rather than dialing out unattended.
 SSH entries always sort after the detected shells and cannot be reordered with
 `NOCTTY_WIN32_PROFILE_ORDER`, which addresses shell profiles only.
 
-Concrete `Include` files are scanned one level deep, up to 16 files. Include
-opens run off the UI thread under one shared 50 ms refresh budget; a slow or
-blocked path is skipped, and a later profile refresh can retry it.
+Concrete `Include` files are scanned one level deep, up to 16 files. The root
+config and Include opens run off the UI thread under one shared 50 ms refresh
+budget; a slow or blocked path is skipped, and a later profile refresh can
+retry it.
 
 Set `ssh-config-hosts = false` to remove these entries. This feature does not
 provide a bundled SSH client, secrets vault, or fleet/connection management.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -87,6 +87,42 @@ in explicitly:
 command = wsl.exe
 ```
 
+## SSH hosts
+
+By default, noctty reads `%USERPROFILE%\.ssh\config` read-only whenever
+Windows profiles are refreshed. Each concrete alias on a `Host` line appears
+as `SSH: <alias>` in the profile picker and `Connect to <alias>` in the
+universal palette. Opening either entry starts the system `ssh.exe` with only
+the alias as its argument, in a new tab whose working directory is the user's
+home directory.
+
+Only `Host` lines are read. A line may carry multiple aliases; wildcard or
+negated patterns and aliases that are not plain printable ASCII are skipped.
+Every other keyword — `HostName`, `User`, `Port`, `ProxyCommand`, and the rest
+— is ignored here and left to `ssh`, which reads the same file. `Match` blocks
+are ignored, including their `Include` lines. `Include` files are read one
+level deep, up to 16 files: relative paths start at the `.ssh` directory,
+absolute and `~/` paths are accepted, and globbed, UNC (`\\server\share`), and
+device (`\\?\`, `\\.\`) paths are skipped so a refresh cannot block on a
+network timeout.
+
+Activating an entry runs `ssh <alias>`, so whatever that alias resolves to in
+your own SSH configuration takes effect — including any `ProxyCommand` or
+`LocalCommand` it specifies, which run locally. This is ordinary `ssh`
+behavior; noctty adds no execution of its own, but it does turn the file into
+a one-click surface.
+
+SSH entries run without shell integration, which is injected into a local
+shell and cannot apply to a remote session. Session restore does not reopen
+them either: a restored window comes back with its local shells, and any SSH
+pane returns as the default shell rather than dialing out unattended.
+
+SSH entries always sort after the detected shells and cannot be reordered with
+`NOCTTY_WIN32_PROFILE_ORDER`, which addresses shell profiles only.
+
+Set `ssh-config-hosts = false` to remove these entries. This feature does not
+provide a bundled SSH client, secrets vault, or fleet/connection management.
+
 ## App identity
 
 Installed builds create Start menu shortcuts with noctty's

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -105,13 +105,12 @@ level deep, up to 16 files: relative paths start at the `.ssh` directory, and
 absolute and `~/` paths are accepted. A leading `"` groups one path containing
 spaces, matching OpenSSH; a backslash is a path separator here, not an escape.
 
-Because that read is synchronous on the UI thread, an include is skipped
-rather than opened when it is globbed, UNC (`\\server\share`), a device path
-(`\\?\`, `\\.\`), or a mapped network drive letter — the last is checked with
-`GetDriveTypeW`, which answers from the local mount table without contacting
-the server. A refresh therefore cannot block on a network timeout. A directory
-junction or a `subst` alias whose target is remote is not detected, since both
-report the drive type of the letter rather than of the target.
+An include is skipped before the worker opens it when it is globbed, UNC
+(`\\server\share`), a device path (`\\?\`, `\\.\`), or a mapped network drive
+letter. The last is checked with `GetDriveTypeW`, which answers from the local
+mount table without contacting the server. A directory junction or a `subst`
+alias whose target is remote is not detected by that classification, but the
+bounded worker below still prevents its open from stalling the UI thread.
 
 Activating an entry runs `ssh <alias>`, so whatever that alias resolves to in
 your own SSH configuration takes effect — including any `ProxyCommand` or

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -101,10 +101,17 @@ negated patterns and aliases that are not plain printable ASCII are skipped.
 Every other keyword — `HostName`, `User`, `Port`, `ProxyCommand`, and the rest
 — is ignored here and left to `ssh`, which reads the same file. `Match` blocks
 are ignored, including their `Include` lines. `Include` files are read one
-level deep, up to 16 files: relative paths start at the `.ssh` directory,
-absolute and `~/` paths are accepted, and globbed, UNC (`\\server\share`), and
-device (`\\?\`, `\\.\`) paths are skipped so a refresh cannot block on a
-network timeout.
+level deep, up to 16 files: relative paths start at the `.ssh` directory, and
+absolute and `~/` paths are accepted. A leading `"` groups one path containing
+spaces, matching OpenSSH; a backslash is a path separator here, not an escape.
+
+Because that read is synchronous on the UI thread, an include is skipped
+rather than opened when it is globbed, UNC (`\\server\share`), a device path
+(`\\?\`, `\\.\`), or a mapped network drive letter — the last is checked with
+`GetDriveTypeW`, which answers from the local mount table without contacting
+the server. A refresh therefore cannot block on a network timeout. A directory
+junction or a `subst` alias whose target is remote is not detected, since both
+report the drive type of the letter rather than of the target.
 
 Activating an entry runs `ssh <alias>`, so whatever that alias resolves to in
 your own SSH configuration takes effect — including any `ProxyCommand` or

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -127,6 +127,10 @@ pane returns as the default shell rather than dialing out unattended.
 SSH entries always sort after the detected shells and cannot be reordered with
 `NOCTTY_WIN32_PROFILE_ORDER`, which addresses shell profiles only.
 
+Concrete `Include` files are scanned one level deep, up to 16 files. Include
+opens run off the UI thread under one shared 50 ms refresh budget; a slow or
+blocked path is skipped, and a later profile refresh can retry it.
+
 Set `ssh-config-hosts = false` to remove these entries. This feature does not
 provide a bundled SSH client, secrets vault, or fleet/connection management.
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -11,6 +11,7 @@ const configpkg = @import("../config.zig");
 const config_edit = @import("../config/edit.zig");
 const themepkg = @import("../config/theme.zig");
 const windows_shell = @import("../config/windows_shell.zig");
+const windows_ssh_hosts = @import("../config/windows_ssh_hosts.zig");
 const input = @import("../input.zig");
 const homedir = @import("../os/homedir.zig");
 const internal_os = @import("../os/main.zig");
@@ -615,8 +616,34 @@ fn applyProfileSurfaceConfig(
     config: *configpkg.Config,
     profile: *const windows_shell.Profile,
 ) !void {
-    try applyProfileCommandConfig(config, profile);
     config.@"working-directory" = .home;
+    try applyProfileLaunchConfig(config, profile);
+}
+
+/// Applies a profile's command plus the kind-specific hardening that has to
+/// hold on EVERY launch path — new surface, split, and restore alike. Splits
+/// used to apply only the command, which silently dropped the SSH guarantees
+/// below, so both paths go through here.
+fn applyProfileLaunchConfig(
+    config: *configpkg.Config,
+    profile: *const windows_shell.Profile,
+) !void {
+    try applyProfileCommandConfig(config, profile);
+    if (profile.kind != .ssh) return;
+
+    // Shell integration injection rewrites the two-element ssh argv into a
+    // space-joined, unquoted `cmd.exe /C` string. A remote session cannot use
+    // it anyway: the integration scripts run locally.
+    config.@"shell-integration" = .none;
+
+    // `.home` alone loses to an inherited working directory, so resolve the
+    // path explicitly and let the drive-absolute branch of the cwd resolver
+    // take it. This is the same directory `ssh` itself expands `~` to.
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (try windows_ssh_hosts.userProfileDir(&home_buf)) |home| {
+        const alloc = config._arena.?.allocator();
+        config.@"working-directory" = .{ .path = try alloc.dupe(u8, home) };
+    }
 }
 
 fn applyProfileCommandConfig(
@@ -2250,7 +2277,13 @@ pub const App = struct {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, open_kind);
         defer config.deinit();
 
-        if (pane.profile) |key| try self.applyRestoredProfileConfig(&config, host, key);
+        // A refused profile (today: SSH) must not leave its key on the surface
+        // either, or a later split of the restored pane would re-resolve it and
+        // launch the connection this restore just declined.
+        const profile_applied = if (pane.profile) |key|
+            try self.applyRestoredProfileConfig(&config, host, key)
+        else
+            false;
         if (pane.cwd) |cwd| {
             const alloc = config._arena.?.allocator();
             config.@"working-directory" = .{ .path = try alloc.dupe(u8, cwd) };
@@ -2269,7 +2302,9 @@ pub const App = struct {
         });
         transaction.noteSurface(surface);
 
-        if (pane.profile) |key| try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, key);
+        if (profile_applied) {
+            try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, pane.profile.?);
+        }
         if (pane.title_override) |title| try surface.setTitleOverride(title);
         if (pane.tab_title_override) |title| try surface.setTabTitleOverride(title);
         if (pane.cwd) |cwd| try surface.setPwd(cwd);
@@ -2281,17 +2316,20 @@ pub const App = struct {
         config: *configpkg.Config,
         host: ?*Host,
         key: []const u8,
-    ) !void {
+    ) !bool {
         if (host) |existing| {
-            if ((try existing.profileForKey(key))) |profile| {
-                try applyProfileSurfaceConfig(config, profile);
-            }
-            return;
+            const profile = (try existing.profileForKey(key)) orelse return false;
+            if (!isSessionRestorableProfile(profile)) return false;
+            try applyProfileSurfaceConfig(config, profile);
+            return true;
         }
 
-        const profiles = try windows_shell.listProfiles(self.core_app.alloc);
+        const profiles = try windows_shell.listProfiles(
+            self.core_app.alloc,
+            self.config.@"ssh-config-hosts",
+        );
         defer windows_shell.deinitProfiles(self.core_app.alloc, profiles);
-        try applyProfileConfigByKey(config, profiles, key);
+        return try applyProfileConfigByKey(config, profiles, key);
     }
 
     fn applyRestoredWindowPlacement(
@@ -2429,12 +2467,22 @@ pub const App = struct {
         const nodes = try alloc.alloc(win32_session_state.Node, tab.tree.nodes.len);
         for (tab.tree.nodes, 0..) |node, i| {
             nodes[i] = switch (node) {
-                .leaf => |surface| .{ .pane = .{
-                    .cwd = surface.pwd,
-                    .profile = surface.launch_profile_key,
-                    .title_override = surface.title_override,
-                    .tab_title_override = surface.tab_title_override,
-                } },
+                .leaf => |surface| .{
+                    .pane = .{
+                        .cwd = surface.pwd,
+                        // Never persist an SSH launch: restore would relaunch
+                        // it unattended. The alias tab title goes with it, or
+                        // it would stick to the local shell that replaces the
+                        // pane. Both read the kind recorded at launch, not the
+                        // key text.
+                        .profile = if (surface.launched_ssh) null else surface.launch_profile_key,
+                        .title_override = surface.title_override,
+                        .tab_title_override = if (surface.launched_ssh)
+                            null
+                        else
+                            surface.tab_title_override,
+                    },
+                },
                 .split => |split| .{ .split = .{
                     .axis = switch (split.layout) {
                         .horizontal => .horizontal,
@@ -3273,6 +3321,7 @@ pub const App = struct {
                 });
                 if (inherited_profile_key) |key| {
                     try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, key);
+                    surface.launched_ssh = source.launched_ssh;
                 }
                 tab_info.tab.clearRedoHistory();
                 if (tab_info.host.pushStructuralUndo(.{
@@ -4214,7 +4263,7 @@ pub const App = struct {
         const key = source.launch_profile_key orelse return null;
         const host = source.host orelse return null;
         const profile = (try host.profileForKey(key)) orelse return null;
-        try applyProfileCommandConfig(config, profile);
+        try applyProfileLaunchConfig(config, profile);
         return profile.key;
     }
 
@@ -4246,7 +4295,8 @@ pub const App = struct {
             else => null,
         };
 
-        const title_w = try std.unicode.utf8ToUtf16LeAllocZ(self.core_app.alloc, profile.label);
+        const surface_title = sshProfileAlias(profile) orelse profile.label;
+        const title_w = try std.unicode.utf8ToUtf16LeAllocZ(self.core_app.alloc, surface_title);
         defer self.core_app.alloc.free(title_w);
         const surface = try self.createWindowSurface(&config, title_w.ptr, .{
             .host_id = if (open_target == .window) null else if (source) |v| v.host_id else null,
@@ -4258,6 +4308,10 @@ pub const App = struct {
             .clone_state_from = source,
         });
         try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, profile.key);
+        surface.launched_ssh = profile.kind == .ssh;
+        if (sshProfileAlias(profile)) |alias| {
+            try appendOwnedString(self.core_app.alloc, &surface.tab_title_override, alias);
+        }
         return surface;
     }
 
@@ -8492,8 +8546,8 @@ const Host = struct {
                 _ = self.appendPaletteDescriptor(.{
                     .item = .{
                         .id = win32_palette.catalog.stableStringId(.profile, profile.key),
-                        .title = profile.label,
-                        .subtitle = "Profile",
+                        .title = profile.palette_title orelse profile.label,
+                        .subtitle = if (profile.kind == .ssh) "SSH host" else "Profile",
                         .keywords = profile.key,
                     },
                     .payload = .{ .profile = profile.key },
@@ -9951,7 +10005,10 @@ const Host = struct {
 
     fn reloadProfiles(self: *Host) !bool {
         const replacing = self.profiles != null;
-        const next_profiles = try windows_shell.listProfiles(self.app.core_app.alloc);
+        const next_profiles = try windows_shell.listProfiles(
+            self.app.core_app.alloc,
+            self.app.config.@"ssh-config-hosts",
+        );
         if (self.profiles) |profiles| windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
         self.profiles = next_profiles;
         if (replacing and self.overlay_mode == .command_palette) self.rebuildPaletteList();
@@ -15771,7 +15828,9 @@ fn drawPaletteRowText(hdc: HDC, text: []const u8, rect: RECT, color: u32) void {
     // under 256 chars); anything longer gets truncated rather than
     // allocating per paint.
     var buf: [256]u16 = undefined;
-    const copied = std.unicode.utf8ToUtf16Le(&buf, text) catch buf.len;
+    // On invalid UTF-8 only a prefix was written, so falling back to `buf.len`
+    // would render uninitialized stack. Draw nothing instead.
+    const copied = std.unicode.utf8ToUtf16Le(&buf, text) catch 0;
     const n: usize = @min(copied, buf.len - 1);
     buf[n] = 0;
 
@@ -17308,9 +17367,23 @@ fn applyProfileConfigByKey(
     config: *configpkg.Config,
     profiles: []const windows_shell.Profile,
     key: []const u8,
-) !void {
-    const index = profileIndexByKey(profiles, key) orelse return;
-    try applyProfileSurfaceConfig(config, &profiles[index]);
+) !bool {
+    const index = profileIndexByKey(profiles, key) orelse return false;
+    const profile = &profiles[index];
+    if (!isSessionRestorableProfile(profile)) return false;
+    try applyProfileSurfaceConfig(config, profile);
+    return true;
+}
+
+/// Session restore relaunches a pane's profile unattended at startup. An SSH
+/// profile would dial out with no interaction, so it is refused here.
+///
+/// The decision is made on the resolved profile rather than on the key text,
+/// so it cannot drift from the case-insensitive comparison `profileIndexByKey`
+/// uses: a state file naming `SSH:prod` resolves to the same profile as
+/// `ssh:prod` and is refused identically.
+fn isSessionRestorableProfile(profile: *const windows_shell.Profile) bool {
+    return profile.kind != .ssh;
 }
 
 const preferredProfileIndex = labels.preferredProfileIndex;
@@ -17505,6 +17578,12 @@ const buildSearchDetailText = labels.buildSearchDetailText;
 const buildProfileChromeBadgeText = labels.buildProfileChromeBadgeText;
 
 const buildProfileStatusBadgeText = labels.buildProfileStatusBadgeText;
+
+fn sshProfileAlias(profile: *const windows_shell.Profile) ?[]const u8 {
+    if (profile.kind != .ssh or !std.mem.startsWith(u8, profile.key, "ssh:")) return null;
+    const alias = profile.key["ssh:".len..];
+    return if (alias.len > 0) alias else null;
+}
 
 const profileStatusBadgeTextLen = labels.profileStatusBadgeTextLen;
 /// Build a label for the profile dropdown menu: "Profile Name\tCtrl+Shift+N"
@@ -20021,6 +20100,9 @@ pub const Surface = struct {
     title_override: ?[:0]const u8 = null,
     tab_title_override: ?[:0]const u8 = null,
     launch_profile_key: ?[:0]const u8 = null,
+    /// Recorded from the resolved profile kind at launch, so nothing downstream
+    /// has to re-derive "is this SSH?" from the key text.
+    launched_ssh: bool = false,
     mouse_shape: terminal.MouseShape = .text,
     mouse_visible: bool = true,
     hovered_link: ?[:0]const u8 = null,
@@ -21252,9 +21334,41 @@ pub const Surface = struct {
     }
 
     fn setTitle(self: *Surface, title: []const u8) !void {
-        if (ownedStringEquals(self.title, title)) return;
         const alloc = self.app.core_app.alloc;
-        try appendOwnedString(alloc, &self.title, title);
+        var changed = false;
+
+        // Direct commands initially report argv[0] as their title. Keep an
+        // SSH alias over that automatic value, then release it as soon as the
+        // remote terminal supplies a different title.
+        if (self.launch_profile_key) |key| {
+            if (self.host) |host| {
+                if (host.profiles) |profiles| {
+                    if (profileIndexByKey(profiles, key)) |index| {
+                        const profile = &profiles[index];
+                        if (sshProfileAlias(profile)) |alias| {
+                            if (self.tab_title_override) |override| {
+                                if (std.mem.eql(u8, override, alias)) {
+                                    const command_title = switch (profile.command) {
+                                        .direct => |argv| argv.len > 0 and std.ascii.eqlIgnoreCase(title, argv[0]),
+                                        .shell => false,
+                                    };
+                                    if (!command_title) {
+                                        try appendOwnedString(alloc, &self.tab_title_override, null);
+                                        changed = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!ownedStringEquals(self.title, title)) {
+            try appendOwnedString(alloc, &self.title, title);
+            changed = true;
+        }
+        if (!changed) return;
         try self.refreshWindowTitle();
         self.notifyTerminalUiaNameChanged();
     }
@@ -27950,6 +28064,122 @@ test "win32 applyProfileCommandConfig preserves inherited working directory" {
     try std.testing.expectEqualStrings("C:\\work", clone.@"working-directory".?.path);
 }
 
+test "win32 ssh profile surface config uses home working directory" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var base = try configpkg.Config.default(std.testing.allocator);
+    defer base.deinit();
+    var clone = base.shallowClone(std.testing.allocator);
+    defer clone.deinit();
+    const clone_alloc = clone._arena.?.allocator();
+    clone.@"working-directory" = .{ .path = try clone_alloc.dupe(u8, "C:\\work") };
+
+    // Production builds SSH profiles as a two-element direct argv.
+    const argv = try std.testing.allocator.alloc([:0]const u8, 2);
+    argv[0] = try std.testing.allocator.dupeZ(u8, "C:\\Windows\\System32\\OpenSSH\\ssh.exe");
+    argv[1] = try std.testing.allocator.dupeZ(u8, "production");
+    var profile: windows_shell.Profile = .{
+        .kind = .ssh,
+        .key = try std.testing.allocator.dupe(u8, "ssh:production"),
+        .label = try std.testing.allocator.dupe(u8, "SSH: production"),
+        .palette_title = try std.testing.allocator.dupe(u8, "Connect to production"),
+        .command = .{ .direct = argv },
+    };
+    defer profile.deinit(std.testing.allocator);
+
+    try applyProfileSurfaceConfig(&clone, &profile);
+
+    try std.testing.expect(clone.command != null);
+    try std.testing.expectEqual(@as(usize, 2), clone.command.?.direct.len);
+    try std.testing.expectEqualStrings("production", clone.command.?.direct[1]);
+
+    // An explicit home path, not `.home`, so it outranks the inherited cwd.
+    try std.testing.expect(clone.@"working-directory".? == .path);
+    try std.testing.expect(!std.mem.eql(u8, "C:\\work", clone.@"working-directory".?.path));
+    try std.testing.expectEqual(configpkg.Config.ShellIntegration.none, clone.@"shell-integration");
+    try std.testing.expectEqualStrings("production", sshProfileAlias(&profile).?);
+}
+
+test "win32 ssh hardening also holds on the split launch path" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // The split path used to apply only the command, which silently dropped
+    // shell-integration=none and let the ssh argv be flattened into cmd.exe /C.
+    var base = try configpkg.Config.default(std.testing.allocator);
+    defer base.deinit();
+    base.@"shell-integration" = .bash;
+    var clone = base.shallowClone(std.testing.allocator);
+    defer clone.deinit();
+    const clone_alloc = clone._arena.?.allocator();
+    clone.@"shell-integration" = .bash;
+    clone.@"working-directory" = .{ .path = try clone_alloc.dupe(u8, "C:\\work") };
+
+    const argv = try std.testing.allocator.alloc([:0]const u8, 2);
+    argv[0] = try std.testing.allocator.dupeZ(u8, "C:\\Windows\\System32\\OpenSSH\\ssh.exe");
+    argv[1] = try std.testing.allocator.dupeZ(u8, "production");
+    var profile: windows_shell.Profile = .{
+        .kind = .ssh,
+        .key = try std.testing.allocator.dupe(u8, "ssh:production"),
+        .label = try std.testing.allocator.dupe(u8, "SSH: production"),
+        .command = .{ .direct = argv },
+    };
+    defer profile.deinit(std.testing.allocator);
+
+    try applyProfileLaunchConfig(&clone, &profile);
+
+    try std.testing.expectEqual(configpkg.Config.ShellIntegration.none, clone.@"shell-integration");
+    try std.testing.expect(clone.@"working-directory".? == .path);
+    try std.testing.expect(!std.mem.eql(u8, "C:\\work", clone.@"working-directory".?.path));
+    try std.testing.expectEqual(@as(usize, 2), clone.command.?.direct.len);
+}
+
+test "win32 session restore refuses ssh profiles regardless of key case" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+    var base = try configpkg.Config.default(alloc);
+    defer base.deinit();
+
+    const argv = try alloc.alloc([:0]const u8, 2);
+    argv[0] = try alloc.dupeZ(u8, "C:\\Windows\\System32\\OpenSSH\\ssh.exe");
+    argv[1] = try alloc.dupeZ(u8, "prod");
+    const cmd_argv = try alloc.alloc([:0]const u8, 1);
+    cmd_argv[0] = try alloc.dupeZ(u8, "cmd.exe");
+    var profiles = [_]windows_shell.Profile{
+        .{
+            .kind = .cmd,
+            .key = try alloc.dupe(u8, "cmd.exe"),
+            .label = try alloc.dupe(u8, "Command Prompt"),
+            .command = .{ .direct = cmd_argv },
+        },
+        .{
+            .kind = .ssh,
+            .key = try alloc.dupe(u8, "ssh:prod"),
+            .label = try alloc.dupe(u8, "SSH: prod"),
+            .command = .{ .direct = argv },
+        },
+    };
+    defer for (&profiles) |*profile| profile.deinit(alloc);
+
+    // profileIndexByKey matches case-insensitively, so a state file naming
+    // "SSH:prod" still resolves the ssh profile. The refusal must key on the
+    // resolved kind, not on the key text, or the guard is bypassed and noctty
+    // dials out at startup with no interaction.
+    for ([_][]const u8{ "ssh:prod", "SSH:prod", "Ssh:PROD" }) |key| {
+        var clone = base.shallowClone(alloc);
+        defer clone.deinit();
+        try std.testing.expect(profileIndexByKey(&profiles, key) != null);
+        try std.testing.expect(!(try applyProfileConfigByKey(&clone, &profiles, key)));
+        try std.testing.expect(clone.command == null);
+    }
+
+    // A local profile still restores.
+    var clone = base.shallowClone(alloc);
+    defer clone.deinit();
+    try std.testing.expect(try applyProfileConfigByKey(&clone, &profiles, "CMD.EXE"));
+    try std.testing.expectEqualStrings("cmd.exe", clone.command.?.direct[0]);
+}
+
 test "win32 applyProfileConfigByKey applies saved first-pane profile before host exists" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -27970,7 +28200,7 @@ test "win32 applyProfileConfigByKey applies saved first-pane profile before host
     defer profile.deinit(std.testing.allocator);
     const profiles = [_]windows_shell.Profile{profile};
 
-    try applyProfileConfigByKey(&clone, &profiles, "cmd.exe");
+    try std.testing.expect(try applyProfileConfigByKey(&clone, &profiles, "cmd.exe"));
 
     try std.testing.expect(clone.command != null);
     try std.testing.expectEqualStrings("cmd.exe", clone.command.?.shell);

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -736,6 +736,10 @@ fn applySplitWorkingDirectoryFromSource(
     return try applySplitWorkingDirectoryPath(config, candidate);
 }
 
+fn shouldInheritSplitWorkingDirectory(source_launched_ssh: bool) bool {
+    return !source_launched_ssh;
+}
+
 fn defaultIpcNamespace() []const u8 {
     return if (builtin.mode == .Debug)
         "io.github.amanthanvi.noctty-debug"
@@ -2469,7 +2473,7 @@ pub const App = struct {
             nodes[i] = switch (node) {
                 .leaf => |surface| .{
                     .pane = .{
-                        .cwd = surface.pwd,
+                        .cwd = if (surface.launched_ssh) null else surface.pwd,
                         // Never persist an SSH launch: restore would relaunch
                         // it unattended. The alias tab title goes with it, or
                         // it would stick to the local shell that replaces the
@@ -3311,7 +3315,9 @@ pub const App = struct {
                 const source = self.findSurfaceForTarget(target) orelse return false;
                 const tab_info = self.findTabForSurface(source) orelse return false;
                 const inherited_profile_key = try applySplitProfileConfigFromSource(&config, source);
-                _ = try applySplitWorkingDirectoryFromSource(&config, source, self.startup_cwd);
+                if (shouldInheritSplitWorkingDirectory(source.launched_ssh)) {
+                    _ = try applySplitWorkingDirectoryFromSource(&config, source, self.startup_cwd);
+                }
                 const split_direction = splitDirectionFromAction(value);
                 const surface = try self.createWindowSurface(&config, default_title, .{
                     .host_id = source.host_id,
@@ -17585,6 +17591,20 @@ fn sshProfileAlias(profile: *const windows_shell.Profile) ?[]const u8 {
     return if (alias.len > 0) alias else null;
 }
 
+fn sshAliasFromLaunchKey(launched_ssh: bool, key: ?[]const u8) ?[]const u8 {
+    if (!launched_ssh) return null;
+    const value = key orelse return null;
+    if (!std.ascii.startsWithIgnoreCase(value, "ssh:")) return null;
+    const alias = value["ssh:".len..];
+    return if (alias.len > 0) alias else null;
+}
+
+fn isAutomaticSshCommandTitle(title: []const u8) bool {
+    const base = std.fs.path.basename(title);
+    return std.ascii.eqlIgnoreCase(base, "ssh.exe") or
+        std.ascii.eqlIgnoreCase(base, "ssh");
+}
+
 const profileStatusBadgeTextLen = labels.profileStatusBadgeTextLen;
 /// Build a label for the profile dropdown menu: "Profile Name\tCtrl+Shift+N"
 const buildDropdownProfileLabel = labels.buildDropdownProfileLabel;
@@ -21340,26 +21360,11 @@ pub const Surface = struct {
         // Direct commands initially report argv[0] as their title. Keep an
         // SSH alias over that automatic value, then release it as soon as the
         // remote terminal supplies a different title.
-        if (self.launch_profile_key) |key| {
-            if (self.host) |host| {
-                if (host.profiles) |profiles| {
-                    if (profileIndexByKey(profiles, key)) |index| {
-                        const profile = &profiles[index];
-                        if (sshProfileAlias(profile)) |alias| {
-                            if (self.tab_title_override) |override| {
-                                if (std.mem.eql(u8, override, alias)) {
-                                    const command_title = switch (profile.command) {
-                                        .direct => |argv| argv.len > 0 and std.ascii.eqlIgnoreCase(title, argv[0]),
-                                        .shell => false,
-                                    };
-                                    if (!command_title) {
-                                        try appendOwnedString(alloc, &self.tab_title_override, null);
-                                        changed = true;
-                                    }
-                                }
-                            }
-                        }
-                    }
+        if (sshAliasFromLaunchKey(self.launched_ssh, self.launch_profile_key)) |alias| {
+            if (self.tab_title_override) |override| {
+                if (std.mem.eql(u8, override, alias) and !isAutomaticSshCommandTitle(title)) {
+                    try appendOwnedString(alloc, &self.tab_title_override, null);
+                    changed = true;
                 }
             }
         }
@@ -28131,6 +28136,40 @@ test "win32 ssh hardening also holds on the split launch path" {
     try std.testing.expect(clone.@"working-directory".? == .path);
     try std.testing.expect(!std.mem.eql(u8, "C:\\work", clone.@"working-directory".?.path));
     try std.testing.expectEqual(@as(usize, 2), clone.command.?.direct.len);
+}
+
+test "win32 ssh split and session state drop remote cwd" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expect(!shouldInheritSplitWorkingDirectory(true));
+    try std.testing.expect(shouldInheritSplitWorkingDirectory(false));
+
+    var surface: Surface = undefined;
+    surface.pwd = "C:\\remote-controlled";
+    surface.launched_ssh = true;
+    surface.launch_profile_key = null;
+    surface.title_override = null;
+    surface.tab_title_override = null;
+    var tab = try Tab.init(std.testing.allocator, 1, &surface);
+    defer tab.deinit();
+
+    const layout = try App.buildSessionLayout(std.testing.allocator, &tab);
+    defer std.testing.allocator.free(layout.nodes);
+    try std.testing.expect(layout.nodes[0].pane.cwd == null);
+}
+
+test "win32 ssh title identity survives profile refresh" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqualStrings(
+        "production",
+        sshAliasFromLaunchKey(true, "ssh:production").?,
+    );
+    try std.testing.expect(sshAliasFromLaunchKey(false, "ssh:production") == null);
+    try std.testing.expect(sshAliasFromLaunchKey(true, "cmd.exe") == null);
+    try std.testing.expect(isAutomaticSshCommandTitle("C:\\Windows\\System32\\OpenSSH\\ssh.exe"));
+    try std.testing.expect(isAutomaticSshCommandTitle("ssh"));
+    try std.testing.expect(!isAutomaticSshCommandTitle("prod.example.com"));
 }
 
 test "win32 session restore refuses ssh profiles regardless of key case" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -3372,6 +3372,8 @@ pub const App = struct {
                 switch (target) {
                     .app => {
                         const config = try value.config.clone(self.core_app.alloc);
+                        const ssh_config_hosts_changed =
+                            self.config.@"ssh-config-hosts" != config.@"ssh-config-hosts";
                         // Palette theme preview owns a reversible baseline
                         // around the app-global config. An external/settings
                         // config change supersedes that transaction: dismiss
@@ -3388,6 +3390,15 @@ pub const App = struct {
                         self.config_revision +%= 1;
                         if (self.config_revision == 0) self.config_revision = 1;
                         for (self.hosts.items) |host| {
+                            if (ssh_config_hosts_changed) {
+                                host.invalidateProfiles();
+                                if (host.overlay_mode == .profile) {
+                                    _ = host.reloadProfiles() catch |err| blk: {
+                                        log.warn("SSH profile reload after config change failed err={}", .{err});
+                                        break :blk false;
+                                    };
+                                }
+                            }
                             if (host.overlay_mode == .command_palette) host.rebuildPaletteList();
                         }
                         self.scheduleGlobalHotkeySync();
@@ -4409,7 +4420,7 @@ pub const App = struct {
         var duplicate_slot: ?usize = null;
         for (self.launcher_quick_slot_keys, 0..) |existing, index| {
             if (existing) |value| {
-                if (std.ascii.eqlIgnoreCase(value, key)) {
+                if (storedProfileKeyEquals(value, key)) {
                     duplicate_slot = index;
                     break;
                 }
@@ -10038,6 +10049,13 @@ const Host = struct {
         if (self.selected_profile >= profiles.len) self.selected_profile = 0;
         _ = try self.setSelectedProfileIndex(self.selected_profile);
         return true;
+    }
+
+    fn invalidateProfiles(self: *Host) void {
+        if (self.profiles) |profiles| {
+            windows_shell.deinitProfiles(self.app.core_app.alloc, profiles);
+            self.profiles = null;
+        }
     }
 
     fn reapplyLauncherProfilePreferences(self: *Host) !void {
@@ -17369,6 +17387,7 @@ const resolveProfileSelection = labels.resolveProfileSelection;
 
 const profileIndexByKey = labels.profileIndexByKey;
 const profileKeyEquals = labels.profileKeyEquals;
+const storedProfileKeyEquals = labels.storedProfileKeyEquals;
 
 fn applyProfileConfigByKey(
     config: *configpkg.Config,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -17368,12 +17368,14 @@ const startsWithIgnoreCase = labels.startsWithIgnoreCase;
 const resolveProfileSelection = labels.resolveProfileSelection;
 
 const profileIndexByKey = labels.profileIndexByKey;
+const profileKeyEquals = labels.profileKeyEquals;
 
 fn applyProfileConfigByKey(
     config: *configpkg.Config,
     profiles: []const windows_shell.Profile,
     key: []const u8,
 ) !bool {
+    if (startsWithIgnoreCase(key, "ssh:")) return false;
     const index = profileIndexByKey(profiles, key) orelse return false;
     const profile = &profiles[index];
     if (!isSessionRestorableProfile(profile)) return false;
@@ -17384,10 +17386,9 @@ fn applyProfileConfigByKey(
 /// Session restore relaunches a pane's profile unattended at startup. An SSH
 /// profile would dial out with no interaction, so it is refused here.
 ///
-/// The decision is made on the resolved profile rather than on the key text,
-/// so it cannot drift from the case-insensitive comparison `profileIndexByKey`
-/// uses: a state file naming `SSH:prod` resolves to the same profile as
-/// `ssh:prod` and is refused identically.
+/// The key prefix is rejected before lookup so case variants in a persisted
+/// state file cannot bypass the guard. Live SSH profile lookup remains
+/// case-sensitive because OpenSSH host aliases are case-sensitive.
 fn isSessionRestorableProfile(profile: *const windows_shell.Profile) bool {
     return profile.kind != .ssh;
 }
@@ -19341,7 +19342,7 @@ fn applyQuickSlotPreferenceOrder(
         const key = key_opt orelse continue;
         var found: ?usize = null;
         for (profiles, 0..) |profile, index| {
-            if (std.ascii.eqlIgnoreCase(profile.key, key)) {
+            if (profileKeyEquals(profile, key)) {
                 found = index;
                 break;
             }
@@ -28200,14 +28201,18 @@ test "win32 session restore refuses ssh profiles regardless of key case" {
     };
     defer for (&profiles) |*profile| profile.deinit(alloc);
 
-    // profileIndexByKey matches case-insensitively, so a state file naming
-    // "SSH:prod" still resolves the ssh profile. The refusal must key on the
-    // resolved kind, not on the key text, or the guard is bypassed and noctty
-    // dials out at startup with no interaction.
+    // Live SSH profile lookup is case-sensitive, so a state file naming
+    // "SSH:prod" does not resolve `ssh:prod`. The refusal must key on the
+    // prefix before lookup, or a case
+    // variant could bypass the guard and dial out at startup with no interaction.
     for ([_][]const u8{ "ssh:prod", "SSH:prod", "Ssh:PROD" }) |key| {
         var clone = base.shallowClone(alloc);
         defer clone.deinit();
-        try std.testing.expect(profileIndexByKey(&profiles, key) != null);
+        if (std.mem.eql(u8, key, "ssh:prod")) {
+            try std.testing.expect(profileIndexByKey(&profiles, key) != null);
+        } else {
+            try std.testing.expect(profileIndexByKey(&profiles, key) == null);
+        }
         try std.testing.expect(!(try applyProfileConfigByKey(&clone, &profiles, key)));
         try std.testing.expect(clone.command == null);
     }

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -552,6 +552,18 @@ pub fn startsWithIgnoreCase(haystack: []const u8, prefix: []const u8) bool {
     return true;
 }
 
+pub fn storedProfileKeyEquals(a: []const u8, b: []const u8) bool {
+    if (startsWithIgnoreCase(a, "ssh:") or startsWithIgnoreCase(b, "ssh:")) {
+        return std.mem.eql(u8, a, b);
+    }
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+pub fn profileKeyEquals(profile: windows_shell.Profile, key: []const u8) bool {
+    if (profile.kind == .ssh) return std.mem.eql(u8, profile.key, key);
+    return storedProfileKeyEquals(profile.key, key);
+}
+
 pub fn resolveProfileSelection(
     profiles: []const windows_shell.Profile,
     input_text: []const u8,
@@ -571,9 +583,11 @@ pub fn resolveProfileSelection(
     var unique_match: ?usize = null;
     var match_count: usize = 0;
     for (profiles, 0..) |profile, index| {
-        if (std.ascii.eqlIgnoreCase(profile.key, input_text) or
-            std.ascii.eqlIgnoreCase(profile.label, input_text))
-        {
+        const label_matches = if (profile.kind == .ssh)
+            std.mem.eql(u8, profile.label, input_text)
+        else
+            std.ascii.eqlIgnoreCase(profile.label, input_text);
+        if (profileKeyEquals(profile, input_text) or label_matches) {
             exact_match = index;
             break;
         }
@@ -592,7 +606,7 @@ pub fn resolveProfileSelection(
 
 pub fn profileIndexByKey(profiles: []const windows_shell.Profile, key: []const u8) ?usize {
     for (profiles, 0..) |profile, index| {
-        if (std.ascii.eqlIgnoreCase(profile.key, key)) return index;
+        if (profileKeyEquals(profile, key)) return index;
     }
     return null;
 }
@@ -614,7 +628,7 @@ pub fn preferredProfileIndex(
         null;
     if (preferred_key) |key| {
         for (profiles, 0..) |profile, index| {
-            if (std.ascii.eqlIgnoreCase(profile.key, key)) return index;
+            if (profileKeyEquals(profile, key)) return index;
         }
     }
 
@@ -2183,7 +2197,7 @@ fn buildInspectorButtonLabel(
 pub fn findLauncherQuickSlotOrdinal(slot_keys: [3]?[:0]const u8, key: []const u8) ?usize {
     for (slot_keys, 0..) |slot_key, index| {
         if (slot_key) |value| {
-            if (std.ascii.eqlIgnoreCase(value, key)) return index;
+            if (storedProfileKeyEquals(value, key)) return index;
         }
     }
     return null;
@@ -2218,9 +2232,25 @@ test "win32 profileIndexByKey finds launch profile key" {
             .label = "Ubuntu",
             .command = .{ .shell = "wsl.exe" },
         },
+        .{
+            .kind = .ssh,
+            .key = "ssh:PROD",
+            .label = "SSH: PROD",
+            .command = .{ .shell = "ssh.exe PROD" },
+        },
+        .{
+            .kind = .ssh,
+            .key = "ssh:prod",
+            .label = "SSH: prod",
+            .command = .{ .shell = "ssh.exe prod" },
+        },
     };
 
     try std.testing.expectEqual(@as(?usize, 1), profileIndexByKey(&profiles, "wsl:Ubuntu"));
+    try std.testing.expectEqual(@as(?usize, 1), profileIndexByKey(&profiles, "WSL:UBUNTU"));
+    try std.testing.expectEqual(@as(?usize, 2), profileIndexByKey(&profiles, "ssh:PROD"));
+    try std.testing.expectEqual(@as(?usize, 3), profileIndexByKey(&profiles, "ssh:prod"));
+    try std.testing.expectEqual(@as(?usize, null), profileIndexByKey(&profiles, "SSH:prod"));
     try std.testing.expectEqual(@as(?usize, null), profileIndexByKey(&profiles, "missing"));
 }
 

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -1745,6 +1745,7 @@ fn profileKindBadge(kind: windows_shell.ProfileKind) []const u8 {
         .powershell => "PS",
         .git_bash => "GIT",
         .cmd => "CMD",
+        .ssh => "SSH",
     };
 }
 
@@ -1755,6 +1756,9 @@ fn profileKindGlyph(kind: windows_shell.ProfileKind) []const u8 {
         .powershell => ">_",
         .git_bash => "$>",
         .cmd => "C>",
+        // Distinct from WSL's "<>": this is the one kind that opens a network
+        // session, so it should not share another kind's cue.
+        .ssh => "->",
     };
 }
 

--- a/src/apprt/win32_theme.zig
+++ b/src/apprt/win32_theme.zig
@@ -705,7 +705,7 @@ pub fn overlayEditBorderColor(mode: HostOverlayMode, focused: bool, is_dark: boo
 pub fn profileChromeAccent(kind: ProfileKind, is_dark: bool) ProfileChromeAccent {
     if (!is_dark) {
         return switch (kind) {
-            .wsl_default, .wsl_distro => .{
+            .wsl_default, .wsl_distro, .ssh => .{
                 .idle_bg = rgb(228, 245, 233),
                 .idle_border = rgb(46, 125, 70),
                 .hover_bg = rgb(218, 238, 224),
@@ -759,7 +759,7 @@ pub fn profileChromeAccent(kind: ProfileKind, is_dark: bool) ProfileChromeAccent
     }
 
     return switch (kind) {
-        .wsl_default, .wsl_distro => .{
+        .wsl_default, .wsl_distro, .ssh => .{
             .idle_bg = rgb(34, 46, 38),
             .idle_border = rgb(92, 176, 118),
             .hover_bg = rgb(40, 54, 44),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1525,7 +1525,9 @@ class: ?[:0]const u8 = null,
 @"working-directory": ?WorkingDirectory = null,
 
 /// Read `%USERPROFILE%\.ssh\config` read-only and list only its host aliases;
-/// no keys or secrets are read, and no other keyword in the file is used.
+/// no keys or secrets are read. Up to 16 concrete, non-network `Include`
+/// files one level deep are also scanned for host aliases; every other
+/// keyword is ignored.
 ///
 /// Activating an entry runs `ssh <alias>`, which applies that alias's own
 /// configuration — including any `ProxyCommand` it specifies. Set this to

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1524,6 +1524,14 @@ class: ?[:0]const u8 = null,
 ///   * `inherit` - The working directory of the launching process.
 @"working-directory": ?WorkingDirectory = null,
 
+/// Read `%USERPROFILE%\.ssh\config` read-only and list only its host aliases;
+/// no keys or secrets are read, and no other keyword in the file is used.
+///
+/// Activating an entry runs `ssh <alias>`, which applies that alias's own
+/// configuration — including any `ProxyCommand` it specifies. Set this to
+/// `false` to remove the SSH entries.
+@"ssh-config-hosts": bool = true,
+
 /// Key bindings. The format is `trigger=action`. Duplicate triggers will
 /// overwrite previously set values. The list of actions is available in
 /// the documentation or using the `noctty +list-actions` command.

--- a/src/config/windows_shell.zig
+++ b/src/config/windows_shell.zig
@@ -4,12 +4,15 @@ const Allocator = std.mem.Allocator;
 const internal_os = @import("../os/main.zig");
 const Command = @import("command.zig").Command;
 const windows_shell_types = @import("windows_shell_types.zig");
+const windows_ssh_hosts = @import("windows_ssh_hosts.zig");
 const log = std.log.scoped(.windows_shell);
 const windows = std.os.windows;
 
 const wsl_probe_timeout_ms: windows.DWORD = 1500;
 var wsl_probe_mutex: std.Thread.Mutex = .{};
 var wsl_probe_cache: ?bool = null;
+var ssh_missing_mutex: std.Thread.Mutex = .{};
+var ssh_missing_logged = false;
 const wsl_shell_integration_next_step =
     "Enable shell integration inside the selected WSL shell startup.";
 
@@ -39,11 +42,13 @@ pub const Profile = struct {
     kind: ProfileKind,
     key: []const u8,
     label: []const u8,
+    palette_title: ?[]const u8 = null,
     command: Command,
 
     pub fn deinit(self: *Profile, alloc: Allocator) void {
         alloc.free(self.key);
         alloc.free(self.label);
+        if (self.palette_title) |value| alloc.free(value);
         self.command.deinit(alloc);
     }
 };
@@ -74,17 +79,39 @@ pub fn previewCommand(alloc: Allocator) !Command {
     return try previewCommandWithLookup(alloc, lookupExecutable);
 }
 
-pub fn listProfiles(alloc: Allocator) ![]Profile {
+pub fn listProfiles(alloc: Allocator, include_ssh_hosts: bool) ![]Profile {
     const order_hint = detectProfileOrderHint(alloc);
     defer if (order_hint) |value| alloc.free(value);
 
-    return try listProfilesWithLookupAndProbeAndWslListAndOrder(
+    const shell_profiles = try listProfilesWithLookupAndProbeAndWslListAndOrder(
         alloc,
         lookupExecutable,
         probeWslExecutableCached,
         listWslDistros,
         order_hint,
     );
+    if (!include_ssh_hosts) return shell_profiles;
+
+    // SSH discovery is additive. Any failure below degrades to the detected
+    // shells rather than propagating, because the caller treats an error as
+    // "no profiles at all" and would leave the user with no picker.
+    const hosts = windows_ssh_hosts.load(alloc) catch |err| {
+        warnSshDiscoveryOnce(err);
+        return shell_profiles;
+    };
+    defer windows_ssh_hosts.deinitHosts(alloc, hosts);
+    if (hosts.len == 0) return shell_profiles;
+
+    const ssh_path = resolveSshExecutable(alloc, lookupExecutable, accessAbsolute) catch |err| {
+        warnSshDiscoveryOnce(err);
+        return shell_profiles;
+    };
+    if (ssh_path == null) {
+        warnMissingSshOnce();
+        return shell_profiles;
+    }
+    defer alloc.free(ssh_path.?);
+    return try appendSshProfiles(alloc, shell_profiles, hosts, ssh_path.?);
 }
 
 pub fn profileOrderHint(alloc: Allocator) ?[:0]const u8 {
@@ -125,6 +152,11 @@ pub fn shellIntegrationDiagnostic(kind: ProfileKind) ShellIntegrationDiagnostic 
             .support = .unavailable,
             .summary = "Command Prompt profile; shell integration unavailable",
             .next_step = "Use PowerShell or WSL when prompt marking or cwd inheritance is required.",
+        },
+        .ssh => .{
+            .support = .unavailable,
+            .summary = "SSH profile; shell integration is disabled for remote sessions",
+            .next_step = "Enable shell integration inside the remote shell's own startup files.",
         },
     };
 }
@@ -196,7 +228,6 @@ pub fn safeCurrentDirectory(
     is_wsl: bool,
 ) !?[]const u8 {
     const current = try currentWindowsDirectory(alloc);
-    defer if (current) |value| alloc.free(value);
 
     return try safeCurrentDirectoryWithCurrent(
         alloc,
@@ -207,6 +238,7 @@ pub fn safeCurrentDirectory(
     );
 }
 
+/// Takes ownership of `current` and frees it on every path.
 fn safeCurrentDirectoryWithCurrent(
     alloc: Allocator,
     cwd: ?[]const u8,
@@ -214,6 +246,8 @@ fn safeCurrentDirectoryWithCurrent(
     is_wsl: bool,
     current: ?[]const u8,
 ) !?[]const u8 {
+    defer if (current) |value| alloc.free(value);
+
     if (cwd) |value| {
         if (isWindowsUriPath(value)) return try uriPathToWindows(alloc, value);
         if (isDriveAbsolutePath(value)) return try alloc.dupe(u8, value);
@@ -227,8 +261,6 @@ fn safeCurrentDirectoryWithCurrent(
     }
 
     if (current) |value| {
-        defer alloc.free(value);
-
         if (isDriveAbsolutePath(value)) return try alloc.dupe(u8, value);
         if (isWindowsUriPath(value)) return try uriPathToWindows(alloc, value);
         if (isObviouslyInvalidWindowsCurrentDirectory(value)) {
@@ -518,6 +550,79 @@ fn appendProfile(
     });
 }
 
+fn appendSshProfiles(
+    alloc: Allocator,
+    shell_profiles: []Profile,
+    hosts: []const windows_ssh_hosts.Host,
+    ssh_path: []const u8,
+) ![]Profile {
+    var profiles: std.ArrayList(Profile) = .empty;
+    profiles.ensureTotalCapacity(alloc, shell_profiles.len + hosts.len) catch |err| {
+        deinitProfiles(alloc, shell_profiles);
+        return err;
+    };
+    profiles.appendSliceAssumeCapacity(shell_profiles);
+    alloc.free(shell_profiles);
+    errdefer deinitProfileList(alloc, &profiles);
+
+    for (hosts) |host| {
+        const key = try std.fmt.allocPrint(alloc, "ssh:{s}", .{host.alias});
+        defer alloc.free(key);
+        const label = try std.fmt.allocPrint(alloc, "SSH: {s}", .{host.alias});
+        defer alloc.free(label);
+        const palette_title = try std.fmt.allocPrint(alloc, "Connect to {s}", .{host.alias});
+        defer alloc.free(palette_title);
+        try appendProfile(
+            alloc,
+            &profiles,
+            .ssh,
+            key,
+            label,
+            &.{ ssh_path, host.alias },
+        );
+        profiles.items[profiles.items.len - 1].palette_title = try alloc.dupe(u8, palette_title);
+    }
+
+    return try profiles.toOwnedSlice(alloc);
+}
+
+fn resolveSshExecutable(alloc: Allocator, lookup: anytype, access: anytype) !?[]u8 {
+    const path_result = lookup(alloc, "ssh.exe") catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => null,
+    };
+    if (path_result) |path| return path;
+
+    const fallback = "C:\\Windows\\System32\\OpenSSH\\ssh.exe";
+    access(fallback) catch return null;
+    return try alloc.dupe(u8, fallback);
+}
+
+fn accessAbsolute(path: []const u8) !void {
+    try std.fs.accessAbsolute(path, .{});
+}
+
+fn warnSshDiscoveryOnce(err: anyerror) void {
+    ssh_missing_mutex.lock();
+    defer ssh_missing_mutex.unlock();
+    if (ssh_missing_logged) return;
+    ssh_missing_logged = true;
+    log.warn("SSH hosts skipped: discovery failed err={}", .{err});
+}
+
+fn warnMissingSshOnce() void {
+    ssh_missing_mutex.lock();
+    defer ssh_missing_mutex.unlock();
+    if (ssh_missing_logged) return;
+    ssh_missing_logged = true;
+    log.warn("SSH hosts skipped: ssh.exe was not found on PATH or in Windows OpenSSH", .{});
+}
+
+fn deinitProfileList(alloc: Allocator, profiles: *std.ArrayList(Profile)) void {
+    for (profiles.items) |*profile| profile.deinit(alloc);
+    profiles.deinit(alloc);
+}
+
 fn detectProfileOrderHint(alloc: Allocator) ?[]u8 {
     const raw = std.process.getEnvVarOwned(alloc, "NOCTTY_WIN32_PROFILE_ORDER") catch
         return null;
@@ -598,6 +703,7 @@ fn profileOrderTokenMatches(token: []const u8, profile: Profile) bool {
         .cmd => std.ascii.eqlIgnoreCase(token, "cmd") or
             std.ascii.eqlIgnoreCase(token, "cmd.exe") or
             std.ascii.eqlIgnoreCase(token, "command-prompt"),
+        .ssh => false,
     };
 }
 
@@ -1144,6 +1250,95 @@ test "listProfilesWithLookupAndProbeAndWslList enumerates windows profiles" {
     try testing.expectEqual(ProfileKind.cmd, profiles[6].kind);
 }
 
+test "ssh profiles append after shells with alias-only argv" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const shell_profiles = try alloc.alloc(Profile, 1);
+    shell_profiles[0] = .{
+        .kind = .cmd,
+        .key = try alloc.dupe(u8, "cmd.exe"),
+        .label = try alloc.dupe(u8, "Command Prompt"),
+        .command = try directCommand(alloc, &.{"cmd.exe"}),
+    };
+    const hosts = [_]windows_ssh_hosts.Host{.{ .alias = "production" }};
+    const profiles = try appendSshProfiles(
+        alloc,
+        shell_profiles,
+        &hosts,
+        "C:\\Windows\\System32\\OpenSSH\\ssh.exe",
+    );
+    defer deinitProfiles(alloc, profiles);
+
+    try testing.expectEqual(@as(usize, 2), profiles.len);
+    try testing.expectEqual(ProfileKind.cmd, profiles[0].kind);
+    try testing.expectEqual(ProfileKind.ssh, profiles[1].kind);
+    try testing.expectEqualStrings("ssh:production", profiles[1].key);
+    try testing.expectEqualStrings("SSH: production", profiles[1].label);
+    try testing.expectEqualStrings("Connect to production", profiles[1].palette_title.?);
+    try testing.expectEqual(@as(usize, 2), profiles[1].command.direct.len);
+    try testing.expectEqualStrings(
+        "C:\\Windows\\System32\\OpenSSH\\ssh.exe",
+        profiles[1].command.direct[0],
+    );
+    try testing.expectEqualStrings("production", profiles[1].command.direct[1]);
+}
+
+test "ssh executable resolution prefers PATH then System32 fallback" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const from_path = (try resolveSshExecutable(alloc, struct {
+        fn lookup(a: Allocator, exe: []const u8) !?[]u8 {
+            try testing.expectEqualStrings("ssh.exe", exe);
+            return try a.dupe(u8, "C:\\Tools\\OpenSSH\\ssh.exe");
+        }
+    }.lookup, struct {
+        fn access(_: []const u8) !void {
+            return error.Unexpected;
+        }
+    }.access)).?;
+    defer alloc.free(from_path);
+    try testing.expectEqualStrings("C:\\Tools\\OpenSSH\\ssh.exe", from_path);
+
+    const fallback = (try resolveSshExecutable(alloc, struct {
+        fn lookup(_: Allocator, _: []const u8) !?[]u8 {
+            return null;
+        }
+    }.lookup, struct {
+        fn access(path: []const u8) !void {
+            try testing.expectEqualStrings(
+                "C:\\Windows\\System32\\OpenSSH\\ssh.exe",
+                path,
+            );
+        }
+    }.access)).?;
+    defer alloc.free(fallback);
+    try testing.expectEqualStrings("C:\\Windows\\System32\\OpenSSH\\ssh.exe", fallback);
+
+    // A PATH lookup error is not fatal: it falls through to the same fallback.
+    const after_lookup_error = (try resolveSshExecutable(alloc, struct {
+        fn lookup(_: Allocator, _: []const u8) anyerror!?[]u8 {
+            return error.AccessDenied;
+        }
+    }.lookup, struct {
+        fn access(_: []const u8) !void {}
+    }.access)).?;
+    defer alloc.free(after_lookup_error);
+    try testing.expectEqualStrings("C:\\Windows\\System32\\OpenSSH\\ssh.exe", after_lookup_error);
+
+    // Neither present: no SSH entries are produced at all.
+    try testing.expectEqual(@as(?[]u8, null), try resolveSshExecutable(alloc, struct {
+        fn lookup(_: Allocator, _: []const u8) !?[]u8 {
+            return null;
+        }
+    }.lookup, struct {
+        fn access(_: []const u8) !void {
+            return error.FileNotFound;
+        }
+    }.access));
+}
+
 test "profileOrderTokenMatches supports Windows profile aliases" {
     const testing = std.testing;
 
@@ -1288,6 +1483,24 @@ test "safeCurrentDirectory keeps inherit semantics for non-wsl shells" {
     defer alloc.free(result);
 
     try testing.expectEqualStrings("C:\\Users\\amant", result);
+}
+
+test "safeCurrentDirectory keeps an inherited cwd ahead of a home request" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // SSH launches ask for home with an explicit path rather than this flag,
+    // so the pre-existing "inherited cwd wins" precedence stays intact.
+    const result = (try safeCurrentDirectoryWithCurrent(
+        alloc,
+        null,
+        true,
+        false,
+        try alloc.dupe(u8, "C:\\work"),
+    )).?;
+    defer alloc.free(result);
+
+    try testing.expectEqualStrings("C:\\work", result);
 }
 
 test "safeCurrentDirectory falls back to home for invalid cwd" {

--- a/src/config/windows_shell_types.zig
+++ b/src/config/windows_shell_types.zig
@@ -10,4 +10,5 @@ pub const ProfileKind = enum {
     powershell,
     git_bash,
     cmd,
+    ssh,
 };

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -292,7 +292,7 @@ fn sshCommentStart(line: []const u8) ?usize {
 
 fn containsAlias(hosts: []const Host, alias: []const u8) bool {
     for (hosts) |host| {
-        if (std.ascii.eqlIgnoreCase(host.alias, alias)) return true;
+        if (std.mem.eql(u8, host.alias, alias)) return true;
     }
     return false;
 }
@@ -560,7 +560,7 @@ test "ssh config rejects shell metacharacter and overlong aliases" {
     try testing.expectEqualStrings("safe", hosts[0].alias);
 }
 
-test "ssh config deduplicates repeated aliases case-insensitively" {
+test "ssh config preserves case-distinct aliases and deduplicates exact repeats" {
     const testing = std.testing;
     const alloc = testing.allocator;
     const hosts = try parse(
@@ -569,9 +569,10 @@ test "ssh config deduplicates repeated aliases case-insensitively" {
     );
     defer deinitHosts(alloc, hosts);
 
-    try testing.expectEqual(@as(usize, 2), hosts.len);
+    try testing.expectEqual(@as(usize, 3), hosts.len);
     try testing.expectEqualStrings("prod", hosts[0].alias);
-    try testing.expectEqualStrings("staging", hosts[1].alias);
+    try testing.expectEqualStrings("PROD", hosts[1].alias);
+    try testing.expectEqualStrings("staging", hosts[2].alias);
 }
 
 test "ssh config caps total concrete aliases" {

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -8,9 +8,11 @@ pub const max_hosts: usize = 256;
 pub const max_file_size: usize = 1024 * 1024;
 pub const max_alias_len: usize = 255;
 pub const max_include_files: usize = 16;
+const include_read_budget_ns: u64 = 50 * std.time.ns_per_ms;
 
 var read_warning_mutex: std.Thread.Mutex = .{};
 var read_warning_logged = false;
+var include_read_in_progress: std.atomic.Value(bool) = .init(false);
 
 pub const Host = struct {
     alias: []const u8,
@@ -71,6 +73,7 @@ fn loadFromHome(alloc: Allocator, home_dir: []const u8) ![]Host {
         .home_dir = home_dir,
         .ssh_dir = ssh_dir,
         .hosts = &hosts,
+        .include_read_started_ns = std.time.nanoTimestamp(),
     };
     try load_context.parseFile(config_path, 0);
     return try hosts.toOwnedSlice(alloc);
@@ -82,6 +85,7 @@ const LoadContext = struct {
     ssh_dir: []const u8,
     hosts: *std.ArrayList(Host),
     includes_read: usize = 0,
+    include_read_started_ns: i128,
 
     fn parseFile(self: *LoadContext, path: []const u8, depth: u8) Allocator.Error!void {
         const contents = readFile(self.alloc, path) catch |err| switch (err) {
@@ -125,7 +129,26 @@ const LoadContext = struct {
                 try std.fs.path.join(self.alloc, &.{ self.ssh_dir, raw_path });
             defer self.alloc.free(path);
 
-            try self.parseFile(path, depth + 1);
+            const elapsed_ns = @max(std.time.nanoTimestamp() - self.include_read_started_ns, 0);
+            if (elapsed_ns >= include_read_budget_ns) return;
+            const remaining_ns: u64 = @intCast(include_read_budget_ns - elapsed_ns);
+            const contents = (readIncludeFileBounded(
+                self.alloc,
+                path,
+                remaining_ns,
+                readFile,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    warnReadOnce(path, err);
+                    continue;
+                },
+            }) orelse {
+                warnReadOnce(path, error.IncludeReadTimedOut);
+                return;
+            };
+            defer self.alloc.free(contents);
+            try parseInto(self.alloc, self.hosts, contents, self, depth + 1);
             if (self.hosts.items.len >= max_hosts) return;
         }
     }
@@ -350,6 +373,103 @@ fn readFile(alloc: Allocator, path: []const u8) ![]u8 {
     const stat = try file.stat();
     if (stat.size > max_file_size) return error.FileTooBig;
     return try file.readToEndAlloc(alloc, max_file_size);
+}
+
+const ReadFileFn = *const fn (Allocator, []const u8) anyerror![]u8;
+
+const AsyncIncludeRead = struct {
+    refs: std.atomic.Value(u32) = .init(2),
+    mutex: std.Thread.Mutex = .{},
+    done_cond: std.Thread.Condition = .{},
+    done: bool = false,
+    path: []u8,
+    read_fn: ReadFileFn,
+    data: ?[]u8 = null,
+    err: ?anyerror = null,
+
+    fn release(self: *@This()) void {
+        if (self.refs.fetchSub(1, .acq_rel) != 1) return;
+        const alloc = std.heap.page_allocator;
+        alloc.free(self.path);
+        if (self.data) |data| alloc.free(data);
+        alloc.destroy(self);
+    }
+
+    fn run(self: *@This()) void {
+        const alloc = std.heap.page_allocator;
+        const result = self.read_fn(alloc, self.path);
+
+        self.mutex.lock();
+        if (result) |data| {
+            self.data = data;
+        } else |err| {
+            self.err = err;
+        }
+        include_read_in_progress.store(false, .release);
+        self.done = true;
+        self.done_cond.broadcast();
+        self.mutex.unlock();
+
+        self.release();
+    }
+};
+
+/// Runs an Include open away from the caller and waits only for the remaining
+/// per-refresh budget. A timed-out worker owns all of its memory until it
+/// finishes. Only one may exist at a time, so a dead network mapping cannot
+/// create an unbounded thread or allocation leak across picker refreshes.
+fn readIncludeFileBounded(
+    alloc: Allocator,
+    path: []const u8,
+    timeout_ns: u64,
+    read_fn: ReadFileFn,
+) !?[]u8 {
+    if (timeout_ns == 0) return null;
+    if (include_read_in_progress.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) {
+        return null;
+    }
+
+    const worker_alloc = std.heap.page_allocator;
+    const owned_path = worker_alloc.dupe(u8, path) catch |err| {
+        include_read_in_progress.store(false, .release);
+        return err;
+    };
+    const request = worker_alloc.create(AsyncIncludeRead) catch |err| {
+        worker_alloc.free(owned_path);
+        include_read_in_progress.store(false, .release);
+        return err;
+    };
+    request.* = .{ .path = owned_path, .read_fn = read_fn };
+
+    const thread = std.Thread.spawn(.{}, AsyncIncludeRead.run, .{request}) catch |err| {
+        request.refs.store(1, .monotonic);
+        include_read_in_progress.store(false, .release);
+        request.release();
+        return err;
+    };
+    thread.detach();
+    defer request.release();
+
+    request.mutex.lock();
+    if (!request.done) {
+        request.done_cond.timedWait(&request.mutex, timeout_ns) catch {
+            request.mutex.unlock();
+            return null;
+        };
+    }
+    if (!request.done) {
+        request.mutex.unlock();
+        return null;
+    }
+    const data = request.data;
+    request.data = null;
+    const read_err = request.err;
+    request.mutex.unlock();
+
+    if (read_err) |err| return err;
+    const worker_data = data orelse return error.UnexpectedEmptyRead;
+    defer worker_alloc.free(worker_data);
+    return try alloc.dupe(u8, worker_data);
 }
 
 fn warnReadOnce(path: []const u8, err: anyerror) void {
@@ -695,6 +815,47 @@ test "ssh config caps the number of include files read" {
     const hosts = try loadFromHome(alloc, home);
     defer deinitHosts(alloc, hosts);
     try testing.expectEqual(max_include_files, hosts.len);
+}
+
+test "ssh config bounds include opens away from the caller" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "include.conf", .data = "Host bounded\n" });
+    const path = try tmp.dir.realpathAlloc(alloc, "include.conf");
+    defer alloc.free(path);
+
+    const contents = (try readIncludeFileBounded(
+        alloc,
+        path,
+        std.time.ns_per_s,
+        readFile,
+    )).?;
+    defer alloc.free(contents);
+    try testing.expectEqualStrings("Host bounded\n", contents);
+
+    const slowRead = struct {
+        fn run(worker_alloc: Allocator, ignored_path: []const u8) ![]u8 {
+            _ = ignored_path;
+            std.Thread.sleep(25 * std.time.ns_per_ms);
+            return try worker_alloc.dupe(u8, "late");
+        }
+    }.run;
+    try testing.expect((try readIncludeFileBounded(
+        alloc,
+        path,
+        std.time.ns_per_ms,
+        slowRead,
+    )) == null);
+
+    const wait_started = std.time.nanoTimestamp();
+    while (include_read_in_progress.load(.acquire)) {
+        if (std.time.nanoTimestamp() - wait_started > std.time.ns_per_s) {
+            return error.TestUnexpectedResult;
+        }
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
 }
 
 test "ssh config missing unreadable and oversized roots produce empty lists" {

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -220,25 +220,26 @@ fn parseInto(
         raw_contents[3..]
     else
         raw_contents;
-    var in_match = false;
+    var in_conditional_block = false;
     var lines = std.mem.splitScalar(u8, contents, '\n');
     while (lines.next()) |raw_line| {
         const directive = parseDirective(raw_line) orelse continue;
         if (std.ascii.eqlIgnoreCase(directive.keyword, "match")) {
-            in_match = true;
+            in_conditional_block = true;
             continue;
         }
         if (std.ascii.eqlIgnoreCase(directive.keyword, "include")) {
-            // A Match block's includes are conditional on runtime state we do
-            // not evaluate, so they are skipped rather than guessed at.
-            if (!in_match) {
+            // Includes inside Host or Match blocks are conditional on runtime
+            // state we do not evaluate, so they are skipped rather than
+            // exposing aliases that `ssh <alias>` may not actually resolve.
+            if (!in_conditional_block) {
                 if (load_context) |context| try context.parseIncludes(directive.value, depth);
             }
             continue;
         }
         if (!std.ascii.eqlIgnoreCase(directive.keyword, "host")) continue;
 
-        in_match = false;
+        in_conditional_block = true;
         var aliases: SshArgIterator = .{ .value = directive.value, .backslash_escape = true };
         while (try aliases.next(alloc)) |alias| {
             defer alloc.free(alias);
@@ -630,6 +631,7 @@ test "ssh config loads one include level and resolves supported paths" {
     try tmp.dir.writeFile(.{ .sub_path = ".ssh/absolute.conf", .data = "Host absolute\n" });
     try tmp.dir.writeFile(.{ .sub_path = ".ssh/globbed.conf", .data = "Host globbed\n" });
     try tmp.dir.writeFile(.{ .sub_path = ".ssh/matched.conf", .data = "Host matched\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/host-scoped.conf", .data = "Host leaked\n" });
 
     const home = try tmp.dir.realpathAlloc(alloc, ".");
     defer alloc.free(home);
@@ -637,7 +639,7 @@ test "ssh config loads one include level and resolves supported paths" {
     defer alloc.free(absolute);
     const root = try std.fmt.allocPrint(
         alloc,
-        "Include relative.conf\nInclude ~/.ssh/tilde.conf\nInclude {s}\nInclude *.conf\nMatch all\nInclude matched.conf\nHost root\n",
+        "Include relative.conf\nInclude ~/.ssh/tilde.conf\nInclude {s}\nInclude *.conf\nHost scoped\nInclude host-scoped.conf\nMatch all\nInclude matched.conf\nHost root\n",
         .{absolute},
     );
     defer alloc.free(root);
@@ -645,11 +647,12 @@ test "ssh config loads one include level and resolves supported paths" {
 
     const hosts = try loadFromHome(alloc, home);
     defer deinitHosts(alloc, hosts);
-    try testing.expectEqual(@as(usize, 4), hosts.len);
+    try testing.expectEqual(@as(usize, 5), hosts.len);
     try testing.expectEqualStrings("relative", hosts[0].alias);
     try testing.expectEqualStrings("tilde", hosts[1].alias);
     try testing.expectEqualStrings("absolute", hosts[2].alias);
-    try testing.expectEqualStrings("root", hosts[3].alias);
+    try testing.expectEqualStrings("scoped", hosts[3].alias);
+    try testing.expectEqualStrings("root", hosts[4].alias);
 }
 
 test "ssh config argument tokenizer follows OpenSSH quote boundaries" {

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -8,11 +8,11 @@ pub const max_hosts: usize = 256;
 pub const max_file_size: usize = 1024 * 1024;
 pub const max_alias_len: usize = 255;
 pub const max_include_files: usize = 16;
-const include_read_budget_ns: u64 = 50 * std.time.ns_per_ms;
+const ssh_config_read_budget_ns: u64 = 50 * std.time.ns_per_ms;
 
 var read_warning_mutex: std.Thread.Mutex = .{};
 var read_warning_logged = false;
-var include_read_in_progress: std.atomic.Value(bool) = .init(false);
+var ssh_config_read_in_progress: std.atomic.Value(bool) = .init(false);
 
 pub const Host = struct {
     alias: []const u8,
@@ -73,7 +73,7 @@ fn loadFromHome(alloc: Allocator, home_dir: []const u8) ![]Host {
         .home_dir = home_dir,
         .ssh_dir = ssh_dir,
         .hosts = &hosts,
-        .include_read_started_ns = std.time.nanoTimestamp(),
+        .ssh_config_read_started_ns = std.time.nanoTimestamp(),
     };
     try load_context.parseFile(config_path, 0);
     return try hosts.toOwnedSlice(alloc);
@@ -85,19 +85,34 @@ const LoadContext = struct {
     ssh_dir: []const u8,
     hosts: *std.ArrayList(Host),
     includes_read: usize = 0,
-    include_read_started_ns: i128,
+    ssh_config_read_started_ns: i128,
 
     fn parseFile(self: *LoadContext, path: []const u8, depth: u8) Allocator.Error!void {
-        const contents = readFile(self.alloc, path) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.FileNotFound => return,
-            else => {
-                warnReadOnce(path, err);
-                return;
-            },
-        };
+        const contents = (try self.readFileWithinBudget(path)) orelse return;
         defer self.alloc.free(contents);
         try parseInto(self.alloc, self.hosts, contents, self, depth);
+    }
+
+    fn readFileWithinBudget(self: *LoadContext, path: []const u8) Allocator.Error!?[]u8 {
+        const elapsed_ns = @max(std.time.nanoTimestamp() - self.ssh_config_read_started_ns, 0);
+        if (elapsed_ns >= ssh_config_read_budget_ns) return null;
+        const remaining_ns: u64 = @intCast(ssh_config_read_budget_ns - elapsed_ns);
+        return readSshConfigFileBounded(
+            self.alloc,
+            path,
+            remaining_ns,
+            readFile,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.FileNotFound => return null,
+            else => {
+                warnReadOnce(path, err);
+                return null;
+            },
+        } orelse {
+            warnReadOnce(path, error.SshConfigReadTimedOut);
+            return null;
+        };
     }
 
     fn parseIncludes(self: *LoadContext, value: []const u8, depth: u8) Allocator.Error!void {
@@ -129,24 +144,7 @@ const LoadContext = struct {
                 try std.fs.path.join(self.alloc, &.{ self.ssh_dir, raw_path });
             defer self.alloc.free(path);
 
-            const elapsed_ns = @max(std.time.nanoTimestamp() - self.include_read_started_ns, 0);
-            if (elapsed_ns >= include_read_budget_ns) return;
-            const remaining_ns: u64 = @intCast(include_read_budget_ns - elapsed_ns);
-            const contents = (readIncludeFileBounded(
-                self.alloc,
-                path,
-                remaining_ns,
-                readFile,
-            ) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
-                else => {
-                    warnReadOnce(path, err);
-                    continue;
-                },
-            }) orelse {
-                warnReadOnce(path, error.IncludeReadTimedOut);
-                return;
-            };
+            const contents = (try self.readFileWithinBudget(path)) orelse return;
             defer self.alloc.free(contents);
             try parseInto(self.alloc, self.hosts, contents, self, depth + 1);
             if (self.hosts.items.len >= max_hosts) return;
@@ -377,7 +375,7 @@ fn readFile(alloc: Allocator, path: []const u8) ![]u8 {
 
 const ReadFileFn = *const fn (Allocator, []const u8) anyerror![]u8;
 
-const AsyncIncludeRead = struct {
+const AsyncSshConfigRead = struct {
     refs: std.atomic.Value(u32) = .init(2),
     mutex: std.Thread.Mutex = .{},
     done_cond: std.Thread.Condition = .{},
@@ -405,7 +403,7 @@ const AsyncIncludeRead = struct {
         } else |err| {
             self.err = err;
         }
-        include_read_in_progress.store(false, .release);
+        ssh_config_read_in_progress.store(false, .release);
         self.done = true;
         self.done_cond.broadcast();
         self.mutex.unlock();
@@ -414,36 +412,36 @@ const AsyncIncludeRead = struct {
     }
 };
 
-/// Runs an Include open away from the caller and waits only for the remaining
-/// per-refresh budget. A timed-out worker owns all of its memory until it
-/// finishes. Only one may exist at a time, so a dead network mapping cannot
+/// Runs an SSH config open away from the caller and waits only for the
+/// remaining per-refresh budget. A timed-out worker owns all of its memory
+/// until it finishes. Only one may exist at a time, so a dead network mapping cannot
 /// create an unbounded thread or allocation leak across picker refreshes.
-fn readIncludeFileBounded(
+fn readSshConfigFileBounded(
     alloc: Allocator,
     path: []const u8,
     timeout_ns: u64,
     read_fn: ReadFileFn,
 ) !?[]u8 {
     if (timeout_ns == 0) return null;
-    if (include_read_in_progress.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) {
+    if (ssh_config_read_in_progress.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) {
         return null;
     }
 
     const worker_alloc = std.heap.page_allocator;
     const owned_path = worker_alloc.dupe(u8, path) catch |err| {
-        include_read_in_progress.store(false, .release);
+        ssh_config_read_in_progress.store(false, .release);
         return err;
     };
-    const request = worker_alloc.create(AsyncIncludeRead) catch |err| {
+    const request = worker_alloc.create(AsyncSshConfigRead) catch |err| {
         worker_alloc.free(owned_path);
-        include_read_in_progress.store(false, .release);
+        ssh_config_read_in_progress.store(false, .release);
         return err;
     };
     request.* = .{ .path = owned_path, .read_fn = read_fn };
 
-    const thread = std.Thread.spawn(.{}, AsyncIncludeRead.run, .{request}) catch |err| {
+    const thread = std.Thread.spawn(.{}, AsyncSshConfigRead.run, .{request}) catch |err| {
         request.refs.store(1, .monotonic);
-        include_read_in_progress.store(false, .release);
+        ssh_config_read_in_progress.store(false, .release);
         request.release();
         return err;
     };
@@ -818,7 +816,7 @@ test "ssh config caps the number of include files read" {
     try testing.expectEqual(max_include_files, hosts.len);
 }
 
-test "ssh config bounds include opens away from the caller" {
+test "ssh config bounds file opens away from the caller" {
     const testing = std.testing;
     const alloc = testing.allocator;
     var tmp = testing.tmpDir(.{});
@@ -827,7 +825,7 @@ test "ssh config bounds include opens away from the caller" {
     const path = try tmp.dir.realpathAlloc(alloc, "include.conf");
     defer alloc.free(path);
 
-    const contents = (try readIncludeFileBounded(
+    const contents = (try readSshConfigFileBounded(
         alloc,
         path,
         std.time.ns_per_s,
@@ -843,7 +841,7 @@ test "ssh config bounds include opens away from the caller" {
             return try worker_alloc.dupe(u8, "late");
         }
     }.run;
-    try testing.expect((try readIncludeFileBounded(
+    try testing.expect((try readSshConfigFileBounded(
         alloc,
         path,
         std.time.ns_per_ms,
@@ -851,7 +849,7 @@ test "ssh config bounds include opens away from the caller" {
     )) == null);
 
     const wait_started = std.time.nanoTimestamp();
-    while (include_read_in_progress.load(.acquire)) {
+    while (ssh_config_read_in_progress.load(.acquire)) {
         if (std.time.nanoTimestamp() - wait_started > std.time.ns_per_s) {
             return error.TestUnexpectedResult;
         }

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const win = @import("../os/windows.zig");
 const log = std.log.scoped(.windows_ssh_hosts);
@@ -98,14 +99,16 @@ const LoadContext = struct {
     fn parseIncludes(self: *LoadContext, value: []const u8, depth: u8) Allocator.Error!void {
         if (depth >= 1) return;
 
-        var paths = std.mem.tokenizeAny(u8, value, " \t");
+        var paths: IncludeArgIterator = .{ .value = value };
         while (paths.next()) |raw_path| {
+            if (raw_path.len == 0) continue;
             if (hasGlobMetacharacter(raw_path)) continue;
             // This read is synchronous on the UI thread and runs on every
-            // profile refresh — app startup and every picker open. A remote or
-            // device path could block on an SMB/TCP timeout, and an uncapped
-            // include count would multiply that.
-            if (isRemoteOrDevicePath(raw_path)) {
+            // profile refresh — app startup, every picker open, and the first
+            // pane of every restored session window. A remote or device path
+            // could block on an SMB/TCP timeout, and an uncapped include count
+            // would multiply that.
+            if (isUnsupportedIncludePath(raw_path)) {
                 warnReadOnce(raw_path, error.UnsupportedIncludePath);
                 continue;
             }
@@ -130,6 +133,48 @@ const LoadContext = struct {
 const Directive = struct {
     keyword: []const u8,
     value: []const u8,
+};
+
+/// `Include` arguments are whitespace separated, except that a leading `"`
+/// groups one path containing spaces (OpenSSH `strdelim`). A plain whitespace
+/// split would shred `Include "C:\Users\Jane Doe\.ssh\work hosts"` into
+/// nonexistent paths and silently drop every host in that file.
+///
+/// Deliberately NOT `AliasIterator`, which exists to find the boundaries of
+/// `Host` patterns: it leaves the quote bytes in the token (harmless there,
+/// since `isConnectableAlias` rejects quotes outright) and treats `\` as an
+/// escape, which would corrupt every Windows path separator here. `'` is not
+/// a grouping quote for the same reason -- OpenSSH does not treat it as one,
+/// and stripping it would break a literal path such as `C:\Bob's\config`.
+const IncludeArgIterator = struct {
+    value: []const u8,
+    index: usize = 0,
+
+    fn next(self: *IncludeArgIterator) ?[]const u8 {
+        while (self.index < self.value.len and
+            (self.value[self.index] == ' ' or self.value[self.index] == '\t')) : (self.index += 1)
+        {}
+        if (self.index >= self.value.len) return null;
+
+        if (self.value[self.index] == '"') {
+            const start = self.index + 1;
+            const end = std.mem.indexOfScalarPos(u8, self.value, start, '"') orelse {
+                // Unterminated quote. OpenSSH rejects the whole line, so
+                // consume the remainder rather than guess at a path.
+                self.index = self.value.len;
+                return null;
+            };
+            self.index = end + 1;
+            return self.value[start..end];
+        }
+
+        const start = self.index;
+        while (self.index < self.value.len and
+            self.value[self.index] != ' ' and
+            self.value[self.index] != '\t') : (self.index += 1)
+        {}
+        return self.value[start..self.index];
+    }
 };
 
 const AliasIterator = struct {
@@ -266,6 +311,15 @@ fn isConnectableAlias(alias: []const u8) bool {
     return true;
 }
 
+const DRIVE_REMOTE: u32 = 4;
+
+extern "kernel32" fn GetDriveTypeW(root_path: ?[*:0]const u16) callconv(.winapi) u32;
+
+/// Every include path we refuse to open from the UI thread.
+fn isUnsupportedIncludePath(path: []const u8) bool {
+    return isRemoteOrDevicePath(path) or isRemoteDriveLetter(path);
+}
+
 /// UNC (`\\server\share`) and device (`\\?\`, `\\.\`) namespaces, in either
 /// slash spelling.
 fn isRemoteOrDevicePath(path: []const u8) bool {
@@ -273,6 +327,36 @@ fn isRemoteOrDevicePath(path: []const u8) bool {
     const a = path[0];
     const b = path[1];
     return (a == '\\' or a == '/') and (b == '\\' or b == '/');
+}
+
+/// The `X` of an `X:\` or `X:/` absolute path, uppercased. Null for anything
+/// else, including a bare `X:` relative-to-current-directory spelling, which
+/// `std.fs.path.isAbsolute` also rejects.
+fn driveLetter(path: []const u8) ?u8 {
+    if (path.len < 3) return null;
+    if (!std.ascii.isAlphabetic(path[0])) return null;
+    if (path[1] != ':') return null;
+    if (path[2] != '\\' and path[2] != '/') return null;
+    return std.ascii.toUpper(path[0]);
+}
+
+/// A mapped network drive (`Z:\ssh\hosts.conf`) is syntactically a plain local
+/// absolute path, so `isRemoteOrDevicePath` cannot see it. Opening one whose
+/// SMB server is gone blocks the UI thread for a full network timeout.
+///
+/// `GetDriveTypeW` answers from the process's local mount table and does not
+/// contact the server, so it cannot itself block on a dead mapping.
+///
+/// This does NOT cover a directory junction or a `subst` alias whose target is
+/// remote: those report the drive type of the letter, not of the target.
+fn isRemoteDriveLetter(path: []const u8) bool {
+    if (comptime builtin.os.tag != .windows) {
+        return false;
+    } else {
+        const letter = driveLetter(path) orelse return false;
+        const root = [_]u16{ letter, ':', '\\', 0 };
+        return GetDriveTypeW(root[0..3 :0]) == DRIVE_REMOTE;
+    }
 }
 
 fn hasGlobMetacharacter(path: []const u8) bool {
@@ -452,6 +536,72 @@ test "ssh config loads one include level and resolves supported paths" {
     try testing.expectEqualStrings("tilde", hosts[1].alias);
     try testing.expectEqualStrings("absolute", hosts[2].alias);
     try testing.expectEqualStrings("root", hosts[3].alias);
+}
+
+test "ssh config include tokenizer keeps quoted paths whole" {
+    const testing = std.testing;
+
+    var quoted: IncludeArgIterator = .{ .value = "\"C:\\Users\\Jane Doe\\.ssh\\work hosts\" plain.conf" };
+    try testing.expectEqualStrings("C:\\Users\\Jane Doe\\.ssh\\work hosts", quoted.next().?);
+    try testing.expectEqualStrings("plain.conf", quoted.next().?);
+    try testing.expect(quoted.next() == null);
+
+    // Backslashes stay verbatim: they are path separators, not escapes.
+    var backslashes: IncludeArgIterator = .{ .value = "C:\\Bob's\\config  ~/.ssh/x.conf" };
+    try testing.expectEqualStrings("C:\\Bob's\\config", backslashes.next().?);
+    try testing.expectEqualStrings("~/.ssh/x.conf", backslashes.next().?);
+    try testing.expect(backslashes.next() == null);
+
+    var unterminated: IncludeArgIterator = .{ .value = "\"C:\\never closed" };
+    try testing.expect(unterminated.next() == null);
+
+    var empty: IncludeArgIterator = .{ .value = "   \t " };
+    try testing.expect(empty.next() == null);
+}
+
+test "ssh config loads a quoted include whose filename contains spaces" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/work hosts.conf", .data = "Host spaced\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/plain.conf", .data = "Host plain\n" });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".ssh/config",
+        .data = "Include \"work hosts.conf\" plain.conf\nHost root\n",
+    });
+
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 3), hosts.len);
+    try testing.expectEqualStrings("spaced", hosts[0].alias);
+    try testing.expectEqualStrings("plain", hosts[1].alias);
+    try testing.expectEqualStrings("root", hosts[2].alias);
+}
+
+test "ssh config recognizes drive-letter roots for the remote-drive check" {
+    const testing = std.testing;
+
+    try testing.expectEqual(@as(?u8, 'Z'), driveLetter("Z:\\ssh\\hosts.conf"));
+    try testing.expectEqual(@as(?u8, 'Z'), driveLetter("z:/ssh/hosts.conf"));
+    try testing.expectEqual(@as(?u8, 'C'), driveLetter("C:\\"));
+    // Not drive-letter roots: relative, UNC, and the `X:name` spelling that
+    // resolves against the drive's current directory.
+    try testing.expectEqual(@as(?u8, null), driveLetter("hosts.conf"));
+    try testing.expectEqual(@as(?u8, null), driveLetter("Z:hosts.conf"));
+    try testing.expectEqual(@as(?u8, null), driveLetter("\\\\server\\share\\x"));
+    try testing.expectEqual(@as(?u8, null), driveLetter("~/.ssh/x.conf"));
+
+    // The local system drive must never be misread as remote, or every
+    // ordinary absolute include would be dropped.
+    try testing.expect(!isRemoteDriveLetter("C:\\Users\\me\\.ssh\\hosts.conf"));
+    try testing.expect(!isRemoteDriveLetter("hosts.conf"));
+    try testing.expect(!isUnsupportedIncludePath("C:\\Users\\me\\.ssh\\hosts.conf"));
+    try testing.expect(isUnsupportedIncludePath("\\\\10.0.0.1\\share\\hosts.conf"));
 }
 
 test "ssh config skips remote and device include paths without opening them" {

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -80,6 +80,13 @@ fn loadFromHome(alloc: Allocator, home_dir: []const u8) ![]Host {
 }
 
 const LoadContext = struct {
+    const ReadResult = union(enum) {
+        contents: []u8,
+        missing,
+        skipped,
+        budget_exhausted,
+    };
+
     alloc: Allocator,
     home_dir: []const u8,
     ssh_dir: []const u8,
@@ -88,31 +95,35 @@ const LoadContext = struct {
     ssh_config_read_started_ns: i128,
 
     fn parseFile(self: *LoadContext, path: []const u8, depth: u8) Allocator.Error!void {
-        const contents = (try self.readFileWithinBudget(path)) orelse return;
+        const contents = switch (try self.readFileWithinBudget(path)) {
+            .contents => |value| value,
+            .missing, .skipped, .budget_exhausted => return,
+        };
         defer self.alloc.free(contents);
         try parseInto(self.alloc, self.hosts, contents, self, depth);
     }
 
-    fn readFileWithinBudget(self: *LoadContext, path: []const u8) Allocator.Error!?[]u8 {
+    fn readFileWithinBudget(self: *LoadContext, path: []const u8) Allocator.Error!ReadResult {
         const elapsed_ns = @max(std.time.nanoTimestamp() - self.ssh_config_read_started_ns, 0);
-        if (elapsed_ns >= ssh_config_read_budget_ns) return null;
+        if (elapsed_ns >= ssh_config_read_budget_ns) return .budget_exhausted;
         const remaining_ns: u64 = @intCast(ssh_config_read_budget_ns - elapsed_ns);
-        return readSshConfigFileBounded(
+        const contents = readSshConfigFileBounded(
             self.alloc,
             path,
             remaining_ns,
             readFile,
         ) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
-            error.FileNotFound => return null,
+            error.FileNotFound => return .missing,
             else => {
                 warnReadOnce(path, err);
-                return null;
+                return .skipped;
             },
         } orelse {
             warnReadOnce(path, error.SshConfigReadTimedOut);
-            return null;
+            return .budget_exhausted;
         };
+        return .{ .contents = contents };
     }
 
     fn parseIncludes(self: *LoadContext, value: []const u8, depth: u8) Allocator.Error!void {
@@ -123,11 +134,9 @@ const LoadContext = struct {
             defer self.alloc.free(raw_path);
             if (raw_path.len == 0) continue;
             if (hasGlobMetacharacter(raw_path)) continue;
-            // This read is synchronous on the UI thread and runs on every
-            // profile refresh — app startup, every picker open, and the first
-            // pane of every restored session window. A remote or device path
-            // could block on an SMB/TCP timeout, and an uncapped include count
-            // would multiply that.
+            // Reject known remote/device paths before the bounded worker opens
+            // them. An uncapped include count would still multiply worker and
+            // filesystem overhead on every profile refresh.
             if (isUnsupportedIncludePath(raw_path)) {
                 warnReadOnce(raw_path, error.UnsupportedIncludePath);
                 continue;
@@ -144,7 +153,11 @@ const LoadContext = struct {
                 try std.fs.path.join(self.alloc, &.{ self.ssh_dir, raw_path });
             defer self.alloc.free(path);
 
-            const contents = (try self.readFileWithinBudget(path)) orelse return;
+            const contents = switch (try self.readFileWithinBudget(path)) {
+                .contents => |contents| contents,
+                .missing, .skipped => continue,
+                .budget_exhausted => return,
+            };
             defer self.alloc.free(contents);
             try parseInto(self.alloc, self.hosts, contents, self, depth + 1);
             if (self.hosts.items.len >= max_hosts) return;
@@ -712,6 +725,28 @@ test "ssh config loads a quoted include whose filename contains spaces" {
     try testing.expectEqualStrings("spaced", hosts[0].alias);
     try testing.expectEqualStrings("plain", hosts[1].alias);
     try testing.expectEqualStrings("root", hosts[2].alias);
+}
+
+test "ssh config continues after a missing include argument" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/valid.conf", .data = "Host valid\n" });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".ssh/config",
+        .data = "Include missing.conf valid.conf\nHost root\n",
+    });
+
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 2), hosts.len);
+    try testing.expectEqualStrings("valid", hosts[0].alias);
+    try testing.expectEqualStrings("root", hosts[1].alias);
 }
 
 test "ssh config loads a quoted include whose filename contains a hash" {

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -1,0 +1,549 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const win = @import("../os/windows.zig");
+const log = std.log.scoped(.windows_ssh_hosts);
+
+pub const max_hosts: usize = 256;
+pub const max_file_size: usize = 1024 * 1024;
+pub const max_alias_len: usize = 255;
+pub const max_include_files: usize = 16;
+
+var read_warning_mutex: std.Thread.Mutex = .{};
+var read_warning_logged = false;
+
+pub const Host = struct {
+    alias: []const u8,
+
+    pub fn deinit(self: *Host, alloc: Allocator) void {
+        alloc.free(self.alias);
+    }
+};
+
+pub fn deinitHosts(alloc: Allocator, hosts: []Host) void {
+    for (hosts) |*host| host.deinit(alloc);
+    alloc.free(hosts);
+}
+
+pub fn parse(alloc: Allocator, contents: []const u8) ![]Host {
+    var hosts: std.ArrayList(Host) = .empty;
+    errdefer deinitHostList(alloc, &hosts);
+    try parseInto(alloc, &hosts, contents, null, 0);
+    return try hosts.toOwnedSlice(alloc);
+}
+
+/// Resolves the directory `ssh` itself expands `~` to on Windows: `%USERPROFILE%`,
+/// falling back to the profile known folder.
+///
+/// Deliberately NOT `homedir.home`, which prefers `HOMEDRIVE`+`HOMEPATH`. On a
+/// domain-joined machine with a redirected home those point at a network share,
+/// so we would parse a different config than Win32-OpenSSH reads and list
+/// aliases `ssh` cannot resolve.
+pub fn userProfileDir(buf: []u8) !?[]const u8 {
+    var fba_instance = std.heap.FixedBufferAllocator.init(buf);
+    const fba = fba_instance.allocator();
+    if (std.process.getEnvVarOwned(fba, "USERPROFILE")) |value| {
+        if (value.len > 0) return value;
+    } else |err| switch (err) {
+        error.OutOfMemory => return error.BufferTooSmall,
+        error.InvalidWtf8, error.EnvironmentVariableNotFound => {},
+    }
+    return try win.knownFolderPathUtf8(&win.FOLDERID_Profile, buf);
+}
+
+pub fn load(alloc: Allocator) ![]Host {
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home_dir = (userProfileDir(&home_buf) catch null) orelse
+        return try alloc.alloc(Host, 0);
+    return try loadFromHome(alloc, home_dir);
+}
+
+fn loadFromHome(alloc: Allocator, home_dir: []const u8) ![]Host {
+    const ssh_dir = try std.fs.path.join(alloc, &.{ home_dir, ".ssh" });
+    defer alloc.free(ssh_dir);
+    const config_path = try std.fs.path.join(alloc, &.{ ssh_dir, "config" });
+    defer alloc.free(config_path);
+
+    var hosts: std.ArrayList(Host) = .empty;
+    errdefer deinitHostList(alloc, &hosts);
+    var load_context: LoadContext = .{
+        .alloc = alloc,
+        .home_dir = home_dir,
+        .ssh_dir = ssh_dir,
+        .hosts = &hosts,
+    };
+    try load_context.parseFile(config_path, 0);
+    return try hosts.toOwnedSlice(alloc);
+}
+
+const LoadContext = struct {
+    alloc: Allocator,
+    home_dir: []const u8,
+    ssh_dir: []const u8,
+    hosts: *std.ArrayList(Host),
+    includes_read: usize = 0,
+
+    fn parseFile(self: *LoadContext, path: []const u8, depth: u8) Allocator.Error!void {
+        const contents = readFile(self.alloc, path) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.FileNotFound => return,
+            else => {
+                warnReadOnce(path, err);
+                return;
+            },
+        };
+        defer self.alloc.free(contents);
+        try parseInto(self.alloc, self.hosts, contents, self, depth);
+    }
+
+    fn parseIncludes(self: *LoadContext, value: []const u8, depth: u8) Allocator.Error!void {
+        if (depth >= 1) return;
+
+        var paths = std.mem.tokenizeAny(u8, value, " \t");
+        while (paths.next()) |raw_path| {
+            if (hasGlobMetacharacter(raw_path)) continue;
+            // This read is synchronous on the UI thread and runs on every
+            // profile refresh — app startup and every picker open. A remote or
+            // device path could block on an SMB/TCP timeout, and an uncapped
+            // include count would multiply that.
+            if (isRemoteOrDevicePath(raw_path)) {
+                warnReadOnce(raw_path, error.UnsupportedIncludePath);
+                continue;
+            }
+            if (self.includes_read >= max_include_files) return;
+            self.includes_read += 1;
+
+            const path = if (std.mem.startsWith(u8, raw_path, "~/") or
+                std.mem.startsWith(u8, raw_path, "~\\"))
+                try std.fs.path.join(self.alloc, &.{ self.home_dir, raw_path[2..] })
+            else if (std.fs.path.isAbsolute(raw_path))
+                try self.alloc.dupe(u8, raw_path)
+            else
+                try std.fs.path.join(self.alloc, &.{ self.ssh_dir, raw_path });
+            defer self.alloc.free(path);
+
+            try self.parseFile(path, depth + 1);
+            if (self.hosts.items.len >= max_hosts) return;
+        }
+    }
+};
+
+const Directive = struct {
+    keyword: []const u8,
+    value: []const u8,
+};
+
+const AliasIterator = struct {
+    value: []const u8,
+    index: usize = 0,
+
+    fn next(self: *AliasIterator) ?[]const u8 {
+        while (self.index < self.value.len and
+            (self.value[self.index] == ' ' or self.value[self.index] == '\t')) : (self.index += 1)
+        {}
+        if (self.index >= self.value.len) return null;
+
+        const start = self.index;
+        var quote: ?u8 = null;
+        while (self.index < self.value.len) {
+            const c = self.value[self.index];
+            if (c == '\\' and self.index + 1 < self.value.len) {
+                self.index += 2;
+                continue;
+            }
+            if (c == '\'' or c == '"') {
+                if (quote == null) {
+                    quote = c;
+                } else if (quote.? == c) {
+                    quote = null;
+                }
+                self.index += 1;
+                continue;
+            }
+            if (quote == null and (c == ' ' or c == '\t')) break;
+            self.index += 1;
+        }
+        return self.value[start..self.index];
+    }
+};
+
+fn parseInto(
+    alloc: Allocator,
+    hosts: *std.ArrayList(Host),
+    raw_contents: []const u8,
+    load_context: ?*LoadContext,
+    depth: u8,
+) Allocator.Error!void {
+    const contents = if (std.mem.startsWith(u8, raw_contents, "\xEF\xBB\xBF"))
+        raw_contents[3..]
+    else
+        raw_contents;
+    var in_match = false;
+    var lines = std.mem.splitScalar(u8, contents, '\n');
+    while (lines.next()) |raw_line| {
+        const directive = parseDirective(raw_line) orelse continue;
+        if (std.ascii.eqlIgnoreCase(directive.keyword, "match")) {
+            in_match = true;
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(directive.keyword, "include")) {
+            // A Match block's includes are conditional on runtime state we do
+            // not evaluate, so they are skipped rather than guessed at.
+            if (!in_match) {
+                if (load_context) |context| try context.parseIncludes(directive.value, depth);
+            }
+            continue;
+        }
+        if (!std.ascii.eqlIgnoreCase(directive.keyword, "host")) continue;
+
+        in_match = false;
+        var aliases: AliasIterator = .{ .value = directive.value };
+        while (aliases.next()) |alias| {
+            if (hosts.items.len >= max_hosts) break;
+            if (!isConnectableAlias(alias)) continue;
+            // Repeated stanzas for one alias are legal ssh_config, but a
+            // second entry would collide on the palette's stable id and
+            // could exhaust `max_hosts` ahead of later unique aliases.
+            if (containsAlias(hosts.items, alias)) continue;
+            try hosts.ensureUnusedCapacity(alloc, 1);
+            hosts.appendAssumeCapacity(.{ .alias = try alloc.dupe(u8, alias) });
+        }
+    }
+}
+
+fn parseDirective(raw_line: []const u8) ?Directive {
+    var line = std.mem.trim(u8, raw_line, " \t\r");
+    if (line.len == 0 or line[0] == '#') return null;
+    if (std.mem.indexOfScalar(u8, line, '#')) |comment_start| {
+        line = std.mem.trimRight(u8, line[0..comment_start], " \t\r");
+    }
+    if (line.len == 0) return null;
+
+    var keyword_end: usize = 0;
+    while (keyword_end < line.len and
+        line[keyword_end] != '=' and
+        line[keyword_end] != ' ' and
+        line[keyword_end] != '\t') : (keyword_end += 1)
+    {}
+    if (keyword_end == 0) return null;
+
+    var value_start = keyword_end;
+    while (value_start < line.len and
+        (line[value_start] == ' ' or line[value_start] == '\t')) : (value_start += 1)
+    {}
+    if (value_start < line.len and line[value_start] == '=') value_start += 1;
+    while (value_start < line.len and
+        (line[value_start] == ' ' or line[value_start] == '\t')) : (value_start += 1)
+    {}
+
+    return .{
+        .keyword = line[0..keyword_end],
+        .value = std.mem.trimRight(u8, line[value_start..], " \t\r"),
+    };
+}
+
+fn containsAlias(hosts: []const Host, alias: []const u8) bool {
+    for (hosts) |host| {
+        if (std.ascii.eqlIgnoreCase(host.alias, alias)) return true;
+    }
+    return false;
+}
+
+/// An accepted alias is passed to `ssh.exe` as one literal argv element, so a
+/// leading `-` (which would become an ssh option) is refused. The shell
+/// metacharacters are refused as well: an explicit `shell-integration` mode can
+/// still rewrite a direct argv into a `cmd.exe /C` string elsewhere in the
+/// launch path, where `&` or `|` would separate commands.
+fn isConnectableAlias(alias: []const u8) bool {
+    if (alias.len == 0 or alias.len > max_alias_len) return false;
+    if (alias[0] == '-') return false;
+    for (alias) |c| {
+        if (std.mem.indexOfScalar(u8, "*?!'\"&|<>^%();,$`", c) != null) return false;
+        if (std.ascii.isWhitespace(c) or std.ascii.isControl(c)) return false;
+        // `std.ascii.isControl` stops at 0x7F, so 0x80-0xFF would otherwise
+        // pass through into display strings that are converted to UTF-16.
+        if (c >= 0x80) return false;
+    }
+    return true;
+}
+
+/// UNC (`\\server\share`) and device (`\\?\`, `\\.\`) namespaces, in either
+/// slash spelling.
+fn isRemoteOrDevicePath(path: []const u8) bool {
+    if (path.len < 2) return false;
+    const a = path[0];
+    const b = path[1];
+    return (a == '\\' or a == '/') and (b == '\\' or b == '/');
+}
+
+fn hasGlobMetacharacter(path: []const u8) bool {
+    return std.mem.indexOfAny(u8, path, "*?[]") != null;
+}
+
+fn readFile(alloc: Allocator, path: []const u8) ![]u8 {
+    const file = try std.fs.openFileAbsolute(path, .{});
+    defer file.close();
+    const stat = try file.stat();
+    if (stat.size > max_file_size) return error.FileTooBig;
+    return try file.readToEndAlloc(alloc, max_file_size);
+}
+
+fn warnReadOnce(path: []const u8, err: anyerror) void {
+    read_warning_mutex.lock();
+    defer read_warning_mutex.unlock();
+    if (read_warning_logged) return;
+    read_warning_logged = true;
+    log.warn("SSH config unreadable path={s} err={}", .{ path, err });
+}
+
+fn deinitHostList(alloc: Allocator, hosts: *std.ArrayList(Host)) void {
+    for (hosts.items) |*host| host.deinit(alloc);
+    hosts.deinit(alloc);
+}
+
+test "ssh config parses concrete aliases and ignores non-Host directives" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const hosts = try parse(
+        alloc,
+        "\xEF\xBB\xBF# comment\r\n" ++
+            "  hOsT alpha beta *.example !blocked ?single -oProxyCommand=calc \"quoted\" bad\x01alias # trailing\r\n" ++
+            "HostName=server.example.com\r\n" ++
+            "USER alice\r\n" ++
+            "pOrT = 2222\r\n" ++
+            "IdentityFile ignored\r\n" ++
+            "Host gamma\r\n" ++
+            "HostName gamma.example.com\r\n" ++
+            "Match host gamma\r\n" ++
+            "User must-not-leak\r\n" ++
+            "Host delta epsilon\r\n" ++
+            "Port 2200\r\n",
+    );
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 5), hosts.len);
+    try testing.expectEqualStrings("alpha", hosts[0].alias);
+    try testing.expectEqualStrings("beta", hosts[1].alias);
+    try testing.expectEqualStrings("gamma", hosts[2].alias);
+    try testing.expectEqualStrings("delta", hosts[3].alias);
+    try testing.expectEqualStrings("epsilon", hosts[4].alias);
+}
+
+test "ssh config rejects non-ascii aliases that would reach a UTF-16 conversion" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    // 0xFF is neither ASCII control nor ASCII whitespace, and a lone 0xFF is
+    // not valid UTF-8, so this must not survive into a display string.
+    const hosts = try parse(alloc, "Host prod\xff latin\xe9 safe\n");
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 1), hosts.len);
+    try testing.expectEqualStrings("safe", hosts[0].alias);
+    for (hosts) |host| try testing.expect(std.unicode.utf8ValidateSlice(host.alias));
+}
+
+test "ssh config rejects option-shaped quoted and control aliases" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const hosts = try parse(
+        alloc,
+        "Host -oProxyCommand=calc -p2222 \"quoted alias\" 'single quoted' escaped\\ alias control\x7falias safe\n",
+    );
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 1), hosts.len);
+    try testing.expectEqualStrings("safe", hosts[0].alias);
+}
+
+test "ssh config rejects shell metacharacter and overlong aliases" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const long = try alloc.alloc(u8, max_alias_len + 1);
+    defer alloc.free(long);
+    @memset(long, 'a');
+    const source = try std.fmt.allocPrint(
+        alloc,
+        "Host safe&calc.exe piped|calc redirect>out sub$(calc) semi;calc {s} safe\n",
+        .{long},
+    );
+    defer alloc.free(source);
+
+    const hosts = try parse(alloc, source);
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 1), hosts.len);
+    try testing.expectEqualStrings("safe", hosts[0].alias);
+}
+
+test "ssh config deduplicates repeated aliases case-insensitively" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const hosts = try parse(
+        alloc,
+        "Host prod\nHostName one.example.com\nHost PROD staging\nHostName two.example.com\nHost prod\n",
+    );
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 2), hosts.len);
+    try testing.expectEqualStrings("prod", hosts[0].alias);
+    try testing.expectEqualStrings("staging", hosts[1].alias);
+}
+
+test "ssh config caps total concrete aliases" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    for (0..max_hosts + 32) |index| {
+        const line = try std.fmt.allocPrint(alloc, "Host host-{d}\n", .{index});
+        defer alloc.free(line);
+        try source.appendSlice(alloc, line);
+    }
+
+    const hosts = try parse(alloc, source.items);
+    defer deinitHosts(alloc, hosts);
+    try testing.expectEqual(max_hosts, hosts.len);
+}
+
+test "ssh config parser cleans up every allocation failure" {
+    const testing = std.testing;
+    const run = struct {
+        fn parseFixture(alloc: Allocator, contents: []const u8) !void {
+            const hosts = try parse(alloc, contents);
+            defer deinitHosts(alloc, hosts);
+        }
+    }.parseFixture;
+
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        run,
+        .{"Host alpha beta\nHostName server.example.com\nUser deploy\nPort 2222\n"},
+    );
+}
+
+test "ssh config loads one include level and resolves supported paths" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/relative.conf", .data = "Include nested.conf\nHost relative\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/nested.conf", .data = "Host nested\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/tilde.conf", .data = "Host tilde\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/absolute.conf", .data = "Host absolute\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/globbed.conf", .data = "Host globbed\n" });
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/matched.conf", .data = "Host matched\n" });
+
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+    const absolute = try tmp.dir.realpathAlloc(alloc, ".ssh/absolute.conf");
+    defer alloc.free(absolute);
+    const root = try std.fmt.allocPrint(
+        alloc,
+        "Include relative.conf\nInclude ~/.ssh/tilde.conf\nInclude {s}\nInclude *.conf\nMatch all\nInclude matched.conf\nHost root\n",
+        .{absolute},
+    );
+    defer alloc.free(root);
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/config", .data = root });
+
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+    try testing.expectEqual(@as(usize, 4), hosts.len);
+    try testing.expectEqualStrings("relative", hosts[0].alias);
+    try testing.expectEqualStrings("tilde", hosts[1].alias);
+    try testing.expectEqualStrings("absolute", hosts[2].alias);
+    try testing.expectEqualStrings("root", hosts[3].alias);
+}
+
+test "ssh config skips remote and device include paths without opening them" {
+    const testing = std.testing;
+
+    try testing.expect(isRemoteOrDevicePath("\\\\10.0.0.1\\x\\c"));
+    try testing.expect(isRemoteOrDevicePath("//10.0.0.1/x/c"));
+    try testing.expect(isRemoteOrDevicePath("\\\\?\\C:\\hosts.conf"));
+    try testing.expect(isRemoteOrDevicePath("\\\\.\\pipe\\x"));
+    try testing.expect(!isRemoteOrDevicePath("C:\\Users\\me\\.ssh\\hosts.conf"));
+    try testing.expect(!isRemoteOrDevicePath("hosts.conf"));
+
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+    // A blocking SMB open here would hang the picker, so the path must be
+    // rejected before `openFileAbsolute` is reached.
+    try tmp.dir.writeFile(.{
+        .sub_path = ".ssh/config",
+        .data = "Include \\\\10.0.0.1\\share\\hosts.conf\nInclude \\\\?\\C:\\hosts.conf\nHost root\n",
+    });
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+    try testing.expectEqual(@as(usize, 1), hosts.len);
+    try testing.expectEqualStrings("root", hosts[0].alias);
+}
+
+test "ssh config caps the number of include files read" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+
+    var root: std.ArrayList(u8) = .empty;
+    defer root.deinit(alloc);
+    for (0..max_include_files + 8) |index| {
+        const name = try std.fmt.allocPrint(alloc, "inc-{d}.conf", .{index});
+        defer alloc.free(name);
+        const sub_path = try std.fmt.allocPrint(alloc, ".ssh/{s}", .{name});
+        defer alloc.free(sub_path);
+        const body = try std.fmt.allocPrint(alloc, "Host inc-{d}\n", .{index});
+        defer alloc.free(body);
+        try tmp.dir.writeFile(.{ .sub_path = sub_path, .data = body });
+        const line = try std.fmt.allocPrint(alloc, "Include {s}\n", .{name});
+        defer alloc.free(line);
+        try root.appendSlice(alloc, line);
+    }
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/config", .data = root.items });
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+    try testing.expectEqual(max_include_files, hosts.len);
+}
+
+test "ssh config missing unreadable and oversized roots produce empty lists" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var missing = testing.tmpDir(.{});
+    defer missing.cleanup();
+    const missing_home = try missing.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(missing_home);
+    const missing_hosts = try loadFromHome(alloc, missing_home);
+    defer deinitHosts(alloc, missing_hosts);
+    try testing.expectEqual(@as(usize, 0), missing_hosts.len);
+
+    var unreadable = testing.tmpDir(.{});
+    defer unreadable.cleanup();
+    try unreadable.dir.makePath(".ssh/config");
+    const unreadable_home = try unreadable.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(unreadable_home);
+    const unreadable_hosts = try loadFromHome(alloc, unreadable_home);
+    defer deinitHosts(alloc, unreadable_hosts);
+    try testing.expectEqual(@as(usize, 0), unreadable_hosts.len);
+
+    var oversized = testing.tmpDir(.{});
+    defer oversized.cleanup();
+    try oversized.dir.makePath(".ssh");
+    const data = try alloc.alloc(u8, max_file_size + 1);
+    defer alloc.free(data);
+    @memset(data, '#');
+    try oversized.dir.writeFile(.{ .sub_path = ".ssh/config", .data = data });
+    const oversized_home = try oversized.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(oversized_home);
+    const oversized_hosts = try loadFromHome(alloc, oversized_home);
+    defer deinitHosts(alloc, oversized_hosts);
+    try testing.expectEqual(@as(usize, 0), oversized_hosts.len);
+}

--- a/src/config/windows_ssh_hosts.zig
+++ b/src/config/windows_ssh_hosts.zig
@@ -99,8 +99,9 @@ const LoadContext = struct {
     fn parseIncludes(self: *LoadContext, value: []const u8, depth: u8) Allocator.Error!void {
         if (depth >= 1) return;
 
-        var paths: IncludeArgIterator = .{ .value = value };
-        while (paths.next()) |raw_path| {
+        var paths: SshArgIterator = .{ .value = value };
+        while (try paths.next(self.alloc)) |raw_path| {
+            defer self.alloc.free(raw_path);
             if (raw_path.len == 0) continue;
             if (hasGlobMetacharacter(raw_path)) continue;
             // This read is synchronous on the UI thread and runs on every
@@ -135,79 +136,42 @@ const Directive = struct {
     value: []const u8,
 };
 
-/// `Include` arguments are whitespace separated, except that a leading `"`
-/// groups one path containing spaces (OpenSSH `strdelim`). A plain whitespace
-/// split would shred `Include "C:\Users\Jane Doe\.ssh\work hosts"` into
-/// nonexistent paths and silently drop every host in that file.
-///
-/// Deliberately NOT `AliasIterator`, which exists to find the boundaries of
-/// `Host` patterns: it leaves the quote bytes in the token (harmless there,
-/// since `isConnectableAlias` rejects quotes outright) and treats `\` as an
-/// escape, which would corrupt every Windows path separator here. `'` is not
-/// a grouping quote for the same reason -- OpenSSH does not treat it as one,
-/// and stripping it would break a literal path such as `C:\Bob's\config`.
-const IncludeArgIterator = struct {
+/// Tokenizes the argument portion of an OpenSSH configuration directive.
+/// Double quotes may begin anywhere in an argument, are removed, and group
+/// whitespace until the matching quote. An unterminated quote consumes the
+/// remainder, matching OpenSSH's `strdelim` behavior. Backslashes and single
+/// quotes remain literal so Windows paths are not corrupted.
+const SshArgIterator = struct {
     value: []const u8,
     index: usize = 0,
+    backslash_escape: bool = false,
 
-    fn next(self: *IncludeArgIterator) ?[]const u8 {
+    fn next(self: *SshArgIterator, alloc: Allocator) Allocator.Error!?[]u8 {
         while (self.index < self.value.len and
             (self.value[self.index] == ' ' or self.value[self.index] == '\t')) : (self.index += 1)
         {}
         if (self.index >= self.value.len) return null;
 
-        if (self.value[self.index] == '"') {
-            const start = self.index + 1;
-            const end = std.mem.indexOfScalarPos(u8, self.value, start, '"') orelse {
-                // Unterminated quote. OpenSSH rejects the whole line, so
-                // consume the remainder rather than guess at a path.
-                self.index = self.value.len;
-                return null;
-            };
-            self.index = end + 1;
-            return self.value[start..end];
-        }
-
-        const start = self.index;
-        while (self.index < self.value.len and
-            self.value[self.index] != ' ' and
-            self.value[self.index] != '\t') : (self.index += 1)
-        {}
-        return self.value[start..self.index];
-    }
-};
-
-const AliasIterator = struct {
-    value: []const u8,
-    index: usize = 0,
-
-    fn next(self: *AliasIterator) ?[]const u8 {
-        while (self.index < self.value.len and
-            (self.value[self.index] == ' ' or self.value[self.index] == '\t')) : (self.index += 1)
-        {}
-        if (self.index >= self.value.len) return null;
-
-        const start = self.index;
-        var quote: ?u8 = null;
+        var token: std.ArrayList(u8) = .empty;
+        errdefer token.deinit(alloc);
+        var quoted = false;
         while (self.index < self.value.len) {
             const c = self.value[self.index];
-            if (c == '\\' and self.index + 1 < self.value.len) {
+            if (self.backslash_escape and c == '\\' and self.index + 1 < self.value.len) {
+                try token.append(alloc, self.value[self.index + 1]);
                 self.index += 2;
                 continue;
             }
-            if (c == '\'' or c == '"') {
-                if (quote == null) {
-                    quote = c;
-                } else if (quote.? == c) {
-                    quote = null;
-                }
+            if (c == '"') {
+                quoted = !quoted;
                 self.index += 1;
                 continue;
             }
-            if (quote == null and (c == ' ' or c == '\t')) break;
+            if (!quoted and (c == ' ' or c == '\t')) break;
+            try token.append(alloc, c);
             self.index += 1;
         }
-        return self.value[start..self.index];
+        return try token.toOwnedSlice(alloc);
     }
 };
 
@@ -241,8 +205,9 @@ fn parseInto(
         if (!std.ascii.eqlIgnoreCase(directive.keyword, "host")) continue;
 
         in_match = false;
-        var aliases: AliasIterator = .{ .value = directive.value };
-        while (aliases.next()) |alias| {
+        var aliases: SshArgIterator = .{ .value = directive.value, .backslash_escape = true };
+        while (try aliases.next(alloc)) |alias| {
+            defer alloc.free(alias);
             if (hosts.items.len >= max_hosts) break;
             if (!isConnectableAlias(alias)) continue;
             // Repeated stanzas for one alias are legal ssh_config, but a
@@ -258,7 +223,7 @@ fn parseInto(
 fn parseDirective(raw_line: []const u8) ?Directive {
     var line = std.mem.trim(u8, raw_line, " \t\r");
     if (line.len == 0 or line[0] == '#') return null;
-    if (std.mem.indexOfScalar(u8, line, '#')) |comment_start| {
+    if (sshCommentStart(line)) |comment_start| {
         line = std.mem.trimRight(u8, line[0..comment_start], " \t\r");
     }
     if (line.len == 0) return null;
@@ -284,6 +249,22 @@ fn parseDirective(raw_line: []const u8) ?Directive {
         .keyword = line[0..keyword_end],
         .value = std.mem.trimRight(u8, line[value_start..], " \t\r"),
     };
+}
+
+fn sshCommentStart(line: []const u8) ?usize {
+    var quoted = false;
+    for (line, 0..) |c, i| {
+        if (c == '"') {
+            quoted = !quoted;
+            continue;
+        }
+        if (c == '#' and !quoted and
+            (i == 0 or line[i - 1] == ' ' or line[i - 1] == '\t'))
+        {
+            return i;
+        }
+    }
+    return null;
 }
 
 fn containsAlias(hosts: []const Host, alias: []const u8) bool {
@@ -404,12 +385,13 @@ test "ssh config parses concrete aliases and ignores non-Host directives" {
     );
     defer deinitHosts(alloc, hosts);
 
-    try testing.expectEqual(@as(usize, 5), hosts.len);
+    try testing.expectEqual(@as(usize, 6), hosts.len);
     try testing.expectEqualStrings("alpha", hosts[0].alias);
     try testing.expectEqualStrings("beta", hosts[1].alias);
-    try testing.expectEqualStrings("gamma", hosts[2].alias);
-    try testing.expectEqualStrings("delta", hosts[3].alias);
-    try testing.expectEqualStrings("epsilon", hosts[4].alias);
+    try testing.expectEqualStrings("quoted", hosts[2].alias);
+    try testing.expectEqualStrings("gamma", hosts[3].alias);
+    try testing.expectEqualStrings("delta", hosts[4].alias);
+    try testing.expectEqualStrings("epsilon", hosts[5].alias);
 }
 
 test "ssh config rejects non-ascii aliases that would reach a UTF-16 conversion" {
@@ -538,25 +520,55 @@ test "ssh config loads one include level and resolves supported paths" {
     try testing.expectEqualStrings("root", hosts[3].alias);
 }
 
-test "ssh config include tokenizer keeps quoted paths whole" {
+test "ssh config argument tokenizer follows OpenSSH quote boundaries" {
     const testing = std.testing;
+    const alloc = testing.allocator;
 
-    var quoted: IncludeArgIterator = .{ .value = "\"C:\\Users\\Jane Doe\\.ssh\\work hosts\" plain.conf" };
-    try testing.expectEqualStrings("C:\\Users\\Jane Doe\\.ssh\\work hosts", quoted.next().?);
-    try testing.expectEqualStrings("plain.conf", quoted.next().?);
-    try testing.expect(quoted.next() == null);
+    var quoted: SshArgIterator = .{ .value = "\"C:\\Users\\Jane Doe\\.ssh\\work hosts\" plain.conf" };
+    const quoted_path = (try quoted.next(alloc)).?;
+    defer alloc.free(quoted_path);
+    try testing.expectEqualStrings("C:\\Users\\Jane Doe\\.ssh\\work hosts", quoted_path);
+    const plain_path = (try quoted.next(alloc)).?;
+    defer alloc.free(plain_path);
+    try testing.expectEqualStrings("plain.conf", plain_path);
+    try testing.expect((try quoted.next(alloc)) == null);
 
     // Backslashes stay verbatim: they are path separators, not escapes.
-    var backslashes: IncludeArgIterator = .{ .value = "C:\\Bob's\\config  ~/.ssh/x.conf" };
-    try testing.expectEqualStrings("C:\\Bob's\\config", backslashes.next().?);
-    try testing.expectEqualStrings("~/.ssh/x.conf", backslashes.next().?);
-    try testing.expect(backslashes.next() == null);
+    var backslashes: SshArgIterator = .{ .value = "C:\\Bob's\\config  ~/.ssh/x.conf" };
+    const first_backslash = (try backslashes.next(alloc)).?;
+    defer alloc.free(first_backslash);
+    try testing.expectEqualStrings("C:\\Bob's\\config", first_backslash);
+    const second_backslash = (try backslashes.next(alloc)).?;
+    defer alloc.free(second_backslash);
+    try testing.expectEqualStrings("~/.ssh/x.conf", second_backslash);
+    try testing.expect((try backslashes.next(alloc)) == null);
 
-    var unterminated: IncludeArgIterator = .{ .value = "\"C:\\never closed" };
-    try testing.expect(unterminated.next() == null);
+    var embedded: SshArgIterator = .{ .value = "C:\\base\" dir\\hosts.conf\"" };
+    const embedded_path = (try embedded.next(alloc)).?;
+    defer alloc.free(embedded_path);
+    try testing.expectEqualStrings("C:\\base dir\\hosts.conf", embedded_path);
 
-    var empty: IncludeArgIterator = .{ .value = "   \t " };
-    try testing.expect(empty.next() == null);
+    var unterminated: SshArgIterator = .{ .value = "\"C:\\never closed" };
+    const unterminated_path = (try unterminated.next(alloc)).?;
+    defer alloc.free(unterminated_path);
+    try testing.expectEqualStrings("C:\\never closed", unterminated_path);
+
+    var empty: SshArgIterator = .{ .value = "   \t " };
+    try testing.expect((try empty.next(alloc)) == null);
+}
+
+test "ssh config preserves hashes and unquotes host aliases" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const hosts = try parse(
+        alloc,
+        "Host prod#bastion \"production\" # trailing comment\n",
+    );
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 2), hosts.len);
+    try testing.expectEqualStrings("prod#bastion", hosts[0].alias);
+    try testing.expectEqualStrings("production", hosts[1].alias);
 }
 
 test "ssh config loads a quoted include whose filename contains spaces" {
@@ -581,6 +593,28 @@ test "ssh config loads a quoted include whose filename contains spaces" {
     try testing.expectEqualStrings("spaced", hosts[0].alias);
     try testing.expectEqualStrings("plain", hosts[1].alias);
     try testing.expectEqualStrings("root", hosts[2].alias);
+}
+
+test "ssh config loads a quoted include whose filename contains a hash" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath(".ssh");
+    try tmp.dir.writeFile(.{ .sub_path = ".ssh/work#hosts.conf", .data = "Host hashed\n" });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".ssh/config",
+        .data = "Include \"work#hosts.conf\" # trailing comment\nHost root\n",
+    });
+
+    const home = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(home);
+    const hosts = try loadFromHome(alloc, home);
+    defer deinitHosts(alloc, hosts);
+
+    try testing.expectEqual(@as(usize, 2), hosts.len);
+    try testing.expectEqualStrings("hashed", hosts[0].alias);
+    try testing.expectEqualStrings("root", hosts[1].alias);
 }
 
 test "ssh config recognizes drive-letter roots for the remote-drive check" {


### PR DESCRIPTION
## Summary

Surfaces the user's own SSH hosts. `%USERPROFILE%\.ssh\config` is parsed for
concrete `Host` aliases, which appear as `SSH: <alias>` in the profile picker
and `Connect to <alias>` in the universal palette. Selecting one launches the
resolved system `ssh.exe` with the bare alias as its only argument, from the
user's home directory, so `ssh` reads its own configuration.

The lean C20 slice only: no bundled SSH client, no secrets vault (deferred
C24), no fleet or connection-management tooling.

Fixes #143

## Changes

- New `src/config/windows_ssh_hosts.zig`: bounded, pure-Zig `~/.ssh/config`
  parser. Only `Host` lines are read; every other keyword is left to `ssh`.
  Multiple aliases per line; `Match` blocks ignored, including their includes;
  comments, BOM, CRLF, `Key=Value`, and case-insensitive keywords tolerated;
  missing file yields an empty list, unreadable warns once. Aliases are
  deduplicated by exact byte equality, so case-distinct OpenSSH aliases remain distinct.
- `listProfiles` takes `include_ssh_hosts` and appends SSH entries after the
  detected shells, keyed `ssh:<alias>`, with `ssh.exe` resolved from PATH and
  falling back to `C:\Windows\System32\OpenSSH\ssh.exe`. SSH discovery is
  additive: any failure degrades to the detected shells rather than leaving the
  user with no picker.
- New `ProfileKind.ssh` with its own badge and glyph; palette rows get the
  "SSH host" subtitle through one optional owned `palette_title` on `Profile`.
- New `ssh-config-hosts` config knob (default `true`).
- Docs: `windows.md` "SSH hosts" section, `status.md` bullet, capability
  matrix row.

### Enforcement

SSH-specific hardening lives in one helper that every launch path calls — new
surface, split, and restore — so no path can inherit the command without the
guarantees attached to it:

- `shell-integration` is forced off. It is a local-shell mechanism that cannot
  reach a remote session, and leaving it on lets the integration rewrite the
  two-element ssh argv into a space-joined, unquoted `cmd.exe /C` string.
- The working directory resolves to `%USERPROFILE%` explicitly — the same
  directory `ssh` expands `~` to, and deliberately not `HOMEDRIVE`+`HOMEPATH`,
  which can point at a network share on a domain-joined machine.

An alias is one literal argv element. Aliases starting with `-` are refused so
they cannot become ssh options, as are shell/`cmd` metacharacters and any byte
outside printable ASCII.

Session restore refuses any `ssh:` profile key case-insensitively before exact
live-profile lookup rather than dialing out unattended at startup. A refused
pane also drops its profile key, so a later split cannot re-resolve the
connection. Whether a surface was launched over SSH is recorded from the
profile kind at launch rather than re-derived from the key.

Include handling is one level deep and capped at 16 files. Root and Include
opens run off the UI thread through a single-in-flight worker under one shared
50 ms refresh budget; UNC/device paths are rejected before opening.

### Incidental fixes

Two pre-existing defects found while working in this area:

- **Double free** in `safeCurrentDirectory`: both the caller and
  `safeCurrentDirectoryWithCurrent` freed `current` on the path where no
  explicit cwd was requested and a current directory existed. Ownership now
  sits entirely in the callee.
- **Uninitialized stack read** in `drawPaletteRowText`: it fell back to
  `buf.len` when `utf8ToUtf16Le` failed, rendering whatever was on the stack
  past the partial prefix. It now draws nothing.

Existing working-directory precedence is otherwise unchanged: SSH gets its
home directory through an explicit resolved path rather than by promoting the
`working-directory = home` flag, so non-SSH profiles (including WSL's `--cd ~`)
behave exactly as before, with a regression test.

## Validation

- `zig fmt --check src` — only the pre-existing failure on the untouched
  generated file `src/build/uucode_tables.zig`.
- `zig build -Demit-exe=true` — pass.
- `zig build test -Demit-test-exe=true` — **full suite green**, no failures.
- `zig build test -Dtest-filter=ssh` / `-Dtest-filter=profile`
  `-Dtest-filter=Profile` `-Dtest-filter=safeCurrentDirectory`
  `-Dtest-filter=session` `-Dtest-filter=palette` — pass.
- `pwsh -NoProfile -File scripts/check-source-format.ps1` — pass.
- Interactive (sandbox `USERPROFILE` with two hosts plus a `Host *` block):
  both aliases appear in the picker and palette; launching one runs
  `ssh.exe` + the bare alias with cwd = the sandbox home and the tab titled
  with the alias. Screenshots: `.t3\worktrees\winghostty\evidence\143\`.

New tests cover the case-variance restore bypass, the split-path invariant,
non-ASCII alias rejection, UNC/device include rejection, the include-count cap,
and both ssh.exe resolution failure modes.

## Residuals


- 256 SSH hosts can crowd theme entries out of the 768-slot palette catalog.
- The System32 fallback path is hardcoded rather than `%SystemRoot%`-derived.
- One-shot warn flags mean a later, different discovery failure is silent.
- The interactive evidence predates the shell-integration, session-restore, and
  `%USERPROFILE%` changes; those are covered by unit tests and build only.

Follow-up prompt (phased, commit per phase):
`.t3\worktrees\winghostty\prompts\c4-143-followup-PARKED.md`.

## Summary by Sourcery

Add safe, configurable Windows SSH host discovery and one-click profile and palette entries backed by the system SSH client.

New Features:
- Discover concrete aliases from the Windows user's SSH configuration and expose them in the profile picker and universal palette.
- Launch selected SSH hosts through the system ssh.exe with the alias as a literal argument and SSH-specific profile presentation.

Bug Fixes:
- Prevent SSH profiles from being relaunched during session restore or unintentionally inherited during splits.
- Fix ownership handling in safeCurrentDirectory to eliminate a double free.
- Avoid rendering uninitialized stack data when palette text conversion fails.

Enhancements:
- Harden SSH launches with explicit user-home working directories, disabled shell integration, bounded alias validation, and safe handling of SSH profile identity and titles.
- Bound and isolate SSH configuration reads, support limited Include processing, deduplicate aliases, and degrade gracefully when discovery fails.
- Preserve case-sensitive SSH alias matching while retaining case-insensitive matching for other profile types.

Documentation:
- Document SSH host discovery, configuration parsing limits, launch behavior, restore behavior, and the configuration toggle.
- Add SSH host discovery to the Windows capability documentation and status overview.

Tests:
- Add coverage for SSH profile construction, executable resolution, parser behavior, include limits, path rejection, launch hardening, session restore, split behavior, title handling, and working-directory precedence.