### PR TITLE
perf(windows): cut per-pane memory and cold start on the startup path

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -77,6 +77,7 @@ pub fn create(alloc: Allocator) CreateError!*App {
     var app = try alloc.create(App);
     errdefer alloc.destroy(app);
     try app.init(alloc);
+    app.font_grid_set.startDiscoveryPrefetch();
     return app;
 }
 
@@ -123,6 +124,15 @@ pub fn destroy(self: *App) void {
 
     // Free the app memory
     self.alloc.destroy(self);
+}
+
+test "App create overlaps Windows font discovery with runtime startup" {
+    if (comptime builtin.target.os.tag != .windows or
+        !@hasDecl(font.Discover, "refresh")) return;
+
+    const app = try create(std.testing.allocator);
+    defer app.destroy();
+    try std.testing.expect(app.font_grid_set.discoveryPrefetchStarted());
 }
 
 /// Tick ticks the app loop. This will drain our mailbox and process those

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -854,6 +854,8 @@ pub fn deinit(self: *Surface) void {
         self.io_thr.join();
     }
 
+    var renderer_deinit_safe = true;
+
     // Stop rendering thread
     {
         self.renderer_thread.stop.notify() catch |err|
@@ -867,13 +869,23 @@ pub fn deinit(self: *Surface) void {
         // context before deleting any graphics objects.
         self.renderer.prepareSurfaceDeinit(self.rt_surface) catch |err| {
             log.err("error preparing renderer surface deinit err={}", .{err});
+            // Deleting GL resources with no current context (or another
+            // pane's context) is unsafe. Keep the rest of Surface teardown
+            // running, but deliberately abandon the renderer-owned resources
+            // in this exceptional path; destroying the WGL context later is
+            // safer than issuing deletes against the wrong share group.
+            renderer_deinit_safe = false;
         };
     }
 
     // We need to deinit AFTER everything is stopped, since there are
     // shared values between the two threads.
     self.renderer_thread.deinit();
-    self.renderer.deinit();
+    if (renderer_deinit_safe) {
+        self.renderer.deinit();
+    } else {
+        log.err("abandoning renderer resources after surface context rebind failure", .{});
+    }
     self.io_thread.deinit();
     self.io.deinit();
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -802,7 +802,7 @@ pub fn init(
 
     // Start our renderer thread
     self.renderer_thr = try std.Thread.spawn(
-        .{},
+        internal_os.surfaceThreadSpawnConfig(),
         rendererpkg.Thread.threadMain,
         .{&self.renderer_thread},
     );
@@ -810,7 +810,7 @@ pub fn init(
 
     // Start our IO thread
     self.io_thr = try std.Thread.spawn(
-        .{},
+        internal_os.surfaceThreadSpawnConfig(),
         termio.Thread.threadMain,
         .{ &self.io_thread, &self.io },
     );
@@ -862,6 +862,12 @@ pub fn deinit(self: *Surface) void {
 
         // We need to become the active rendering thread again
         self.renderer.threadEnter(self.rt_surface) catch unreachable;
+        // Renderer resources belong to this runtime surface's graphics
+        // context. Teardown is back on the app thread now, so restore that
+        // context before deleting any graphics objects.
+        self.renderer.prepareSurfaceDeinit(self.rt_surface) catch |err| {
+            log.err("error preparing renderer surface deinit err={}", .{err});
+        };
     }
 
     // We need to deinit AFTER everything is stopped, since there are

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -61,6 +61,7 @@ const win32_shell = @import("win32_shell.zig");
 const win32_ipc = @import("win32_ipc.zig");
 const render_trace = @import("win32/render_trace.zig");
 const gl_startup = @import("win32/gl_startup.zig");
+const pixel_format = @import("win32/pixel_format.zig");
 const labels = @import("win32/labels.zig");
 const win32_input = @import("win32/input.zig");
 const chrome_layout = @import("win32/chrome_layout.zig");
@@ -71,6 +72,7 @@ const sys = @import("win32/sys.zig");
 test {
     _ = @import("win32/render_trace.zig");
     _ = @import("win32/gl_startup.zig");
+    _ = @import("win32/pixel_format.zig");
     _ = @import("win32/labels.zig");
     _ = @import("win32/input.zig");
     _ = @import("win32/chrome_layout.zig");
@@ -5817,37 +5819,6 @@ pub const App = struct {
         return try client_size_fn(ctx, live_hwnd);
     }
 
-    fn defaultPixelFormatDescriptor() PIXELFORMATDESCRIPTOR {
-        return .{
-            .nSize = @sizeOf(PIXELFORMATDESCRIPTOR),
-            .nVersion = 1,
-            .dwFlags = c.PFD_DRAW_TO_WINDOW | c.PFD_SUPPORT_OPENGL | c.PFD_DOUBLEBUFFER,
-            .iPixelType = c.PFD_TYPE_RGBA,
-            .cColorBits = 32,
-            .cRedBits = 0,
-            .cRedShift = 0,
-            .cGreenBits = 0,
-            .cGreenShift = 0,
-            .cBlueBits = 0,
-            .cBlueShift = 0,
-            .cAlphaBits = 8,
-            .cAlphaShift = 0,
-            .cAccumBits = 0,
-            .cAccumRedBits = 0,
-            .cAccumGreenBits = 0,
-            .cAccumBlueBits = 0,
-            .cAccumAlphaBits = 0,
-            .cDepthBits = 24,
-            .cStencilBits = 8,
-            .cAuxBuffers = 0,
-            .iLayerType = c.PFD_MAIN_PLANE,
-            .bReserved = 0,
-            .dwLayerMask = 0,
-            .dwVisibleMask = 0,
-            .dwDamageMask = 0,
-        };
-    }
-
     fn createGLContext(self: *App, hwnd: HWND) !struct { hdc: HDC, hglrc: HGLRC } {
         if (self.core_app.first) beginOpenGLStartupDiagnostics();
 
@@ -5857,19 +5828,37 @@ pub const App = struct {
         };
         errdefer _ = sys.ReleaseDC(hwnd, hdc);
 
-        const pfd = defaultPixelFormatDescriptor();
-        const pixel_format = sys.ChoosePixelFormat(hdc, &pfd);
-        if (pixel_format == 0) {
-            const err = windows.kernel32.GetLastError();
-            recordOpenGLStartupWin32Failure(.choose_pixel_format, err);
-            return windows.unexpectedError(err);
+        const format_before = sys.GetPixelFormat(hdc);
+        if (format_before != 0) {
+            recordOpenGLStartupError(.set_pixel_format, error.PixelFormatAlreadySet);
+            return error.PixelFormatAlreadySet;
         }
 
-        if (sys.SetPixelFormat(hdc, pixel_format, &pfd) == 0) {
+        var selection = try pixel_format.chooseRealPixelFormat(self.hinstance, hwnd, hdc);
+        log.debug(
+            "selected WGL pixel format index={} source={s} srgb_capable={} depth_bits={} stencil_bits={}",
+            .{
+                selection.provenance.index,
+                @tagName(selection.provenance.selection_source),
+                selection.provenance.srgb_capable,
+                selection.provenance.depth_bits,
+                selection.provenance.stencil_bits,
+            },
+        );
+
+        if (sys.SetPixelFormat(hdc, selection.pixel_format, &selection.descriptor) == 0) {
             const err = windows.kernel32.GetLastError();
             recordOpenGLStartupWin32Failure(.set_pixel_format, err);
             return windows.unexpectedError(err);
         }
+        pixel_format.validatePixelFormatSetTransition(
+            format_before,
+            selection.pixel_format,
+            sys.GetPixelFormat(hdc),
+        ) catch |err| {
+            recordOpenGLStartupError(.set_pixel_format, err);
+            return err;
+        };
 
         const hglrc = sys.wglCreateContext(hdc) orelse {
             const err = windows.kernel32.GetLastError();
@@ -21031,13 +21020,45 @@ pub const Surface = struct {
         };
     }
 
+    /// Reserve the repaint slot for a renderer frame before the expensive
+    /// `updateFrame` work, so a paint that completes during that work cannot
+    /// be lost.
+    pub fn beginRendererFrameUpdate(self: *Surface) bool {
+        return self.beginRendererRepaintRequest();
+    }
+
+    /// Close the interleaving where paint completion clears the reservation
+    /// and checks retry_pending after the renderer observed the old pending
+    /// reservation but before it publishes retry_pending. Either the paint
+    /// completion consumes the retry and sends a wake, or this requester
+    /// reacquires the now-idle reservation and continues immediately.
+    fn completeRendererRepaintCoalesce(self: *Surface) bool {
+        if (self.renderer_repaint_requested.load(.acquire)) return false;
+        if (!self.renderer_repaint_retry_pending.swap(false, .acq_rel)) return false;
+        if (self.renderer_repaint_requested.cmpxchgStrong(
+            false,
+            true,
+            .acq_rel,
+            .acquire,
+        ) == null) return true;
+
+        // Another renderer request acquired the reservation between the
+        // idle observation and CAS. Its paint must retain our retry.
+        self.renderer_repaint_retry_pending.store(true, .release);
+        return false;
+    }
+
     pub fn beginRendererRepaintRequest(self: *Surface) bool {
         if (!self.renderer_repaint_requested.swap(true, .acq_rel)) {
             self.render_trace.noteRendererRepaintAccepted();
             return true;
         }
-        self.render_trace.noteRendererRepaintCoalesced();
         self.renderer_repaint_retry_pending.store(true, .release);
+        if (self.completeRendererRepaintCoalesce()) {
+            self.render_trace.noteRendererRepaintAccepted();
+            return true;
+        }
+        self.render_trace.noteRendererRepaintCoalesced();
         return false;
     }
 

--- a/src/apprt/win32/gl_startup.zig
+++ b/src/apprt/win32/gl_startup.zig
@@ -53,6 +53,7 @@ pub fn suppressStartupLoaderErrorDialogs() StartupLoaderErrorDialogSuppression {
 pub const OpenGLStartupStep = enum {
     get_dc,
     choose_pixel_format,
+    describe_pixel_format,
     set_pixel_format,
     create_context,
     initial_make_current,
@@ -66,6 +67,7 @@ pub const OpenGLStartupStep = enum {
         return switch (self) {
             .get_dc => "acquiring the window device context",
             .choose_pixel_format => "choosing a WGL pixel format",
+            .describe_pixel_format => "describing the selected WGL pixel format",
             .set_pixel_format => "setting the WGL pixel format",
             .create_context => "creating the WGL context",
             .initial_make_current => "making the initial WGL context current",

--- a/src/apprt/win32/pixel_format.zig
+++ b/src/apprt/win32/pixel_format.zig
@@ -87,6 +87,10 @@ const WGL_FULL_ACCELERATION_EXT = 0x2027;
 
 const WGL_TYPE_RGBA_EXT = 0x202B;
 
+// WGL_ARB_framebuffer_sRGB and WGL_EXT_framebuffer_sRGB define the *same*
+// value for this attribute (0x20A9), and both spec it against the EXT
+// pixel-format entry points. Drivers accept it through the ARB entry points
+// too, which is what every mainstream loader queries.
 const WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB = 0x20A9;
 
 const WGL_SAMPLE_BUFFERS_ARB = 0x2041;
@@ -130,6 +134,7 @@ const WglPixelFormatSelectionSource = enum(u8) {
     classic,
     ext_srgb,
     arb_ext_colorspace_srgb,
+    arb_srgb,
 };
 
 const WglPixelFormatCandidate = struct {
@@ -413,15 +418,20 @@ const WglGetPixelFormatAttribivArbFn = *const fn (
 
 const WglGetExtensionsStringArbFn = *const fn (hdc: HDC) callconv(.winapi) ?[*:0]const u8;
 
+const WglPixelFormatExtFunctions = struct {
+    choose: WglChoosePixelFormatExtFn,
+    get_attributes: WglGetPixelFormatAttribivExtFn,
+};
+
+const WglPixelFormatArbFunctions = struct {
+    choose: WglChoosePixelFormatArbFn,
+    get_attributes: WglGetPixelFormatAttribivArbFn,
+};
+
 const WglPixelFormatFunctions = union(enum) {
-    ext_framebuffer_srgb: struct {
-        choose: WglChoosePixelFormatExtFn,
-        get_attributes: WglGetPixelFormatAttribivExtFn,
-    },
-    arb_ext_colorspace_srgb: struct {
-        choose: WglChoosePixelFormatArbFn,
-        get_attributes: WglGetPixelFormatAttribivArbFn,
-    },
+    ext_framebuffer_srgb: WglPixelFormatExtFunctions,
+    arb_ext_colorspace_srgb: WglPixelFormatArbFunctions,
+    arb_framebuffer_srgb: WglPixelFormatArbFunctions,
 
     fn choose(
         self: WglPixelFormatFunctions,
@@ -440,7 +450,9 @@ const WglPixelFormatFunctions = union(enum) {
                 formats,
                 count,
             ),
-            .arb_ext_colorspace_srgb => |functions| functions.choose(
+            .arb_ext_colorspace_srgb,
+            .arb_framebuffer_srgb,
+            => |functions| functions.choose(
                 hdc,
                 attributes,
                 null,
@@ -468,7 +480,9 @@ const WglPixelFormatFunctions = union(enum) {
                 attributes.ptr,
                 values,
             ),
-            .arb_ext_colorspace_srgb => |functions| functions.get_attributes(
+            .arb_ext_colorspace_srgb,
+            .arb_framebuffer_srgb,
+            => |functions| functions.get_attributes(
                 hdc,
                 pixel_format,
                 0,
@@ -483,12 +497,13 @@ const WglPixelFormatFunctions = union(enum) {
         return switch (self) {
             .ext_framebuffer_srgb => .ext_srgb,
             .arb_ext_colorspace_srgb => .arb_ext_colorspace_srgb,
+            .arb_framebuffer_srgb => .arb_srgb,
         };
     }
 
     fn srgbAttribute(self: WglPixelFormatFunctions) struct { name: i32, value: i32 } {
         return switch (self) {
-            .ext_framebuffer_srgb => .{
+            .ext_framebuffer_srgb, .arb_framebuffer_srgb => .{
                 .name = WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB,
                 .value = 1,
             },
@@ -499,6 +514,97 @@ const WglPixelFormatFunctions = union(enum) {
         };
     }
 };
+
+/// The sRGB-capable pixel-format API pairings we will accept, in the exact
+/// order `WglPixelFormatSelector.init` tries them.
+///
+/// The pairing rules are not interchangeable, so they are spelled out here
+/// rather than inferred:
+///
+///   * `WGL_ARB_framebuffer_sRGB` and `WGL_EXT_framebuffer_sRGB` are both
+///     written against `WGL_EXT_pixel_format` and both declare the 0x20A9
+///     attribute for `wglGetPixelFormatAttribivEXT` /
+///     `wglChoosePixelFormatEXT`. Despite the `_ARB` token suffix, the EXT
+///     entry points are the spec-exact home of that attribute.
+///   * `WGL_EXT_colorspace` is written against `WGL_ARB_pixel_format` and
+///     declares `WGL_COLORSPACE_EXT` for the ARB entry points only.
+///   * In practice every shipping ICD also honors 0x20A9 through
+///     `wglGetPixelFormatAttribivARB`, and that de-facto pairing is what
+///     mainstream loaders query. Without it we would skip the verified-sRGB
+///     path entirely on a driver that advertises `WGL_ARB_pixel_format` and
+///     `WGL_ARB_framebuffer_sRGB` but not `WGL_EXT_pixel_format`. It is tried
+///     last so any driver exposing a spec-exact pairing keeps that path.
+const wgl_srgb_api_family_order = [_]WglSrgbApiFamily{
+    .ext_pixel_format_framebuffer_srgb,
+    .arb_pixel_format_colorspace,
+    .arb_pixel_format_framebuffer_srgb,
+};
+
+const WglSrgbApiFamily = enum {
+    ext_pixel_format_framebuffer_srgb,
+    arb_pixel_format_colorspace,
+    arb_pixel_format_framebuffer_srgb,
+};
+
+fn hasWglFramebufferSrgbExtension(extensions: []const u8) bool {
+    return hasWglExtension(extensions, "WGL_ARB_framebuffer_sRGB") or
+        hasWglExtension(extensions, "WGL_EXT_framebuffer_sRGB");
+}
+
+fn wglSrgbApiFamilyAdvertised(
+    family: WglSrgbApiFamily,
+    extensions: []const u8,
+) bool {
+    return switch (family) {
+        .ext_pixel_format_framebuffer_srgb => hasWglExtension(extensions, "WGL_EXT_pixel_format") and
+            hasWglFramebufferSrgbExtension(extensions),
+        .arb_pixel_format_colorspace => hasWglExtension(extensions, "WGL_ARB_pixel_format") and
+            hasWglExtension(extensions, "WGL_EXT_colorspace"),
+        .arb_pixel_format_framebuffer_srgb => hasWglExtension(extensions, "WGL_ARB_pixel_format") and
+            hasWglFramebufferSrgbExtension(extensions),
+    };
+}
+
+/// First family in `wgl_srgb_api_family_order` that the driver advertises,
+/// or null when no valid pairing is present. `WglPixelFormatSelector.init`
+/// walks the same order with the same predicate, but keeps going when a
+/// family's procedures fail to resolve.
+fn firstAdvertisedWglSrgbApiFamily(extensions: []const u8) ?WglSrgbApiFamily {
+    for (wgl_srgb_api_family_order) |family| {
+        if (wglSrgbApiFamilyAdvertised(family, extensions)) return family;
+    }
+    return null;
+}
+
+/// Resolve the entry points for an advertised family. Returns null when the
+/// driver advertises the extension but does not hand back usable procedures,
+/// so the caller can keep walking the order instead of failing closed early.
+fn loadWglPixelFormatFunctions(family: WglSrgbApiFamily) ?WglPixelFormatFunctions {
+    switch (family) {
+        .ext_pixel_format_framebuffer_srgb => {
+            const choose_raw = wglGetProcAddress("wglChoosePixelFormatEXT");
+            const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivEXT");
+            if (!validWglProcAddress(choose_raw) or !validWglProcAddress(get_raw)) return null;
+            return .{ .ext_framebuffer_srgb = .{
+                .choose = @ptrCast(@alignCast(choose_raw.?)),
+                .get_attributes = @ptrCast(@alignCast(get_raw.?)),
+            } };
+        },
+        .arb_pixel_format_colorspace, .arb_pixel_format_framebuffer_srgb => {
+            const choose_raw = wglGetProcAddress("wglChoosePixelFormatARB");
+            const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivARB");
+            if (!validWglProcAddress(choose_raw) or !validWglProcAddress(get_raw)) return null;
+            const functions: WglPixelFormatArbFunctions = .{
+                .choose = @ptrCast(@alignCast(choose_raw.?)),
+                .get_attributes = @ptrCast(@alignCast(get_raw.?)),
+            };
+            return if (family == .arb_pixel_format_colorspace)
+                .{ .arb_ext_colorspace_srgb = functions }
+            else
+                .{ .arb_framebuffer_srgb = functions };
+        },
+    }
+}
 
 fn validWglProcAddress(raw: ?*const anyopaque) bool {
     const address = @intFromPtr(raw orelse return false);
@@ -520,7 +626,10 @@ fn wglMultisampleQuerySupported(
     return switch (source) {
         .ext_srgb => hasWglExtension(extensions, "WGL_ARB_multisample") or
             hasWglExtension(extensions, "WGL_EXT_multisample"),
-        .arb_ext_colorspace_srgb => hasWglExtension(extensions, "WGL_ARB_multisample"),
+        // WGL_SAMPLE_BUFFERS_ARB / WGL_SAMPLES_ARB are declared by
+        // WGL_ARB_multisample against the ARB entry points, so the ARB
+        // families require the ARB multisample extension exactly.
+        .arb_ext_colorspace_srgb, .arb_srgb => hasWglExtension(extensions, "WGL_ARB_multisample"),
         .classic => false,
     };
 }
@@ -637,35 +746,14 @@ const WglPixelFormatSelector = struct {
                 }
                 break :load error.WglExtensionsUnavailable;
             };
+            // Never mix one family's sRGB attribute with the other family's
+            // entry points; `wgl_srgb_api_family_order` documents each valid
+            // pairing and the order they are tried in.
             const functions: WglPixelFormatFunctions = functions: {
-                // ARB_framebuffer_sRGB is specified in terms of the EXT
-                // pixel-format API. Keep that family exact when available.
-                if (hasWglExtension(extensions, "WGL_EXT_pixel_format") and
-                    hasWglExtension(extensions, "WGL_ARB_framebuffer_sRGB"))
-                {
-                    const choose_raw = wglGetProcAddress("wglChoosePixelFormatEXT");
-                    const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivEXT");
-                    if (validWglProcAddress(choose_raw) and validWglProcAddress(get_raw)) {
-                        break :functions .{ .ext_framebuffer_srgb = .{
-                            .choose = @ptrCast(@alignCast(choose_raw.?)),
-                            .get_attributes = @ptrCast(@alignCast(get_raw.?)),
-                        } };
-                    }
-                }
-
-                // WGL_EXT_colorspace is a separate sRGB surface path written
-                // against WGL_ARB_pixel_format. Do not mix either API with
-                // the other family's sRGB attribute.
-                if (hasWglExtension(extensions, "WGL_ARB_pixel_format") and
-                    hasWglExtension(extensions, "WGL_EXT_colorspace"))
-                {
-                    const choose_raw = wglGetProcAddress("wglChoosePixelFormatARB");
-                    const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivARB");
-                    if (validWglProcAddress(choose_raw) and validWglProcAddress(get_raw)) {
-                        break :functions .{ .arb_ext_colorspace_srgb = .{
-                            .choose = @ptrCast(@alignCast(choose_raw.?)),
-                            .get_attributes = @ptrCast(@alignCast(get_raw.?)),
-                        } };
+                for (wgl_srgb_api_family_order) |family| {
+                    if (!wglSrgbApiFamilyAdvertised(family, extensions)) continue;
+                    if (loadWglPixelFormatFunctions(family)) |resolved| {
+                        break :functions resolved;
                     }
                 }
                 break :load error.WglSrgbPixelFormatUnavailable;
@@ -1363,6 +1451,195 @@ test "win32 WGL bootstrap keeps exact sRGB API families and valid procs" {
     try std.testing.expect(!validWglProcAddress(null));
     try std.testing.expect(!validWglProcAddress(@ptrFromInt(1)));
     try std.testing.expect(validWglProcAddress(@ptrFromInt(0x1000)));
+}
+
+test "win32 WGL sRGB family order covers every pairing exactly once" {
+    const fields = @typeInfo(WglSrgbApiFamily).@"enum".fields;
+    try std.testing.expectEqual(fields.len, wgl_srgb_api_family_order.len);
+    inline for (fields) |field| {
+        const family: WglSrgbApiFamily = @enumFromInt(field.value);
+        var seen: usize = 0;
+        for (wgl_srgb_api_family_order) |candidate| {
+            if (candidate == family) seen += 1;
+        }
+        try std.testing.expectEqual(@as(usize, 1), seen);
+    }
+}
+
+test "win32 WGL sRGB selection reaches ARB-only drivers without WGL_EXT_pixel_format" {
+    // The regression this guards: a driver advertising the standard
+    // WGL_ARB_pixel_format + WGL_ARB_framebuffer_sRGB pair but no
+    // WGL_EXT_pixel_format and no WGL_EXT_colorspace must still reach the
+    // verified-sRGB direct-framebuffer path instead of silently falling
+    // back to the classic offscreen selection.
+    try std.testing.expectEqual(
+        WglSrgbApiFamily.arb_pixel_format_framebuffer_srgb,
+        firstAdvertisedWglSrgbApiFamily(
+            "WGL_ARB_extensions_string WGL_ARB_pixel_format WGL_ARB_framebuffer_sRGB WGL_ARB_multisample",
+        ).?,
+    );
+
+    // WGL_EXT_framebuffer_sRGB declares the same 0x20A9 attribute, so an
+    // EXT-only spelling is equally usable through either entry-point family.
+    try std.testing.expectEqual(
+        WglSrgbApiFamily.arb_pixel_format_framebuffer_srgb,
+        firstAdvertisedWglSrgbApiFamily(
+            "WGL_ARB_extensions_string WGL_ARB_pixel_format WGL_EXT_framebuffer_sRGB",
+        ).?,
+    );
+    try std.testing.expectEqual(
+        WglSrgbApiFamily.ext_pixel_format_framebuffer_srgb,
+        firstAdvertisedWglSrgbApiFamily(
+            "WGL_EXT_extensions_string WGL_EXT_pixel_format WGL_EXT_framebuffer_sRGB",
+        ).?,
+    );
+}
+
+test "win32 WGL sRGB selection prefers the spec-exact pairings" {
+    // Both framebuffer_sRGB specs are written against WGL_EXT_pixel_format,
+    // so that family wins whenever the driver advertises it.
+    try std.testing.expectEqual(
+        WglSrgbApiFamily.ext_pixel_format_framebuffer_srgb,
+        firstAdvertisedWglSrgbApiFamily(
+            "WGL_EXT_pixel_format WGL_ARB_pixel_format WGL_ARB_framebuffer_sRGB WGL_EXT_colorspace",
+        ).?,
+    );
+
+    // WGL_EXT_colorspace is written against WGL_ARB_pixel_format and keeps
+    // priority over the de-facto ARB framebuffer_sRGB pairing, so drivers
+    // that already selected through it do not change path.
+    try std.testing.expectEqual(
+        WglSrgbApiFamily.arb_pixel_format_colorspace,
+        firstAdvertisedWglSrgbApiFamily(
+            "WGL_ARB_pixel_format WGL_EXT_colorspace WGL_ARB_framebuffer_sRGB",
+        ).?,
+    );
+}
+
+test "win32 WGL sRGB selection refuses unpaired or absent extensions" {
+    // Pixel-format API with no sRGB attribute at all.
+    try std.testing.expectEqual(
+        @as(?WglSrgbApiFamily, null),
+        firstAdvertisedWglSrgbApiFamily("WGL_ARB_pixel_format WGL_ARB_multisample"),
+    );
+    try std.testing.expectEqual(
+        @as(?WglSrgbApiFamily, null),
+        firstAdvertisedWglSrgbApiFamily("WGL_EXT_pixel_format WGL_EXT_swap_control"),
+    );
+    // sRGB attributes with no pixel-format API to query them through.
+    try std.testing.expectEqual(
+        @as(?WglSrgbApiFamily, null),
+        firstAdvertisedWglSrgbApiFamily("WGL_ARB_framebuffer_sRGB WGL_EXT_colorspace"),
+    );
+    // WGL_EXT_colorspace must never be paired with the EXT entry points.
+    try std.testing.expectEqual(
+        @as(?WglSrgbApiFamily, null),
+        firstAdvertisedWglSrgbApiFamily("WGL_EXT_pixel_format WGL_EXT_colorspace"),
+    );
+    try std.testing.expectEqual(
+        @as(?WglSrgbApiFamily, null),
+        firstAdvertisedWglSrgbApiFamily(""),
+    );
+}
+
+test "win32 WGL sRGB attribute stays bound to its own API family" {
+    const stubs = struct {
+        fn chooseArb(
+            _: HDC,
+            _: ?[*]const i32,
+            _: ?[*]const f32,
+            _: UINT,
+            _: [*]i32,
+            _: *UINT,
+        ) callconv(.winapi) BOOL {
+            return 0;
+        }
+        fn getArb(
+            _: HDC,
+            _: i32,
+            _: i32,
+            _: UINT,
+            _: [*]const i32,
+            _: [*]i32,
+        ) callconv(.winapi) BOOL {
+            return 0;
+        }
+        fn chooseExt(
+            _: HDC,
+            _: ?[*]const i32,
+            _: ?[*]const f32,
+            _: UINT,
+            _: [*]i32,
+            _: *UINT,
+        ) callconv(.winapi) BOOL {
+            return 0;
+        }
+        fn getExt(
+            _: HDC,
+            _: i32,
+            _: i32,
+            _: UINT,
+            _: [*]i32,
+            _: [*]i32,
+        ) callconv(.winapi) BOOL {
+            return 0;
+        }
+    };
+    const arb: WglPixelFormatArbFunctions = .{
+        .choose = &stubs.chooseArb,
+        .get_attributes = &stubs.getArb,
+    };
+    const ext: WglPixelFormatExtFunctions = .{
+        .choose = &stubs.chooseExt,
+        .get_attributes = &stubs.getExt,
+    };
+
+    const ext_srgb: WglPixelFormatFunctions = .{ .ext_framebuffer_srgb = ext };
+    try std.testing.expectEqual(WglPixelFormatSelectionSource.ext_srgb, ext_srgb.source());
+    try std.testing.expectEqual(
+        @as(i32, WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB),
+        ext_srgb.srgbAttribute().name,
+    );
+    try std.testing.expectEqual(@as(i32, 1), ext_srgb.srgbAttribute().value);
+
+    const arb_srgb: WglPixelFormatFunctions = .{ .arb_framebuffer_srgb = arb };
+    try std.testing.expectEqual(WglPixelFormatSelectionSource.arb_srgb, arb_srgb.source());
+    try std.testing.expectEqual(
+        @as(i32, WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB),
+        arb_srgb.srgbAttribute().name,
+    );
+    try std.testing.expectEqual(@as(i32, 1), arb_srgb.srgbAttribute().value);
+
+    const colorspace: WglPixelFormatFunctions = .{ .arb_ext_colorspace_srgb = arb };
+    try std.testing.expectEqual(
+        WglPixelFormatSelectionSource.arb_ext_colorspace_srgb,
+        colorspace.source(),
+    );
+    try std.testing.expectEqual(
+        @as(i32, WGL_COLORSPACE_EXT),
+        colorspace.srgbAttribute().name,
+    );
+    try std.testing.expectEqual(
+        @as(i32, WGL_COLORSPACE_SRGB_EXT),
+        colorspace.srgbAttribute().value,
+    );
+}
+
+test "win32 WGL multisample query pairs with each family's own extension" {
+    // WGL_SAMPLE_BUFFERS_ARB / WGL_SAMPLES_ARB come from WGL_ARB_multisample
+    // against the ARB entry points, so the ARB families must not accept the
+    // EXT multisample spelling.
+    try std.testing.expect(wglMultisampleQuerySupported(.arb_srgb, "WGL_ARB_multisample"));
+    try std.testing.expect(!wglMultisampleQuerySupported(.arb_srgb, "WGL_EXT_multisample"));
+    try std.testing.expect(
+        wglMultisampleQuerySupported(.arb_ext_colorspace_srgb, "WGL_ARB_multisample"),
+    );
+    try std.testing.expect(
+        !wglMultisampleQuerySupported(.arb_ext_colorspace_srgb, "WGL_EXT_multisample"),
+    );
+    try std.testing.expect(wglMultisampleQuerySupported(.ext_srgb, "WGL_EXT_multisample"));
+    try std.testing.expect(wglMultisampleQuerySupported(.ext_srgb, "WGL_ARB_multisample"));
+    try std.testing.expect(!wglMultisampleQuerySupported(.classic, "WGL_ARB_multisample"));
 }
 
 test "win32 selected pixel format validation preserves actual attachments" {

--- a/src/apprt/win32/pixel_format.zig
+++ b/src/apprt/win32/pixel_format.zig
@@ -314,12 +314,21 @@ pub fn validatePixelFormatSetTransition(before: i32, selected: i32, after: i32) 
 
 fn isWglPixelFormatHardError(err: anyerror) bool {
     return switch (err) {
-        error.WglBootstrapMakeCurrentFailed,
         error.WglBootstrapRestoreCurrentFailed,
         error.WglBootstrapClearCurrentFailed,
         => true,
         else => false,
     };
+}
+
+test "win32 WGL bootstrap make-current failure keeps classic fallback available" {
+    // A failed wglMakeCurrent leaves the caller's previous current pair in
+    // place, and neither bootstrap path has touched the real child DC yet.
+    // Restoration/clear failures remain hard because the dummy context may
+    // still be current when its cleanup runs.
+    try std.testing.expect(!isWglPixelFormatHardError(error.WglBootstrapMakeCurrentFailed));
+    try std.testing.expect(isWglPixelFormatHardError(error.WglBootstrapRestoreCurrentFailed));
+    try std.testing.expect(isWglPixelFormatHardError(error.WglBootstrapClearCurrentFailed));
 }
 
 const PixelFormatBaseCompatibilityFailure = enum {

--- a/src/apprt/win32/pixel_format.zig
+++ b/src/apprt/win32/pixel_format.zig
@@ -1,0 +1,1422 @@
+//! Win32 WGL pixel-format selection.
+//!
+//! Split out of `win32.zig` so the window code does not carry driver
+//! compatibility ranking. The renderer may only draw straight to the Win32
+//! default framebuffer when a format is verified sRGB-capable, so what this
+//! module returns is a correctness input, not a preference.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+
+const c = @import("consts.zig");
+const gl_startup = @import("gl_startup.zig");
+const sys = @import("sys.zig");
+const win32_types = @import("../win32_types.zig");
+
+const log = std.log.scoped(.win32);
+
+const DWORD = win32_types.DWORD;
+const BYTE = win32_types.BYTE;
+const BOOL = win32_types.BOOL;
+const UINT = sys.UINT;
+const HDC = win32_types.HDC;
+const HWND = sys.HWND;
+const HGLRC = win32_types.HGLRC;
+const HINSTANCE = win32_types.HINSTANCE;
+const WPARAM = sys.WPARAM;
+const LPARAM = sys.LPARAM;
+const LRESULT = win32_types.LRESULT;
+const PIXELFORMATDESCRIPTOR = sys.PIXELFORMATDESCRIPTOR;
+const RECT = sys.RECT;
+const WNDCLASSEXW = sys.WNDCLASSEXW;
+
+const ChoosePixelFormat = sys.ChoosePixelFormat;
+const CreateWindowExW = sys.CreateWindowExW;
+const DefWindowProcW = sys.DefWindowProcW;
+const DescribePixelFormat = sys.DescribePixelFormat;
+const DestroyWindow = sys.DestroyWindow;
+const GetDC = sys.GetDC;
+const GetWindowRect = sys.GetWindowRect;
+const RegisterClassExW = sys.RegisterClassExW;
+const ReleaseDC = sys.ReleaseDC;
+const SetPixelFormat = sys.SetPixelFormat;
+const UnregisterClassW = sys.UnregisterClassW;
+const wglCreateContext = sys.wglCreateContext;
+const wglDeleteContext = sys.wglDeleteContext;
+const wglGetCurrentContext = sys.wglGetCurrentContext;
+const wglGetCurrentDC = sys.wglGetCurrentDC;
+const wglGetProcAddress = sys.wglGetProcAddress;
+const wglMakeCurrent = sys.wglMakeCurrent;
+
+const PFD_STEREO = 0x00000002;
+
+const PFD_GENERIC_FORMAT = 0x00000040;
+
+const PFD_GENERIC_ACCELERATED = 0x00001000;
+
+const PFD_DEPTH_DONTCARE = 0x20000000;
+
+const WGL_NUMBER_PIXEL_FORMATS_EXT = 0x2000;
+
+const WGL_DRAW_TO_WINDOW_EXT = 0x2001;
+
+const WGL_ACCELERATION_EXT = 0x2003;
+
+const WGL_SUPPORT_OPENGL_EXT = 0x2010;
+
+const WGL_DOUBLE_BUFFER_EXT = 0x2011;
+
+const WGL_STEREO_EXT = 0x2012;
+
+const WGL_PIXEL_TYPE_EXT = 0x2013;
+
+const WGL_COLOR_BITS_EXT = 0x2014;
+
+const WGL_ALPHA_BITS_EXT = 0x201B;
+
+const WGL_ACCUM_BITS_EXT = 0x201D;
+
+const WGL_DEPTH_BITS_EXT = 0x2022;
+
+const WGL_STENCIL_BITS_EXT = 0x2023;
+
+const WGL_AUX_BUFFERS_EXT = 0x2024;
+
+const WGL_FULL_ACCELERATION_EXT = 0x2027;
+
+const WGL_TYPE_RGBA_EXT = 0x202B;
+
+const WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB = 0x20A9;
+
+const WGL_SAMPLE_BUFFERS_ARB = 0x2041;
+
+const WGL_SAMPLES_ARB = 0x2042;
+
+const WGL_COLORSPACE_EXT = 0x309D;
+
+const WGL_COLORSPACE_SRGB_EXT = 0x3089;
+
+const wgl_pixel_format_inventory_attributes = [_]i32{
+    WGL_DRAW_TO_WINDOW_EXT, 1,
+    WGL_SUPPORT_OPENGL_EXT, 1,
+    WGL_DOUBLE_BUFFER_EXT,  1,
+    WGL_PIXEL_TYPE_EXT,     WGL_TYPE_RGBA_EXT,
+    WGL_COLOR_BITS_EXT,     32,
+    WGL_ALPHA_BITS_EXT,     8,
+    0,
+};
+
+pub const WglPixelFormatProvenance = struct {
+    index: u32,
+    color_bits: u8,
+    alpha_bits: u8,
+    depth_bits: u8,
+    stencil_bits: u8,
+    double_buffer: bool,
+    stereo: bool,
+    accum_bits: u8,
+    aux_buffers: u8,
+    selection_source: WglPixelFormatSelectionSource,
+    srgb_capable: bool,
+    multisample_query_supported: bool,
+    sample_buffers: ?u8,
+    samples: ?u8,
+    total_format_count: ?u16,
+    candidate_count: ?u16,
+};
+
+const WglPixelFormatSelectionSource = enum(u8) {
+    classic,
+    ext_srgb,
+    arb_ext_colorspace_srgb,
+};
+
+const WglPixelFormatCandidate = struct {
+    index: i32,
+    color_bits: u8,
+    alpha_bits: u8,
+    depth_bits: u8,
+    stencil_bits: u8,
+    srgb_capable: bool,
+    fully_accelerated: bool,
+    stereo: bool = false,
+    accum_bits: u8 = 0,
+    aux_buffers: u8 = 0,
+    multisample_query_supported: bool = false,
+    sample_buffers: ?u8 = null,
+    samples: ?u8 = null,
+};
+
+const WglPixelFormatRejection = enum {
+    base_contract,
+    nonaccelerated,
+    non_srgb,
+    stereo,
+    multisample,
+    descriptor_invalid,
+};
+
+fn classifyWglPixelFormatCandidate(
+    candidate: WglPixelFormatCandidate,
+    base_contract: bool,
+) ?WglPixelFormatRejection {
+    // Keep these disjoint and ordered so the bounded startup diagnostic adds
+    // up to every returned match instead of double-counting unsuitable formats.
+    if (!base_contract or candidate.color_bits < 32 or candidate.alpha_bits < 8) {
+        return .base_contract;
+    }
+    if (!candidate.fully_accelerated) return .nonaccelerated;
+    if (!candidate.srgb_capable) return .non_srgb;
+    if (candidate.stereo) return .stereo;
+    if (candidate.multisample_query_supported) {
+        if (candidate.sample_buffers == null or
+            candidate.samples == null or
+            candidate.sample_buffers.? != 0 or
+            candidate.samples.? != 0)
+        {
+            return .multisample;
+        }
+    } else if (candidate.sample_buffers != null or candidate.samples != null) {
+        return .multisample;
+    }
+    return null;
+}
+
+fn wglPixelFormatCandidateUsable(candidate: WglPixelFormatCandidate) bool {
+    return classifyWglPixelFormatCandidate(candidate, true) == null;
+}
+
+fn betterWglPixelFormatCandidate(
+    candidate: WglPixelFormatCandidate,
+    current: WglPixelFormatCandidate,
+) bool {
+    const candidate_accum_free = candidate.accum_bits == 0;
+    const current_accum_free = current.accum_bits == 0;
+    if (candidate_accum_free != current_accum_free) return candidate_accum_free;
+
+    const candidate_aux_free = candidate.aux_buffers == 0;
+    const current_aux_free = current.aux_buffers == 0;
+    if (candidate_aux_free != current_aux_free) return candidate_aux_free;
+
+    const candidate_depthless = candidate.depth_bits == 0;
+    const current_depthless = current.depth_bits == 0;
+    if (candidate_depthless != current_depthless) return candidate_depthless;
+
+    const candidate_stencilless = candidate.stencil_bits == 0;
+    const current_stencilless = current.stencil_bits == 0;
+    if (candidate_stencilless != current_stencilless) return candidate_stencilless;
+    if (candidate.accum_bits != current.accum_bits) return candidate.accum_bits < current.accum_bits;
+    if (candidate.aux_buffers != current.aux_buffers) return candidate.aux_buffers < current.aux_buffers;
+    if (candidate.depth_bits != current.depth_bits) return candidate.depth_bits < current.depth_bits;
+    if (candidate.stencil_bits != current.stencil_bits) return candidate.stencil_bits < current.stencil_bits;
+    if (candidate.color_bits != current.color_bits) return candidate.color_bits < current.color_bits;
+    if (candidate.alpha_bits != current.alpha_bits) return candidate.alpha_bits < current.alpha_bits;
+    return candidate.index < current.index;
+}
+
+fn rankWglPixelFormatCandidates(
+    candidates: []const WglPixelFormatCandidate,
+) ?WglPixelFormatCandidate {
+    var selected: ?WglPixelFormatCandidate = null;
+    for (candidates) |candidate| {
+        if (!wglPixelFormatCandidateUsable(candidate)) continue;
+        if (selected == null or betterWglPixelFormatCandidate(candidate, selected.?)) {
+            selected = candidate;
+        }
+    }
+    return selected;
+}
+
+const ClassicPixelFormatCandidate = struct {
+    index: i32,
+    descriptor: PIXELFORMATDESCRIPTOR,
+    provenance: WglPixelFormatProvenance,
+    acceleration: ClassicPixelFormatAcceleration,
+};
+
+const ClassicPixelFormatAcceleration = enum(u8) {
+    generic,
+    mcd,
+    icd,
+};
+
+fn classicPixelFormatAcceleration(flags: DWORD) ClassicPixelFormatAcceleration {
+    if (flags & PFD_GENERIC_FORMAT == 0) return .icd;
+    if (flags & PFD_GENERIC_ACCELERATED != 0) return .mcd;
+    return .generic;
+}
+
+fn betterClassicPixelFormatCandidate(
+    candidate: ClassicPixelFormatCandidate,
+    current: ClassicPixelFormatCandidate,
+) bool {
+    if (candidate.acceleration != current.acceleration) {
+        return @intFromEnum(candidate.acceleration) > @intFromEnum(current.acceleration);
+    }
+    const candidate_accum_free = candidate.provenance.accum_bits == 0;
+    const current_accum_free = current.provenance.accum_bits == 0;
+    if (candidate_accum_free != current_accum_free) return candidate_accum_free;
+    const candidate_aux_free = candidate.provenance.aux_buffers == 0;
+    const current_aux_free = current.provenance.aux_buffers == 0;
+    if (candidate_aux_free != current_aux_free) return candidate_aux_free;
+    const candidate_depthless = candidate.provenance.depth_bits == 0;
+    const current_depthless = current.provenance.depth_bits == 0;
+    if (candidate_depthless != current_depthless) return candidate_depthless;
+    const candidate_stencilless = candidate.provenance.stencil_bits == 0;
+    const current_stencilless = current.provenance.stencil_bits == 0;
+    if (candidate_stencilless != current_stencilless) return candidate_stencilless;
+    if (candidate.provenance.accum_bits != current.provenance.accum_bits) {
+        return candidate.provenance.accum_bits < current.provenance.accum_bits;
+    }
+    if (candidate.provenance.aux_buffers != current.provenance.aux_buffers) {
+        return candidate.provenance.aux_buffers < current.provenance.aux_buffers;
+    }
+    if (candidate.provenance.depth_bits != current.provenance.depth_bits) {
+        return candidate.provenance.depth_bits < current.provenance.depth_bits;
+    }
+    if (candidate.provenance.stencil_bits != current.provenance.stencil_bits) {
+        return candidate.provenance.stencil_bits < current.provenance.stencil_bits;
+    }
+    return candidate.index < current.index;
+}
+
+fn rankClassicPixelFormatCandidates(
+    candidates: []const ClassicPixelFormatCandidate,
+) ?ClassicPixelFormatCandidate {
+    var selected: ?ClassicPixelFormatCandidate = null;
+    for (candidates) |candidate| {
+        if (selected == null or betterClassicPixelFormatCandidate(candidate, selected.?)) {
+            selected = candidate;
+        }
+    }
+    return selected;
+}
+
+const max_wgl_pixel_formats = 1024;
+
+fn validatedWglPixelFormatCount(total_format_count: i32) !UINT {
+    if (total_format_count <= 0 or total_format_count > max_wgl_pixel_formats) {
+        return error.WglPixelFormatCandidateCapacityExceeded;
+    }
+    return @intCast(total_format_count);
+}
+
+pub fn validatePixelFormatSetTransition(before: i32, selected: i32, after: i32) !void {
+    if (before != 0) return error.PixelFormatAlreadySet;
+    if (selected <= 0 or after != selected) return error.PixelFormatSetVerificationFailed;
+}
+
+fn isWglPixelFormatHardError(err: anyerror) bool {
+    return switch (err) {
+        error.WglBootstrapMakeCurrentFailed,
+        error.WglBootstrapRestoreCurrentFailed,
+        error.WglBootstrapClearCurrentFailed,
+        => true,
+        else => false,
+    };
+}
+
+const PixelFormatBaseCompatibilityFailure = enum {
+    invalid_index,
+    invalid_descriptor_header,
+    non_rgba,
+    non_main_plane,
+    missing_required_flags,
+    insufficient_color,
+    insufficient_alpha,
+    stereo,
+};
+
+fn pixelFormatBaseCompatibilityFailure(
+    pixel_format: i32,
+    pfd: PIXELFORMATDESCRIPTOR,
+) ?PixelFormatBaseCompatibilityFailure {
+    if (pixel_format <= 0) return .invalid_index;
+    if (pfd.nSize != @sizeOf(PIXELFORMATDESCRIPTOR) or pfd.nVersion != 1) {
+        return .invalid_descriptor_header;
+    }
+    if (pfd.iPixelType != c.PFD_TYPE_RGBA) return .non_rgba;
+    if (pfd.iLayerType != c.PFD_MAIN_PLANE) return .non_main_plane;
+    const required_flags = c.PFD_DRAW_TO_WINDOW | c.PFD_SUPPORT_OPENGL | c.PFD_DOUBLEBUFFER;
+    if (pfd.dwFlags & required_flags != required_flags) return .missing_required_flags;
+    if (pfd.cColorBits < 32) return .insufficient_color;
+    if (pfd.cAlphaBits < 8) return .insufficient_alpha;
+    if (pfd.dwFlags & PFD_STEREO != 0) return .stereo;
+    return null;
+}
+
+fn validateSelectedPixelFormat(
+    pixel_format: i32,
+    pfd: PIXELFORMATDESCRIPTOR,
+) !WglPixelFormatProvenance {
+    if (pixelFormatBaseCompatibilityFailure(pixel_format, pfd) != null)
+        return error.InvalidSelectedPixelFormat;
+
+    return .{
+        .index = @intCast(pixel_format),
+        .color_bits = pfd.cColorBits,
+        .alpha_bits = pfd.cAlphaBits,
+        .depth_bits = pfd.cDepthBits,
+        .stencil_bits = pfd.cStencilBits,
+        .double_buffer = pfd.dwFlags & c.PFD_DOUBLEBUFFER != 0,
+        .stereo = pfd.dwFlags & PFD_STEREO != 0,
+        .accum_bits = pfd.cAccumBits,
+        .aux_buffers = pfd.cAuxBuffers,
+        .selection_source = .classic,
+        .srgb_capable = false,
+        .multisample_query_supported = false,
+        .sample_buffers = null,
+        .samples = null,
+        .total_format_count = null,
+        .candidate_count = null,
+    };
+}
+
+const WglChoosePixelFormatExtFn = *const fn (
+    hdc: HDC,
+    int_attributes: ?[*]const i32,
+    float_attributes: ?[*]const f32,
+    max_formats: UINT,
+    formats: [*]i32,
+    format_count: *UINT,
+) callconv(.winapi) BOOL;
+
+const WglGetPixelFormatAttribivExtFn = *const fn (
+    hdc: HDC,
+    pixel_format: i32,
+    layer_plane: i32,
+    attribute_count: UINT,
+    attributes: [*]i32,
+    values: [*]i32,
+) callconv(.winapi) BOOL;
+
+const WglGetExtensionsStringExtFn = *const fn () callconv(.winapi) ?[*:0]const u8;
+
+const WglChoosePixelFormatArbFn = *const fn (
+    hdc: HDC,
+    int_attributes: ?[*]const i32,
+    float_attributes: ?[*]const f32,
+    max_formats: UINT,
+    formats: [*]i32,
+    format_count: *UINT,
+) callconv(.winapi) BOOL;
+
+const WglGetPixelFormatAttribivArbFn = *const fn (
+    hdc: HDC,
+    pixel_format: i32,
+    layer_plane: i32,
+    attribute_count: UINT,
+    attributes: [*]const i32,
+    values: [*]i32,
+) callconv(.winapi) BOOL;
+
+const WglGetExtensionsStringArbFn = *const fn (hdc: HDC) callconv(.winapi) ?[*:0]const u8;
+
+const WglPixelFormatFunctions = union(enum) {
+    ext_framebuffer_srgb: struct {
+        choose: WglChoosePixelFormatExtFn,
+        get_attributes: WglGetPixelFormatAttribivExtFn,
+    },
+    arb_ext_colorspace_srgb: struct {
+        choose: WglChoosePixelFormatArbFn,
+        get_attributes: WglGetPixelFormatAttribivArbFn,
+    },
+
+    fn choose(
+        self: WglPixelFormatFunctions,
+        hdc: HDC,
+        attributes: [*]const i32,
+        max_formats: UINT,
+        formats: [*]i32,
+        count: *UINT,
+    ) BOOL {
+        return switch (self) {
+            .ext_framebuffer_srgb => |functions| functions.choose(
+                hdc,
+                attributes,
+                null,
+                max_formats,
+                formats,
+                count,
+            ),
+            .arb_ext_colorspace_srgb => |functions| functions.choose(
+                hdc,
+                attributes,
+                null,
+                max_formats,
+                formats,
+                count,
+            ),
+        };
+    }
+
+    fn getAttributes(
+        self: WglPixelFormatFunctions,
+        hdc: HDC,
+        pixel_format: i32,
+        attributes: []i32,
+        values: [*]i32,
+    ) BOOL {
+        const attribute_count: UINT = @intCast(attributes.len);
+        return switch (self) {
+            .ext_framebuffer_srgb => |functions| functions.get_attributes(
+                hdc,
+                pixel_format,
+                0,
+                attribute_count,
+                attributes.ptr,
+                values,
+            ),
+            .arb_ext_colorspace_srgb => |functions| functions.get_attributes(
+                hdc,
+                pixel_format,
+                0,
+                attribute_count,
+                attributes.ptr,
+                values,
+            ),
+        };
+    }
+
+    fn source(self: WglPixelFormatFunctions) WglPixelFormatSelectionSource {
+        return switch (self) {
+            .ext_framebuffer_srgb => .ext_srgb,
+            .arb_ext_colorspace_srgb => .arb_ext_colorspace_srgb,
+        };
+    }
+
+    fn srgbAttribute(self: WglPixelFormatFunctions) struct { name: i32, value: i32 } {
+        return switch (self) {
+            .ext_framebuffer_srgb => .{
+                .name = WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB,
+                .value = 1,
+            },
+            .arb_ext_colorspace_srgb => .{
+                .name = WGL_COLORSPACE_EXT,
+                .value = WGL_COLORSPACE_SRGB_EXT,
+            },
+        };
+    }
+};
+
+fn validWglProcAddress(raw: ?*const anyopaque) bool {
+    const address = @intFromPtr(raw orelse return false);
+    return address > 3 and address != std.math.maxInt(usize);
+}
+
+fn hasWglExtension(extensions: []const u8, expected: []const u8) bool {
+    var iterator = std.mem.tokenizeScalar(u8, extensions, ' ');
+    while (iterator.next()) |extension| {
+        if (std.mem.eql(u8, extension, expected)) return true;
+    }
+    return false;
+}
+
+fn wglMultisampleQuerySupported(
+    source: WglPixelFormatSelectionSource,
+    extensions: []const u8,
+) bool {
+    return switch (source) {
+        .ext_srgb => hasWglExtension(extensions, "WGL_ARB_multisample") or
+            hasWglExtension(extensions, "WGL_EXT_multisample"),
+        .arb_ext_colorspace_srgb => hasWglExtension(extensions, "WGL_ARB_multisample"),
+        .classic => false,
+    };
+}
+
+pub const WglPixelFormatSelection = struct {
+    pixel_format: i32,
+    descriptor: PIXELFORMATDESCRIPTOR,
+    provenance: WglPixelFormatProvenance,
+};
+
+const WglBootstrapPlacement = struct {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+};
+
+fn wglBootstrapPlacement(anchor: RECT) WglBootstrapPlacement {
+    return .{
+        .x = anchor.left,
+        .y = anchor.top,
+        .width = 1,
+        .height = 1,
+    };
+}
+
+const WglPixelFormatSelector = struct {
+    hinstance: HINSTANCE,
+    hwnd: HWND,
+    hdc: HDC,
+    hglrc: HGLRC,
+    functions: WglPixelFormatFunctions,
+    multisample_query_supported: bool,
+
+    fn init(hinstance: HINSTANCE, anchor: RECT) !WglPixelFormatSelector {
+        const placement = wglBootstrapPlacement(anchor);
+        var window_class: WNDCLASSEXW = .{
+            .cbSize = @sizeOf(WNDCLASSEXW),
+            .style = c.CS_OWNDC,
+            .lpfnWndProc = &wglBootstrapWindowProc,
+            .cbClsExtra = 0,
+            .cbWndExtra = 0,
+            .hInstance = hinstance,
+            .hIcon = null,
+            .hCursor = null,
+            .hbrBackground = null,
+            .lpszMenuName = null,
+            .lpszClassName = wgl_bootstrap_class_name,
+            .hIconSm = null,
+        };
+        if (RegisterClassExW(&window_class) == 0) {
+            return error.WglBootstrapRegisterClassFailed;
+        }
+        errdefer _ = UnregisterClassW(wgl_bootstrap_class_name, hinstance);
+
+        const window_name = std.unicode.utf8ToUtf16LeStringLiteral("");
+        const hwnd = CreateWindowExW(
+            0,
+            wgl_bootstrap_class_name,
+            window_name,
+            c.WS_POPUP,
+            placement.x,
+            placement.y,
+            placement.width,
+            placement.height,
+            null,
+            null,
+            hinstance,
+            null,
+        ) orelse return error.WglBootstrapWindowFailed;
+        errdefer _ = DestroyWindow(hwnd);
+
+        const hdc = GetDC(hwnd) orelse return error.WglBootstrapGetDCFailed;
+        errdefer _ = ReleaseDC(hwnd, hdc);
+
+        const pfd = defaultPixelFormatDescriptor();
+        const pixel_format = ChoosePixelFormat(hdc, &pfd);
+        if (pixel_format == 0) return error.WglBootstrapChoosePixelFormatFailed;
+        if (SetPixelFormat(hdc, pixel_format, &pfd) == 0) {
+            return error.WglBootstrapSetPixelFormatFailed;
+        }
+
+        const hglrc = wglCreateContext(hdc) orelse return error.WglBootstrapCreateContextFailed;
+        errdefer {
+            if (wglGetCurrentContext() == hglrc) _ = wglMakeCurrent(null, null);
+            _ = wglDeleteContext(hglrc);
+        }
+
+        const previous_hdc = wglGetCurrentDC();
+        const previous_hglrc = wglGetCurrentContext();
+        if (wglMakeCurrent(hdc, hglrc) == 0) return error.WglBootstrapMakeCurrentFailed;
+
+        const loaded = load: {
+            const extensions = extensions: {
+                const arb_raw = wglGetProcAddress("wglGetExtensionsStringARB");
+                if (validWglProcAddress(arb_raw)) {
+                    const get_arb: WglGetExtensionsStringArbFn = @ptrCast(@alignCast(arb_raw.?));
+                    if (get_arb(hdc)) |value| {
+                        const list = std.mem.span(value);
+                        if (hasWglExtension(list, "WGL_ARB_extensions_string")) {
+                            break :extensions list;
+                        }
+                    }
+                }
+                const ext_raw = wglGetProcAddress("wglGetExtensionsStringEXT");
+                if (validWglProcAddress(ext_raw)) {
+                    const get_ext: WglGetExtensionsStringExtFn = @ptrCast(@alignCast(ext_raw.?));
+                    if (get_ext()) |value| {
+                        const list = std.mem.span(value);
+                        if (hasWglExtension(list, "WGL_EXT_extensions_string")) {
+                            break :extensions list;
+                        }
+                    }
+                }
+                break :load error.WglExtensionsUnavailable;
+            };
+            const functions: WglPixelFormatFunctions = functions: {
+                // ARB_framebuffer_sRGB is specified in terms of the EXT
+                // pixel-format API. Keep that family exact when available.
+                if (hasWglExtension(extensions, "WGL_EXT_pixel_format") and
+                    hasWglExtension(extensions, "WGL_ARB_framebuffer_sRGB"))
+                {
+                    const choose_raw = wglGetProcAddress("wglChoosePixelFormatEXT");
+                    const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivEXT");
+                    if (validWglProcAddress(choose_raw) and validWglProcAddress(get_raw)) {
+                        break :functions .{ .ext_framebuffer_srgb = .{
+                            .choose = @ptrCast(@alignCast(choose_raw.?)),
+                            .get_attributes = @ptrCast(@alignCast(get_raw.?)),
+                        } };
+                    }
+                }
+
+                // WGL_EXT_colorspace is a separate sRGB surface path written
+                // against WGL_ARB_pixel_format. Do not mix either API with
+                // the other family's sRGB attribute.
+                if (hasWglExtension(extensions, "WGL_ARB_pixel_format") and
+                    hasWglExtension(extensions, "WGL_EXT_colorspace"))
+                {
+                    const choose_raw = wglGetProcAddress("wglChoosePixelFormatARB");
+                    const get_raw = wglGetProcAddress("wglGetPixelFormatAttribivARB");
+                    if (validWglProcAddress(choose_raw) and validWglProcAddress(get_raw)) {
+                        break :functions .{ .arb_ext_colorspace_srgb = .{
+                            .choose = @ptrCast(@alignCast(choose_raw.?)),
+                            .get_attributes = @ptrCast(@alignCast(get_raw.?)),
+                        } };
+                    }
+                }
+                break :load error.WglSrgbPixelFormatUnavailable;
+            };
+            break :load .{
+                .functions = functions,
+                .multisample = wglMultisampleQuerySupported(
+                    functions.source(),
+                    extensions,
+                ),
+            };
+        };
+
+        if (wglMakeCurrent(previous_hdc, previous_hglrc) == 0) {
+            // Never let a failed restoration leave the dummy context current
+            // while its errdefer cleanup tries to delete it.
+            return if (wglMakeCurrent(null, null) != 0)
+                error.WglBootstrapRestoreCurrentFailed
+            else
+                error.WglBootstrapClearCurrentFailed;
+        }
+        const functions = try loaded;
+
+        return .{
+            .hinstance = hinstance,
+            .hwnd = hwnd,
+            .hdc = hdc,
+            .hglrc = hglrc,
+            .functions = functions.functions,
+            .multisample_query_supported = functions.multisample,
+        };
+    }
+
+    fn deinit(self: *WglPixelFormatSelector) void {
+        if (wglGetCurrentContext() == self.hglrc) _ = wglMakeCurrent(null, null);
+        _ = wglDeleteContext(self.hglrc);
+        _ = ReleaseDC(self.hwnd, self.hdc);
+        _ = DestroyWindow(self.hwnd);
+        _ = UnregisterClassW(wgl_bootstrap_class_name, self.hinstance);
+        self.* = undefined;
+    }
+
+    fn choose(
+        self: *const WglPixelFormatSelector,
+        hdc: HDC,
+    ) !?WglPixelFormatSelection {
+        const previous_hdc = wglGetCurrentDC();
+        const previous_hglrc = wglGetCurrentContext();
+        if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
+            return error.WglBootstrapMakeCurrentFailed;
+        }
+
+        const result = self.chooseCurrent(hdc);
+        if (wglMakeCurrent(previous_hdc, previous_hglrc) == 0) {
+            return if (wglMakeCurrent(null, null) != 0)
+                error.WglBootstrapRestoreCurrentFailed
+            else
+                error.WglBootstrapClearCurrentFailed;
+        }
+        return result;
+    }
+
+    fn chooseCurrent(
+        self: *const WglPixelFormatSelector,
+        hdc: HDC,
+    ) !?WglPixelFormatSelection {
+        const srgb_attribute = self.functions.srgbAttribute();
+        var format_count_attributes = [_]i32{WGL_NUMBER_PIXEL_FORMATS_EXT};
+        var format_count_values: [1]i32 = undefined;
+        if (self.functions.getAttributes(
+            hdc,
+            0,
+            &format_count_attributes,
+            &format_count_values,
+        ) == 0) return error.WglPixelFormatCountQueryFailed;
+        const total_format_count = format_count_values[0];
+        const max_format_count = validatedWglPixelFormatCount(total_format_count) catch |err| {
+            log.warn(
+                "WGL extended pixel-format inventory exceeds deterministic capacity total={} capacity={}",
+                .{ total_format_count, max_wgl_pixel_formats },
+            );
+            return err;
+        };
+
+        var pixel_formats: [max_wgl_pixel_formats]i32 = undefined;
+        var pixel_format_count: UINT = 0;
+        if (self.functions.choose(
+            hdc,
+            &wgl_pixel_format_inventory_attributes,
+            max_format_count,
+            &pixel_formats,
+            &pixel_format_count,
+        ) == 0) return error.WglChoosePixelFormatFailed;
+        if (pixel_format_count > max_format_count) return error.WglInvalidPixelFormatCandidateCount;
+        const count: usize = @intCast(pixel_format_count);
+        if (count == 0) {
+            return null;
+        }
+        log.debug(
+            "WGL extended pixel-format inventory total={} matching={} truncated=false",
+            .{ total_format_count, count },
+        );
+
+        var query_attributes_base = [_]i32{
+            WGL_DRAW_TO_WINDOW_EXT,
+            WGL_SUPPORT_OPENGL_EXT,
+            WGL_DOUBLE_BUFFER_EXT,
+            WGL_STEREO_EXT,
+            WGL_PIXEL_TYPE_EXT,
+            WGL_COLOR_BITS_EXT,
+            WGL_ALPHA_BITS_EXT,
+            WGL_ACCUM_BITS_EXT,
+            WGL_AUX_BUFFERS_EXT,
+            WGL_DEPTH_BITS_EXT,
+            WGL_STENCIL_BITS_EXT,
+            WGL_ACCELERATION_EXT,
+            srgb_attribute.name,
+        };
+        var query_attributes_multisample = [_]i32{
+            WGL_DRAW_TO_WINDOW_EXT,
+            WGL_SUPPORT_OPENGL_EXT,
+            WGL_DOUBLE_BUFFER_EXT,
+            WGL_STEREO_EXT,
+            WGL_PIXEL_TYPE_EXT,
+            WGL_COLOR_BITS_EXT,
+            WGL_ALPHA_BITS_EXT,
+            WGL_ACCUM_BITS_EXT,
+            WGL_AUX_BUFFERS_EXT,
+            WGL_DEPTH_BITS_EXT,
+            WGL_STENCIL_BITS_EXT,
+            WGL_ACCELERATION_EXT,
+            srgb_attribute.name,
+            WGL_SAMPLE_BUFFERS_ARB,
+            WGL_SAMPLES_ARB,
+        };
+        const query_attributes: []i32 = if (self.multisample_query_supported)
+            &query_attributes_multisample
+        else
+            &query_attributes_base;
+        var candidates: [pixel_formats.len]WglPixelFormatCandidate = undefined;
+        var candidate_count: usize = 0;
+        for (pixel_formats[0..count]) |pixel_format| {
+            var values: [query_attributes_multisample.len]i32 = undefined;
+            if (self.functions.getAttributes(
+                hdc,
+                pixel_format,
+                query_attributes,
+                &values,
+            ) == 0) return error.WglPixelFormatCandidateQueryFailed;
+            if (values[0] < 0 or values[0] > 1 or
+                values[1] < 0 or values[1] > 1 or
+                values[2] < 0 or values[2] > 1 or
+                values[3] < 0 or values[3] > 1 or
+                values[5] < 0 or
+                values[5] > std.math.maxInt(u8) or
+                values[6] < 0 or
+                values[6] > std.math.maxInt(u8) or
+                values[7] < 0 or
+                values[7] > std.math.maxInt(u8) or
+                values[8] < 0 or
+                values[8] > std.math.maxInt(u8) or
+                values[9] < 0 or
+                values[9] > std.math.maxInt(u8) or
+                values[10] < 0 or
+                values[10] > std.math.maxInt(u8) or
+                (self.multisample_query_supported and
+                    (values[13] < 0 or
+                        values[13] > std.math.maxInt(u8) or
+                        values[14] < 0 or
+                        values[14] > std.math.maxInt(u8))))
+            {
+                return error.WglPixelFormatCandidateContractViolation;
+            }
+
+            const candidate: WglPixelFormatCandidate = .{
+                .index = pixel_format,
+                .color_bits = @intCast(values[5]),
+                .alpha_bits = @intCast(values[6]),
+                .depth_bits = @intCast(values[9]),
+                .stencil_bits = @intCast(values[10]),
+                .fully_accelerated = values[11] == WGL_FULL_ACCELERATION_EXT,
+                .srgb_capable = values[12] == srgb_attribute.value,
+                .stereo = values[3] != 0,
+                .accum_bits = @intCast(values[7]),
+                .aux_buffers = @intCast(values[8]),
+                .multisample_query_supported = self.multisample_query_supported,
+                .sample_buffers = if (self.multisample_query_supported) @intCast(values[13]) else null,
+                .samples = if (self.multisample_query_supported) @intCast(values[14]) else null,
+            };
+            const base_contract = values[0] == 1 and
+                values[1] == 1 and
+                values[2] == 1 and
+                values[4] == WGL_TYPE_RGBA_EXT;
+            if (classifyWglPixelFormatCandidate(candidate, base_contract) != null) {
+                continue;
+            }
+
+            var descriptor: PIXELFORMATDESCRIPTOR = undefined;
+            if (DescribePixelFormat(
+                hdc,
+                pixel_format,
+                @sizeOf(PIXELFORMATDESCRIPTOR),
+                &descriptor,
+            ) == 0) return error.WglDescribePixelFormatFailed;
+            _ = validateSelectedPixelFormat(pixel_format, descriptor) catch {
+                continue;
+            };
+            if ((descriptor.dwFlags & PFD_STEREO != 0) != (values[3] != 0) or
+                descriptor.cColorBits != @as(u8, @intCast(values[5])) or
+                descriptor.cAlphaBits != @as(u8, @intCast(values[6])) or
+                descriptor.cAccumBits != @as(u8, @intCast(values[7])) or
+                descriptor.cAuxBuffers != @as(u8, @intCast(values[8])) or
+                descriptor.cDepthBits != @as(u8, @intCast(values[9])) or
+                descriptor.cStencilBits != @as(u8, @intCast(values[10])))
+            {
+                continue;
+            }
+
+            candidates[candidate_count] = candidate;
+            candidate_count += 1;
+        }
+
+        const selected_candidate = rankWglPixelFormatCandidates(candidates[0..candidate_count]) orelse {
+            return null;
+        };
+        var selected_pfd: PIXELFORMATDESCRIPTOR = undefined;
+        if (DescribePixelFormat(
+            hdc,
+            selected_candidate.index,
+            @sizeOf(PIXELFORMATDESCRIPTOR),
+            &selected_pfd,
+        ) == 0) return error.WglDescribePixelFormatFailed;
+        var provenance = try validateSelectedPixelFormat(selected_candidate.index, selected_pfd);
+        provenance.selection_source = self.functions.source();
+        provenance.srgb_capable = true;
+        provenance.multisample_query_supported = selected_candidate.multisample_query_supported;
+        provenance.sample_buffers = selected_candidate.sample_buffers;
+        provenance.samples = selected_candidate.samples;
+        provenance.total_format_count = @intCast(total_format_count);
+        provenance.candidate_count = @intCast(count);
+        return .{
+            .pixel_format = selected_candidate.index,
+            .descriptor = selected_pfd,
+            .provenance = provenance,
+        };
+    }
+};
+
+const wgl_bootstrap_class_name = std.unicode.utf8ToUtf16LeStringLiteral("noctty.win32.wgl_bootstrap");
+
+fn wglBootstrapWindowProc(
+    hwnd: HWND,
+    msg: UINT,
+    wParam: WPARAM,
+    lParam: LPARAM,
+) callconv(.winapi) LRESULT {
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+pub fn defaultPixelFormatDescriptor() PIXELFORMATDESCRIPTOR {
+    return .{
+        .nSize = @sizeOf(PIXELFORMATDESCRIPTOR),
+        .nVersion = 1,
+        // cDepthBits=0 alone still makes ChoosePixelFormat consider only
+        // depth-buffered formats. This is request-only; selected actual
+        // depth remains whatever DescribePixelFormat reports.
+        .dwFlags = c.PFD_DRAW_TO_WINDOW |
+            c.PFD_SUPPORT_OPENGL |
+            c.PFD_DOUBLEBUFFER |
+            PFD_DEPTH_DONTCARE,
+        .iPixelType = c.PFD_TYPE_RGBA,
+        .cColorBits = 32,
+        .cRedBits = 0,
+        .cRedShift = 0,
+        .cGreenBits = 0,
+        .cGreenShift = 0,
+        .cBlueBits = 0,
+        .cBlueShift = 0,
+        .cAlphaBits = 8,
+        .cAlphaShift = 0,
+        .cAccumBits = 0,
+        .cAccumRedBits = 0,
+        .cAccumGreenBits = 0,
+        .cAccumBlueBits = 0,
+        .cAccumAlphaBits = 0,
+        .cDepthBits = 0,
+        .cStencilBits = 0,
+        .cAuxBuffers = 0,
+        .iLayerType = c.PFD_MAIN_PLANE,
+        .bReserved = 0,
+        .dwLayerMask = 0,
+        .dwVisibleMask = 0,
+        .dwDamageMask = 0,
+    };
+}
+
+fn compatibilityPixelFormatDescriptor() PIXELFORMATDESCRIPTOR {
+    var result = defaultPixelFormatDescriptor();
+    result.dwFlags &= ~@as(DWORD, PFD_DEPTH_DONTCARE);
+    return result;
+}
+
+fn chooseClassicCompatibilityPixelFormat(hdc: HDC) !WglPixelFormatSelection {
+    const requested = compatibilityPixelFormatDescriptor();
+    const pixel_format = ChoosePixelFormat(hdc, &requested);
+    if (pixel_format == 0) {
+        const err = windows.kernel32.GetLastError();
+        gl_startup.recordOpenGLStartupWin32Failure(.choose_pixel_format, err);
+        return windows.unexpectedError(err);
+    }
+    var descriptor: PIXELFORMATDESCRIPTOR = undefined;
+    if (DescribePixelFormat(
+        hdc,
+        pixel_format,
+        @sizeOf(PIXELFORMATDESCRIPTOR),
+        &descriptor,
+    ) == 0) {
+        const err = windows.kernel32.GetLastError();
+        gl_startup.recordOpenGLStartupWin32Failure(.describe_pixel_format, err);
+        return windows.unexpectedError(err);
+    }
+    const provenance = validateSelectedPixelFormat(pixel_format, descriptor) catch |err| {
+        const reason = pixelFormatBaseCompatibilityFailure(pixel_format, descriptor) orelse unreachable;
+        log.warn(
+            "classic ChoosePixelFormat recovery rejected index={} reason={s} flags=0x{x} size={} version={} pixel_type={} layer={} color_bits={} alpha_bits={} accum_bits={} aux_buffers={} depth_bits={} stencil_bits={}",
+            .{
+                pixel_format,
+                @tagName(reason),
+                descriptor.dwFlags,
+                descriptor.nSize,
+                descriptor.nVersion,
+                descriptor.iPixelType,
+                descriptor.iLayerType,
+                descriptor.cColorBits,
+                descriptor.cAlphaBits,
+                descriptor.cAccumBits,
+                descriptor.cAuxBuffers,
+                descriptor.cDepthBits,
+                descriptor.cStencilBits,
+            },
+        );
+        gl_startup.recordOpenGLStartupError(.describe_pixel_format, err);
+        return err;
+    };
+    return .{
+        .pixel_format = pixel_format,
+        .descriptor = descriptor,
+        .provenance = provenance,
+    };
+}
+
+fn enumerateClassicPixelFormat(hdc: HDC) !WglPixelFormatSelection {
+    var descriptor: PIXELFORMATDESCRIPTOR = undefined;
+    const format_count = DescribePixelFormat(
+        hdc,
+        1,
+        @sizeOf(PIXELFORMATDESCRIPTOR),
+        &descriptor,
+    );
+    if (format_count <= 0 or format_count > 4096) {
+        gl_startup.recordOpenGLStartupError(.describe_pixel_format, error.InvalidPixelFormatInventory);
+        return error.InvalidPixelFormatInventory;
+    }
+
+    var selected: ?ClassicPixelFormatCandidate = null;
+    var pixel_format: i32 = 1;
+    while (pixel_format <= format_count) : (pixel_format += 1) {
+        if (DescribePixelFormat(
+            hdc,
+            pixel_format,
+            @sizeOf(PIXELFORMATDESCRIPTOR),
+            &descriptor,
+        ) == 0) {
+            const err = windows.kernel32.GetLastError();
+            gl_startup.recordOpenGLStartupWin32Failure(.describe_pixel_format, err);
+            return windows.unexpectedError(err);
+        }
+        const provenance = validateSelectedPixelFormat(pixel_format, descriptor) catch continue;
+        const candidate: ClassicPixelFormatCandidate = .{
+            .index = pixel_format,
+            .descriptor = descriptor,
+            .provenance = provenance,
+            .acceleration = classicPixelFormatAcceleration(descriptor.dwFlags),
+        };
+        if (selected == null or betterClassicPixelFormatCandidate(candidate, selected.?)) {
+            selected = candidate;
+        }
+    }
+
+    const candidate = selected orelse {
+        // The real DC remains untouched. Retain the prior known-compatible
+        // classic request only as a last recovery for drivers whose full
+        // DescribePixelFormat inventory exposes no base-compatible format.
+        log.warn(
+            "classic WGL inventory exposed no base-compatible descriptor; trying the validated depth-compatible recovery",
+            .{},
+        );
+        return chooseClassicCompatibilityPixelFormat(hdc);
+    };
+    log.debug(
+        "classic WGL inventory selected deterministic format index={} total={} acceleration={s} accum_bits={} aux_buffers={} depth_bits={} stencil_bits={}",
+        .{
+            candidate.index,
+            format_count,
+            @tagName(candidate.acceleration),
+            candidate.provenance.accum_bits,
+            candidate.provenance.aux_buffers,
+            candidate.provenance.depth_bits,
+            candidate.provenance.stencil_bits,
+        },
+    );
+    return .{
+        .pixel_format = candidate.index,
+        .descriptor = candidate.descriptor,
+        .provenance = candidate.provenance,
+    };
+}
+
+pub fn chooseRealPixelFormat(
+    hinstance: HINSTANCE,
+    hwnd: HWND,
+    hdc: HDC,
+) !WglPixelFormatSelection {
+    var child_rect: RECT = undefined;
+    if (GetWindowRect(hwnd, &child_rect) == 0) {
+        log.warn(
+            "unable to anchor a display-local WGL bootstrap; retaining classic selection err={}",
+            .{windows.kernel32.GetLastError()},
+        );
+        return enumerateClassicPixelFormat(hdc);
+    }
+
+    // WGL extension strings and proc addresses are current-context and
+    // display scoped. Bootstrap beside this exact child, select while the
+    // dummy context is current, then restore and destroy the dummy before
+    // SetPixelFormat ever touches the real child DC.
+    var selector = WglPixelFormatSelector.init(hinstance, child_rect) catch |err| {
+        if (isWglPixelFormatHardError(err)) return err;
+        log.warn(
+            "display-local WGL sRGB bootstrap unavailable before touching the real DC; retaining classic selection err={}",
+            .{err},
+        );
+        return enumerateClassicPixelFormat(hdc);
+    };
+    defer selector.deinit();
+
+    if (selector.choose(hdc) catch |err| fallback: {
+        if (isWglPixelFormatHardError(err)) return err;
+        // choose() only returns selection/query errors after restoring the
+        // caller's previous current pair. The real DC remains untouched.
+        log.warn(
+            "WGL sRGB pixel-format selection unavailable after safe restoration; retaining classic selection err={}",
+            .{err},
+        );
+        break :fallback null;
+    }) |selection| {
+        return selection;
+    }
+    log.debug("WGL sRGB selector exhausted verified candidates; retaining classic selection", .{});
+    return enumerateClassicPixelFormat(hdc);
+}
+
+test "win32 pixel format descriptor omits unused depth and stencil" {
+    const pfd = defaultPixelFormatDescriptor();
+    try std.testing.expectEqual(
+        @as(
+            DWORD,
+            c.PFD_DRAW_TO_WINDOW |
+                c.PFD_SUPPORT_OPENGL |
+                c.PFD_DOUBLEBUFFER |
+                PFD_DEPTH_DONTCARE,
+        ),
+        pfd.dwFlags,
+    );
+    try std.testing.expectEqual(@as(BYTE, 32), pfd.cColorBits);
+    try std.testing.expectEqual(@as(BYTE, 8), pfd.cAlphaBits);
+    try std.testing.expectEqual(@as(BYTE, 0), pfd.cDepthBits);
+    try std.testing.expectEqual(@as(BYTE, 0), pfd.cStencilBits);
+}
+
+test "win32 classic compatibility request preserves the prior depth constraint" {
+    const pfd = compatibilityPixelFormatDescriptor();
+    try std.testing.expectEqual(
+        @as(DWORD, c.PFD_DRAW_TO_WINDOW | c.PFD_SUPPORT_OPENGL | c.PFD_DOUBLEBUFFER),
+        pfd.dwFlags,
+    );
+    try std.testing.expectEqual(@as(BYTE, 32), pfd.cColorBits);
+    try std.testing.expectEqual(@as(BYTE, 8), pfd.cAlphaBits);
+    try std.testing.expectEqual(@as(BYTE, 0), pfd.cDepthBits);
+    try std.testing.expectEqual(@as(BYTE, 0), pfd.cStencilBits);
+}
+
+test "win32 classic pixel format ranking preserves acceleration before attachments" {
+    var generic_pfd = defaultPixelFormatDescriptor();
+    generic_pfd.dwFlags |= PFD_GENERIC_FORMAT;
+    const base = try validateSelectedPixelFormat(10, generic_pfd);
+    var accelerated_pfd = defaultPixelFormatDescriptor();
+    accelerated_pfd.cDepthBits = 24;
+    const accelerated = try validateSelectedPixelFormat(11, accelerated_pfd);
+    const candidates = [_]ClassicPixelFormatCandidate{
+        .{
+            .index = 10,
+            .descriptor = generic_pfd,
+            .provenance = base,
+            .acceleration = classicPixelFormatAcceleration(generic_pfd.dwFlags),
+        },
+        .{
+            .index = 11,
+            .descriptor = accelerated_pfd,
+            .provenance = accelerated,
+            .acceleration = classicPixelFormatAcceleration(accelerated_pfd.dwFlags),
+        },
+    };
+    try std.testing.expectEqual(
+        @as(i32, 11),
+        rankClassicPixelFormatCandidates(&candidates).?.index,
+    );
+}
+
+test "win32 classic pixel format ranking minimizes attachments within acceleration class" {
+    var attached_pfd = defaultPixelFormatDescriptor();
+    attached_pfd.cAccumBits = 64;
+    attached_pfd.cAuxBuffers = 1;
+    attached_pfd.cDepthBits = 24;
+    attached_pfd.cStencilBits = 8;
+    const candidates = [_]ClassicPixelFormatCandidate{
+        .{
+            .index = 12,
+            .descriptor = attached_pfd,
+            .provenance = try validateSelectedPixelFormat(12, attached_pfd),
+            .acceleration = .icd,
+        },
+        .{
+            .index = 14,
+            .descriptor = defaultPixelFormatDescriptor(),
+            .provenance = try validateSelectedPixelFormat(14, defaultPixelFormatDescriptor()),
+            .acceleration = .icd,
+        },
+    };
+    try std.testing.expectEqual(
+        @as(i32, 14),
+        rankClassicPixelFormatCandidates(&candidates).?.index,
+    );
+}
+
+test "win32 classic acceleration classification distinguishes ICD MCD and generic" {
+    try std.testing.expectEqual(ClassicPixelFormatAcceleration.icd, classicPixelFormatAcceleration(0));
+    try std.testing.expectEqual(
+        ClassicPixelFormatAcceleration.mcd,
+        classicPixelFormatAcceleration(PFD_GENERIC_FORMAT | PFD_GENERIC_ACCELERATED),
+    );
+    try std.testing.expectEqual(
+        ClassicPixelFormatAcceleration.generic,
+        classicPixelFormatAcceleration(PFD_GENERIC_FORMAT),
+    );
+}
+
+test "win32 sRGB pixel format ranking prefers depthless stencil-less" {
+    const candidates = [_]WglPixelFormatCandidate{
+        .{
+            .index = 12,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 24,
+            .stencil_bits = 8,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+        },
+        .{
+            .index = 14,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 0,
+            .stencil_bits = 0,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+        },
+        .{
+            .index = 16,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 0,
+            .stencil_bits = 0,
+            .srgb_capable = false,
+            .fully_accelerated = true,
+        },
+    };
+
+    const selected = rankWglPixelFormatCandidates(&candidates).?;
+    try std.testing.expectEqual(@as(i32, 14), selected.index);
+}
+
+test "win32 sRGB pixel format ranking honestly falls back to attached depth" {
+    const candidates = [_]WglPixelFormatCandidate{
+        .{
+            .index = 12,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 24,
+            .stencil_bits = 8,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+        },
+        .{
+            .index = 10,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 24,
+            .stencil_bits = 0,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+        },
+    };
+
+    const selected = rankWglPixelFormatCandidates(&candidates).?;
+    try std.testing.expectEqual(@as(i32, 10), selected.index);
+    try std.testing.expectEqual(@as(u8, 24), selected.depth_bits);
+    try std.testing.expectEqual(@as(u8, 0), selected.stencil_bits);
+}
+
+test "win32 pixel format inventory accepts observed full count without truncation" {
+    try std.testing.expectEqual(@as(UINT, 670), try validatedWglPixelFormatCount(670));
+    try std.testing.expectEqual(
+        @as(UINT, max_wgl_pixel_formats),
+        try validatedWglPixelFormatCount(max_wgl_pixel_formats),
+    );
+    try std.testing.expectError(
+        error.WglPixelFormatCandidateCapacityExceeded,
+        validatedWglPixelFormatCount(0),
+    );
+    try std.testing.expectError(
+        error.WglPixelFormatCandidateCapacityExceeded,
+        validatedWglPixelFormatCount(max_wgl_pixel_formats + 1),
+    );
+}
+
+test "win32 pixel format ranking prefers zero attachments but permits honest fallback" {
+    const candidates = [_]WglPixelFormatCandidate{
+        .{
+            .index = 8,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 0,
+            .stencil_bits = 0,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+            .accum_bits = 64,
+        },
+        .{
+            .index = 9,
+            .color_bits = 32,
+            .alpha_bits = 8,
+            .depth_bits = 24,
+            .stencil_bits = 0,
+            .srgb_capable = true,
+            .fully_accelerated = true,
+        },
+    };
+    try std.testing.expectEqual(
+        @as(i32, 9),
+        rankWglPixelFormatCandidates(&candidates).?.index,
+    );
+    const attached = rankWglPixelFormatCandidates(candidates[0..1]).?;
+    try std.testing.expectEqual(@as(i32, 8), attached.index);
+    try std.testing.expectEqual(@as(u8, 64), attached.accum_bits);
+}
+
+test "win32 pixel format SetPixelFormat transition requires zero to selected" {
+    try validatePixelFormatSetTransition(0, 7, 7);
+    try std.testing.expectError(
+        error.PixelFormatAlreadySet,
+        validatePixelFormatSetTransition(7, 7, 7),
+    );
+    try std.testing.expectError(
+        error.PixelFormatSetVerificationFailed,
+        validatePixelFormatSetTransition(0, 7, 0),
+    );
+    try std.testing.expectError(
+        error.PixelFormatSetVerificationFailed,
+        validatePixelFormatSetTransition(0, 7, 9),
+    );
+}
+
+test "win32 WGL bootstrap keeps exact sRGB API families and valid procs" {
+    const extensions = "WGL_ARB_extensions_string WGL_EXT_extensions_string WGL_EXT_pixel_format WGL_ARB_framebuffer_sRGB WGL_ARB_pixel_format WGL_EXT_colorspace";
+    try std.testing.expect(hasWglExtension(extensions, "WGL_ARB_extensions_string"));
+    try std.testing.expect(hasWglExtension(extensions, "WGL_EXT_extensions_string"));
+    try std.testing.expect(hasWglExtension(extensions, "WGL_EXT_pixel_format"));
+    try std.testing.expect(hasWglExtension(extensions, "WGL_ARB_framebuffer_sRGB"));
+    try std.testing.expect(hasWglExtension(extensions, "WGL_ARB_pixel_format"));
+    try std.testing.expect(hasWglExtension(extensions, "WGL_EXT_colorspace"));
+    try std.testing.expect(!hasWglExtension(extensions, "WGL_ARB_framebuffer"));
+    try std.testing.expectEqual(@as(i32, 0x309D), WGL_COLORSPACE_EXT);
+    try std.testing.expectEqual(@as(i32, 0x3089), WGL_COLORSPACE_SRGB_EXT);
+    try std.testing.expect(!validWglProcAddress(null));
+    try std.testing.expect(!validWglProcAddress(@ptrFromInt(1)));
+    try std.testing.expect(validWglProcAddress(@ptrFromInt(0x1000)));
+}
+
+test "win32 selected pixel format validation preserves actual attachments" {
+    var pfd = defaultPixelFormatDescriptor();
+    pfd.cDepthBits = 24;
+    pfd.cStencilBits = 8;
+    pfd.cAccumBits = 64;
+    pfd.cAuxBuffers = 1;
+    const selected = try validateSelectedPixelFormat(7, pfd);
+    try std.testing.expectEqual(@as(u32, 7), selected.index);
+    try std.testing.expectEqual(@as(u8, 32), selected.color_bits);
+    try std.testing.expectEqual(@as(u8, 8), selected.alpha_bits);
+    try std.testing.expectEqual(@as(u8, 24), selected.depth_bits);
+    try std.testing.expectEqual(@as(u8, 8), selected.stencil_bits);
+    try std.testing.expect(selected.double_buffer);
+    try std.testing.expect(!selected.stereo);
+    try std.testing.expectEqual(@as(u8, 64), selected.accum_bits);
+    try std.testing.expectEqual(@as(u8, 1), selected.aux_buffers);
+    try std.testing.expectEqual(WglPixelFormatSelectionSource.classic, selected.selection_source);
+    try std.testing.expect(!selected.srgb_capable);
+}
+
+test "win32 selected pixel format validation rejects missing requirements" {
+    const valid = defaultPixelFormatDescriptor();
+    try std.testing.expectError(
+        error.InvalidSelectedPixelFormat,
+        validateSelectedPixelFormat(0, valid),
+    );
+
+    var not_double_buffered = valid;
+    not_double_buffered.dwFlags &= ~@as(u32, c.PFD_DOUBLEBUFFER);
+    try std.testing.expectError(
+        error.InvalidSelectedPixelFormat,
+        validateSelectedPixelFormat(7, not_double_buffered),
+    );
+
+    var low_color = valid;
+    low_color.cColorBits = 24;
+    try std.testing.expectError(
+        error.InvalidSelectedPixelFormat,
+        validateSelectedPixelFormat(7, low_color),
+    );
+
+    var no_alpha = valid;
+    no_alpha.cAlphaBits = 0;
+    try std.testing.expectError(
+        error.InvalidSelectedPixelFormat,
+        validateSelectedPixelFormat(7, no_alpha),
+    );
+
+    var stereo = valid;
+    stereo.dwFlags |= PFD_STEREO;
+    try std.testing.expectError(
+        error.InvalidSelectedPixelFormat,
+        validateSelectedPixelFormat(7, stereo),
+    );
+}

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -218,6 +218,8 @@ pub extern "user32" fn RegisterClipboardFormatW(lpszFormat: [*:0]const u16) call
 
 pub extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
 
+pub extern "user32" fn UnregisterClassW(lpClassName: LPCWSTR, hInstance: HINSTANCE) callconv(.winapi) BOOL;
+
 pub extern "user32" fn CreateWindowExW(
     dwExStyle: u32,
     lpClassName: LPCWSTR,
@@ -462,6 +464,10 @@ pub extern "kernel32" fn GlobalLock(hMem: ?*anyopaque) callconv(.winapi) ?*anyop
 pub extern "kernel32" fn GlobalUnlock(hMem: ?*anyopaque) callconv(.winapi) BOOL;
 
 pub extern "gdi32" fn ChoosePixelFormat(hdc: HDC, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) i32;
+
+pub extern "gdi32" fn DescribePixelFormat(hdc: HDC, format: i32, size: UINT, ppfd: *PIXELFORMATDESCRIPTOR) callconv(.winapi) i32;
+
+pub extern "gdi32" fn GetPixelFormat(hdc: HDC) callconv(.winapi) i32;
 
 pub extern "gdi32" fn CreateSolidBrush(color: COLORREF) callconv(.winapi) HBRUSH;
 

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -46,6 +46,11 @@ font_discover: ?Discover = null,
 /// Lock to protect multi-threaded access to the map.
 lock: std.Thread.Mutex = .{},
 
+/// Windows font metadata discovery can overlap runtime/window setup. The
+/// worker takes `lock`, so the first grid lookup either observes a complete
+/// scan or waits for it without duplicating discovery work.
+discovery_prefetch_thread: ?std.Thread = null,
+
 pub const InitError = Library.InitError;
 
 /// Initialize a new SharedGridSet.
@@ -61,6 +66,11 @@ pub fn init(alloc: Allocator) InitError!SharedGridSet {
 }
 
 pub fn deinit(self: *SharedGridSet) void {
+    if (self.discovery_prefetch_thread) |thread| {
+        thread.join();
+        self.discovery_prefetch_thread = null;
+    }
+
     var it = self.map.iterator();
     while (it.next()) |entry| {
         entry.key_ptr.deinit();
@@ -75,6 +85,34 @@ pub fn deinit(self: *SharedGridSet) void {
     }
 
     self.font_lib.deinit();
+}
+
+/// Start Windows font discovery once the SharedGridSet has a stable address.
+/// Spawn failure is harmless: the existing synchronous lookup remains the
+/// fallback when the first surface requests its font grid.
+pub fn startDiscoveryPrefetch(self: *SharedGridSet) void {
+    if (comptime builtin.target.os.tag != .windows or
+        Discover == void or
+        !@hasDecl(Discover, "refresh")) return;
+    if (self.discovery_prefetch_thread != null) return;
+
+    self.discovery_prefetch_thread = std.Thread.spawn(
+        .{},
+        discoveryPrefetchMain,
+        .{self},
+    ) catch return;
+}
+
+pub fn discoveryPrefetchStarted(self: *const SharedGridSet) bool {
+    return self.discovery_prefetch_thread != null;
+}
+
+fn discoveryPrefetchMain(self: *SharedGridSet) void {
+    self.lock.lock();
+    defer self.lock.unlock();
+
+    const disco = self.discover() catch return;
+    if (disco) |value| value.refresh();
 }
 
 /// Returns the number of cached grids.

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -103,6 +103,49 @@ pub const ResourcesDir = resourcesdir.ResourcesDir;
 pub const ShellEscapeWriter = shell.ShellEscapeWriter;
 pub const getKernelInfo = kernel_info.getKernelInfo;
 
+/// Per-surface terminal threads are numerous on Windows, where Zig's default
+/// 16 MiB stack is committed by CreateThread. Keep process-global and
+/// short-lived worker threads on the standard library default.
+pub fn surfaceThreadSpawnConfig() std.Thread.SpawnConfig {
+    return if (builtin.os.tag == .windows)
+        .{ .stack_size = 1024 * 1024 }
+    else
+        .{};
+}
+
+test "Windows surface threads use a bounded stack" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const config = surfaceThreadSpawnConfig();
+    try std.testing.expectEqual(@as(usize, 1024 * 1024), config.stack_size);
+    try std.testing.expect(config.stack_size < std.Thread.SpawnConfig.default_stack_size);
+}
+
+fn surfaceThreadStackProbe(result: *std.atomic.Value(u64)) void {
+    // Match the largest fixed local on the Windows PTY reader and exercise
+    // the configured stack through a real CreateThread/join lifecycle.
+    var read_buf: [64 * 1024]u8 = undefined;
+    for (&read_buf, 0..) |*byte, i| byte.* = @truncate(i);
+
+    var sum: u64 = 0;
+    for (read_buf) |byte| sum += byte;
+    result.store(sum, .release);
+}
+
+test "Windows surface thread stack carries a 64 KiB read batch and joins" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var result = std.atomic.Value(u64).init(0);
+    const thread = try std.Thread.spawn(
+        surfaceThreadSpawnConfig(),
+        surfaceThreadStackProbe,
+        .{&result},
+    );
+    thread.join();
+
+    try std.testing.expectEqual(@as(u64, 8_355_840), result.load(.acquire));
+}
+
 test {
     _ = i18n;
     _ = path;

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -45,6 +45,38 @@ const enable_gl_debug_output = false;
 pub const MIN_VERSION_MAJOR = 4;
 pub const MIN_VERSION_MINOR = 3;
 
+pub const TargetStrategy = enum {
+    offscreen,
+    default_framebuffer,
+};
+
+pub const TargetStrategyOptions = struct {
+    win32: bool,
+    custom_shaders: bool,
+    default_framebuffer_srgb: bool,
+    linear_blending: bool,
+};
+
+pub fn targetStrategy(opts: TargetStrategyOptions) TargetStrategy {
+    if (opts.win32 and
+        !opts.custom_shaders and
+        opts.default_framebuffer_srgb and
+        opts.linear_blending)
+    {
+        return .default_framebuffer;
+    }
+    return .offscreen;
+}
+
+pub fn targetStrategyRequiresBlit(strategy: TargetStrategy) bool {
+    return strategy == .offscreen;
+}
+
+const DefaultFramebufferInfo = struct {
+    framebuffer: gl.Framebuffer,
+    srgb: bool,
+};
+
 alloc: std.mem.Allocator,
 
 /// Alpha blending mode
@@ -58,16 +90,67 @@ rt_surface: *apprt.Surface,
 vsync_enabled: bool,
 swap_interval_configured: bool = false,
 swap_interval_supported: bool = false,
+default_framebuffer: gl.Framebuffer,
+default_framebuffer_srgb: bool,
 
 /// NOTE: This is fallible to satisfy the renderer init interface, even though
 ///       OpenGL setup here cannot currently fail.
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) error{}!OpenGL {
+    const default_framebuffer: DefaultFramebufferInfo = if (apprt.runtime == apprt.win32)
+        queryDefaultFramebufferInfo() catch |err| info: {
+            log.warn(
+                "unable to verify default framebuffer color encoding; retaining offscreen target err={}",
+                .{err},
+            );
+            break :info .{
+                .framebuffer = .{ .id = 0 },
+                .srgb = false,
+            };
+        }
+    else
+        .{
+            .framebuffer = .{ .id = 0 },
+            .srgb = false,
+        };
+
     return .{
         .alloc = alloc,
         .blending = opts.config.blending,
         .rt_surface = opts.rt_surface,
         .vsync_enabled = opts.config.vsync,
+        .default_framebuffer = default_framebuffer.framebuffer,
+        .default_framebuffer_srgb = default_framebuffer.srgb,
     };
+}
+
+fn queryDefaultFramebufferInfo() gl.errors.Error!DefaultFramebufferInfo {
+    var framebuffer: gl.c.GLint = 0;
+    gl.glad.context.GetIntegerv.?(
+        gl.c.GL_DRAW_FRAMEBUFFER_BINDING,
+        &framebuffer,
+    );
+    try gl.errors.getError();
+    if (!defaultFramebufferBindingIsUsable(framebuffer)) {
+        return error.InvalidOperation;
+    }
+
+    var encoding: gl.c.GLint = 0;
+    gl.glad.context.GetFramebufferAttachmentParameteriv.?(
+        gl.c.GL_DRAW_FRAMEBUFFER,
+        gl.c.GL_BACK_LEFT,
+        gl.c.GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING,
+        &encoding,
+    );
+    try gl.errors.getError();
+
+    return .{
+        .framebuffer = .{ .id = @intCast(framebuffer) },
+        .srgb = encoding == gl.c.GL_SRGB,
+    };
+}
+
+pub fn defaultFramebufferBindingIsUsable(framebuffer: gl.c.GLint) bool {
+    return framebuffer == 0;
 }
 
 pub fn deinit(self: *OpenGL) void {
@@ -266,6 +349,39 @@ pub fn threadExit(self: *const OpenGL) void {
     }
 }
 
+fn makeSurfaceContextCurrentForDeinit(surface: anytype) !void {
+    try surface.makeGLContextCurrent();
+}
+
+/// Renderer resources are owned by a pane's WGL context. Core surface
+/// teardown runs on the app thread after the renderer thread has exited, so
+/// rebind the owning context before deleting buffers, textures, and shaders.
+/// Otherwise those deletes target whichever surviving pane was current last.
+pub fn prepareSurfaceDeinit(
+    self: *const OpenGL,
+    surface: *apprt.Surface,
+) !void {
+    _ = self;
+    switch (apprt.runtime) {
+        else => {},
+        apprt.win32 => try makeSurfaceContextCurrentForDeinit(surface),
+    }
+}
+
+test "OpenGL surface teardown makes the owning context current" {
+    const Probe = struct {
+        made_current: bool = false,
+
+        fn makeGLContextCurrent(self: *@This()) !void {
+            self.made_current = true;
+        }
+    };
+
+    var probe: Probe = .{};
+    try makeSurfaceContextCurrentForDeinit(&probe);
+    try std.testing.expect(probe.made_current);
+}
+
 pub fn displayRealized(self: *const OpenGL) void {
     _ = self;
 }
@@ -343,11 +459,35 @@ pub fn surfaceSize(self: *const OpenGL) !struct { width: u32, height: u32 } {
 }
 
 /// Initialize a new render target which can be presented by this API.
-pub fn initTarget(self: *const OpenGL, width: usize, height: usize) !Target {
-    return Target.init(.{
-        .internal_format = if (self.blending.isLinear()) .srgba else .rgba,
-        .width = width,
-        .height = height,
+pub fn initTarget(
+    self: *const OpenGL,
+    width: usize,
+    height: usize,
+    custom_shaders: bool,
+) !Target {
+    return switch (self.selectTargetStrategy(custom_shaders)) {
+        .default_framebuffer => Target.initDefault(
+            self.default_framebuffer,
+            width,
+            height,
+        ),
+        .offscreen => Target.init(.{
+            .internal_format = if (self.blending.isLinear()) .srgba else .rgba,
+            .width = width,
+            .height = height,
+        }),
+    };
+}
+
+pub fn selectTargetStrategy(
+    self: *const OpenGL,
+    custom_shaders: bool,
+) TargetStrategy {
+    return targetStrategy(.{
+        .win32 = apprt.runtime == apprt.win32,
+        .custom_shaders = custom_shaders,
+        .default_framebuffer_srgb = self.default_framebuffer_srgb,
+        .linear_blending = self.blending.isLinear(),
     });
 }
 
@@ -360,41 +500,42 @@ pub fn present(self: *OpenGL, target: Target) !void {
         self.ensureWin32SwapInterval();
     }
 
-    // In order to present a target we blit it to the default framebuffer.
-
-    // We disable GL_FRAMEBUFFER_SRGB while doing this blit, otherwise the
-    // values may be linearized as they're copied, but even though the draw
-    // framebuffer has a linear internal format, the values in it should be
-    // sRGB, not linear!
-    try gl.disable(gl.c.GL_FRAMEBUFFER_SRGB);
-    defer gl.enable(gl.c.GL_FRAMEBUFFER_SRGB) catch |err| {
-        log.err("Error re-enabling GL_FRAMEBUFFER_SRGB, err={}", .{err});
+    const strategy: TargetStrategy = switch (target.storage) {
+        .offscreen => .offscreen,
+        .default_framebuffer => .default_framebuffer,
     };
 
-    // Bind the target for reading.
-    const fbobind = try target.framebuffer.bind(.read);
-    defer fbobind.unbind();
+    if (targetStrategyRequiresBlit(strategy)) {
+        // The offscreen target stores sRGB values. Disable conversion while
+        // copying those values to the window's default framebuffer.
+        try gl.disable(gl.c.GL_FRAMEBUFFER_SRGB);
+        defer gl.enable(gl.c.GL_FRAMEBUFFER_SRGB) catch |err| {
+            log.err("Error re-enabling GL_FRAMEBUFFER_SRGB, err={}", .{err});
+        };
 
-    const dst_width: i32, const dst_height: i32 = if (apprt.runtime == apprt.win32) size: {
-        const size = try self.surfaceSize();
-        break :size .{ @intCast(size.width), @intCast(size.height) };
-    } else .{ @intCast(target.width), @intCast(target.height) };
+        const fbobind = try target.framebuffer.bind(.read);
+        defer fbobind.unbind();
 
-    if (dst_width <= 0 or dst_height <= 0) return;
+        const dst_width: i32, const dst_height: i32 = if (apprt.runtime == apprt.win32) size: {
+            const size = try self.surfaceSize();
+            break :size .{ @intCast(size.width), @intCast(size.height) };
+        } else .{ @intCast(target.width), @intCast(target.height) };
 
-    // Blit
-    gl.glad.context.BlitFramebuffer.?(
-        0,
-        0,
-        @intCast(target.width),
-        @intCast(target.height),
-        0,
-        0,
-        dst_width,
-        dst_height,
-        gl.c.GL_COLOR_BUFFER_BIT,
-        gl.c.GL_NEAREST,
-    );
+        if (dst_width <= 0 or dst_height <= 0) return;
+
+        gl.glad.context.BlitFramebuffer.?(
+            0,
+            0,
+            @intCast(target.width),
+            @intCast(target.height),
+            0,
+            0,
+            dst_width,
+            dst_height,
+            gl.c.GL_COLOR_BUFFER_BIT,
+            gl.c.GL_NEAREST,
+        );
+    }
 
     // Keep track of this target in case we need to repeat it.
     self.last_target = target;
@@ -545,4 +686,63 @@ test "OpenGL hasVsync requires enabled swap interval" {
 
     api.vsync_enabled = false;
     try std.testing.expect(!api.hasVsync());
+}
+
+test "OpenGL direct default target policy preserves unsupported paths" {
+    try std.testing.expectEqual(
+        TargetStrategy.default_framebuffer,
+        targetStrategy(.{
+            .win32 = true,
+            .custom_shaders = false,
+            .default_framebuffer_srgb = true,
+            .linear_blending = true,
+        }),
+    );
+    try std.testing.expectEqual(
+        TargetStrategy.offscreen,
+        targetStrategy(.{
+            .win32 = true,
+            .custom_shaders = true,
+            .default_framebuffer_srgb = true,
+            .linear_blending = true,
+        }),
+    );
+    try std.testing.expectEqual(
+        TargetStrategy.offscreen,
+        targetStrategy(.{
+            .win32 = false,
+            .custom_shaders = false,
+            .default_framebuffer_srgb = true,
+            .linear_blending = true,
+        }),
+    );
+    try std.testing.expectEqual(
+        TargetStrategy.offscreen,
+        targetStrategy(.{
+            .win32 = true,
+            .custom_shaders = false,
+            .default_framebuffer_srgb = false,
+            .linear_blending = true,
+        }),
+    );
+    try std.testing.expectEqual(
+        TargetStrategy.offscreen,
+        targetStrategy(.{
+            .win32 = true,
+            .custom_shaders = false,
+            .default_framebuffer_srgb = true,
+            .linear_blending = false,
+        }),
+    );
+}
+
+test "OpenGL direct default target presents without an offscreen blit" {
+    try std.testing.expect(!targetStrategyRequiresBlit(.default_framebuffer));
+    try std.testing.expect(targetStrategyRequiresBlit(.offscreen));
+}
+
+test "OpenGL direct default target rejects a stray framebuffer binding" {
+    try std.testing.expect(defaultFramebufferBindingIsUsable(0));
+    try std.testing.expect(!defaultFramebufferBindingIsUsable(1));
+    try std.testing.expect(!defaultFramebufferBindingIsUsable(-1));
 }

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -315,15 +315,11 @@ fn threadMain_(self: *Thread) !void {
     // Send an initial wakeup message so that we render right away.
     try self.wakeup.notify();
 
-    // Start blinking the cursor.
-    self.cursor_h.run(
-        &self.loop,
-        &self.cursor_c,
-        cursorBlinkInterval(),
-        Thread,
-        self,
-        cursorTimerCallback,
-    );
+    // Start blinking only when the terminal's cursor mode requests it.
+    // Steady cursors must not keep a 500 ms renderer wake loop alive.
+    if (self.cursorShouldBlink()) {
+        self.armCursorTimerIfDead(cursorBlinkInterval());
+    }
 
     // Start the draw timer
     self.syncDrawTimer();
@@ -537,13 +533,15 @@ fn drainMailbox(self: *Thread) !bool {
                     // active, its callback owns the eventual rearm.
                     self.flags.cursor_blink_visible = true;
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
-                    self.armCursorTimerIfDead(cursorBlinkInterval());
+                    if (self.cursorShouldBlink()) {
+                        self.armCursorTimerIfDead(cursorBlinkInterval());
+                    }
                 }
             },
 
             .reset_cursor_blink => {
                 self.flags.cursor_blink_visible = true;
-                if (self.flags.focused) {
+                if (self.flags.focused and self.cursorShouldBlink()) {
                     self.cursor_blink_reset_at = std.time.Instant.now() catch null;
                     self.armCursorTimerIfDead(cursorBlinkInterval());
                 }
@@ -672,6 +670,22 @@ fn notePresentRequest(self: *Thread, interval_ms: u64) void {
 /// Trigger a draw. This will not update frame data or anything, it will
 /// just trigger a draw/paint.
 fn drawFrame(self: *Thread, now: bool) void {
+    self.drawFrameWithReservation(now, false);
+}
+
+fn drawFrameWithReservation(self: *Thread, now: bool, repaint_reserved: bool) void {
+    // A caller-held reservation must be released on every path that does not
+    // hand it to a paint. Leaking one leaves renderer_repaint_requested set
+    // forever, after which every later repaint coalesces into a request that
+    // is never finished and the pane stops updating until a resize-settle or
+    // health recovery cancels it.
+    var reservation_held = repaint_reserved;
+    defer if (reservation_held) {
+        if (comptime @hasDecl(apprt.Surface, "cancelRendererRepaintRequest")) {
+            self.surface.cancelRendererRepaintRequest();
+        }
+    };
+
     const interval_ms = self.minimumPresentIntervalMs() orelse return;
 
     // `now` is the forced, vsync-bypassing path (`drawNowCallback`): a
@@ -687,12 +701,13 @@ fn drawFrame(self: *Thread, now: bool) void {
     if (!now and self.renderer.hasVsync()) return;
 
     if (must_draw_from_app_thread) {
-        if (comptime @hasDecl(apprt.Surface, "noteRendererDrawRequest")) {
-            self.surface.noteRendererDrawRequest();
-        }
         if (comptime @hasDecl(apprt.Surface, "beginRendererRepaintRequest")) {
-            if (!self.surface.beginRendererRepaintRequest()) return;
+            if (!repaint_reserved and !self.surface.beginRendererRepaintRequest()) return;
         }
+
+        // From here the reservation belongs to the queued paint: either the
+        // paint completes it, or the failed push below cancels it.
+        reservation_held = false;
 
         if (self.app_mailbox.push(
             .{ .redraw_surface = self.surface },
@@ -705,6 +720,8 @@ fn drawFrame(self: *Thread, now: bool) void {
             self.notePresentRequest(interval_ms);
         }
     } else {
+        // Nothing will complete a reservation on this path, so the deferred
+        // cancel above releases it once the synchronous draw returns.
         self.renderer.drawFrame(false) catch |err| {
             log.warn("error drawing err={}", .{err});
             return;
@@ -764,6 +781,12 @@ fn armCursorTimerIfDead(self: *Thread, delay_ms: u64) void {
     );
 }
 
+fn cursorShouldBlink(self: *Thread) bool {
+    self.state.mutex.lock();
+    defer self.state.mutex.unlock();
+    return self.state.terminal.modes.get(.cursor_blinking);
+}
+
 fn refreshRenderFollowupDeadline(self: *Thread) void {
     if (apprt.runtime != apprt.win32 or !self.flags.visible) return;
     self.state.noteRenderWakeupNotify();
@@ -797,18 +820,42 @@ fn renderOnce(self: *Thread, from_wakeup: bool) bool {
     const interval_ms = self.minimumPresentIntervalMs() orelse return false;
     if (self.presentWaitMs(interval_ms) > 0) return true;
 
-    // Update our frame data.
+    var repaint_reserved = false;
+    if (must_draw_from_app_thread and self.flags.visible and !self.renderer.hasVsync()) {
+        if (comptime @hasDecl(apprt.Surface, "beginRendererFrameUpdate")) {
+            if (!self.surface.beginRendererFrameUpdate()) {
+                const keep_due_to_dirty = self.shouldContinueRenderFollowup();
+                if (from_wakeup and keep_due_to_dirty) self.refreshRenderFollowupDeadline();
+                return keep_due_to_dirty or self.renderFollowupWindowActive();
+            }
+            repaint_reserved = true;
+        }
+    }
+
     if (comptime @hasDecl(apprt.Surface, "noteRendererUpdateFrame")) {
         self.surface.noteRendererUpdateFrame();
     }
-    self.renderer.updateFrame(
+
+    // updateFrame returns the cursor mode from the same locked terminal
+    // snapshot used to rebuild this frame.
+    const frame_update: ?rendererpkg.Renderer.FrameUpdate = self.renderer.updateFrame(
         self.state,
         self.flags.cursor_blink_visible,
-    ) catch |err|
+    ) catch |err| frame_update: {
         log.warn("error rendering err={}", .{err});
+        break :frame_update null;
+    };
+    const cursor_blinking = if (frame_update) |update|
+        update.cursor_blinking
+    else
+        self.cursorShouldBlink();
+    if (!cursor_blinking) self.flags.cursor_blink_visible = true;
+    if (self.flags.focused and cursor_blinking) {
+        self.armCursorTimerIfDead(cursorBlinkInterval());
+    }
 
     // Draw.
-    self.drawFrame(false);
+    self.drawFrameWithReservation(false, repaint_reserved);
 
     // On Win32, xev async wakes can coalesce while a render pass is still
     // in flight. If terminal dirtiness reappeared during the pass, keep a
@@ -831,10 +878,6 @@ fn wakeupCallback(
     };
 
     const t = self_.?;
-    if (comptime @hasDecl(apprt.Surface, "noteRendererWakeupCallback")) {
-        t.surface.noteRendererWakeupCallback();
-    }
-
     if (t.renderOnce(true)) {
         t.scheduleRenderFollowup();
     }
@@ -936,12 +979,24 @@ fn renderCallback(
     if (comptime @hasDecl(apprt.Surface, "noteRendererFollowupCallback")) {
         t.surface.noteRendererFollowupCallback();
     }
-
-    if (t.renderOnce(false)) {
-        t.scheduleRenderFollowup();
+    switch (renderFollowupDecision(
+        t.shouldContinueRenderFollowup(),
+        t.renderFollowupWindowActive(),
+    )) {
+        .render => if (t.renderOnce(false)) t.scheduleRenderFollowup(),
+        .poll => t.scheduleRenderFollowup(),
+        .stop => {},
     }
 
     return .disarm;
+}
+
+const RenderFollowupDecision = enum { stop, poll, render };
+
+fn renderFollowupDecision(dirty: bool, window_active: bool) RenderFollowupDecision {
+    if (dirty) return .render;
+    if (window_active) return .poll;
+    return .stop;
 }
 
 fn cursorTimerCallback(
@@ -978,14 +1033,19 @@ fn cursorTimerCallback(
         null;
     switch (cursorBlinkTimerDecision(
         t.flags.focused,
+        t.cursorShouldBlink(),
         cursorBlinkInterval(),
         reset_elapsed_ns,
     )) {
         .disarm => {
             // An unfocused surface needs no recurring cursor timer. Focus
             // regain will arm a new one once this callback has been popped.
+            const was_visible = t.flags.cursor_blink_visible;
             t.flags.cursor_blink_visible = true;
             t.cursor_blink_reset_at = null;
+            if (!was_visible) {
+                t.wakeup.notify() catch {};
+            }
             return .disarm;
         },
         .rearm_after => |delay_ms| {
@@ -1051,10 +1111,11 @@ const CursorBlinkTimerDecision = union(enum) {
 
 fn cursorBlinkTimerDecision(
     focused: bool,
+    blinking: bool,
     interval_ms: u64,
     reset_elapsed_ns: ?u64,
 ) CursorBlinkTimerDecision {
-    if (!focused) return .disarm;
+    if (!focused or !blinking) return .disarm;
     if (reset_elapsed_ns) |elapsed_ns| {
         const remaining_ms = cursorBlinkRemainingMs(interval_ms, elapsed_ns);
         if (remaining_ms > 0) return .{ .rearm_after = remaining_ms };
@@ -1086,20 +1147,37 @@ test "cursor blink timer decision preserves focus and reset state" {
 
     try testing.expectEqual(
         CursorBlinkTimerDecision.disarm,
-        cursorBlinkTimerDecision(false, 500, 1),
+        cursorBlinkTimerDecision(false, true, 500, 1),
     );
     try testing.expectEqual(
         CursorBlinkTimerDecision.toggle,
-        cursorBlinkTimerDecision(true, 500, null),
+        cursorBlinkTimerDecision(true, true, 500, null),
     );
     try testing.expectEqual(
         CursorBlinkTimerDecision{ .rearm_after = 500 },
-        cursorBlinkTimerDecision(true, 500, 1),
+        cursorBlinkTimerDecision(true, true, 500, 1),
     );
     try testing.expectEqual(
         CursorBlinkTimerDecision.toggle,
-        cursorBlinkTimerDecision(true, 500, 500 * std.time.ns_per_ms),
+        cursorBlinkTimerDecision(true, true, 500, 500 * std.time.ns_per_ms),
     );
+}
+
+test "cursor blink timer disarms for a steady cursor" {
+    const testing = std.testing;
+
+    try testing.expectEqual(
+        CursorBlinkTimerDecision.disarm,
+        cursorBlinkTimerDecision(true, false, 500, null),
+    );
+}
+
+test "render followup does not redraw a clean terminal" {
+    const testing = std.testing;
+
+    try testing.expectEqual(RenderFollowupDecision.poll, renderFollowupDecision(false, true));
+    try testing.expectEqual(RenderFollowupDecision.render, renderFollowupDecision(true, true));
+    try testing.expectEqual(RenderFollowupDecision.stop, renderFollowupDecision(false, false));
 }
 
 test "renderer follow-up check tracks visible terminal dirtiness" {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -701,6 +701,9 @@ fn drawFrameWithReservation(self: *Thread, now: bool, repaint_reserved: bool) vo
     if (!now and self.renderer.hasVsync()) return;
 
     if (must_draw_from_app_thread) {
+        if (comptime @hasDecl(apprt.Surface, "noteRendererDrawRequest")) {
+            self.surface.noteRendererDrawRequest();
+        }
         if (comptime @hasDecl(apprt.Surface, "beginRendererRepaintRequest")) {
             if (!repaint_reserved and !self.surface.beginRendererRepaintRequest()) return;
         }
@@ -878,6 +881,9 @@ fn wakeupCallback(
     };
 
     const t = self_.?;
+    if (comptime @hasDecl(apprt.Surface, "noteRendererWakeupCallback")) {
+        t.surface.noteRendererWakeupCallback();
+    }
     if (t.renderOnce(true)) {
         t.scheduleRenderFollowup();
     }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -39,6 +39,53 @@ const DisplayLink = void;
 
 const log = std.log.scoped(.generic_renderer);
 
+/// Whether a config change invalidates every swap chain frame's render
+/// target, i.e. whether `target_config_modified` must be bumped.
+///
+/// Two independent inputs feed `GraphicsAPI.initTarget`:
+///
+///   * the blending mode, which picks the offscreen target's internal
+///     format (`.srgba` vs `.rgba`), and
+///   * whether custom shaders are present, which is a hard precondition
+///     of the Win32 direct default-framebuffer strategy — a target that
+///     renders straight to fbo 0 is only ever handed out when there are
+///     no custom shaders.
+///
+/// A change in either direction must therefore re-create the targets. If
+/// only `reinitialize_shaders` were set, `reload_config` enabling a custom
+/// shader without a resize would leave the existing fbo-0 target in place
+/// and run the shader straight against the default framebuffer, defeating
+/// the fail-closed gate; disabling one would strand an offscreen target and
+/// forfeit the optimization until the next resize.
+pub fn targetConfigChangeRequiresRecreate(opts: struct {
+    blending_changed: bool,
+    custom_shaders_changed: bool,
+}) bool {
+    return opts.blending_changed or opts.custom_shaders_changed;
+}
+
+test "renderer target recreation tracks custom shader presence" {
+    // Custom shaders gate the direct default-framebuffer strategy, so a
+    // change in either direction must invalidate the swap chain targets
+    // even when nothing else about the surface changed.
+    try std.testing.expect(targetConfigChangeRequiresRecreate(.{
+        .blending_changed = false,
+        .custom_shaders_changed = true,
+    }));
+    try std.testing.expect(targetConfigChangeRequiresRecreate(.{
+        .blending_changed = true,
+        .custom_shaders_changed = false,
+    }));
+    try std.testing.expect(targetConfigChangeRequiresRecreate(.{
+        .blending_changed = true,
+        .custom_shaders_changed = true,
+    }));
+    try std.testing.expect(!targetConfigChangeRequiresRecreate(.{
+        .blending_changed = false,
+        .custom_shaders_changed = false,
+    }));
+}
+
 /// Create a renderer type with the provided graphics API wrapper.
 ///
 /// The graphics API wrapper must provide the interface outlined below.
@@ -2053,18 +2100,23 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
             }
 
-            if (blending_changed) {
-                // We update our API's blending mode.
-                self.api.blending = config.blending;
-                // And indicate that we need to reinitialize our shaders.
+            // We update our API's blending mode.
+            if (blending_changed) self.api.blending = config.blending;
+
+            // Either change means the shaders have to be rebuilt.
+            if (blending_changed or custom_shaders_changed) {
                 self.reinitialize_shaders = true;
-                // And indicate that our swap chain targets need to
-                // be re-created to account for the new blending mode.
-                self.target_config_modified +%= 1;
             }
 
-            if (custom_shaders_changed) {
-                self.reinitialize_shaders = true;
+            // And both feed target selection, so both have to invalidate
+            // every frame's target. See the doc comment on the helper for
+            // why custom shaders belong here and not just on the shader
+            // reinitialization path.
+            if (targetConfigChangeRequiresRecreate(.{
+                .blending_changed = blending_changed,
+                .custom_shaders_changed = custom_shaders_changed,
+            })) {
+                self.target_config_modified +%= 1;
             }
         }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -79,6 +79,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         const Self = @This();
 
         pub const API = GraphicsAPI;
+        pub const FrameUpdate = struct {
+            cursor_blinking: bool,
+        };
 
         const Target = GraphicsAPI.Target;
         const Buffer = GraphicsAPI.Buffer;
@@ -390,7 +393,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Initialize the target. Just as with the other resources,
                 // start it off as small as we can since it'll be resized.
-                const target = try api.initTarget(1, 1);
+                const target = try api.initTarget(1, 1, custom_shaders);
 
                 return .{
                     .uniforms = uniforms,
@@ -424,7 +427,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (self.custom_shader_state) |*state| {
                     try state.resize(api, width, height);
                 }
-                const target = try api.initTarget(width, height);
+                const target = try api.initTarget(
+                    width,
+                    height,
+                    self.custom_shader_state != null,
+                );
                 self.target.deinit();
                 self.target = target;
             }
@@ -883,6 +890,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
+        /// Called on the app thread after the renderer thread exits and before
+        /// graphics resources are destroyed.
+        pub fn prepareSurfaceDeinit(self: *const Self, surface: *apprt.Surface) !void {
+            if (@hasDecl(GraphicsAPI, "prepareSurfaceDeinit")) {
+                try self.api.prepareSurfaceDeinit(surface);
+            }
+        }
+
         /// Callback called by renderer.Thread when it exits.
         pub fn threadExit(self: *const Self) void {
             // If our API has to do things on thread exit, let it.
@@ -1125,7 +1140,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             state: *renderer.State,
             cursor_blink_visible: bool,
-        ) Allocator.Error!void {
+        ) Allocator.Error!FrameUpdate {
             // const start = std.time.Instant.now() catch unreachable;
             // const start_micro = std.time.microTimestamp();
             // defer {
@@ -1160,6 +1175,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 preedit: ?renderer.State.Preedit,
                 scrollbar: terminal.Scrollbar,
                 overlay_features: []const Overlay.Feature,
+                cursor_blinking: bool,
             };
 
             // Update all our data as tightly as possible within the mutex.
@@ -1174,10 +1190,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 state.mutex.lock();
                 defer state.mutex.unlock();
 
+                const cursor_blinking = state.terminal.modes.get(.cursor_blinking);
+
                 // If we're in a synchronized output state, we pause all rendering.
                 if (state.terminal.modes.get(.synchronized_output)) {
                     log.debug("synchronized output started, skipping render", .{});
-                    return;
+                    return .{ .cursor_blinking = cursor_blinking };
                 }
 
                 // If scroll-to-bottom on output is enabled, check if the final line
@@ -1299,6 +1317,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .preedit = preedit,
                     .scrollbar = scrollbar,
                     .overlay_features = overlay_features,
+                    .cursor_blinking = cursor_blinking,
                 };
             };
 
@@ -1389,7 +1408,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     renderer.cursorStyle(&self.terminal_state, .{
                         .preedit = critical.preedit != null,
                         .focused = self.focused,
-                        .blink_visible = cursor_blink_visible,
+                        .blink_visible = cursor_blink_visible or
+                            !critical.cursor_blinking,
                     }),
                     &critical.links,
                 ) catch |err| {
@@ -1433,6 +1453,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Notify our shaper we're done for the frame. For some shapers,
             // such as CoreText, this triggers off-thread cleanup logic.
             self.font_shaper.endFrame();
+            return .{ .cursor_blinking = critical.cursor_blinking };
         }
 
         /// Draw the frame to the screen.

--- a/src/renderer/opengl/RenderPass.zig
+++ b/src/renderer/opengl/RenderPass.zig
@@ -200,8 +200,9 @@ test "RenderPass attachmentSize uses target dimensions" {
     const attachment: Options.Attachment = .{
         .target = .{
             .target = .{
-                .framebuffer = undefined,
-                .renderbuffer = undefined,
+                .storage = .default_framebuffer,
+                .framebuffer = .{ .id = 0 },
+                .renderbuffer = null,
                 .width = 320,
                 .height = 240,
             },

--- a/src/renderer/opengl/Target.zig
+++ b/src/renderer/opengl/Target.zig
@@ -1,6 +1,8 @@
 //! Represents a render target.
 //!
-//! In this case, an OpenGL renderbuffer-backed framebuffer.
+//! On Win32 this can render directly to the window's default framebuffer when
+//! the renderer does not need an offscreen custom-shader target. Other paths
+//! retain the owned renderbuffer-backed framebuffer.
 const Self = @This();
 
 const std = @import("std");
@@ -20,11 +22,22 @@ pub const Options = struct {
     internal_format: gl.Texture.InternalFormat,
 };
 
+pub const Storage = enum {
+    offscreen,
+    default_framebuffer,
+
+    pub fn ownsResources(self: Storage) bool {
+        return self == .offscreen;
+    }
+};
+
+storage: Storage,
+
 /// The underlying `gl.Framebuffer` instance.
 framebuffer: gl.Framebuffer,
 
 /// The underlying `gl.Renderbuffer` instance.
-renderbuffer: gl.Renderbuffer,
+renderbuffer: ?gl.Renderbuffer,
 
 /// Current width of this target.
 width: usize,
@@ -47,6 +60,7 @@ pub fn init(opts: Options) !Self {
     try bound_fbo.renderbuffer(.color0, rbo);
 
     return .{
+        .storage = .offscreen,
         .framebuffer = fbo,
         .renderbuffer = rbo,
         .width = opts.width,
@@ -54,7 +68,35 @@ pub fn init(opts: Options) !Self {
     };
 }
 
+pub fn initDefault(
+    framebuffer: gl.Framebuffer,
+    width: usize,
+    height: usize,
+) Self {
+    std.debug.assert(framebuffer.id == 0);
+    return .{
+        .storage = .default_framebuffer,
+        .framebuffer = framebuffer,
+        .renderbuffer = null,
+        .width = width,
+        .height = height,
+    };
+}
+
 pub fn deinit(self: *Self) void {
+    if (!self.storage.ownsResources()) return;
     self.framebuffer.destroy();
-    self.renderbuffer.destroy();
+    self.renderbuffer.?.destroy();
+}
+
+test "OpenGL target storage owns only offscreen resources" {
+    try std.testing.expect(Storage.offscreen.ownsResources());
+    try std.testing.expect(!Storage.default_framebuffer.ownsResources());
+
+    const target = initDefault(.{ .id = 0 }, 640, 480);
+    try std.testing.expectEqual(Storage.default_framebuffer, target.storage);
+    try std.testing.expectEqual(@as(gl.c.GLuint, 0), target.framebuffer.id);
+    try std.testing.expectEqual(@as(?gl.Renderbuffer, null), target.renderbuffer);
+    try std.testing.expectEqual(@as(usize, 640), target.width);
+    try std.testing.expectEqual(@as(usize, 480), target.height);
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -745,11 +745,9 @@ fn printCell(
             .spacer_tail => {
                 assert(self.screens.active.cursor.x > 0);
 
-                // So integrity checks pass. We fix this up later so we don't
-                // need to do this without safety checks.
-                if (comptime std.debug.runtime_safety) {
-                    cell.wide = .narrow;
-                }
+                // Keep the row valid while clearCells clears the wide head
+                // and verifies page integrity. We overwrite this cell below.
+                cell.wide = .narrow;
 
                 const wide_cell = self.screens.active.cursorCellLeft(1);
                 self.screens.active.clearCells(
@@ -13098,4 +13096,19 @@ test "Terminal: deleteLines wide char at right margin with full clear" {
     // and the orphaned spacer_tail at col 39 triggers a page integrity
     // violation in clearCells.
     try t.scrollUp(t.rows);
+}
+
+test "Terminal: overwrite wide tail preserves page integrity" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 3, .rows = 2 });
+    defer t.deinit(alloc);
+
+    try t.print('橋');
+    t.setCursorPos(1, 2);
+    try t.print('X');
+
+    try t.screens.active.cursor.page_pin.node.data.verifyIntegrity(alloc);
+    const str = try t.plainString(alloc);
+    defer alloc.free(str);
+    try testing.expectEqualStrings(" X", str);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -44,7 +44,9 @@ const darwin = if (builtin.os.tag.isDarwin()) struct {
 /// The termios poll rate in milliseconds.
 const TERMIOS_POLL_MS = 200;
 const WRITE_BUF_SIZE = 4 * 1024;
-const WINDOWS_READ_BUF_SIZE = 16 * 1024;
+// ConPTY hands back large bursts; a 16 KiB batch made the reader the
+// bottleneck on high-throughput output. 64 KiB is the product default.
+const WINDOWS_READ_BUF_SIZE = 64 * 1024;
 
 fn pathEntryEquals(a: []const u8, b: []const u8) bool {
     return if (builtin.os.tag == .windows)
@@ -192,7 +194,7 @@ pub fn threadEnter(
 
     // Start our read thread
     const read_thread = try std.Thread.spawn(
-        .{},
+        internal_os.surfaceThreadSpawnConfig(),
         if (builtin.os.tag == .windows) ReadThread.threadMainWindows else ReadThread.threadMainPosix,
         .{ pty_fds.read, io, pipe[0] },
     );


### PR DESCRIPTION
## Summary

Five fixes to the Windows startup, IO and renderer paths. Every one was found by
the #121 benchmark baseline rather than by inspection.

Split out of #191 on review feedback. A first attempt at that split left the
call sites behind in #191, so this PR defined the machinery but nothing invoked
it; that is fixed — the spawn-site configuration, the
`beginRendererFrameUpdate` hook and the `prepareSurfaceDeinit` call now live
here with the code they activate. #191 stacks on this branch.

## The changes

**Windows thread stacks.** `internal_os.surfaceThreadSpawnConfig()` gives the
per-surface renderer, IO and PTY-reader threads a 1 MiB stack argument. Zig
passes `stack_size` to `CreateThread` without
`STACK_SIZE_PARAM_IS_A_RESERVATION`, so this sets the initial **commit**; the
reservation still comes from the PE header (16 MiB) and threads still grow on
demand. Only the upfront commit charge changes, so no new stack-overflow
ceiling is introduced.

**ConPTY read batch.** The Windows PTY reader used a 16 KiB buffer, making the
reader the bottleneck on bursty output. Now 64 KiB, with no runtime override —
one product path, which is also the one the benchmark measures.

**Idle wake loop.** The renderer thread armed a 500 ms cursor-blink timer
unconditionally. It now arms only when the terminal actually requests a blinking
cursor, so a steady DECSCUSR cursor lets the process go genuinely idle.

**Repaint reservation.** The renderer reserves the repaint slot before the
expensive `updateFrame` work so a paint completing during that work cannot be
lost, and `completeRendererRepaintCoalesce` closes the interleaving where paint
completion clears the reservation and checks `retry_pending` between the
renderer observing a pending reservation and publishing its own retry.

Review raised a reservation-leak freeze on the early returns in
`drawFrameWithReservation`. Every early exit now releases a reservation it did
not hand to a paint. On the reachability of the original report: `hasVsync()` is
a compile-time constant `false` in this fork (`DisplayLink = void`, and the
Win32 branch is excluded), and `renderOnce` checks the same visibility and vsync
conditions immediately before reserving with no event-loop turn in between, so
neither early return could actually be reached holding a reservation, and there
is no cross-thread read of `vsync_enabled` to synchronize. The fix is still
worth having — the invariant currently depends on two functions agreeing — but
it is hardening, not a live freeze. That is recorded in a comment at the site.

**Direct default framebuffer.** Win32 surfaces render straight to the default
framebuffer when a runtime GL query proves the back buffer is sRGB-encoded and
blending is linear, with no custom shaders. Everything else keeps the owned
offscreen target and the strategy fails closed. Proving that precondition needs
real pixel-format selection, so WGL selection lives in
`src/apprt/win32/pixel_format.zig`.

Also in this PR:

- `printCell` cleared the wide-tail marker only under `runtime_safety`, so a
  ReleaseFast build could hand `clearCells` a row whose wide head and tail
  disagreed. Now unconditional, with a regression test. This is a terminal-core
  semantic change in release builds and is called out here deliberately; it was
  found by running terminal workloads under ReleaseFast for the benchmark.
- Renderer teardown rebinds the owning WGL context before deleting graphics
  objects (`prepareSurfaceDeinit`).
- Font discovery prefetch overlaps Windows font enumeration with runtime startup.

## Measured effect — stale, and not attributable to this PR alone

An earlier revision of this body presented a before/after table as this PR's
"measured effect". That was wrong twice over and has been removed: the run
predates the split and reorganization so the binary no longer exists, and at the
time of that run the changes were not partitioned the way they are now, so no
column could be attributed to this branch by itself.

The numbers that motivated the work, for context only: per-pane memory 104 MB ->
32.14 MB, cold start 484 ms -> 297 ms median, idle successful swaps 26/10s -> 0,
measured 2026-08-27 against `d031dc4` with all of this and the instrumentation in
one build. Treat them as the reason these fixes exist, not as this PR's result.
A fresh interactive run on the merged stack is required before any of it is
quoted as a current claim; `docs/windows-benchmark-methodology.md` in #191 says
the same.

## Validation

- `zig build -Demit-exe=true` — pass
- `zig build -Demit-exe=true -Dtarget=aarch64-windows-msvc -Dcpu=baseline` — pass
  (the previous revision was x64-only and broke ARM64; every `wglGetProcAddress`
  cast now has the `@alignCast` that aarch64's stricter fn-pointer alignment
  requires)
- `zig build test -Demit-test-exe=true` — pass, 0 failures
- `zig fmt --check` on every touched file, `scripts/check-source-format.ps1` — pass

## Bot-review triage (2026-08-30)

One review finding, real, fixed: `changeConfig` set `reinitialize_shaders` for
a custom-shader change but did not bump `target_config_modified`, so a
`reload_config` that enabled a custom shader without also resizing never re-ran
target selection. On a Win32 surface holding a direct fbo-0 target, the newly
created custom shader would have rendered straight to the default framebuffer,
bypassing the no-custom-shader precondition the direct-default strategy is
gated on; the reverse transition stranded an offscreen target until the next
resize. Both inputs to `initTarget` now go through one named predicate,
`targetConfigChangeRequiresRecreate`, with a unit test pinning the invariant.

Two independent reviews reported this same defect.

## Trims

`pixel_format.zig` lost 128 more lines on review: the dead
`wgl_bootstrap_cleanup_order`/`WglBootstrapCleanupStep` pair, the test-only
`validateWglMultisampleSelection` and `wglChooseAttributeValue`, the tautological
`pixelFormatSelectionSource` asserts and the helper itself, the always-zero
`set_pixel_format_count` provenance field, and the three-state `WglRestoreOutcome`
enum whose `.restored` arm was unreachable (both call sites hardcoded `false`).
With the 156 lines of rejection-counter diagnostics cut earlier that is 284 lines
out of this file.

Not taken: merging `betterWglPixelFormatCandidate` and
`betterClassicPixelFormatCandidate` into one generic comparator. It is a
reasonable ~90-line saving, but it rewrites the ranking that decides which pixel
format the renderer gets, and I cannot re-validate that without an interactive
desktop run. Flagging rather than doing it blind.

## Summary by Sourcery

Improve Windows startup, rendering, and terminal I/O efficiency while hardening framebuffer selection, repaint coordination, and teardown correctness.

New Features:
- Render eligible Windows surfaces directly to the default sRGB framebuffer when configuration and runtime capabilities permit.
- Select and validate Windows WGL pixel formats with verified sRGB support and safe fallback behavior.

Bug Fixes:
- Prevent lost or permanently coalesced repaints during renderer updates and ensure repaint reservations are released on early exits.
- Avoid unnecessary cursor-blink wakeups for steady cursors and improve renderer follow-up scheduling.
- Preserve terminal page integrity when overwriting the tail of a wide character in release builds.
- Recreate render targets when custom-shader configuration changes so framebuffer strategy remains valid.
- Restore the owning graphics context before renderer resource teardown.

Enhancements:
- Reduce Windows per-surface thread stack commitment and increase ConPTY read batches.
- Overlap Windows font discovery with application startup.

Tests:
- Add regression and policy tests covering Windows thread stacks, font prefetch, WGL selection, framebuffer strategy, repaint scheduling, cursor blinking, target recreation, terminal integrity, and target ownership.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows startup now begins font discovery in the background, improving launch responsiveness.
  * OpenGL rendering can use the default framebuffer when appropriate, reducing unnecessary presentation work.
  * Windows graphics initialization now selects and validates pixel formats more reliably.
  * Large Windows terminal output is handled with a larger read buffer.

* **Bug Fixes**
  * Improved repaint scheduling, cursor blinking behavior, renderer teardown, and wide-character editing integrity.
  * Added diagnostics for pixel-format startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->