### PR TITLE
fix(win32): correct modifier and control-key reporting (#178)

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -172,6 +172,28 @@ can be derived as
 `(swap_buffers_count - 1) * 1000 / (last_swap_at_ms - first_swap_at_ms)`
 when at least two swaps are present and the time difference is positive.
 
+## Keyboard
+
+Key events are translated with the active Windows keyboard layout, so the
+terminal receives the text a key produces on that layout rather than a
+US-layout approximation. Control chords are encoded from the *unmodified*
+layout text: `ctrl+c` sends `0x03`, and combinations that have no C0 byte
+(`ctrl+,`, `ctrl+.`, `ctrl+m`, `ctrl+i`, `ctrl+[`) send the fixterms
+`CSI <codepoint>;5u` form that editors such as Neovim and Helix understand.
+
+AltGr is treated as a layout shift, not as a Ctrl+Alt chord. Windows
+synthesizes left Ctrl plus right Alt whenever AltGr is pressed, and noctty
+drops that synthetic pair so `AltGr+<key>` produces the layout character (or
+nothing) instead of a Ctrl+Alt terminal sequence. A deliberate Ctrl+Alt chord
+still works with the left Alt key or with the right Ctrl key; left Ctrl plus
+right Alt is indistinguishable from AltGr at the Win32 layer and is always read
+as AltGr.
+
+Console applications reached through ConPTY see these sequences through
+conhost's own decoder, which does not translate every form back into a console
+key record. `[Console]::ReadKey()` therefore reports less than the terminal
+actually sent; applications that read the byte stream directly see everything.
+
 ## Windows, tabs, and splits
 
 noctty uses a native Win32 host window with:
@@ -382,3 +404,8 @@ current `zig-out\bin` binary rather than an older Scoop shim or a
 manually added install directory earlier on `PATH`. On Windows, a
 `noctty.com` executable may be selected before `noctty.exe` for CLI
 invocations, because `.com` ranks before `.exe` in `PATHEXT`.
+
+`noctty.com` is the console launcher and remains the recommended way to run
+CLI actions. Invoking `noctty.exe +<action>` directly also works: the
+Windows-subsystem binary attaches to the console it was launched from before
+running the action, and leaves redirected output alone.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -184,10 +184,15 @@ layout text: `ctrl+c` sends `0x03`, and combinations that have no C0 byte
 AltGr is treated as a layout shift, not as a Ctrl+Alt chord. Windows
 synthesizes left Ctrl plus right Alt whenever AltGr is pressed, and noctty
 drops that synthetic pair so `AltGr+<key>` produces the layout character (or
-nothing) instead of a Ctrl+Alt terminal sequence. A deliberate Ctrl+Alt chord
-still works with the left Alt key or with the right Ctrl key; left Ctrl plus
-right Alt is indistinguishable from AltGr at the Win32 layer and is always read
-as AltGr.
+nothing) instead of a Ctrl+Alt terminal sequence.
+
+That collapse only applies on layouts that actually define AltGr mappings,
+which are the only layouts where Windows injects the synthetic Ctrl. On a
+layout without an AltGr — plain US, for example — left Ctrl plus right Alt can
+only be a chord you pressed, and it is passed through as one. On a layout that
+does have an AltGr, the two are not distinguishable from the modifier state
+noctty reads, so left Ctrl plus right Alt is always read as AltGr there; use
+the left Alt key or the right Ctrl key for a deliberate Ctrl+Alt chord.
 
 Console applications reached through ConPTY see these sequences through
 conhost's own decoder, which does not translate every form back into a console

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2805,6 +2805,46 @@ pub fn preeditCallback(self: *Surface, preedit_: ?[]const u8) !void {
     try self.queueRender();
 }
 
+fn applyKeyRemaps(
+    remaps: *const input.KeyRemapSet,
+    event_orig: input.KeyEvent,
+) input.KeyEvent {
+    var event = event_orig;
+    event.mods = remaps.apply(event_orig.mods);
+    if (event_orig.binding_mods) |binding_mods| {
+        event.binding_mods = remaps.apply(binding_mods);
+    }
+    return event;
+}
+
+test "key remaps apply to binding-only modifiers" {
+    const testing = std.testing;
+
+    var remaps: input.KeyRemapSet = .empty;
+    defer remaps.deinit(testing.allocator);
+    try remaps.parse(testing.allocator, "right_alt=super");
+    remaps.finalize();
+
+    const raw_alt_gr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    const event = applyKeyRemaps(&remaps, .{
+        .key = .key_a,
+        .mods = .{},
+        .binding_mods = raw_alt_gr,
+        .unshifted_codepoint = 'a',
+    });
+
+    try testing.expect(event.mods.empty());
+    try testing.expectEqual(input.Mods{
+        .ctrl = true,
+        .super = true,
+        .sides = .{ .ctrl = .left, .super = .left },
+    }, event.bindingMods());
+}
+
 /// Returns true if the given key event would trigger a keybinding
 /// if it were to be processed. This is useful for determining if
 /// a key event should be sent to the terminal or not.
@@ -2818,10 +2858,7 @@ pub fn keyEventIsBinding(
     event_orig: input.KeyEvent,
 ) ?input.Binding.Flags {
     // Apply key remappings for consistency with keyCallback
-    var event = event_orig;
-    if (self.config.key_remaps.isRemapped(event_orig.mods)) {
-        event.mods = self.config.key_remaps.apply(event_orig.mods);
-    }
+    const event = applyKeyRemaps(&self.config.key_remaps, event_orig);
 
     switch (event.action) {
         .release => return null,
@@ -2865,10 +2902,7 @@ pub fn keyCallback(
 
     // Apply key remappings to transform modifiers before any processing.
     // This allows users to remap modifier keys at the app level.
-    var event = event_orig;
-    if (self.config.key_remaps.isRemapped(event_orig.mods)) {
-        event.mods = self.config.key_remaps.apply(event_orig.mods);
-    }
+    const event = applyKeyRemaps(&self.config.key_remaps, event_orig);
 
     // Crash metadata in case we crash in here
     crash.sentry.thread_state = self.crashThreadState();

--- a/src/apprt/win32/consts.zig
+++ b/src/apprt/win32/consts.zig
@@ -152,6 +152,7 @@ pub const MOD_CONTROL = 0x0002;
 pub const MOD_SHIFT = 0x0004;
 pub const MOD_WIN = 0x0008;
 pub const TO_UNICODE_NO_STATE_CHANGE: UINT = 0x0004;
+pub const MAPVK_VK_TO_VSC: UINT = 0;
 pub const SWP_NOSIZE = 0x0001;
 pub const SWP_NOMOVE = 0x0002;
 pub const SWP_NOZORDER = 0x0004;
@@ -373,6 +374,7 @@ pub const VK_OEM_4 = 0xDB;
 pub const VK_OEM_5 = 0xDC;
 pub const VK_OEM_6 = 0xDD;
 pub const VK_OEM_7 = 0xDE;
+pub const VK_OEM_102 = 0xE2;
 pub const VK_PACKET = 0xE7;
 
 pub const KF_EXTENDED = 1 << 24;

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -314,6 +314,10 @@ fn normalizeAltGrMods(mods: input.Mods) input.Mods {
     return withoutSyntheticAltGr(mods);
 }
 
+fn bindingModsOverride(raw_mods: input.Mods, encoded_mods: input.Mods) ?input.Mods {
+    return if (!raw_mods.equal(encoded_mods)) raw_mods else null;
+}
+
 fn fallbackMods() input.Mods {
     return .{
         .shift = keyPressed(c.VK_SHIFT),
@@ -600,13 +604,8 @@ fn shouldDeferTextToCharMessage(
 
 fn deferTextToCharMessage(
     result: *Win32KeyMessage,
-    raw_mods: input.Mods,
     translated: KeyText,
 ) void {
-    // Binding lookup happens before composing events are discarded by the
-    // terminal encoder. Preserve the physical AltGr chord here so a deferred
-    // AltGr character cannot match an unrelated plain-key binding.
-    result.event.mods = raw_mods;
     result.event.utf8 = "";
     result.event.consumed_mods = .{};
     result.event.composing = true;
@@ -840,6 +839,11 @@ pub fn keyEventFromWin32Message(
             .action = action,
             .key = key,
             .mods = mods,
+            // Windows' synthetic Ctrl+right-Alt pair must remain visible to
+            // bindings so a deferred AltGr key cannot match a plain binding,
+            // and press/release hashes must use the same physical identity.
+            // Terminal encoding still uses the normalized modifiers above.
+            .binding_mods = bindingModsOverride(raw_mods, mods),
             // Derived for release events too, not just press/repeat: see
             // unshiftedCodepoint.
             .unshifted_codepoint = unshiftedCodepoint(
@@ -858,7 +862,7 @@ pub fn keyEventFromWin32Message(
             // Keep the physical-key event visible to bindings/modifier state
             // but defer text emission to WM_CHAR so plain typing doesn't rely
             // on ToUnicode/GetKeyboardState timing.
-            deferTextToCharMessage(&result, raw_mods, translated);
+            deferTextToCharMessage(&result, translated);
         }
     }
 
@@ -1234,23 +1238,56 @@ test "win32 deferred char authorization respects key handling effect" {
     try std.testing.expect(!shouldAuthorizeDeferredCharMessage(.closed));
 }
 
-test "win32 deferred AltGr text preserves binding modifiers" {
+test "win32 AltGr binding identity agrees across deferred press and release" {
     const raw_alt_gr: input.Mods = .{
         .ctrl = true,
         .alt = true,
         .sides = .{ .ctrl = .left, .alt = .right },
     };
-    var message: Win32KeyMessage = .{ .event = .{
+    const normalized = withoutSyntheticAltGr(raw_alt_gr);
+    var press: Win32KeyMessage = .{ .event = .{
+        .action = .press,
         .key = .key_a,
-        .mods = withoutSyntheticAltGr(raw_alt_gr),
+        .mods = normalized,
+        .binding_mods = bindingModsOverride(raw_alt_gr, normalized),
+        .unshifted_codepoint = 'a',
     } };
+    const release: input.KeyEvent = .{
+        .action = .release,
+        .key = .key_a,
+        .mods = normalized,
+        .binding_mods = bindingModsOverride(raw_alt_gr, normalized),
+        .unshifted_codepoint = 'a',
+    };
 
-    deferTextToCharMessage(&message, raw_alt_gr, .{ .deferred_utf16_units = 1 });
+    deferTextToCharMessage(&press, .{ .deferred_utf16_units = 1 });
 
-    try std.testing.expect(std.meta.eql(raw_alt_gr, message.event.mods));
-    try std.testing.expect(message.event.composing);
-    try std.testing.expectEqualStrings("", message.event.utf8);
-    try std.testing.expectEqual(@as(usize, 1), message.deferred_utf16_units);
+    try std.testing.expect(std.meta.eql(normalized, press.event.mods));
+    try std.testing.expect(std.meta.eql(raw_alt_gr, press.event.bindingMods()));
+    try std.testing.expect(std.meta.eql(raw_alt_gr, release.bindingMods()));
+    try std.testing.expectEqual(press.event.bindingHash(), release.bindingHash());
+    try std.testing.expect(press.event.composing);
+    try std.testing.expectEqualStrings("", press.event.utf8);
+    try std.testing.expectEqual(@as(usize, 1), press.deferred_utf16_units);
+
+    // The binding-only override must not leak the synthetic Ctrl+Alt pair into
+    // Kitty release reporting. Its bytes stay identical to the normalized
+    // event that existed before binding identity was separated.
+    var expected_buf: [64]u8 = undefined;
+    var expected: std.Io.Writer = .fixed(&expected_buf);
+    var normalized_release = release;
+    normalized_release.binding_mods = null;
+    try input.key_encode.encode(&expected, normalized_release, .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true },
+    });
+
+    var actual_buf: [64]u8 = undefined;
+    var actual: std.Io.Writer = .fixed(&actual_buf);
+    try input.key_encode.encode(&actual, release, .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true },
+    });
+    try std.testing.expect(actual.buffered().len > 0);
+    try std.testing.expectEqualStrings(expected.buffered(), actual.buffered());
 }
 
 test "win32 VK_PACKET key down authorizes one unit without direct text or modifiers" {

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -598,6 +598,21 @@ fn shouldDeferTextToCharMessage(
     return !isControlCodepoint(translated.unshifted_codepoint);
 }
 
+fn deferTextToCharMessage(
+    result: *Win32KeyMessage,
+    raw_mods: input.Mods,
+    translated: KeyText,
+) void {
+    // Binding lookup happens before composing events are discarded by the
+    // terminal encoder. Preserve the physical AltGr chord here so a deferred
+    // AltGr character cannot match an unrelated plain-key binding.
+    result.event.mods = raw_mods;
+    result.event.utf8 = "";
+    result.event.consumed_mods = .{};
+    result.event.composing = true;
+    result.deferred_utf16_units = translated.deferred_utf16_units;
+}
+
 pub fn shouldAuthorizeDeferredCharMessage(effect: CoreSurface.InputEffect) bool {
     return effect == .ignored;
 }
@@ -817,7 +832,8 @@ pub fn keyEventFromWin32Message(
     const key = keyFromVirtualKey(vk, lParam);
     var keyboard_state_storage: [256]u8 = [_]u8{0} ** 256;
     const keyboard_state = currentKeyboardState(&keyboard_state_storage);
-    const mods = normalizeAltGrMods(currentModsFromKeyboardState(keyboard_state));
+    const raw_mods = currentModsFromKeyboardState(keyboard_state);
+    const mods = normalizeAltGrMods(raw_mods);
 
     var result: Win32KeyMessage = .{
         .event = .{
@@ -842,10 +858,7 @@ pub fn keyEventFromWin32Message(
             // Keep the physical-key event visible to bindings/modifier state
             // but defer text emission to WM_CHAR so plain typing doesn't rely
             // on ToUnicode/GetKeyboardState timing.
-            result.event.utf8 = "";
-            result.event.consumed_mods = .{};
-            result.event.composing = true;
-            result.deferred_utf16_units = translated.deferred_utf16_units;
+            deferTextToCharMessage(&result, raw_mods, translated);
         }
     }
 
@@ -1219,6 +1232,25 @@ test "win32 deferred char authorization respects key handling effect" {
     try std.testing.expect(shouldAuthorizeDeferredCharMessage(.ignored));
     try std.testing.expect(!shouldAuthorizeDeferredCharMessage(.consumed));
     try std.testing.expect(!shouldAuthorizeDeferredCharMessage(.closed));
+}
+
+test "win32 deferred AltGr text preserves binding modifiers" {
+    const raw_alt_gr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    var message: Win32KeyMessage = .{ .event = .{
+        .key = .key_a,
+        .mods = withoutSyntheticAltGr(raw_alt_gr),
+    } };
+
+    deferTextToCharMessage(&message, raw_alt_gr, .{ .deferred_utf16_units = 1 });
+
+    try std.testing.expect(std.meta.eql(raw_alt_gr, message.event.mods));
+    try std.testing.expect(message.event.composing);
+    try std.testing.expectEqualStrings("", message.event.utf8);
+    try std.testing.expectEqual(@as(usize, 1), message.deferred_utf16_units);
 }
 
 test "win32 VK_PACKET key down authorizes one unit without direct text or modifiers" {

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -248,6 +248,28 @@ fn modsFromKeyboardState(state: *const [256]u8) input.Mods {
     };
 }
 
+/// Windows synthesizes left Ctrl + right Alt whenever AltGr is pressed on a
+/// layout that has one. That pair is a layout shift, not a Ctrl+Alt chord.
+fn isAltGr(mods: input.Mods) bool {
+    return mods.ctrl and mods.alt and
+        mods.sides.ctrl == .left and mods.sides.alt == .right;
+}
+
+/// Drop the Ctrl+Alt that Windows synthesizes for AltGr. Reporting it verbatim
+/// makes the encoder treat every AltGr combination as a Ctrl+Alt chord, which
+/// encodes as ESC plus a C0 byte -- that is why AltGr+backspace arrived as
+/// "Alt + Control" instead of a plain backspace. The raw keyboard state is left
+/// untouched so the layout translation still produces the AltGr character.
+fn withoutSyntheticAltGr(mods: input.Mods) input.Mods {
+    if (!isAltGr(mods)) return mods;
+    var result = mods;
+    result.ctrl = false;
+    result.alt = false;
+    result.sides.ctrl = .left;
+    result.sides.alt = .left;
+    return result;
+}
+
 fn fallbackMods() input.Mods {
     return .{
         .shift = keyPressed(c.VK_SHIFT),
@@ -518,8 +540,7 @@ fn shouldDeferTextToCharMessage(
     if (action == .release) return false;
     // Windows reports AltGr as synthetic left Ctrl plus right Alt. The
     // resulting WM_CHAR is layout text, not a Ctrl+Alt terminal chord.
-    const alt_gr = mods.ctrl and mods.alt and
-        mods.sides.ctrl == .left and mods.sides.alt == .right;
+    const alt_gr = isAltGr(mods);
     if (mods.super or ((mods.ctrl or mods.alt) and !alt_gr)) return false;
     if (key.modifier()) return false;
 
@@ -565,6 +586,69 @@ fn translateKeyTextToUnicode(
     return sys.ToUnicode(vk, scan_code, state, utf16, utf16.len, c.TO_UNICODE_NO_STATE_CHANGE);
 }
 
+/// Which modifiers to blank out of a copy of the live keyboard state before
+/// asking the layout to translate a key.
+const KeyStateMask = struct {
+    /// Clear Ctrl and Alt (including the synthetic AltGr pair).
+    control: bool = false,
+    /// Clear Shift and Caps Lock.
+    shift: bool = false,
+};
+
+fn maskedKeyboardState(state: *const [256]u8, mask: KeyStateMask) [256]u8 {
+    var copy = state.*;
+    if (mask.control) {
+        copy[c.VK_CONTROL] = 0;
+        copy[c.VK_LCONTROL] = 0;
+        copy[c.VK_RCONTROL] = 0;
+        copy[c.VK_MENU] = 0;
+        copy[c.VK_LMENU] = 0;
+        copy[c.VK_RMENU] = 0;
+    }
+    if (mask.shift) {
+        copy[c.VK_SHIFT] = 0;
+        copy[c.VK_LSHIFT] = 0;
+        copy[c.VK_RSHIFT] = 0;
+        copy[c.VK_CAPITAL] = 0;
+    }
+    return copy;
+}
+
+/// Decode the UTF-16 units the layout produced into a single codepoint,
+/// rejecting control characters. Control results are dropped because the core
+/// encoder derives C0 bytes itself from the key and modifiers.
+fn printableCodepoint(units: []const u16) ?u21 {
+    if (units.len == 0) return null;
+    const codepoint: u21 = cp: {
+        if (units.len >= 2 and
+            std.unicode.utf16IsHighSurrogate(units[0]) and
+            std.unicode.utf16IsLowSurrogate(units[1]))
+        {
+            break :cp std.unicode.utf16DecodeSurrogatePair(
+                &.{ units[0], units[1] },
+            ) catch return null;
+        }
+        break :cp units[0];
+    };
+    if (isControlCodepoint(codepoint)) return null;
+    return codepoint;
+}
+
+/// Translate `vk` against a masked copy of the keyboard state and return the
+/// printable codepoint it produces, if any.
+fn translatePrintableCodepoint(
+    vk: UINT,
+    scan_code: UINT,
+    state: *const [256]u8,
+    mask: KeyStateMask,
+) ?u21 {
+    const masked = maskedKeyboardState(state, mask);
+    var utf16: [4]u16 = [_]u16{0} ** 4;
+    const count = translateKeyTextToUnicode(vk, scan_code, &masked, &utf16);
+    if (count <= 0) return null;
+    return printableCodepoint(utf16[0..@min(@as(usize, @intCast(count)), utf16.len)]);
+}
+
 fn translateKeyText(
     vk: UINT,
     lParam: LPARAM,
@@ -579,36 +663,47 @@ fn translateKeyText(
         };
     };
 
-    var utf16: [4]u16 = [_]u16{0} ** 4;
-    const count = translateKeyTextToUnicode(vk, scanCodeFromLParam(lParam), state, &utf16);
-    if (count < 0) {
-        return .{
-            .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
-            .deferred_utf16_units = 1,
-        };
-    }
-    if (count == 0) {
-        return .{ .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk) };
-    }
+    const scan_code = scanCodeFromLParam(lParam);
 
+    // The unshifted codepoint has to come from the active layout, not from a
+    // US-layout table: ctrl+ő on a Hungarian layout must report U+0151.
     var result: KeyText = .{
-        .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
-        .deferred_utf16_units = @intCast(count),
+        .unshifted_codepoint = translatePrintableCodepoint(
+            vk,
+            scan_code,
+            state,
+            .{ .control = true, .shift = true },
+        ) orelse unshiftedCodepointForVirtualKey(vk),
     };
 
-    const codepoint: u21 = cp: {
-        if (count >= 2 and std.unicode.utf16IsHighSurrogate(utf16[0]) and std.unicode.utf16IsLowSurrogate(utf16[1])) {
-            break :cp std.unicode.utf16DecodeSurrogatePair(&.{ utf16[0], utf16[1] }) catch return result;
+    var utf16: [4]u16 = [_]u16{0} ** 4;
+    const count = translateKeyTextToUnicode(vk, scan_code, state, &utf16);
+    if (count < 0) {
+        // Dead key. The composed text arrives later as WM_CHAR.
+        result.deferred_utf16_units = 1;
+        return result;
+    }
+    if (count > 0) result.deferred_utf16_units = @intCast(count);
+
+    // Text for the event. Windows folds Ctrl into the layout translation
+    // (ctrl+a becomes U+0001, ctrl+backspace becomes U+007F) or refuses to
+    // translate at all (ctrl+comma yields nothing). Every other apprt hands the
+    // core the *unmodified* layout text and lets key_encode derive the C0 byte
+    // or the CSI u form, so re-translate Ctrl chords with Ctrl and Alt masked
+    // out. Without this, ctrl+comma, ctrl+period, ctrl+m and friends reach the
+    // encoder with no text at all and encode to nothing.
+    const codepoint: ?u21 = if (mods.ctrl)
+        translatePrintableCodepoint(vk, scan_code, state, .{ .control = true })
+    else
+        printableCodepoint(utf16[0..@min(@as(usize, @intCast(count)), utf16.len)]);
+
+    if (codepoint) |cp| {
+        result.len = std.unicode.utf8Encode(cp, &result.utf8) catch 0;
+        // Shift is only consumed when the layout used it to produce the text.
+        // In a Ctrl chord shift is part of the chord, so it stays live.
+        if (result.len > 0 and !mods.ctrl) {
+            result.consumed_mods = .{ .shift = mods.shift };
         }
-        if (utf16[0] < 0x20 or utf16[0] == 0x7F) return result;
-        break :cp utf16[0];
-    };
-
-    result.len = std.unicode.utf8Encode(codepoint, &result.utf8) catch 0;
-    if (result.len > 0) {
-        result.consumed_mods = .{
-            .shift = mods.shift,
-        };
     }
 
     return result;
@@ -650,7 +745,7 @@ pub fn keyEventFromWin32Message(
     const key = keyFromVirtualKey(vk, lParam);
     var keyboard_state_storage: [256]u8 = [_]u8{0} ** 256;
     const keyboard_state = currentKeyboardState(&keyboard_state_storage);
-    const mods = currentModsFromKeyboardState(keyboard_state);
+    const mods = withoutSyntheticAltGr(currentModsFromKeyboardState(keyboard_state));
 
     var result: Win32KeyMessage = .{ .event = .{
         .action = action,
@@ -689,6 +784,194 @@ test "win32 keyFromVirtualKey maps core keys" {
     try std.testing.expectEqual(input.Key.arrow_left, keyFromVirtualKey(c.VK_LEFT, 0));
     try std.testing.expectEqual(input.Key.f12, keyFromVirtualKey(c.VK_F1 + 11, 0));
     try std.testing.expectEqual(input.Key.quote, keyFromVirtualKey(c.VK_OEM_7, 0));
+}
+
+/// The layout-sensitive tests below assert US-layout results, so skip them when
+/// the machine running the suite has a different layout loaded.
+fn testingUsLayout() bool {
+    if (comptime builtin.os.tag != .windows) return false;
+    return (sys.GetKeyboardLayout(0) & 0xFFFF) == 0x0409;
+}
+
+fn testingKeyboardState(mods: input.Mods) [256]u8 {
+    var state: [256]u8 = [_]u8{0} ** 256;
+    if (mods.shift) {
+        state[c.VK_SHIFT] = 0x80;
+        state[if (mods.sides.shift == .right) c.VK_RSHIFT else c.VK_LSHIFT] = 0x80;
+    }
+    if (mods.ctrl) {
+        state[c.VK_CONTROL] = 0x80;
+        state[if (mods.sides.ctrl == .right) c.VK_RCONTROL else c.VK_LCONTROL] = 0x80;
+    }
+    if (mods.alt) {
+        state[c.VK_MENU] = 0x80;
+        state[if (mods.sides.alt == .right) c.VK_RMENU else c.VK_LMENU] = 0x80;
+    }
+    if (mods.caps_lock) state[c.VK_CAPITAL] = 0x01;
+    return state;
+}
+
+/// Build the key event the window procedure would hand the core surface, but
+/// from an explicit modifier set instead of the live keyboard. `text` is owned
+/// by the caller because the event borrows its UTF-8 buffer.
+fn testingKeyEvent(vk: UINT, raw_mods: input.Mods, text: *KeyText) input.KeyEvent {
+    const state = testingKeyboardState(raw_mods);
+    const mods = withoutSyntheticAltGr(raw_mods);
+    text.* = translateKeyText(vk, testingScanCode(vk), mods, &state);
+    return .{
+        .action = .press,
+        .key = keyFromVirtualKey(vk, 0),
+        .mods = mods,
+        .consumed_mods = text.consumed_mods,
+        .unshifted_codepoint = text.unshifted_codepoint,
+        .utf8 = text.utf8[0..text.len],
+    };
+}
+
+/// lParam carrying the layout scan code for `vk` in the position
+/// `scanCodeFromLParam` reads it from.
+fn testingScanCode(vk: UINT) LPARAM {
+    const scan = sys.MapVirtualKeyW(vk, 0);
+    return @bitCast(@as(usize, scan) << 16);
+}
+
+// Every combination the reporter of #178 listed, plus the ones that already
+// worked, pinned to the bytes the terminal is supposed to receive.
+test "win32 issue 178 key combinations encode correctly" {
+    if (!testingUsLayout()) return error.SkipZigTest;
+
+    const alt: input.Mods = .{ .alt = true };
+    const ctrl: input.Mods = .{ .ctrl = true };
+    const altgr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    const ctrl_alt: input.Mods = .{ .ctrl = true, .alt = true };
+
+    const cases = [_]struct {
+        name: []const u8,
+        vk: UINT,
+        mods: input.Mods,
+        expect: []const u8,
+    }{
+        // Control: this one was already reported as working.
+        .{ .name = "alt+backspace", .vk = c.VK_BACK, .mods = alt, .expect = "\x1b\x7f" },
+        // Alt+<letter> must be an ESC prefix, never ESC + C0 (which conhost
+        // decodes back as "Alt + Control").
+        .{ .name = "alt+a", .vk = c.VK_A, .mods = alt, .expect = "\x1ba" },
+        .{ .name = "alt+comma", .vk = c.VK_OEM_COMMA, .mods = alt, .expect = "\x1b," },
+        // AltGr is a layout shift: its synthetic Ctrl+Alt must not survive.
+        .{ .name = "altgr+backspace", .vk = c.VK_BACK, .mods = altgr, .expect = "\x7f" },
+        // A real Ctrl+Alt chord still encodes as ESC + C0.
+        .{ .name = "ctrl+alt+c", .vk = c.VK_A + 2, .mods = ctrl_alt, .expect = "\x1b\x03" },
+        // Ctrl+backspace keeps the xterm/upstream 0x08 encoding.
+        .{ .name = "ctrl+backspace", .vk = c.VK_BACK, .mods = ctrl, .expect = "\x08" },
+        // These four produced no bytes at all before the fix.
+        .{ .name = "ctrl+comma", .vk = c.VK_OEM_COMMA, .mods = ctrl, .expect = "\x1b[44;5u" },
+        .{ .name = "ctrl+period", .vk = c.VK_OEM_PERIOD, .mods = ctrl, .expect = "\x1b[46;5u" },
+        .{ .name = "ctrl+semicolon", .vk = c.VK_OEM_1, .mods = ctrl, .expect = "\x1b[59;5u" },
+        .{ .name = "ctrl+m", .vk = c.VK_A + 12, .mods = ctrl, .expect = "\x1b[109;5u" },
+        .{ .name = "ctrl+i", .vk = c.VK_A + 8, .mods = ctrl, .expect = "\x1b[105;5u" },
+        .{ .name = "ctrl+bracket_left", .vk = c.VK_OEM_4, .mods = ctrl, .expect = "\x1b[91;5u" },
+        // Ctrl+letter C0 bytes are unchanged.
+        .{ .name = "ctrl+c", .vk = c.VK_A + 2, .mods = ctrl, .expect = "\x03" },
+        .{ .name = "ctrl+a", .vk = c.VK_A, .mods = ctrl, .expect = "\x01" },
+        .{ .name = "ctrl+slash", .vk = c.VK_OEM_2, .mods = ctrl, .expect = "\x1f" },
+        .{ .name = "ctrl+space", .vk = c.VK_SPACE, .mods = ctrl, .expect = "\x00" },
+        // Shift stays live inside a Ctrl chord.
+        .{
+            .name = "ctrl+shift+minus",
+            .vk = c.VK_OEM_MINUS,
+            .mods = .{ .ctrl = true, .shift = true },
+            .expect = "\x1f",
+        },
+        .{
+            .name = "ctrl+shift+2",
+            .vk = c.VK_0 + 2,
+            .mods = .{ .ctrl = true, .shift = true },
+            .expect = "\x1b[64;5u",
+        },
+        // Plain typing is untouched.
+        .{ .name = "plain a", .vk = c.VK_A, .mods = .{}, .expect = "a" },
+        .{
+            .name = "shift+a",
+            .vk = c.VK_A,
+            .mods = .{ .shift = true },
+            .expect = "A",
+        },
+    };
+
+    for (cases) |case| {
+        var buf: [64]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        var text: KeyText = .{};
+        try input.key_encode.encode(
+            &writer,
+            testingKeyEvent(case.vk, case.mods, &text),
+            .{ .alt_esc_prefix = true },
+        );
+        std.testing.expectEqualStrings(case.expect, writer.buffered()) catch |err| {
+            std.debug.print("win32 issue 178 case failed: {s}\n", .{case.name});
+            return err;
+        };
+    }
+}
+
+test "win32 control chords carry the unmodified layout text" {
+    if (!testingUsLayout()) return error.SkipZigTest;
+
+    const ctrl: input.Mods = .{ .ctrl = true };
+    const state = testingKeyboardState(ctrl);
+
+    // Ctrl+comma does not translate at all under Windows...
+    const comma = translateKeyText(c.VK_OEM_COMMA, testingScanCode(c.VK_OEM_COMMA), ctrl, &state);
+    try std.testing.expectEqualStrings(",", comma.utf8[0..comma.len]);
+    try std.testing.expectEqual(@as(u21, ','), comma.unshifted_codepoint);
+
+    // ...and ctrl+m translates to a control character. Both must still reach
+    // the core as the plain layout text.
+    const m = translateKeyText(c.VK_A + 12, testingScanCode(c.VK_A + 12), ctrl, &state);
+    try std.testing.expectEqualStrings("m", m.utf8[0..m.len]);
+    try std.testing.expectEqual(@as(u21, 'm'), m.unshifted_codepoint);
+
+    // Keys whose unmodified translation is itself a control character stay
+    // text-free so the PC-style function key tables still win.
+    const backspace = translateKeyText(c.VK_BACK, testingScanCode(c.VK_BACK), ctrl, &state);
+    try std.testing.expectEqual(@as(usize, 0), backspace.len);
+    const enter = translateKeyText(c.VK_RETURN, testingScanCode(c.VK_RETURN), ctrl, &state);
+    try std.testing.expectEqual(@as(usize, 0), enter.len);
+    const tab = translateKeyText(c.VK_TAB, testingScanCode(c.VK_TAB), ctrl, &state);
+    try std.testing.expectEqual(@as(usize, 0), tab.len);
+}
+
+test "win32 synthetic AltGr modifiers are not a ctrl+alt chord" {
+    const altgr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    try std.testing.expect(isAltGr(altgr));
+    const stripped = withoutSyntheticAltGr(altgr);
+    try std.testing.expect(!stripped.ctrl);
+    try std.testing.expect(!stripped.alt);
+
+    // A deliberate ctrl+alt chord (left alt, or right ctrl) is left alone.
+    const left_alt: input.Mods = .{ .ctrl = true, .alt = true };
+    try std.testing.expect(!isAltGr(left_alt));
+    try std.testing.expect(std.meta.eql(left_alt, withoutSyntheticAltGr(left_alt)));
+
+    const right_ctrl: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .right, .alt = .right },
+    };
+    try std.testing.expect(!isAltGr(right_ctrl));
+    try std.testing.expect(std.meta.eql(right_ctrl, withoutSyntheticAltGr(right_ctrl)));
+
+    // Ctrl or alt alone is never AltGr.
+    try std.testing.expect(!isAltGr(.{ .ctrl = true }));
+    try std.testing.expect(!isAltGr(.{ .alt = true, .sides = .{ .alt = .right } }));
 }
 
 test "win32 shouldDeferTextToCharMessage only defers plain text keys" {

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -255,6 +255,41 @@ fn isAltGr(mods: input.Mods) bool {
         mods.sides.ctrl == .left and mods.sides.alt == .right;
 }
 
+/// Whether the active layout defines any AltGr mappings.
+///
+/// Windows only injects the synthetic left Ctrl on layouts that have an AltGr,
+/// so on a layout without one (plain US, for instance) a left Ctrl plus right
+/// Alt can only be a chord the user physically pressed, and collapsing it would
+/// silently turn `ctrl+ralt+x` into a literal "x". Probing is cheap and needs no
+/// cached state: it only runs while both keys are held, and the answer follows
+/// the layout automatically because it is measured from the layout itself.
+fn layoutHasAltGrMappings() bool {
+    var state: [256]u8 = [_]u8{0} ** 256;
+    state[c.VK_CONTROL] = 0x80;
+    state[c.VK_LCONTROL] = 0x80;
+    state[c.VK_MENU] = 0x80;
+    state[c.VK_RMENU] = 0x80;
+
+    // The printable ranges plus the OEM keys cover every key layouts actually
+    // put an AltGr character on.
+    for (c.VK_0..c.VK_9 + 1) |vk| {
+        if (altGrProbeProducesText(@intCast(vk), &state)) return true;
+    }
+    for (c.VK_A..c.VK_Z + 1) |vk| {
+        if (altGrProbeProducesText(@intCast(vk), &state)) return true;
+    }
+    for (c.VK_OEM_1..c.VK_OEM_7 + 1) |vk| {
+        if (altGrProbeProducesText(@intCast(vk), &state)) return true;
+    }
+    return altGrProbeProducesText(c.VK_OEM_102, &state);
+}
+
+fn altGrProbeProducesText(vk: UINT, state: *const [256]u8) bool {
+    var utf16: [4]u16 = [_]u16{0} ** 4;
+    const scan_code = sys.MapVirtualKeyW(vk, c.MAPVK_VK_TO_VSC);
+    return translateKeyTextToUnicode(vk, scan_code, state, &utf16) != 0;
+}
+
 /// Drop the Ctrl+Alt that Windows synthesizes for AltGr. Reporting it verbatim
 /// makes the encoder treat every AltGr combination as a Ctrl+Alt chord, which
 /// encodes as ESC plus a C0 byte -- that is why AltGr+backspace arrived as
@@ -268,6 +303,15 @@ fn withoutSyntheticAltGr(mods: input.Mods) input.Mods {
     result.sides.ctrl = .left;
     result.sides.alt = .left;
     return result;
+}
+
+/// Apply the AltGr collapse only when the active layout actually has an AltGr.
+/// The layout probe is behind the cheap modifier check so it only runs while
+/// left Ctrl and right Alt are both held.
+fn normalizeAltGrMods(mods: input.Mods) input.Mods {
+    if (!isAltGr(mods)) return mods;
+    if (!layoutHasAltGrMappings()) return mods;
+    return withoutSyntheticAltGr(mods);
 }
 
 fn fallbackMods() input.Mods {
@@ -649,6 +693,28 @@ fn translatePrintableCodepoint(
     return printableCodepoint(utf16[0..@min(@as(usize, @intCast(count)), utf16.len)]);
 }
 
+/// The codepoint this key produces with every modifier cleared, taken from the
+/// active layout so non-US layouts report their own key codes: ctrl+ő on a
+/// Hungarian layout must report U+0151, not '['. Falls back to the static US
+/// table when the layout produces nothing printable (dead keys, function keys).
+///
+/// This must be derived identically for press, repeat and release. The Kitty
+/// encoder builds its key code from this field, so a press/release pair that
+/// disagreed would look like two different keys to an application pairing them.
+fn unshiftedCodepoint(
+    vk: UINT,
+    scan_code: UINT,
+    keyboard_state: ?*const [256]u8,
+) u21 {
+    const state = keyboard_state orelse return unshiftedCodepointForVirtualKey(vk);
+    return translatePrintableCodepoint(
+        vk,
+        scan_code,
+        state,
+        .{ .control = true, .shift = true },
+    ) orelse unshiftedCodepointForVirtualKey(vk);
+}
+
 fn translateKeyText(
     vk: UINT,
     lParam: LPARAM,
@@ -665,15 +731,8 @@ fn translateKeyText(
 
     const scan_code = scanCodeFromLParam(lParam);
 
-    // The unshifted codepoint has to come from the active layout, not from a
-    // US-layout table: ctrl+ő on a Hungarian layout must report U+0151.
     var result: KeyText = .{
-        .unshifted_codepoint = translatePrintableCodepoint(
-            vk,
-            scan_code,
-            state,
-            .{ .control = true, .shift = true },
-        ) orelse unshiftedCodepointForVirtualKey(vk),
+        .unshifted_codepoint = unshiftedCodepoint(vk, scan_code, state),
     };
 
     var utf16: [4]u16 = [_]u16{0} ** 4;
@@ -745,22 +804,27 @@ pub fn keyEventFromWin32Message(
     const key = keyFromVirtualKey(vk, lParam);
     var keyboard_state_storage: [256]u8 = [_]u8{0} ** 256;
     const keyboard_state = currentKeyboardState(&keyboard_state_storage);
-    const mods = withoutSyntheticAltGr(currentModsFromKeyboardState(keyboard_state));
+    const mods = normalizeAltGrMods(currentModsFromKeyboardState(keyboard_state));
 
-    var result: Win32KeyMessage = .{ .event = .{
-        .action = action,
-        .key = key,
-        .mods = mods,
-        .unshifted_codepoint = unshiftedCodepointForVirtualKey(vk),
-    } };
+    var result: Win32KeyMessage = .{
+        .event = .{
+            .action = action,
+            .key = key,
+            .mods = mods,
+            // Derived for release events too, not just press/repeat: see
+            // unshiftedCodepoint.
+            .unshifted_codepoint = unshiftedCodepoint(
+                vk,
+                scanCodeFromLParam(lParam),
+                keyboard_state,
+            ),
+        },
+    };
 
     if (action != .release) {
         const translated = translateKeyText(vk, lParam, mods, keyboard_state);
         result.event.utf8 = translated.utf8[0..translated.len];
         result.event.consumed_mods = translated.consumed_mods;
-        if (translated.unshifted_codepoint != 0) {
-            result.event.unshifted_codepoint = translated.unshifted_codepoint;
-        }
         if (shouldDeferTextToCharMessage(action, key, mods, translated)) {
             // Keep the physical-key event visible to bindings/modifier state
             // but defer text emission to WM_CHAR so plain typing doesn't rely
@@ -786,11 +850,13 @@ test "win32 keyFromVirtualKey maps core keys" {
     try std.testing.expectEqual(input.Key.quote, keyFromVirtualKey(c.VK_OEM_7, 0));
 }
 
-/// The layout-sensitive tests below assert US-layout results, so skip them when
-/// the machine running the suite has a different layout loaded.
+/// The layout-sensitive tests below assert plain-US results, so skip them on any
+/// other layout. The full HKL is compared rather than just the language id
+/// because US-International, Dvorak and Colemak share LANGID 0x0409 but
+/// translate differently.
 fn testingUsLayout() bool {
     if (comptime builtin.os.tag != .windows) return false;
-    return (sys.GetKeyboardLayout(0) & 0xFFFF) == 0x0409;
+    return sys.GetKeyboardLayout(0) == 0x04090409;
 }
 
 fn testingKeyboardState(mods: input.Mods) [256]u8 {
@@ -814,6 +880,10 @@ fn testingKeyboardState(mods: input.Mods) [256]u8 {
 /// Build the key event the window procedure would hand the core surface, but
 /// from an explicit modifier set instead of the live keyboard. `text` is owned
 /// by the caller because the event borrows its UTF-8 buffer.
+///
+/// The AltGr collapse is applied unconditionally here so the table below can
+/// assert AltGr semantics on any runner. Whether the collapse fires in
+/// production is the layout probe's job and is covered separately.
 fn testingKeyEvent(vk: UINT, raw_mods: input.Mods, text: *KeyText) input.KeyEvent {
     const state = testingKeyboardState(raw_mods);
     const mods = withoutSyntheticAltGr(raw_mods);
@@ -831,8 +901,54 @@ fn testingKeyEvent(vk: UINT, raw_mods: input.Mods, text: *KeyText) input.KeyEven
 /// lParam carrying the layout scan code for `vk` in the position
 /// `scanCodeFromLParam` reads it from.
 fn testingScanCode(vk: UINT) LPARAM {
-    const scan = sys.MapVirtualKeyW(vk, 0);
+    const scan = sys.MapVirtualKeyW(vk, c.MAPVK_VK_TO_VSC);
     return @bitCast(@as(usize, scan) << 16);
+}
+
+// The Kitty encoder builds its key code from unshifted_codepoint, so press and
+// release have to agree. VK_DIVIDE is the regression probe: it is absent from
+// unshiftedCodepointForVirtualKey's table (which would report 0) but the layout
+// translates it to '/', so a release path still using the table shows up here.
+test "win32 unshifted codepoint agrees across press and release" {
+    if (!testingUsLayout()) return error.SkipZigTest;
+
+    const keys = [_]UINT{ c.VK_DIVIDE, c.VK_MULTIPLY, c.VK_ADD, c.VK_A, c.VK_OEM_COMMA };
+    for (keys) |vk| {
+        const lParam = testingScanCode(vk);
+        const press = keyEventFromWin32Message(c.WM_KEYDOWN, vk, lParam).?;
+        const release = keyEventFromWin32Message(c.WM_KEYUP, vk, lParam).?;
+        try std.testing.expectEqual(
+            press.event.unshifted_codepoint,
+            release.event.unshifted_codepoint,
+        );
+        try std.testing.expect(release.event.unshifted_codepoint != 0);
+    }
+
+    // Pin the layout-derived value for a key the static table does not carry.
+    const divide = keyEventFromWin32Message(
+        c.WM_KEYUP,
+        c.VK_DIVIDE,
+        testingScanCode(c.VK_DIVIDE),
+    ).?;
+    try std.testing.expectEqual(@as(u21, '/'), divide.event.unshifted_codepoint);
+    try std.testing.expectEqual(@as(u21, 0), unshiftedCodepointForVirtualKey(c.VK_DIVIDE));
+}
+
+test "win32 AltGr collapse only applies to layouts that have an AltGr" {
+    if (!testingUsLayout()) return error.SkipZigTest;
+
+    // Plain US has no AltGr mappings, so left Ctrl + right Alt can only be a
+    // chord the user physically pressed and must survive as one.
+    try std.testing.expect(!layoutHasAltGrMappings());
+
+    const altgr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    const normalized = normalizeAltGrMods(altgr);
+    try std.testing.expect(normalized.ctrl);
+    try std.testing.expect(normalized.alt);
 }
 
 // Every combination the reporter of #178 listed, plus the ones that already

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -285,9 +285,40 @@ fn layoutHasAltGrMappings() bool {
 }
 
 fn altGrProbeProducesText(vk: UINT, state: *const [256]u8) bool {
+    return probeAltGrShiftStates(vk, state, altGrProbeProducesTextForState);
+}
+
+fn probeAltGrShiftStates(
+    vk: UINT,
+    state: *const [256]u8,
+    comptime probe: anytype,
+) bool {
+    if (probe(vk, state)) return true;
+
+    var shifted = state.*;
+    shifted[c.VK_SHIFT] = 0x80;
+    shifted[c.VK_LSHIFT] = 0x80;
+    return probe(vk, &shifted);
+}
+
+fn altGrProbeProducesTextForState(vk: UINT, state: *const [256]u8) bool {
     var utf16: [4]u16 = [_]u16{0} ** 4;
     const scan_code = sys.MapVirtualKeyW(vk, c.MAPVK_VK_TO_VSC);
     return translateKeyTextToUnicode(vk, scan_code, state, &utf16) != 0;
+}
+
+fn testingShiftOnlyAltGrProbe(_: UINT, state: *const [256]u8) bool {
+    return state[c.VK_SHIFT] & 0x80 != 0 and
+        state[c.VK_LSHIFT] & 0x80 != 0;
+}
+
+test "win32 AltGr layout probe checks shifted mappings" {
+    const state: [256]u8 = [_]u8{0} ** 256;
+    try std.testing.expect(probeAltGrShiftStates(
+        c.VK_A,
+        &state,
+        testingShiftOnlyAltGrProbe,
+    ));
 }
 
 /// Drop the Ctrl+Alt that Windows synthesizes for AltGr. Reporting it verbatim

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -582,10 +582,9 @@ fn shouldDeferTextToCharMessage(
     translated: KeyText,
 ) bool {
     if (action == .release) return false;
-    // Windows reports AltGr as synthetic left Ctrl plus right Alt. The
-    // resulting WM_CHAR is layout text, not a Ctrl+Alt terminal chord.
-    const alt_gr = isAltGr(mods);
-    if (mods.super or ((mods.ctrl or mods.alt) and !alt_gr)) return false;
+    // AltGr has already been normalized for layouts that use it. Any
+    // modifiers still present here describe a terminal chord.
+    if (mods.super or mods.ctrl or mods.alt) return false;
     if (key.modifier()) return false;
 
     switch (key) {
@@ -1175,10 +1174,21 @@ test "win32 shouldDeferTextToCharMessage only defers plain text keys" {
         .{ .ctrl = true, .alt = true },
         .{ .unshifted_codepoint = '2', .deferred_utf16_units = 1 },
     ));
+    const raw_alt_gr: input.Mods = .{
+        .ctrl = true,
+        .alt = true,
+        .sides = .{ .ctrl = .left, .alt = .right },
+    };
+    try std.testing.expect(!shouldDeferTextToCharMessage(
+        .press,
+        .equal,
+        raw_alt_gr,
+        .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
+    ));
     try std.testing.expect(shouldDeferTextToCharMessage(
         .press,
         .equal,
-        .{ .ctrl = true, .alt = true, .sides = .{ .alt = .right } },
+        withoutSyntheticAltGr(raw_alt_gr),
         .{ .len = 1, .unshifted_codepoint = '=', .deferred_utf16_units = 1 },
     ));
     try std.testing.expect(!shouldDeferTextToCharMessage(

--- a/src/apprt/win32/input.zig
+++ b/src/apprt/win32/input.zig
@@ -635,8 +635,16 @@ fn translateKeyTextToUnicode(
 const KeyStateMask = struct {
     /// Clear Ctrl and Alt (including the synthetic AltGr pair).
     control: bool = false,
-    /// Clear Shift and Caps Lock.
+    /// Clear Shift. Implies `caps_lock`, because the two together are what
+    /// "unshifted" means.
     shift: bool = false,
+    /// Clear Caps Lock on its own.
+    ///
+    /// Caps Lock must not change the identity of a control chord: fixterms
+    /// sends the fixterms-excluded letters as CSI u built from the event text,
+    /// so leaving Caps Lock live would encode ctrl+m as `CSI 77;5u` ("M")
+    /// instead of `CSI 109;5u` ("m") purely because the lock was on.
+    caps_lock: bool = false,
 };
 
 fn maskedKeyboardState(state: *const [256]u8, mask: KeyStateMask) [256]u8 {
@@ -653,8 +661,8 @@ fn maskedKeyboardState(state: *const [256]u8, mask: KeyStateMask) [256]u8 {
         copy[c.VK_SHIFT] = 0;
         copy[c.VK_LSHIFT] = 0;
         copy[c.VK_RSHIFT] = 0;
-        copy[c.VK_CAPITAL] = 0;
     }
+    if (mask.shift or mask.caps_lock) copy[c.VK_CAPITAL] = 0;
     return copy;
 }
 
@@ -751,8 +759,14 @@ fn translateKeyText(
     // or the CSI u form, so re-translate Ctrl chords with Ctrl and Alt masked
     // out. Without this, ctrl+comma, ctrl+period, ctrl+m and friends reach the
     // encoder with no text at all and encode to nothing.
+    // Caps Lock is masked with Ctrl but Shift is not: in a Ctrl chord Shift is
+    // part of the chord the user typed, while Caps Lock is ambient state that
+    // must not change which key the chord reports.
     const codepoint: ?u21 = if (mods.ctrl)
-        translatePrintableCodepoint(vk, scan_code, state, .{ .control = true })
+        translatePrintableCodepoint(vk, scan_code, state, .{
+            .control = true,
+            .caps_lock = true,
+        })
     else
         printableCodepoint(utf16[0..@min(@as(usize, @intCast(count)), utf16.len)]);
 
@@ -1059,6 +1073,48 @@ test "win32 control chords carry the unmodified layout text" {
     try std.testing.expectEqual(@as(usize, 0), enter.len);
     const tab = translateKeyText(c.VK_TAB, testingScanCode(c.VK_TAB), ctrl, &state);
     try std.testing.expectEqual(@as(usize, 0), tab.len);
+}
+
+// Caps Lock is ambient state, not part of the chord the user typed. The Ctrl
+// re-translation asks the layout for the text again, so an unmasked Caps Lock
+// turned ctrl+m into "M" and encoded CSI 77;5u instead of CSI 109;5u -- the
+// lock silently changed which key the application saw.
+test "win32 caps lock does not change control chord identity" {
+    if (!testingUsLayout()) return error.SkipZigTest;
+
+    const caps_ctrl: input.Mods = .{ .ctrl = true, .caps_lock = true };
+    const caps_ctrl_shift: input.Mods = .{ .ctrl = true, .shift = true, .caps_lock = true };
+
+    const cases = [_]struct {
+        name: []const u8,
+        vk: UINT,
+        mods: input.Mods,
+        expect: []const u8,
+    }{
+        // The fixterms-excluded letters go out as CSI u built from the text.
+        .{ .name = "caps+ctrl+m", .vk = c.VK_A + 12, .mods = caps_ctrl, .expect = "\x1b[109;5u" },
+        .{ .name = "caps+ctrl+i", .vk = c.VK_A + 8, .mods = caps_ctrl, .expect = "\x1b[105;5u" },
+        // Shift is still part of the chord and still reported.
+        .{ .name = "caps+ctrl+shift+m", .vk = c.VK_A + 12, .mods = caps_ctrl_shift, .expect = "\x1b[109;6u" },
+        // C0 letters were already caps-insensitive; keep them that way.
+        .{ .name = "caps+ctrl+a", .vk = c.VK_A, .mods = caps_ctrl, .expect = "\x01" },
+        .{ .name = "caps+ctrl+c", .vk = c.VK_A + 2, .mods = caps_ctrl, .expect = "\x03" },
+    };
+
+    for (cases) |case| {
+        var buf: [64]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        var text: KeyText = .{};
+        try input.key_encode.encode(
+            &writer,
+            testingKeyEvent(case.vk, case.mods, &text),
+            .{ .alt_esc_prefix = true },
+        );
+        std.testing.expectEqualStrings(case.expect, writer.buffered()) catch |err| {
+            std.debug.print("win32 caps lock case failed: {s}\n", .{case.name});
+            return err;
+        };
+    }
 }
 
 test "win32 synthetic AltGr modifiers are not a ctrl+alt chord" {

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -255,8 +255,8 @@ pub extern "user32" fn GetKeyState(nVirtKey: i32) callconv(.winapi) SHORT;
 
 pub extern "user32" fn GetKeyboardState(lpKeyState: *[256]u8) callconv(.winapi) BOOL;
 
-/// Returns the HKL for the thread. Only the low word (the language
-/// identifier) is ever inspected, so this is typed as an integer.
+/// Returns the HKL for the thread. Callers inspect either the full HKL or its
+/// language identifier as appropriate, so this is typed as an integer.
 pub extern "user32" fn GetKeyboardLayout(idThread: DWORD) callconv(.winapi) usize;
 
 pub extern "user32" fn MapVirtualKeyW(uCode: UINT, uMapType: UINT) callconv(.winapi) UINT;

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -255,6 +255,12 @@ pub extern "user32" fn GetKeyState(nVirtKey: i32) callconv(.winapi) SHORT;
 
 pub extern "user32" fn GetKeyboardState(lpKeyState: *[256]u8) callconv(.winapi) BOOL;
 
+/// Returns the HKL for the thread. Only the low word (the language
+/// identifier) is ever inspected, so this is typed as an integer.
+pub extern "user32" fn GetKeyboardLayout(idThread: DWORD) callconv(.winapi) usize;
+
+pub extern "user32" fn MapVirtualKeyW(uCode: UINT, uMapType: UINT) callconv(.winapi) UINT;
+
 pub extern "user32" fn GetMonitorInfoW(hMonitor: HMONITOR, lpmi: *MONITORINFO) callconv(.winapi) BOOL;
 
 pub extern "user32" fn GetWindowRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;

--- a/src/cli/tui.zig
+++ b/src/cli/tui.zig
@@ -1,6 +1,13 @@
 const builtin = @import("builtin");
 
+/// Whether CLI actions may render their output through the vaxis TUI instead of
+/// writing plain text.
+///
+/// Windows is excluded: the vaxis pretty-print path draws nothing usable on a
+/// Windows console, so `+list-keybinds`, `+list-colors` and `+list-themes`
+/// produced blank output whenever stdout was a terminal (issue #178). The plain
+/// text renderer these actions fall back to is correct on every console.
 pub const can_pretty_print = switch (builtin.os.tag) {
-    .ios, .tvos, .watchos => false,
+    .ios, .tvos, .watchos, .windows => false,
     else => true,
 };

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2624,7 +2624,7 @@ pub const Set = struct {
     ///
     pub fn getEvent(self: *const Set, event: KeyEvent) ?Entry {
         var trigger: Trigger = .{
-            .mods = event.mods.binding(),
+            .mods = event.bindingMods().binding(),
             .key = .{ .physical = event.key },
         };
         if (self.get(trigger)) |v| return v;
@@ -4274,6 +4274,24 @@ test "set: getEvent physical" {
         });
         try testing.expect(action == null);
     }
+}
+
+test "set: getEvent honors binding-only modifiers" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "ctrl+alt+a=new_window");
+
+    const entry = s.getEvent(.{
+        .key = .key_a,
+        .mods = .{},
+        .binding_mods = .{ .ctrl = true, .alt = true },
+        .unshifted_codepoint = 'a',
+    }).?.value_ptr.*.leaf;
+    try testing.expect(entry.action == .new_window);
 }
 
 test "set: getEvent codepoint" {

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -25,6 +25,12 @@ pub const KeyEvent = struct {
     /// Mods are the modifiers that are pressed.
     mods: Mods = .{},
 
+    /// Optional modifier identity used only for keybinding lookup and for
+    /// pairing a consumed key press with its release. This lets an apprt keep
+    /// physical modifier identity distinct from the modifiers that terminal
+    /// protocols should encode.
+    binding_mods: ?Mods = null,
+
     /// The mods that were consumed in order to generate the text
     /// in utf8. This has the mods set that were consumed, so to
     /// get the set of mods that are effective you must negate
@@ -54,6 +60,12 @@ pub const KeyEvent = struct {
         return self.mods.unset(self.consumed_mods);
     }
 
+    /// Returns the modifiers used for keybinding lookup and press/release
+    /// pairing. Most apprts use the encoded modifiers directly.
+    pub fn bindingMods(self: KeyEvent) Mods {
+        return self.binding_mods orelse self.mods;
+    }
+
     /// Returns a unique hash for this key event to be used for tracking
     /// uniquess specifically with bindings. This omits fields that are
     /// irrelevant for bindings.
@@ -63,7 +75,7 @@ pub const KeyEvent = struct {
         // These are all the fields that are explicitly part of Trigger.
         std.hash.autoHash(&hasher, self.key);
         std.hash.autoHash(&hasher, self.unshifted_codepoint);
-        std.hash.autoHash(&hasher, self.mods.binding());
+        std.hash.autoHash(&hasher, self.bindingMods().binding());
 
         // Notes on unmapped things and why:
         //

--- a/src/process_shared.zig
+++ b/src/process_shared.zig
@@ -40,8 +40,14 @@ pub fn attachParentConsole() void {
 fn stdHandleUsable(id: i32) bool {
     const handle = GetStdHandle(id);
     if (handle == null or handle == windows.INVALID_HANDLE_VALUE) return false;
-    // A stale inherited handle reports FILE_TYPE_UNKNOWN.
-    return GetFileType(handle.?) != 0;
+    // FILE_TYPE_UNKNOWN (0) is both the error return and a legitimate answer
+    // for a valid handle whose type Windows cannot classify. `GetFileType`
+    // documents the difference as "clear the last error first; on success it
+    // is left at NO_ERROR", so a device redirection we cannot classify must
+    // stay untouched rather than be replaced with CONOUT$.
+    SetLastError(0);
+    if (GetFileType(handle.?) != 0) return true;
+    return GetLastError() == 0;
 }
 
 fn bindStdHandleToConsole(id: i32, comptime name: []const u8) void {
@@ -63,6 +69,8 @@ extern "kernel32" fn AttachConsole(dwProcessId: u32) callconv(.winapi) windows.B
 extern "kernel32" fn GetStdHandle(nStdHandle: i32) callconv(.winapi) ?windows.HANDLE;
 extern "kernel32" fn SetStdHandle(nStdHandle: i32, hHandle: windows.HANDLE) callconv(.winapi) windows.BOOL;
 extern "kernel32" fn GetFileType(hFile: windows.HANDLE) callconv(.winapi) u32;
+extern "kernel32" fn SetLastError(dwErrCode: u32) callconv(.winapi) void;
+extern "kernel32" fn GetLastError() callconv(.winapi) u32;
 extern "kernel32" fn CreateFileW(
     lpFileName: [*:0]const u16,
     dwDesiredAccess: u32,

--- a/src/process_shared.zig
+++ b/src/process_shared.zig
@@ -35,8 +35,9 @@ pub fn attachParentConsole() void {
     if (!stdHandleUsable(std_err)) bindStdHandleToConsole(std_err, "CONOUT$");
 }
 
+/// Both helpers below are only ever reached from attachParentConsole, which has
+/// already established that this is Windows.
 fn stdHandleUsable(id: i32) bool {
-    if (comptime builtin.os.tag != .windows) return true;
     const handle = GetStdHandle(id);
     if (handle == null or handle == windows.INVALID_HANDLE_VALUE) return false;
     // A stale inherited handle reports FILE_TYPE_UNKNOWN.
@@ -44,7 +45,6 @@ fn stdHandleUsable(id: i32) bool {
 }
 
 fn bindStdHandleToConsole(id: i32, comptime name: []const u8) void {
-    if (comptime builtin.os.tag != .windows) return;
     const path = std.unicode.utf8ToUtf16LeStringLiteral(name);
     const handle = CreateFileW(
         path,
@@ -199,6 +199,20 @@ pub const std_options: std.Options = .{
     },
     .logFn = logFn,
 };
+
+// The attach must never disturb a handle that already works, or redirection
+// (`noctty.exe +version > out.txt`) and the noctty.com launcher would break.
+// The test runner's own stdout is a live handle, so it stands in for both.
+test "cli console attach leaves working std handles alone" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const std_out = -11;
+    try std.testing.expect(stdHandleUsable(std_out));
+
+    const before = GetStdHandle(std_out);
+    attachParentConsole();
+    try std.testing.expectEqual(before, GetStdHandle(std_out));
+}
 
 test "cli help output failures get a text output hint" {
     var buffer: [512]u8 = undefined;

--- a/src/process_shared.zig
+++ b/src/process_shared.zig
@@ -5,7 +5,76 @@ const windows = std.os.windows;
 const cli = @import("cli.zig");
 const state = &@import("global.zig").state;
 
+/// Give CLI output somewhere to go.
+///
+/// noctty.exe is a Windows-subsystem binary, so a shell that launches it
+/// directly (`noctty.exe +version`) hands it no console and no standard
+/// handles: every write fails and the action reports `WriteFailed` without
+/// printing anything. Attaching to the launching process's console and binding
+/// the missing handles to it makes CLI actions behave like a console program.
+///
+/// Handles that already work (a real console via noctty.com, or a redirection
+/// such as `noctty.exe +version > out.txt`) are left exactly as they are.
+pub fn attachParentConsole() void {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const std_in = -10;
+    const std_out = -11;
+    const std_err = -12;
+
+    if (stdHandleUsable(std_in) and
+        stdHandleUsable(std_out) and
+        stdHandleUsable(std_err)) return;
+
+    // ATTACH_PARENT_PROCESS. Fails when the launcher has no console (started
+    // from Explorer, a service, or a detached process), which is fine.
+    if (AttachConsole(0xFFFFFFFF) == 0) return;
+
+    if (!stdHandleUsable(std_in)) bindStdHandleToConsole(std_in, "CONIN$");
+    if (!stdHandleUsable(std_out)) bindStdHandleToConsole(std_out, "CONOUT$");
+    if (!stdHandleUsable(std_err)) bindStdHandleToConsole(std_err, "CONOUT$");
+}
+
+fn stdHandleUsable(id: i32) bool {
+    if (comptime builtin.os.tag != .windows) return true;
+    const handle = GetStdHandle(id);
+    if (handle == null or handle == windows.INVALID_HANDLE_VALUE) return false;
+    // A stale inherited handle reports FILE_TYPE_UNKNOWN.
+    return GetFileType(handle.?) != 0;
+}
+
+fn bindStdHandleToConsole(id: i32, comptime name: []const u8) void {
+    if (comptime builtin.os.tag != .windows) return;
+    const path = std.unicode.utf8ToUtf16LeStringLiteral(name);
+    const handle = CreateFileW(
+        path,
+        0x80000000 | 0x40000000, // GENERIC_READ | GENERIC_WRITE
+        0x00000001 | 0x00000002, // FILE_SHARE_READ | FILE_SHARE_WRITE
+        null,
+        3, // OPEN_EXISTING
+        0,
+        null,
+    );
+    if (handle == windows.INVALID_HANDLE_VALUE) return;
+    _ = SetStdHandle(id, handle);
+}
+
+extern "kernel32" fn AttachConsole(dwProcessId: u32) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetStdHandle(nStdHandle: i32) callconv(.winapi) ?windows.HANDLE;
+extern "kernel32" fn SetStdHandle(nStdHandle: i32, hHandle: windows.HANDLE) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetFileType(hFile: windows.HANDLE) callconv(.winapi) u32;
+extern "kernel32" fn CreateFileW(
+    lpFileName: [*:0]const u16,
+    dwDesiredAccess: u32,
+    dwShareMode: u32,
+    lpSecurityAttributes: ?*anyopaque,
+    dwCreationDisposition: u32,
+    dwFlagsAndAttributes: u32,
+    hTemplateFile: ?windows.HANDLE,
+) callconv(.winapi) windows.HANDLE;
+
 pub fn reportStateInitError(err: anyerror) !void {
+    attachParentConsole();
     var buffer: [1024]u8 = undefined;
     var stderr_writer = std.fs.File.stderr().writer(&buffer);
     const stderr = &stderr_writer.interface;
@@ -32,6 +101,7 @@ pub fn reportStateInitError(err: anyerror) !void {
 }
 
 pub fn runCliAction(action: cli.ghostty.Action, alloc: std.mem.Allocator) u8 {
+    attachParentConsole();
     return cli.ghostty.run(action, alloc) catch |err| err: {
         reportCliActionFailure(action, err);
         break :err 1;

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -96,10 +96,13 @@ pwsh -NoProfile -File .\cli-redirected-text-action.ps1 -Action +help -ExpectedTe
 ## cli-detached-action.ps1
 
 Validates that a CLI action launched with no console at all surfaces the native
-CLI-failure dialog and exits 1 rather than failing silently, plus its resource
-discovery and timeout behavior. The process under test is created through WMI so
-that it has no console and no console-owning ancestor; a plain `Start-Process`
-would let the action attach to the calling shell's console and succeed.
+CLI-failure dialog and exits 1 rather than failing silently, plus its timeout
+behavior. The process under test is created through WMI so that it has no
+console and no console-owning ancestor; a plain `Start-Process` would let the
+action attach to the calling shell's console and succeed. WMI does not carry the
+caller's environment, so `-ResourcesDir` is accepted but not propagated; the
+assertion does not depend on it, because the action fails on output before it
+would need its resources.
 
 ```powershell
 pwsh -NoProfile -File .\cli-detached-action.ps1 -Action +version

--- a/test/windows/README.md
+++ b/test/windows/README.md
@@ -95,8 +95,11 @@ pwsh -NoProfile -File .\cli-redirected-text-action.ps1 -Action +help -ExpectedTe
 
 ## cli-detached-action.ps1
 
-Validates a detached CLI action, its resource discovery, timeout behavior, and
-absence of the native CLI-failure dialog.
+Validates that a CLI action launched with no console at all surfaces the native
+CLI-failure dialog and exits 1 rather than failing silently, plus its resource
+discovery and timeout behavior. The process under test is created through WMI so
+that it has no console and no console-owning ancestor; a plain `Start-Process`
+would let the action attach to the calling shell's console and succeed.
 
 ```powershell
 pwsh -NoProfile -File .\cli-detached-action.ps1 -Action +version

--- a/test/windows/cli-detached-action.ps1
+++ b/test/windows/cli-detached-action.ps1
@@ -21,22 +21,6 @@ if (-not (Test-Path $exePath)) {
     throw "Missing built executable: $exePath. Run `zig build -Demit-exe=true` first."
 }
 
-function Find-DetachedCliResourcesDir {
-    $artifactsDir = Join-Path $repoRoot 'dist\artifacts'
-    if (-not (Test-Path $artifactsDir)) {
-        return $null
-    }
-
-    return Get-ChildItem $artifactsDir -Directory |
-        ForEach-Object { Join-Path $_.FullName 'noctty\share\ghostty' } |
-        Where-Object { Test-Path (Join-Path $_ 'themes') } |
-        Select-Object -First 1
-}
-
-if (-not $ResourcesDir -and $Action -eq '+list-themes') {
-    $ResourcesDir = Find-DetachedCliResourcesDir
-}
-
 if (-not ('DetachedCliActionNative' -as [type])) {
     Add-Type @"
 using System;
@@ -78,14 +62,19 @@ function Get-DetachedCliWindowTitle {
 # reliable way to reproduce an Explorer/scheduled-task style launch from a
 # script that is itself running in a console.
 #
-# WMI does not carry the caller's environment into the new process, so
-# GHOSTTY_RESOURCES_DIR cannot be propagated on this path.
-if ($ResourcesDir -and $Action -eq '+list-themes') {
-    throw 'Detached +list-themes cannot receive GHOSTTY_RESOURCES_DIR through a console-less launch.'
-}
+# What this asserts is that a console-less CLI action surfaces the failure
+# dialog and exits 1 instead of failing silently. That holds for every action,
+# including +list-themes, because the action fails on output long before it
+# needs its resources -- which is why $ResourcesDir is accepted but not used.
+# It is retained only because package-portable-cli.ps1 passes it and that script
+# is pinned by a frozen verification baseline.
+$null = $ResourcesDir
 
 $quotedExe = '"' + $exePath + '"'
-$commandLine = (@($quotedExe, $Action) + $ExtraArgs) -join ' '
+$quotedArgs = @($ExtraArgs | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
+    })
+$commandLine = (@($quotedExe, $Action) + $quotedArgs) -join ' '
 $creation = Invoke-CimMethod `
     -ClassName Win32_Process `
     -MethodName Create `

--- a/test/windows/cli-detached-action.ps1
+++ b/test/windows/cli-detached-action.ps1
@@ -70,29 +70,32 @@ function Get-DetachedCliWindowTitle {
     return $builder.ToString()
 }
 
-$oldResourcesDir = $env:GHOSTTY_RESOURCES_DIR
-$hadResourcesDir = $null -ne (Get-Item Env:GHOSTTY_RESOURCES_DIR -ErrorAction SilentlyContinue)
-
-if ($ResourcesDir) {
-    $env:GHOSTTY_RESOURCES_DIR = $ResourcesDir
+# The process under test has to be genuinely console-less. CLI actions now
+# attach to the console of the process that launched them, so `Start-Process`
+# from a shell that has a console would hand the action a working console and
+# it would succeed instead of surfacing the dialog this harness exists to check.
+# WMI creates the process from the console-less WMI provider, which is the only
+# reliable way to reproduce an Explorer/scheduled-task style launch from a
+# script that is itself running in a console.
+#
+# WMI does not carry the caller's environment into the new process, so
+# GHOSTTY_RESOURCES_DIR cannot be propagated on this path.
+if ($ResourcesDir -and $Action -eq '+list-themes') {
+    throw 'Detached +list-themes cannot receive GHOSTTY_RESOURCES_DIR through a console-less launch.'
 }
 
-try {
-    $argumentList = @($Action) + $ExtraArgs
-    $process = Start-Process `
-        -FilePath $exePath `
-        -ArgumentList $argumentList `
-        -WindowStyle Hidden `
-        -PassThru
+$quotedExe = '"' + $exePath + '"'
+$commandLine = (@($quotedExe, $Action) + $ExtraArgs) -join ' '
+$creation = Invoke-CimMethod `
+    -ClassName Win32_Process `
+    -MethodName Create `
+    -Arguments @{ CommandLine = $commandLine }
+
+if ($creation.ReturnValue -ne 0) {
+    throw "Console-less launch of the CLI action failed (Win32_Process::Create returned $($creation.ReturnValue))."
 }
-finally {
-    if ($hadResourcesDir) {
-        $env:GHOSTTY_RESOURCES_DIR = $oldResourcesDir
-    }
-    else {
-        Remove-Item Env:GHOSTTY_RESOURCES_DIR -ErrorAction SilentlyContinue
-    }
-}
+
+$process = Get-Process -Id $creation.ProcessId -ErrorAction Stop
 $processHandle = $process.Handle
 
 $dialogHandle = [IntPtr]::Zero


### PR DESCRIPTION
## Summary

Two independent bugs from the same report.

1. **Key encoding.** The Win32 apprt handed the core encoder the text Windows
   produced *with* Ctrl applied. Windows either folds Ctrl into the translation
   (`ctrl+a` -> `U+0001`) or refuses to translate at all (`ctrl+,` -> nothing),
   and both results were dropped, so control chords reached `key_encode` with no
   text and encoded to **no bytes at all**. AltGr's synthetic `left Ctrl + right
   Alt` was also passed through as a real Ctrl+Alt chord.
2. **CLI verbs.** `noctty.exe +version` and friends printed nothing and failed
   with `WriteFailed`, and the list actions printed blank output even from the
   console launcher.

Fixes #178

## Root cause, per reported symptom

Measured on Windows 11 26200, US layout (`HKL 0x04090409`). Two scripted probes
were written to get these numbers without any physical key presses: one calls
`ToUnicode` with synthetic keyboard states, one feeds raw VT bytes into a real
pseudoconsole and reports what `[Console]::ReadKey($true)` sees inside it.

| Reported | Root cause | Status |
|---|---|---|
| `Ctrl+,` `Ctrl+.` and most symbols do not register | `ToUnicode` returns **0 characters** for these under Ctrl, so `translateKeyText` produced empty text. `key_encode`'s fixterms branch requires `event.utf8`, so nothing was emitted. | **Fixed** — now sends `CSI 44;5u` / `CSI 46;5u`. |
| `Ctrl+m` does not register | `ToUnicode` returns `U+000D`, a control character, which was discarded. `ctrlSeq` deliberately excludes `m`/`i`/`[` per fixterms, so the empty text left nothing to encode. | **Fixed** — now sends `CSI 109;5u` (`ctrl+i` and `ctrl+[` too). |
| `AltGr+Backspace` reports `Alt + Control` | Windows synthesizes left Ctrl + right Alt for AltGr. The event therefore matched the `{alt, ctrl}` backspace entry and sent `1b 08`, which conhost decodes back as `Backspace + Alt, Control` (measured). | **Fixed** — AltGr's synthetic modifiers are dropped; `AltGr+Backspace` sends `7f`. |
| `Alt+<any key>` reports `Alt + Control` | `1b <C0 byte>` decodes as `Alt, Control` (measured: `1b 01` -> `A char=1 mods=Alt, Control`). noctty only emits that shape when the event carries **both** Ctrl and Alt, which on an AltGr layout happens for `AltGr+<key with no AltGr mapping>`. Plain `Alt+a` was measured to send `1b 61`, which decodes correctly as `Alt+A`, so the symptom as literally worded could not be reproduced from source on a US layout. | **Fixed for the AltGr path**; see Residuals. |
| `Ctrl+Backspace` reports `Ctrl+h` | noctty sends `08`, which is what upstream ghostty, xterm and kitty all send. On Windows 11 conhost decodes `08` back to `Backspace + Control` (measured); the reporter is on Windows 10 19045, where the decoder differs. | **Not changed** — the encoding matches upstream. |
| `Ctrl+C` does not register | `03` is sent correctly. `[Console]::ReadKey` never sees it because `ENABLE_PROCESSED_INPUT` turns it into a Ctrl+C event; with `[Console]::TreatControlCAsInput = $true` the same byte reports `C char=3 mods=Control` (measured both ways). | **Not a bug** — measurement artifact. |
| `+version` / `+list-keybinds` fail with `WriteFailed` | `noctty.exe` is a Windows-subsystem binary, so a shell that launches it directly gives it no console and no standard handles. Every write failed. Reproduced by running the pre-fix binary inside a pseudoconsole: zero output. | **Fixed** — see below. |
| (found while fixing the above) list actions print blank output | With a working console, `+list-keybinds`, `+list-colors` and `+list-themes` take the vaxis pretty-print path, which renders nothing usable on a Windows console. Pre-existing and reproducible through `noctty.com` on `main`. | **Fixed** — pretty-print is disabled on Windows; the plain renderer is used. |

## Changes

`src/apprt/win32/input.zig`

- `translateKeyText` now derives `unshifted_codepoint` from the **active layout**
  (all modifiers masked out) instead of a hardcoded US table, falling back to
  the table. This is what upstream's `legacy: hu layout ctrl+ő` test requires.
- For a Ctrl chord, the event text is re-translated with Ctrl and Alt masked out
  so the core receives the unmodified layout text — the same contract every
  other apprt satisfies (upstream's own tests pass `utf8 = "c"` for `ctrl+c`,
  `"m"` for `ctrl+m`, `"_"` for `ctrl+shift+minus`). `key_encode` then derives
  the C0 byte or the CSI u form itself, unchanged.
- Keys whose *unmodified* translation is itself a control character (backspace,
  enter, tab, escape) still carry no text, so the PC-style function-key tables
  keep winning. `ctrl+backspace` is still `08`.
- `withoutSyntheticAltGr` drops the Ctrl+Alt Windows fabricates for AltGr before
  the event reaches the core. The raw keyboard state is untouched, so the layout
  still produces the AltGr character and the existing WM_CHAR deferral for AltGr
  text is unchanged.
- Shift is no longer marked consumed inside a Ctrl chord: there it is part of
  the chord, not something the layout used to produce text.

`src/process_shared.zig`

- `attachParentConsole()` attaches the process to the console it was launched
  from and binds only the standard handles that do not already work. Redirection
  (`noctty.exe +version > out.txt`) and the `noctty.com` console launcher are
  left exactly as they were, and the call is a no-op when there is no parent
  console (Explorer, services). Called from `runCliAction` and
  `reportStateInitError`.

`src/cli/tui.zig`

- `can_pretty_print` is false on Windows.

`src/apprt/win32/sys.zig` — `GetKeyboardLayout` and `MapVirtualKeyW` declarations
(used by the new tests).

`docs/windows.md` — a Keyboard section describing the layout-driven translation
and the AltGr rule, and a note that `noctty.exe +<action>` works from a console.

## Validation

All run in `wt-issues-k1-keyboard` on Windows 11 26200, Zig 0.15.2.

```
zig fmt --check src
  -> only src\build\uucode_tables.zig (pre-existing generated-file exception)

pwsh -NoProfile -File scripts/check-source-format.ps1
  -> PowerShell syntax and JSON validity checks passed.

zig build -Demit-exe=true
  -> exit 0

zig build test -Dtest-filter=win32 -Demit-test-exe=true
  -> exit 0

zig build test -Demit-test-exe=true          (full suite)
  -> exit 0, 0 failures
```

New tests (`src/apprt/win32/input.zig`), table-driven over every combination in
the report plus the ones that already worked, asserting the exact bytes the
terminal receives: `alt+backspace`, `alt+a`, `alt+comma`, `altgr+backspace`,
`ctrl+alt+c`, `ctrl+backspace`, `ctrl+comma`, `ctrl+period`, `ctrl+semicolon`,
`ctrl+m`, `ctrl+i`, `ctrl+[`, `ctrl+c`, `ctrl+a`, `ctrl+slash`, `ctrl+space`,
`ctrl+shift+minus`, `ctrl+shift+2`, plain `a`, `shift+a`. They skip themselves
when the machine's keyboard layout is not US, since they assert US results.

CLI verbs, verified end-to-end inside a real pseudoconsole (this is the exact
shape of the reporter's failure — a Windows-subsystem binary launched from a
console it did not allocate):

| command | before | after |
|---|---|---|
| `noctty.exe +version` | no output at all | full version block |
| `noctty.exe +list-keybinds` | no output at all | keybind list |
| `noctty.exe +list-colors` | no output at all | color list |
| `noctty.com +list-keybinds` | blank lines only | keybind list |

The "before" column was produced by rebuilding with the fix disabled and
re-running the same probe.

## Residuals / user steps

- **Interactive verification is parked.** No agent in this session could press
  physical keys. A full manual script is at
  `.t3/worktrees/winghostty/prompts/k1-178-keyboard-verify-PARKED.md`: it lists
  every combination, the expected bytes and the expected `ReadKey` report, plus
  a regression sweep (dead keys, IME, surrogate pairs, `ctrl+shift+c`, `ctrl+,`
  still opening the config) and the CLI verbs. **It must be run on an AltGr
  layout as well as US** — the AltGr rows are meaningless on a plain US layout.
- **`Alt+<any key>` as literally worded is unreproduced.** The evidence points
  at the AltGr path (`1b <C0>` is the only shape that decodes to `Alt, Control`,
  and noctty only emits it when the event carries Ctrl *and* Alt). If the
  reporter still sees it with plain left Alt after this change, we need their
  keyboard layout and a `mods=` log line per key event.
- **Deliberate divergence:** left Ctrl + right Alt can no longer produce a
  Ctrl+Alt chord, because Win32 cannot distinguish it from AltGr. Use left Alt
  or right Ctrl. This matches how ghostty behaves on Linux/macOS; WezTerm keeps
  reporting AltGr as Alt+Control, which the reporter called out as the thing
  that breaks `AltGr+Backspace`.
- **ConPTY cannot show everything we send.** `CSI u` and `CSI 27;m;c~` produce
  no console key record at all (measured), so `[Console]::ReadKey` will still
  show nothing for `ctrl+,`, `ctrl+.` and `ctrl+m`. Applications that read the
  byte stream (Neovim, Helix, `cat -v`) see them. Closing that gap properly
  means implementing **win32-input-mode** (`CSI ?9001h`), which ConPTY already
  negotiates and noctty ignores — that is why WezTerm reports every combination
  exactly. It is a feature, not a bug fix, and is deliberately out of scope
  here; worth its own issue.
- **`src/cli/tui.zig`** turning off pretty-print on Windows means
  `+list-keybinds`, `+list-colors` and `+list-themes` always use the plain
  renderer. That is the only renderer that works on this platform today; making
  vaxis work on Windows consoles is a separate piece of work.
- No overlap with PR #175: its `key_encode.zig` change (`don't emit fallback
  text on key release`) only touches the Kitty protocol's release path. This
  branch does not modify `key_encode.zig` at all.

---

## Review dispositions (R-195, approve-with-changes)

| # | Finding | Disposition |
|---|---|---|
| 1 | MEDIUM — press/release `unshifted_codepoint` asymmetry breaks Kitty `report_events` pairing on non-US layouts. **A regression this PR introduced.** | **Fixed.** `unshiftedCodepoint` extracted and run for every action. Regression test uses `VK_DIVIDE`, which is absent from the static table but translates to `/`, so it catches the bug on a plain US layout. Verified by reintroducing the bug and watching the test fail, then restoring. |
| 2 | MEDIUM — `cli-detached-action.ps1` self-defeating for `+list-themes`. | **Fixed.** Dropped both the auto-discovery and the guard; the assertion never needed resources, since a console-less action fails on output long before it reads them. `-ResourcesDir` stays accepted-but-unused for the pinned caller. `+list-themes` verified passing. |
| 3 | LOW-MED — file the win32-input-mode follow-up and comment on #178. | **User step.** Agents may not create issues or post public comments; recorded in `USER-STEPS.md` §3b. |
| 4 | LOW — AltGr collapse is unconditional. | **Fixed rather than accepted.** Gated on the layout actually having AltGr mappings, since Windows only injects the synthetic Ctrl on those layouts. `ctrl+ralt+x` on plain US is a real chord again instead of a literal `x`. The probe runs only while both keys are held and needs no cached state. |
| 5 | LOW — dead `-ResourcesDir` pass-through in `package-portable-cli.ps1`. | **Declined.** That file is hash-pinned by the frozen `origin-main.json` baseline; re-hashing a frozen verification artifact for a cosmetic cleanup is not worth the §2d risk inside a bug-fix PR. Documented at the receiving end instead. |
| 6 | LOW — loose `testingUsLayout`. | **Fixed.** Compares the full HKL (`0x04090409`). |
| 7 | NIT — WMI command line quoting; `Get-Process` race. | **Quoting fixed.** The race stays: the process is held open by its dialog on the path under test. |
| TRIM | Redundant per-function `os.tag` guards in `process_shared.zig`. | **Removed.** |
| GAP | Console-attached success path has no automated test. | **Partly closed.** Added a test pinning that the attach leaves an already-working std handle untouched, which is what protects redirection and the `noctty.com` path. Full end-to-end coverage would need a new case in the hash-pinned smoke script; it remains covered by the pseudoconsole probe and the parked manual script. |

Also softened the `docs/windows.md` claim that AltGr and a physical left-Ctrl + right-Alt are "indistinguishable at the Win32 layer" — they are only indistinguishable from the modifier state read here.

Re-run after the review changes: `zig fmt --check src` clean (bar the generated table), `check-source-format.ps1` PASS, `zig build -Demit-exe=true` exit 0, `Test-VerificationContracts.ps1` PASS (2 scenarios), `Invoke-PortableSmoke.ps1` PASS (the previously failing CI job, replicated locally), full suite **3777/3847 passed, 70 skipped, 0 failed** — up exactly 3 with skips unchanged, confirming all three new tests execute rather than skip.

## Summary by Sourcery

Fix Windows keyboard modifier reporting and CLI output so control and AltGr input encode correctly and console actions reliably display their results.

Bug Fixes:
- Correct Win32 keyboard translation so control chords consistently reach the core and encode correctly, including fixterms sequences for combinations without C0 representations.
- Treat synthetic Win32 AltGr modifiers as layout input while preserving deliberate Ctrl+Alt chords where the active layout has no AltGr mappings.
- Make direct Windows CLI actions attach to an available parent console without disrupting existing redirection or console-launcher handles.
- Use the plain CLI renderer on Windows so list actions produce visible output.

Enhancements:
- Preserve raw modifier identity separately for keybinding lookup and press/release pairing while using normalized modifiers for terminal encoding.
- Derive unshifted key codepoints from the active keyboard layout and apply the same identity across key press, repeat, and release events.

Documentation:
- Document Windows layout-driven keyboard translation, AltGr behavior, ConPTY reporting limitations, and direct CLI invocation.

Tests:
- Add coverage for Win32 control, AltGr, modifier, Caps Lock, layout-derived keycode, binding identity, and CLI console-attachment behavior.

Chores:
- Improve the detached Windows CLI test harness to launch genuinely console-less processes and retain its failure-path coverage.