### PR TITLE
feat(cli): documented Windows automation verb set (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ panes, `Ctrl+Shift+P` opens the command palette, and `Ctrl+Shift+C` /
 `Ctrl+Shift+V` copy and paste. The full table, plus how to rebind, is in
 [docs/getting-started.md](docs/getting-started.md#5-keybindings).
 
+Local CLI automation is documented in
+[docs/automation.md](docs/automation.md).
+
 ## Status
 
 noctty is young: it has a single maintainer, and its first public

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -32,12 +32,20 @@ server's fixed 10-second wait or change connection and wire I/O limits.
 | `+perform-action` | Optional `--surface-id=<id>` and exactly one action string. Omission targets the focused surface for surface-scoped actions or the app for app-scoped actions. | 0, 1, 2, 3, 4, 5 |
 | `+new-tab` | Optional `--window-id=<id>` (default: focused window) and optional `--working-directory=<dir>`. | 0, 1, 2, 3, 4, 5 |
 | `+new-split` | Optional `--surface-id=<id>` (default: focused pane), optional `--direction=left\|right\|up\|down` (default: `right`), and optional `--working-directory=<dir>`. | 0, 1, 2, 3, 4, 5 |
-| `+focus` | Exactly one required `--surface-id=<id>` or `--window-id=<id>`. Foreground activation is best-effort under Windows foreground-lock rules. | 0, 1, 2, 3, 5 |
+| `+focus` | Exactly one required `--surface-id=<id>` or `--window-id=<id>`. Selects the target and requests foreground activation, including across another application's window. | 0, 1, 2, 3, 5 |
 | `+send-text` | Required `--surface-id=<id>` and exactly one text argument. | 0, 1, 2, 3, 4, 5 |
 
 Explicit IDs are opaque, nonzero decimal unsigned integers. Window IDs must
 fit `u32`; surface IDs must fit `u64`. An unknown ID in a live instance is a
 target-not-found failure, never a request to use the focused target.
+
+`+focus` exit 0 means the target was selected and foreground activation was
+requested. In practice the activation does cross application boundaries:
+validated against a live instance with an unrelated foreground window in
+front, `+focus` brought noctty forward and the pane reported `focused` and
+`active`. Selection is what exit 0 guarantees, because Windows
+foreground-lock rules can still refuse the activation half in situations
+where the requesting process holds no foreground rights.
 
 `--working-directory` is the only launch override. Accepted values are
 `home`, `inherit`, `~`, paths beginning `~/` or `~\`, and local drive-letter
@@ -144,6 +152,14 @@ controls, and also applies noctty's unsafe-paste inspection. Refused control
 text returns 4 and never reaches IPC; malformed or oversized input is a usage
 error. Printable shell metacharacters and mixed printable content remain
 allowed.
+
+NUL is refused by the same check as the other `Cc` code points, but it cannot
+actually be delivered through the command line to begin with: a Win32 command
+line is a NUL-terminated string, so an embedded NUL truncates the argument and
+the verb only ever receives the printable prefix. The rejection is therefore
+unreachable over argv by construction rather than untested — it still guards
+the app-thread check against a direct pipe client, which is not bound by that
+argv limitation.
 
 Delivery uses the protected paste path. Automation cannot transmit Enter,
 newline, or control input and never raises a paste-confirm prompt. This is a

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,172 @@
+# Automation
+
+noctty exposes a local, current-user command-line automation surface over
+the running Windows instance. It provides versioned JSON state, explicit
+targets, and stable exit codes for PowerShell and other scripts.
+
+## PowerShell quick start
+
+```powershell
+noctty +list-windows | ConvertFrom-Json
+
+$state = noctty +list-windows --class=work | ConvertFrom-Json
+$pane = $state.windows[0].tabs[0].panes[0]
+noctty +focus --class=work --surface-id=$($pane.surface_id)
+noctty +send-text --class=work --surface-id=$($pane.surface_id) 'git status'
+```
+
+`+send-text` does not append Enter. Check `$LASTEXITCODE` after a command
+when failure handling matters.
+
+## Verbs
+
+Every verb accepts `--class=<name>` and `--timeout=<ms>`. The class selects
+an instance namespace. The timeout is only the response timeout, accepts
+`0..10000`, and defaults to `10000` milliseconds; it does not extend the
+server's fixed 10-second wait or change connection and wire I/O limits.
+
+| Verb | Target and arguments | Exit codes |
+| --- | --- | --- |
+| `+new-window` | No target. Existing forwarded window arguments remain subject to the receiver policy described below. | 0, 1, 5 |
+| `+list-windows` | `--format=json`; JSON is the default and only accepted format. | 0, 1, 2, 5 |
+| `+perform-action` | Optional `--surface-id=<id>` and exactly one action string. Omission targets the focused surface for surface-scoped actions or the app for app-scoped actions. | 0, 1, 2, 3, 4, 5 |
+| `+new-tab` | Optional `--window-id=<id>` (default: focused window) and optional `--working-directory=<dir>`. | 0, 1, 2, 3, 4, 5 |
+| `+new-split` | Optional `--surface-id=<id>` (default: focused pane), optional `--direction=left\|right\|up\|down` (default: `right`), and optional `--working-directory=<dir>`. | 0, 1, 2, 3, 4, 5 |
+| `+focus` | Exactly one required `--surface-id=<id>` or `--window-id=<id>`. Foreground activation is best-effort under Windows foreground-lock rules. | 0, 1, 2, 3, 5 |
+| `+send-text` | Required `--surface-id=<id>` and exactly one text argument. | 0, 1, 2, 3, 4, 5 |
+
+Explicit IDs are opaque, nonzero decimal unsigned integers. Window IDs must
+fit `u32`; surface IDs must fit `u64`. An unknown ID in a live instance is a
+target-not-found failure, never a request to use the focused target.
+
+`--working-directory` is the only launch override. Accepted values are
+`home`, `inherit`, `~`, paths beginning `~/` or `~\`, and local drive-letter
+absolute paths such as `C:\src`. Relative, drive-relative, and UNC/device
+paths such as `\\host\share`, `//host/share`, `\\?\`, and `\\.\` are
+refused. `+new-tab` and `+new-split` inherit the source pane's command; no
+verb can choose a program to run. There is no `-e`, `--command`, or `--title`
+override for those verbs.
+
+## JSON schema v3
+
+`+list-windows` always emits one JSON document with this shape:
+
+```json
+{
+  "schema": "noctty.windows.v3",
+  "api_version": 3,
+  "instance": {
+    "pid": 1234,
+    "version": "1.3.123",
+    "class": "work"
+  },
+  "windows": [
+    {
+      "window_id": 17,
+      "title": "PowerShell",
+      "focused": true,
+      "active_tab_id": 4,
+      "tab_count": 1,
+      "pane_count": 1,
+      "tabs": [
+        {
+          "tab_id": 4,
+          "active": true,
+          "focused_surface_id": 702,
+          "pane_count": 1,
+          "panes": [
+            {
+              "surface_id": 702,
+              "title": null,
+              "working_directory": null,
+              "focused": true,
+              "active": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `instance.pid` is the running noctty process ID, `instance.version` is its
+  build version, and `instance.class` is the effective sanitized pipe
+  namespace captured when the server starts. That class can be passed back
+  to `--class`.
+- `window.title` is the cached host caption. It is non-null, although it can
+  be empty; the read-only query never changes the native window to refresh it.
+- Window, tab, and surface IDs are the opaque targets used by the verbs.
+  Counts match the corresponding arrays; `window.focused` reports host focus.
+- `active_tab_id` and `focused_surface_id` are nullable IDs. `active` marks
+  the active tab and the globally active pane; pane `focused` is tab-local.
+- Pane `title` is nullable and uses runtime precedence: tab override, surface
+  override, then terminal title. It is `null` before any title exists.
+- Pane `working_directory` is the last-known cwd, seeded from the launch cwd
+  and refreshed by OSC 7. It is `null` when unknown.
+- Nullable fields are emitted as JSON `null`, never omitted. Retained hosts
+  with no tabs are omitted from `windows`.
+
+Pane-level child PIDs are deliberately not exposed: they are not available
+on the app thread, and the direct ConPTY child is often a wrapper on Windows.
+
+Scripts should check both `schema` and `api_version`. Field names,
+nullability, and semantics are stable within v3; an incompatible change will
+use a new schema suffix and API version. JSON is the sole output contract;
+there is no text format.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Usage or argument error. |
+| 2 | No matching running instance. |
+| 3 | Live instance, but the requested target was not found. |
+| 4 | Refused by automation policy. |
+| 5 | IPC transport failure or response timeout; for `+new-window`, also fallback process-launch failure. |
+
+`+new-window` retains its process-launch fallback and therefore never returns
+2. New verbs used against an older server that does not know their request
+kinds fail generically with 5; there is no capability negotiation.
+
+## Automation policy
+
+For `+perform-action`, “safe” means allowed by automation policy, not
+harmless. Allowed actions can include destructive UI operations such as
+reset, close, quit, undo, and redo. Unknown action variants and actions that
+inject terminal input, read arbitrary files, or select code to run are
+denied until explicitly reviewed; a policy denial returns 4.
+
+`+send-text` accepts non-empty valid UTF-8 up to 16 KiB. It refuses every
+Unicode `Cc` control character, including NUL, TAB, CR, LF, ESC, DEL, and C1
+controls, and also applies noctty's unsafe-paste inspection. Refused control
+text returns 4 and never reaches IPC; malformed or oversized input is a usage
+error. Printable shell metacharacters and mixed printable content remain
+allowed.
+
+Delivery uses the protected paste path. Automation cannot transmit Enter,
+newline, or control input and never raises a paste-confirm prompt. This is a
+narrow guarantee: printable text can still affect a TUI or a pending
+confirmation prompt. There is no raw or bypass mode.
+
+## Trust and privacy
+
+The channel protections land in PR #185, and this automation work depends on
+that PR merging first. They are a current-user DACL,
+`PIPE_REJECT_REMOTE_CLIENTS`, a `NO_WRITE_UP` mandatory-integrity label when
+elevated, and a deny-by-default allowlist for forwarded `+new-window`
+arguments. This work does not duplicate or widen those protections.
+
+The pipe is not a privilege boundary against code already running as your
+user. No verb can select a program to run. `--working-directory` is the only
+launch override and is restricted to the local, non-UNC forms documented
+above; receiver-side validation prevents a direct pipe client from bypassing
+that policy.
+
+Terminal grid text, scrollback, selection, clipboard contents, and pending
+shell input are never included in the JSON payload. noctty intentionally
+exposes this metadata over a local, current-user automation channel.
+
+Wire request kind 8 is reserved for the planned `launch_layout` work in issue
+#133. There is no `+launch-layout` verb today.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -184,5 +184,7 @@ Terminal grid text, scrollback, selection, clipboard contents, and pending
 shell input are never included in the JSON payload. noctty intentionally
 exposes this metadata over a local, current-user automation channel.
 
-Wire request kind 8 is reserved for the planned `launch_layout` work in issue
-#133. There is no `+launch-layout` verb today.
+Wire request kind 8 carries `launch_layout` for
+`+new-window --launch-layout=<name>`. There is intentionally no standalone
+`+launch-layout` verb, and layout launch remains outside the generic forwarded
+argument allowlist.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -21,16 +21,22 @@ when failure handling matters.
 ## Verbs
 
 Every verb accepts `--class=<name>` and `--timeout=<ms>`. The class selects
-an instance namespace. The timeout is only the response timeout, accepts
-`0..10000`, and defaults to `10000` milliseconds; it does not extend the
-server's fixed 10-second wait or change connection and wire I/O limits.
+an instance namespace. The timeout sets how long a request may remain unclaimed
+after connection, accepts `0..10000`, and defaults to `10000` milliseconds; it
+does not extend the server's fixed 10-second bound or change connection and wire
+I/O limits. Claimed work may keep the CLI waiting beyond that timeout so the
+caller receives its actual outcome instead of an ambiguous failure. There is no
+separate post-claim deadline; the final server result or a pipe disconnect ends
+that wait.
 Deadline-capable request kinds 9 through 15 carry that caller deadline as an
 absolute system-uptime tick. The app thread atomically claims only unexpired
 requests; if the deadline wins first, queued work is cancelled and cannot run
 later. Equality permits the documented zero-timeout one-attempt poll. Once
 work is claimed by the deadline, the server waits for and reports its actual
-outcome instead of returning an ambiguous timeout. The original wire-v1 kinds
-2 through 8 remain accepted for older clients under the server's fixed
+outcome instead of returning an ambiguous timeout. After sending a deadline-
+capable request, the client leaves the pipe open for that server-authoritative
+decision rather than independently timing out the response read. The original
+wire-v1 kinds 2 through 8 remain accepted for older clients under the server's fixed
 10-second bound; new clients use the deadline-capable kinds, which older
 servers reject generically rather than misparsing a changed v1 payload.
 
@@ -141,7 +147,7 @@ there is no text format.
 | 2 | No matching running instance. |
 | 3 | Live instance, but the requested target was not found. |
 | 4 | Refused by automation policy. |
-| 5 | IPC transport failure or response timeout; for `+new-window`, also fallback process-launch failure. |
+| 5 | IPC transport failure or automation claim-deadline expiry; for `+new-window`, also response timeout or fallback process-launch failure. |
 
 `+new-window` retains its process-launch fallback and therefore never returns
 2. New verbs used against an older server that does not know their request

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -24,6 +24,11 @@ Every verb accepts `--class=<name>` and `--timeout=<ms>`. The class selects
 an instance namespace. The timeout is only the response timeout, accepts
 `0..10000`, and defaults to `10000` milliseconds; it does not extend the
 server's fixed 10-second wait or change connection and wire I/O limits.
+Automation request kinds 2 through 8 carry that caller deadline as an absolute
+system-uptime tick. The app thread atomically claims only unexpired requests;
+if the deadline wins first, queued work is cancelled and cannot run later.
+Once work is claimed before the deadline, the server waits for and reports its
+actual outcome instead of returning an ambiguous timeout.
 
 | Verb | Target and arguments | Exit codes |
 | --- | --- | --- |

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -24,11 +24,15 @@ Every verb accepts `--class=<name>` and `--timeout=<ms>`. The class selects
 an instance namespace. The timeout is only the response timeout, accepts
 `0..10000`, and defaults to `10000` milliseconds; it does not extend the
 server's fixed 10-second wait or change connection and wire I/O limits.
-Automation request kinds 2 through 8 carry that caller deadline as an absolute
-system-uptime tick. The app thread atomically claims only unexpired requests;
-if the deadline wins first, queued work is cancelled and cannot run later.
-Once work is claimed before the deadline, the server waits for and reports its
-actual outcome instead of returning an ambiguous timeout.
+Deadline-capable request kinds 9 through 15 carry that caller deadline as an
+absolute system-uptime tick. The app thread atomically claims only unexpired
+requests; if the deadline wins first, queued work is cancelled and cannot run
+later. Equality permits the documented zero-timeout one-attempt poll. Once
+work is claimed by the deadline, the server waits for and reports its actual
+outcome instead of returning an ambiguous timeout. The original wire-v1 kinds
+2 through 8 remain accepted for older clients under the server's fixed
+10-second bound; new clients use the deadline-capable kinds, which older
+servers reject generically rather than misparsing a changed v1 payload.
 
 | Verb | Target and arguments | Exit codes |
 | --- | --- | --- |

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -63,10 +63,12 @@ foreground-lock rules can still refuse the activation half in situations
 where the requesting process holds no foreground rights.
 
 `--working-directory` is the only launch override. Accepted values are
-`home`, `inherit`, `~`, paths beginning `~/` or `~\`, and local drive-letter
-absolute paths such as `C:\src`. Relative, drive-relative, and UNC/device
+`home`, `inherit`, `~`, paths beginning `~/` or `~\`, and drive-letter absolute
+paths such as `C:\src`. Relative, drive-relative, and UNC/device
 paths such as `\\host\share`, `//host/share`, `\\?\`, and `\\.\` are
-refused. `+new-tab` and `+new-split` inherit the source pane's command; no
+refused. This is syntax validation, not a locality guarantee: mapped or
+`subst` drives and junctions or other reparse points may still resolve
+off-box. `+new-tab` and `+new-split` inherit the source pane's command; no
 verb can choose a program to run. There is no `-e`, `--command`, or `--title`
 override for those verbs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,10 +230,9 @@ crash-report details, and diagnostic bundles are covered in
 ## 9. Automate it
 
 noctty has a local automation surface: `noctty +list-windows`
-reports windows, tabs, and panes as JSON, and
-`noctty +perform-action` invokes keybinding actions over IPC. The
-full surface, including the actions it blocks, is documented in
-[windows.md](windows.md#automation).
+reports versioned JSON state, and targeted verbs can create, split,
+focus, act on, and send control-free text to panes. The stable contract
+is documented in [automation.md](automation.md).
 
 ## 10. Uninstall
 
@@ -251,6 +250,8 @@ clean slate.
   caveats
 - [docs/windows.md](windows.md): the Windows behavior reference; paths,
   shells, updates, automation, and troubleshooting
+- [docs/automation.md](automation.md): CLI verbs, JSON schema, exit codes,
+  and local-channel policy
 - [docs/windows-capability-matrix.md](windows-capability-matrix.md):
   row-by-row mapping against upstream Ghostty docs
 - [HACKING.md](../HACKING.md): build, test, and runtime notes for

--- a/docs/status.md
+++ b/docs/status.md
@@ -4,7 +4,7 @@ What currently works in noctty, what is experimental, and what is out
 of scope. When this page disagrees with a commit message, trust this
 page.
 
-Last updated: 2026-08-21, against current fork HEAD.
+Last updated: 2026-08-30, against current fork HEAD.
 
 For a row-by-row mapping against official Ghostty docs (including the
 implementation nuance this page deliberately leaves out), see
@@ -76,6 +76,9 @@ Win32-validated VT protocol coverage is tracked in
 - Universal palette: actions, tabs, panes, profiles, named layouts, themes, native
   settings, help, and recent commands in one fuzzy-searched,
   keyboard-driven list.
+- Local CLI automation with versioned JSON state and policy-bounded verbs
+  for windows, tabs, splits, focus, actions, and control-free text; see
+  [automation.md](automation.md).
 
 ### Renderer
 

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -47,7 +47,7 @@ Last reviewed: 2026-08-21.
 | [Features overview](https://ghostty.org/docs/features)                            | Upstream docs still say Windows support is planned. noctty ships a native Win32 app on Windows 10/11 x64 and ARM64.    |
 | [Features overview: GPU-accelerated rendering](https://ghostty.org/docs/features) | Terminal content renders with OpenGL 4.3+ via WGL. See [renderer notes](#renderer).                                        |
 | [Configuration](https://ghostty.org/docs/config)                                  | Windows state/config paths live under `%LOCALAPPDATA%\noctty\...`, not the macOS/Linux paths documented upstream.      |
-| Local automation                                                                  | `+list-windows` JSON plus allowlisted `+perform-action` over single-instance IPC. See [windows.md](windows.md#automation). |
+| Local automation                                                                  | Versioned JSON state and stable local verbs for windows, tabs, splits, focus, policy-allowed actions, and control-free text. See [automation.md](automation.md). |
 | [Features overview](https://ghostty.org/docs/features)                            | Win32-specific UX: DWM dark title bar, high-contrast palette switching, IME, drag-and-drop, and native context menus.      |
 | Universal palette                                                                 | One blended, fuzzy-ranked command surface. See [universal palette notes](#universal-palette).                              |
 | Named layouts                                                                     | Saves one window's tab/split/profile/cwd/title shape and materializes it in a new window from keybind, palette, or CLI.     |

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -641,6 +641,11 @@ limited to a validated layout name under `%LOCALAPPDATA%\noctty\layouts\`,
 writes atomically, and **replaces an existing layout of the same name without
 prompting**. It only accepts the focused target, so `--surface-id` is rejected.
 
+noctty exposes a local, current-user CLI surface for versioned JSON state
+and policy-bounded window, tab, split, focus, action, and text operations.
+The stable verb, schema, exit-code, trust, and privacy contract is in
+[automation.md](automation.md).
+
 ## Crash reports and diagnostics
 
 noctty keeps a local crash directory and never uploads anything from

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -506,7 +506,7 @@ inferred. From a medium-integrity process, `CreateFileW` on the elevated
 instance's pipe fails with `win32=5` for both
 `GENERIC_READ | GENERIC_WRITE` and `GENERIC_WRITE` alone — the refusal
 happens at `CreateFileW`, not as a timeout or a missing acknowledgement.
-At the command line `+perform-action` and `+list-windows` exit 1 with
+At the command line `+perform-action` and `+list-windows` exit 2 with
 "No matching noctty instance is listening", and `+new-window` exits 0
 having quietly started its **own** local instance rather than driving the
 elevated one. From an elevated shell `+perform-action new_tab` still
@@ -576,16 +576,21 @@ List windows, tabs, and panes:
 noctty +list-windows
 ```
 
-The JSON schema is `noctty.windows.v2`. It exposes local window, tab,
-and pane IDs, focus/active state, and structural counts only. It never
-includes terminal text, shell input, working directories, or file paths.
+The JSON schema is `noctty.windows.v3`. It exposes instance, window, tab,
+and pane metadata, including nullable pane titles and working directories. It
+never includes terminal grid text, scrollback, selection, clipboard contents,
+pending shell input, or pane process IDs.
 
-Invoke a keybinding action on the focused surface, or on a specific pane
-from `+list-windows`:
+The CLI can invoke a keybinding action, create tabs or splits, focus a target,
+and deliver policy-checked printable text. For example:
 
 ```powershell
 noctty +perform-action new_tab
 noctty +perform-action --surface-id=<surface_id> toggle_fullscreen
+noctty +new-tab --window-id=<window_id>
+noctty +new-split --surface-id=<surface_id> --direction=right
+noctty +focus --surface-id=<surface_id>
+noctty +send-text --surface-id=<surface_id> -- "hello"
 ```
 
 Actions use the same names as `keybind` values. `--surface-id` is only
@@ -623,7 +628,7 @@ release — is refused by default rather than allowed by omission. The
 whole request is refused rather than the key being dropped.
 
 `--working-directory` is allowed as `home`, `inherit`, `~/...`, or a
-local drive-letter absolute path. UNC *syntax* (`\\host\share`) is
+drive-letter absolute path. UNC *syntax* (`\\host\share`) is
 refused so the running instance is not made to authenticate to a remote
 SMB host. Note this is a check on syntax only: a mapped or `subst`
 drive, or a junction under a local drive, still resolves off-box.

--- a/src/App.zig
+++ b/src/App.zig
@@ -401,6 +401,13 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
                 request.completed.store(true, .release);
                 request.release();
             },
+            .automation_command => |request| {
+                rt_app.performAutomationCommand(request.command) catch |err| {
+                    request.err = err;
+                };
+                request.completed.store(true, .release);
+                request.release();
+            },
             .close => |surface| self.closeSurface(surface),
             .surface_message => |msg| try self.surfaceMessage(msg.surface, msg.message),
             .redraw_surface => |surface| try self.redrawSurface(rt_app, surface),
@@ -875,6 +882,9 @@ pub const Message = union(enum) {
     /// Perform a safe parsed keybinding action on the app thread.
     automation_action: *AutomationActionRequest,
 
+    /// Perform a stable automation verb on the app thread.
+    automation_command: *AutomationCommandRequest,
+
     /// Close a surface. This notifies the runtime that a surface
     /// should close.
     close: *Surface,
@@ -899,6 +909,7 @@ pub const Message = union(enum) {
             .new_window => |message| message.deinit(alloc),
             .automation_window_list => |request| request.release(),
             .automation_action => |request| request.release(),
+            .automation_command => |request| request.release(),
             .surface_message => |payload| {
                 var message = payload.message;
                 message.deinit();
@@ -971,6 +982,41 @@ pub const Message = union(enum) {
         }
     };
 
+    pub const AutomationCommandRequest = struct {
+        alloc: Allocator,
+        refs: std.atomic.Value(u32) = .init(1),
+        command: apprt.ipc.AutomationCommand,
+        completed: std.atomic.Value(bool) = .init(false),
+        err: ?anyerror = null,
+
+        pub fn create(alloc: Allocator, command: apprt.ipc.AutomationCommand) !*@This() {
+            const request = try alloc.create(@This());
+            errdefer alloc.destroy(request);
+            const owned: apprt.ipc.AutomationCommand = switch (command) {
+                .focus => |target| .{ .focus = target },
+                .send_text => |value| .{ .send_text = .{
+                    .target = value.target,
+                    .text = try alloc.dupe(u8, value.text),
+                } },
+            };
+            request.* = .{ .alloc = alloc, .command = owned };
+            return request;
+        }
+
+        pub fn retain(self: *@This()) void {
+            _ = self.refs.fetchAdd(1, .monotonic);
+        }
+
+        pub fn release(self: *@This()) void {
+            if (self.refs.fetchSub(1, .acq_rel) != 1) return;
+            switch (self.command) {
+                .send_text => |value| self.alloc.free(value.text),
+                .focus => {},
+            }
+            self.alloc.destroy(self);
+        }
+    };
+
     const NewWindow = struct {
         /// The parent surface
         parent: ?*Surface = null,
@@ -1001,6 +1047,22 @@ test "queued automation messages release consumer ownership during teardown" {
     list_request.retain();
     list_request.release();
     (Message{ .automation_window_list = list_request }).deinit(std.testing.allocator);
+
+    const focus_request = try Message.AutomationCommandRequest.create(
+        std.testing.allocator,
+        .{ .focus = .{ .surface_id = 42 } },
+    );
+    focus_request.retain();
+    focus_request.release();
+    (Message{ .automation_command = focus_request }).deinit(std.testing.allocator);
+
+    const text_request = try Message.AutomationCommandRequest.create(
+        std.testing.allocator,
+        .{ .send_text = .{ .target = .{ .surface_id = 42 }, .text = "hello" } },
+    );
+    text_request.retain();
+    text_request.release();
+    (Message{ .automation_command = text_request }).deinit(std.testing.allocator);
 }
 
 /// Mailbox is the way that other threads send the app thread messages.

--- a/src/App.zig
+++ b/src/App.zig
@@ -932,13 +932,27 @@ pub const Message = union(enum) {
             cancelled,
         };
 
-        state: std.atomic.Value(u8) = .init(@intFromEnum(State.pending)),
+        state: std.atomic.Value(u8),
+        deadline_ms: u64,
+        now_ms: *const fn () u64,
+
+        pub fn init(deadline_ms: u64, now_ms: *const fn () u64) @This() {
+            return .{
+                .state = .init(@intFromEnum(State.pending)),
+                .deadline_ms = deadline_ms,
+                .now_ms = now_ms,
+            };
+        }
 
         pub fn load(self: *const @This()) State {
             return @enumFromInt(self.state.load(.acquire));
         }
 
         pub fn claim(self: *@This()) bool {
+            if (self.now_ms() >= self.deadline_ms) {
+                _ = self.cancel();
+                return false;
+            }
             return self.state.cmpxchgStrong(
                 @intFromEnum(State.pending),
                 @intFromEnum(State.claimed),
@@ -965,13 +979,20 @@ pub const Message = union(enum) {
     pub const AutomationWindowListRequest = struct {
         alloc: Allocator,
         refs: std.atomic.Value(u32) = .init(1),
-        lifecycle: AutomationRequestLifecycle = .{},
+        lifecycle: AutomationRequestLifecycle,
         result: ?[]u8 = null,
         err: ?anyerror = null,
 
-        pub fn create(alloc: Allocator) !*@This() {
+        pub fn create(
+            alloc: Allocator,
+            deadline_ms: u64,
+            now_ms: *const fn () u64,
+        ) !*@This() {
             const request = try alloc.create(@This());
-            request.* = .{ .alloc = alloc };
+            request.* = .{
+                .alloc = alloc,
+                .lifecycle = .init(deadline_ms, now_ms),
+            };
             return request;
         }
 
@@ -997,13 +1018,15 @@ pub const Message = union(enum) {
         refs: std.atomic.Value(u32) = .init(1),
         target: apprt.ipc.AutomationActionTarget,
         action_text: []const u8,
-        lifecycle: AutomationRequestLifecycle = .{},
+        lifecycle: AutomationRequestLifecycle,
         err: ?anyerror = null,
 
         pub fn create(
             alloc: Allocator,
             target: apprt.ipc.AutomationActionTarget,
             action_text: []const u8,
+            deadline_ms: u64,
+            now_ms: *const fn () u64,
         ) !*@This() {
             const request = try alloc.create(@This());
             errdefer alloc.destroy(request);
@@ -1011,6 +1034,7 @@ pub const Message = union(enum) {
                 .alloc = alloc,
                 .target = target,
                 .action_text = try alloc.dupe(u8, action_text),
+                .lifecycle = .init(deadline_ms, now_ms),
             };
             return request;
         }
@@ -1030,10 +1054,15 @@ pub const Message = union(enum) {
         alloc: Allocator,
         refs: std.atomic.Value(u32) = .init(1),
         command: apprt.ipc.AutomationCommand,
-        lifecycle: AutomationRequestLifecycle = .{},
+        lifecycle: AutomationRequestLifecycle,
         err: ?anyerror = null,
 
-        pub fn create(alloc: Allocator, command: apprt.ipc.AutomationCommand) !*@This() {
+        pub fn create(
+            alloc: Allocator,
+            command: apprt.ipc.AutomationCommand,
+            deadline_ms: u64,
+            now_ms: *const fn () u64,
+        ) !*@This() {
             const request = try alloc.create(@This());
             errdefer alloc.destroy(request);
             const owned: apprt.ipc.AutomationCommand = switch (command) {
@@ -1052,7 +1081,11 @@ pub const Message = union(enum) {
                     .text = try alloc.dupe(u8, value.text),
                 } },
             };
-            request.* = .{ .alloc = alloc, .command = owned };
+            request.* = .{
+                .alloc = alloc,
+                .command = owned,
+                .lifecycle = .init(deadline_ms, now_ms),
+            };
             return request;
         }
 
@@ -1093,12 +1126,18 @@ test "queued automation messages release consumer ownership during teardown" {
         std.testing.allocator,
         .focused,
         "new_tab",
+        std.math.maxInt(u64),
+        automationTestNow,
     );
     action_request.retain();
     action_request.release();
     (Message{ .automation_action = action_request }).deinit(std.testing.allocator);
 
-    const list_request = try Message.AutomationWindowListRequest.create(std.testing.allocator);
+    const list_request = try Message.AutomationWindowListRequest.create(
+        std.testing.allocator,
+        std.math.maxInt(u64),
+        automationTestNow,
+    );
     list_request.retain();
     list_request.release();
     (Message{ .automation_window_list = list_request }).deinit(std.testing.allocator);
@@ -1106,6 +1145,8 @@ test "queued automation messages release consumer ownership during teardown" {
     const focus_request = try Message.AutomationCommandRequest.create(
         std.testing.allocator,
         .{ .focus = .{ .surface_id = 42 } },
+        std.math.maxInt(u64),
+        automationTestNow,
     );
     focus_request.retain();
     focus_request.release();
@@ -1114,14 +1155,22 @@ test "queued automation messages release consumer ownership during teardown" {
     const text_request = try Message.AutomationCommandRequest.create(
         std.testing.allocator,
         .{ .send_text = .{ .target = .{ .surface_id = 42 }, .text = "hello" } },
+        std.math.maxInt(u64),
+        automationTestNow,
     );
     text_request.retain();
     text_request.release();
     (Message{ .automation_command = text_request }).deinit(std.testing.allocator);
 }
 
+var automation_test_now_ms: u64 = 0;
+
+fn automationTestNow() u64 {
+    return automation_test_now_ms;
+}
+
 test "automation request cancellation prevents late consumer execution" {
-    var lifecycle: Message.AutomationRequestLifecycle = .{};
+    var lifecycle: Message.AutomationRequestLifecycle = .init(100, automationTestNow);
     try std.testing.expect(lifecycle.cancel());
     try std.testing.expect(!lifecycle.claim());
     try std.testing.expectEqual(
@@ -1131,7 +1180,7 @@ test "automation request cancellation prevents late consumer execution" {
 }
 
 test "claimed automation request cannot report an ambiguous timeout" {
-    var lifecycle: Message.AutomationRequestLifecycle = .{};
+    var lifecycle: Message.AutomationRequestLifecycle = .init(100, automationTestNow);
     try std.testing.expect(lifecycle.claim());
     try std.testing.expect(!lifecycle.cancel());
     try std.testing.expectEqual(
@@ -1141,6 +1190,17 @@ test "claimed automation request cannot report an ambiguous timeout" {
     lifecycle.complete();
     try std.testing.expectEqual(
         Message.AutomationRequestLifecycle.State.completed,
+        lifecycle.load(),
+    );
+}
+
+test "expired automation request cannot be claimed" {
+    automation_test_now_ms = 100;
+    defer automation_test_now_ms = 0;
+    var lifecycle: Message.AutomationRequestLifecycle = .init(100, automationTestNow);
+    try std.testing.expect(!lifecycle.claim());
+    try std.testing.expectEqual(
+        Message.AutomationRequestLifecycle.State.cancelled,
         lifecycle.load(),
     );
 }

--- a/src/App.zig
+++ b/src/App.zig
@@ -993,6 +993,15 @@ pub const Message = union(enum) {
             const request = try alloc.create(@This());
             errdefer alloc.destroy(request);
             const owned: apprt.ipc.AutomationCommand = switch (command) {
+                .new_tab => |value| .{ .new_tab = .{
+                    .target = value.target,
+                    .working_directory = if (value.working_directory) |cwd| try alloc.dupe(u8, cwd) else null,
+                } },
+                .new_split => |value| .{ .new_split = .{
+                    .target = value.target,
+                    .direction = value.direction,
+                    .working_directory = if (value.working_directory) |cwd| try alloc.dupe(u8, cwd) else null,
+                } },
                 .focus => |target| .{ .focus = target },
                 .send_text => |value| .{ .send_text = .{
                     .target = value.target,
@@ -1010,6 +1019,8 @@ pub const Message = union(enum) {
         pub fn release(self: *@This()) void {
             if (self.refs.fetchSub(1, .acq_rel) != 1) return;
             switch (self.command) {
+                .new_tab => |value| if (value.working_directory) |cwd| self.alloc.free(cwd),
+                .new_split => |value| if (value.working_directory) |cwd| self.alloc.free(cwd),
                 .send_text => |value| self.alloc.free(value.text),
                 .focus => {},
             }

--- a/src/App.zig
+++ b/src/App.zig
@@ -1170,6 +1170,30 @@ test "queued automation messages release consumer ownership during teardown" {
     text_request.retain();
     text_request.release();
     (Message{ .automation_command = text_request }).deinit(std.testing.allocator);
+
+    const tab_request = try Message.AutomationCommandRequest.create(
+        std.testing.allocator,
+        .{ .new_tab = .{ .target = .focused, .working_directory = "C:\\src" } },
+        std.math.maxInt(u64),
+        automationTestNow,
+    );
+    tab_request.retain();
+    tab_request.release();
+    (Message{ .automation_command = tab_request }).deinit(std.testing.allocator);
+
+    const split_request = try Message.AutomationCommandRequest.create(
+        std.testing.allocator,
+        .{ .new_split = .{
+            .target = .{ .surface_id = 42 },
+            .direction = .down,
+            .working_directory = "C:\\src",
+        } },
+        std.math.maxInt(u64),
+        automationTestNow,
+    );
+    split_request.retain();
+    split_request.release();
+    (Message{ .automation_command = split_request }).deinit(std.testing.allocator);
 }
 
 var automation_test_now_ms: u64 = 0;

--- a/src/App.zig
+++ b/src/App.zig
@@ -949,16 +949,25 @@ pub const Message = union(enum) {
         }
 
         pub fn claim(self: *@This()) bool {
-            if (self.now_ms() >= self.deadline_ms) {
-                _ = self.cancel();
-                return false;
-            }
-            return self.state.cmpxchgStrong(
+            if (self.state.cmpxchgStrong(
                 @intFromEnum(State.pending),
                 @intFromEnum(State.claimed),
                 .acq_rel,
                 .acquire,
-            ) == null;
+            ) != null) return false;
+
+            // Recheck only after winning the claim. Checking first leaves a
+            // preemption window where the deadline can pass before the CAS.
+            // Equality is the documented zero-timeout one-attempt window.
+            if (self.now_ms() <= self.deadline_ms) return true;
+            const observed = self.state.cmpxchgStrong(
+                @intFromEnum(State.claimed),
+                @intFromEnum(State.cancelled),
+                .acq_rel,
+                .acquire,
+            );
+            std.debug.assert(observed == null);
+            return false;
         }
 
         pub fn cancel(self: *@This()) bool {
@@ -1194,8 +1203,19 @@ test "claimed automation request cannot report an ambiguous timeout" {
     );
 }
 
-test "expired automation request cannot be claimed" {
+test "automation request can be claimed on the exact deadline tick" {
     automation_test_now_ms = 100;
+    defer automation_test_now_ms = 0;
+    var lifecycle: Message.AutomationRequestLifecycle = .init(100, automationTestNow);
+    try std.testing.expect(lifecycle.claim());
+    try std.testing.expectEqual(
+        Message.AutomationRequestLifecycle.State.claimed,
+        lifecycle.load(),
+    );
+}
+
+test "automation request cannot be claimed after the deadline tick" {
+    automation_test_now_ms = 101;
     defer automation_test_now_ms = 0;
     var lifecycle: Message.AutomationRequestLifecycle = .init(100, automationTestNow);
     try std.testing.expect(!lifecycle.claim());

--- a/src/App.zig
+++ b/src/App.zig
@@ -383,29 +383,35 @@ fn drainMailbox(self: *App, rt_app: *apprt.App) !void {
                 try self.newWindow(rt_app, msg);
             },
             .automation_window_list => |request| {
-                request.result = rt_app.buildAutomationWindowListJson(request.alloc) catch |err| blk: {
-                    request.err = err;
-                    break :blk null;
-                };
-                request.completed.store(true, .release);
+                if (request.lifecycle.claim()) {
+                    request.result = rt_app.buildAutomationWindowListJson(request.alloc) catch |err| blk: {
+                        request.err = err;
+                        break :blk null;
+                    };
+                    request.lifecycle.complete();
+                }
                 request.release();
             },
             .automation_action => |request| {
-                self.performAutomationAction(
-                    rt_app,
-                    request.target,
-                    request.action_text,
-                ) catch |err| {
-                    request.err = err;
-                };
-                request.completed.store(true, .release);
+                if (request.lifecycle.claim()) {
+                    self.performAutomationAction(
+                        rt_app,
+                        request.target,
+                        request.action_text,
+                    ) catch |err| {
+                        request.err = err;
+                    };
+                    request.lifecycle.complete();
+                }
                 request.release();
             },
             .automation_command => |request| {
-                rt_app.performAutomationCommand(request.command) catch |err| {
-                    request.err = err;
-                };
-                request.completed.store(true, .release);
+                if (request.lifecycle.claim()) {
+                    rt_app.performAutomationCommand(request.command) catch |err| {
+                        request.err = err;
+                    };
+                    request.lifecycle.complete();
+                }
                 request.release();
             },
             .close => |surface| self.closeSurface(surface),
@@ -918,10 +924,48 @@ pub const Message = union(enum) {
         }
     }
 
+    pub const AutomationRequestLifecycle = struct {
+        pub const State = enum(u8) {
+            pending,
+            claimed,
+            completed,
+            cancelled,
+        };
+
+        state: std.atomic.Value(u8) = .init(@intFromEnum(State.pending)),
+
+        pub fn load(self: *const @This()) State {
+            return @enumFromInt(self.state.load(.acquire));
+        }
+
+        pub fn claim(self: *@This()) bool {
+            return self.state.cmpxchgStrong(
+                @intFromEnum(State.pending),
+                @intFromEnum(State.claimed),
+                .acq_rel,
+                .acquire,
+            ) == null;
+        }
+
+        pub fn cancel(self: *@This()) bool {
+            return self.state.cmpxchgStrong(
+                @intFromEnum(State.pending),
+                @intFromEnum(State.cancelled),
+                .acq_rel,
+                .acquire,
+            ) == null;
+        }
+
+        pub fn complete(self: *@This()) void {
+            std.debug.assert(self.load() == .claimed);
+            self.state.store(@intFromEnum(State.completed), .release);
+        }
+    };
+
     pub const AutomationWindowListRequest = struct {
         alloc: Allocator,
         refs: std.atomic.Value(u32) = .init(1),
-        completed: std.atomic.Value(bool) = .init(false),
+        lifecycle: AutomationRequestLifecycle = .{},
         result: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -953,7 +997,7 @@ pub const Message = union(enum) {
         refs: std.atomic.Value(u32) = .init(1),
         target: apprt.ipc.AutomationActionTarget,
         action_text: []const u8,
-        completed: std.atomic.Value(bool) = .init(false),
+        lifecycle: AutomationRequestLifecycle = .{},
         err: ?anyerror = null,
 
         pub fn create(
@@ -986,7 +1030,7 @@ pub const Message = union(enum) {
         alloc: Allocator,
         refs: std.atomic.Value(u32) = .init(1),
         command: apprt.ipc.AutomationCommand,
-        completed: std.atomic.Value(bool) = .init(false),
+        lifecycle: AutomationRequestLifecycle = .{},
         err: ?anyerror = null,
 
         pub fn create(alloc: Allocator, command: apprt.ipc.AutomationCommand) !*@This() {
@@ -1074,6 +1118,31 @@ test "queued automation messages release consumer ownership during teardown" {
     text_request.retain();
     text_request.release();
     (Message{ .automation_command = text_request }).deinit(std.testing.allocator);
+}
+
+test "automation request cancellation prevents late consumer execution" {
+    var lifecycle: Message.AutomationRequestLifecycle = .{};
+    try std.testing.expect(lifecycle.cancel());
+    try std.testing.expect(!lifecycle.claim());
+    try std.testing.expectEqual(
+        Message.AutomationRequestLifecycle.State.cancelled,
+        lifecycle.load(),
+    );
+}
+
+test "claimed automation request cannot report an ambiguous timeout" {
+    var lifecycle: Message.AutomationRequestLifecycle = .{};
+    try std.testing.expect(lifecycle.claim());
+    try std.testing.expect(!lifecycle.cancel());
+    try std.testing.expectEqual(
+        Message.AutomationRequestLifecycle.State.claimed,
+        lifecycle.load(),
+    );
+    lifecycle.complete();
+    try std.testing.expectEqual(
+        Message.AutomationRequestLifecycle.State.completed,
+        lifecycle.load(),
+    );
 }
 
 /// Mailbox is the way that other threads send the app thread messages.

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -147,7 +147,23 @@ pub const AutomationTarget = union(enum) {
     window_id: u32,
 };
 
+pub const AutomationSplitDirection = enum(u8) {
+    left = 1,
+    right = 2,
+    up = 3,
+    down = 4,
+};
+
 pub const AutomationCommand = union(enum) {
+    new_tab: struct {
+        target: AutomationTarget,
+        working_directory: ?[]const u8,
+    },
+    new_split: struct {
+        target: AutomationTarget,
+        direction: AutomationSplitDirection,
+        working_directory: ?[]const u8,
+    },
     focus: AutomationTarget,
     send_text: struct {
         target: AutomationTarget,

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -53,8 +53,8 @@ pub const Target = union(Key) {
     }
 };
 
-pub const automation_window_list_schema = "noctty.windows.v2";
-pub const automation_window_list_api_version: u32 = 2;
+pub const automation_window_list_schema = "noctty.windows.v3";
+pub const automation_window_list_api_version: u32 = 3;
 
 comptime {
     const version_suffix = std.fmt.comptimePrint(".v{d}", .{automation_window_list_api_version});
@@ -66,17 +66,32 @@ comptime {
 pub const AutomationWindowList = struct {
     schema: []const u8 = automation_window_list_schema,
     api_version: u32 = automation_window_list_api_version,
+    instance: AutomationInstance,
     windows: []AutomationWindow,
 
     pub fn deinit(self: *AutomationWindowList, alloc: Allocator) void {
+        self.instance.deinit(alloc);
         for (self.windows) |*window| window.deinit(alloc);
         alloc.free(self.windows);
         self.* = undefined;
     }
 };
 
+pub const AutomationInstance = struct {
+    pid: u32,
+    version: []const u8,
+    class: []const u8,
+
+    pub fn deinit(self: *AutomationInstance, alloc: Allocator) void {
+        alloc.free(self.version);
+        alloc.free(self.class);
+        self.* = undefined;
+    }
+};
+
 pub const AutomationWindow = struct {
     window_id: u32,
+    title: []const u8,
     focused: bool,
     active_tab_id: ?u32,
     tab_count: u64,
@@ -84,6 +99,7 @@ pub const AutomationWindow = struct {
     tabs: []AutomationTab,
 
     pub fn deinit(self: *AutomationWindow, alloc: Allocator) void {
+        alloc.free(self.title);
         for (self.tabs) |*tab| tab.deinit(alloc);
         alloc.free(self.tabs);
         self.* = undefined;
@@ -98,6 +114,7 @@ pub const AutomationTab = struct {
     panes: []AutomationPane,
 
     pub fn deinit(self: *AutomationTab, alloc: Allocator) void {
+        for (self.panes) |*pane| pane.deinit(alloc);
         alloc.free(self.panes);
         self.* = undefined;
     }
@@ -105,8 +122,16 @@ pub const AutomationTab = struct {
 
 pub const AutomationPane = struct {
     surface_id: u64,
+    title: ?[]const u8,
+    working_directory: ?[]const u8,
     focused: bool,
     active: bool,
+
+    pub fn deinit(self: *AutomationPane, alloc: Allocator) void {
+        if (self.title) |title| alloc.free(title);
+        if (self.working_directory) |working_directory| alloc.free(working_directory);
+        self.* = undefined;
+    }
 };
 
 pub const AutomationActionTarget = union(enum) {

--- a/src/apprt/ipc.zig
+++ b/src/apprt/ipc.zig
@@ -139,6 +139,22 @@ pub const AutomationActionTarget = union(enum) {
     surface_id: u64,
 };
 
+/// Target used by the stable Win32 automation verbs. Omitted targets are
+/// represented by `.focused`, never by a numeric zero.
+pub const AutomationTarget = union(enum) {
+    focused,
+    surface_id: u64,
+    window_id: u32,
+};
+
+pub const AutomationCommand = union(enum) {
+    focus: AutomationTarget,
+    send_text: struct {
+        target: AutomationTarget,
+        text: []const u8,
+    },
+};
+
 pub const Action = union(enum) {
     // A GUIDE TO ADDING NEW ACTIONS:
     //

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -12,6 +12,7 @@ pub const App = struct {
         _: apprt.ipc.Target,
         comptime action: apprt.ipc.Action.Key,
         _: apprt.ipc.Action.Value(action),
+        _: u64,
     ) !bool {
         return false;
     }
@@ -19,6 +20,7 @@ pub const App = struct {
     pub fn queryAutomationWindowList(
         _: Allocator,
         _: apprt.ipc.Target,
+        _: u64,
     ) !?[]u8 {
         return null;
     }
@@ -28,9 +30,31 @@ pub const App = struct {
         _: apprt.ipc.Target,
         _: apprt.ipc.AutomationActionTarget,
         _: []const u8,
+        _: u64,
     ) !bool {
         return false;
     }
+
+    pub fn focusAutomationTarget(
+        _: Allocator,
+        _: apprt.ipc.Target,
+        _: apprt.ipc.AutomationTarget,
+        _: u64,
+    ) !bool {
+        return false;
+    }
+
+    pub fn sendAutomationText(
+        _: Allocator,
+        _: apprt.ipc.Target,
+        _: apprt.ipc.AutomationTarget,
+        _: []const u8,
+        _: u64,
+    ) !bool {
+        return false;
+    }
+
+    pub fn performAutomationCommand(_: *App, _: apprt.ipc.AutomationCommand) !void {}
 
     pub fn buildAutomationWindowListJson(
         _: *App,

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -44,6 +44,27 @@ pub const App = struct {
         return false;
     }
 
+    pub fn newAutomationTab(
+        _: Allocator,
+        _: apprt.ipc.Target,
+        _: apprt.ipc.AutomationTarget,
+        _: ?[]const u8,
+        _: u64,
+    ) !bool {
+        return false;
+    }
+
+    pub fn newAutomationSplit(
+        _: Allocator,
+        _: apprt.ipc.Target,
+        _: apprt.ipc.AutomationTarget,
+        _: apprt.ipc.AutomationSplitDirection,
+        _: ?[]const u8,
+        _: u64,
+    ) !bool {
+        return false;
+    }
+
     pub fn sendAutomationText(
         _: Allocator,
         _: apprt.ipc.Target,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1035,6 +1035,10 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
                 );
                 return error.PipeUnreachable;
             }
+            setIpcClientNonblocking(handle) catch |err| {
+                _ = windows.CloseHandle(handle);
+                return err;
+            };
             return handle;
         }
 
@@ -1060,6 +1064,13 @@ fn connectToIpcPipe(pipe_name: [:0]const u16) !windows.HANDLE {
             },
             else => return windows.unexpectedError(err),
         }
+    }
+}
+
+fn setIpcClientNonblocking(pipe: windows.HANDLE) !void {
+    var mode: u32 = c.PIPE_READMODE_BYTE | win32_ipc.pipe_nowait;
+    if (sys.SetNamedPipeHandleState(pipe, &mode, null, null) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
     }
 }
 
@@ -5822,7 +5833,14 @@ pub const App = struct {
         return .{
             .window_id = host.id,
             .title = title,
-            .focused = if (host.activeSurface()) |surface| surface.window_focused else false,
+            // `GetForegroundWindow` returns the top-level host even when the
+            // keyboard focus is in one of its child controls. Surface focus
+            // alone would incorrectly report every host as unfocused then.
+            .focused = automationHostFocused(
+                host.hwnd,
+                sys.GetForegroundWindow(),
+                if (host.activeSurface()) |surface| surface.window_focused else false,
+            ),
             .active_tab_id = active_tab_id,
             .tab_count = @intCast(tabs.len),
             .pane_count = automationPaneCount(tabs),
@@ -8325,6 +8343,15 @@ fn detachHostReference(hosts: *std.ArrayListUnmanaged(*Host), host: *Host) bool 
         return true;
     }
     return false;
+}
+
+fn automationHostFocused(
+    host_hwnd: ?HWND,
+    foreground_hwnd: ?HWND,
+    surface_focused_fallback: bool,
+) bool {
+    const hwnd = host_hwnd orelse return surface_focused_fallback;
+    return foreground_hwnd == hwnd;
 }
 
 fn updateCheckThreadMain(request: *UpdateCheckRequest) void {
@@ -27699,17 +27726,16 @@ test "automation in-app new_tab action does not query source pwd" {
             _: LPCWSTR,
             opts: SurfaceInitOptions,
         ) anyerror!*Surface {
-            const direct = config.command.?.direct;
-            try std.testing.expectEqual(@as(usize, 2), direct.len);
-            try std.testing.expectEqualStrings("pwsh.exe", direct[0]);
-            try std.testing.expectEqualStrings("-NoLogo", direct[1]);
+            // Ordinary in-app tabs retain the configured default rather than
+            // inheriting the source profile command used by automation.
+            try std.testing.expect(config.command == null);
             created_ref.app = hook_app;
             created_ref.host = host_ref;
             created_ref.host_id = host_ref.id;
             try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
             try host_ref.tabs.insert(
                 hook_app.core_app.alloc,
-                opts.tab_insert_index.?,
+                opts.tab_insert_index orelse host_ref.tabs.items.len,
                 try Tab.init(hook_app.core_app.alloc, host_ref.nextTabId(), created_ref),
             );
             return created_ref;
@@ -27724,7 +27750,7 @@ test "automation in-app new_tab action does not query source pwd" {
 
     try std.testing.expect(try app.performAction(.app, .new_tab, {}));
     try std.testing.expectEqual(@as(usize, 0), Hook.pwd_calls);
-    try std.testing.expectEqualStrings("pwsh", created.launch_profile_key.?);
+    try std.testing.expect(created.launch_profile_key == null);
 }
 
 test "automation explicit-window new_tab reanchors inactive host cwd and override wins" {
@@ -30595,6 +30621,7 @@ test "automation-window-list win32 json includes host tab and pane ids" {
 
     var host: Host = undefined;
     host.id = 17;
+    host.hwnd = null;
     host.tabs = .empty;
     host.active_tab = 1;
     host.cached_window_title = "host \"quote\"\\slash\t\r\n";
@@ -30710,6 +30737,18 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     for ([_][]const u8{ "grid", "scrollback", "selection", "clipboard", "shell_input" }) |key| {
         try std.testing.expect(std.mem.indexOf(u8, json, key) == null);
     }
+}
+
+test "automation-window-list host focus follows the foreground host" {
+    const host: HWND = @ptrFromInt(1);
+    const other: HWND = @ptrFromInt(2);
+
+    // Child-control focus still presents its top-level host as foreground.
+    try std.testing.expect(automationHostFocused(host, host, false));
+    try std.testing.expect(!automationHostFocused(host, other, true));
+    try std.testing.expect(!automationHostFocused(host, null, true));
+    // HWND-free unit fixtures retain the existing surface-state fallback.
+    try std.testing.expect(automationHostFocused(null, null, true));
 }
 
 test "automation-window-list win32 json skips empty hosts kept alive for undo history" {
@@ -31814,7 +31853,7 @@ test "automation send text enforces receiver policy and protected paste path" {
     );
 }
 
-test "win32 IPC silent client read is bounded" {
+test "win32 IPC silent synchronous client read is bounded" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     const pipe_name_utf8 = try std.fmt.allocPrintSentinel(
@@ -31857,6 +31896,7 @@ test "win32 IPC silent client read is bounded" {
     );
     try std.testing.expect(client != windows.INVALID_HANDLE_VALUE);
     defer _ = windows.CloseHandle(client);
+    try setIpcClientNonblocking(client);
 
     const connected = sys.ConnectNamedPipe(server, null);
     if (connected == 0) {
@@ -31866,7 +31906,7 @@ test "win32 IPC silent client read is bounded" {
     var byte: [1]u8 = undefined;
     try std.testing.expectError(
         error.IpcTimeout,
-        win32_ipc.readExactWithTimeout(server, &byte, 10),
+        win32_ipc.readExactWithTimeout(client, &byte, 10),
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1063,6 +1063,7 @@ fn sendNewWindowIpc(
     alloc: Allocator,
     pipe_name: [:0]const u16,
     arguments: ?[]const [:0]const u8,
+    response_timeout_ms: u64,
 ) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         error.FileNotFound => return false,
@@ -1084,12 +1085,13 @@ fn sendNewWindowIpc(
     defer alloc.free(request);
 
     try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAck(pipe);
+    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
 }
 
 fn sendListWindowsIpc(
     alloc: Allocator,
     pipe_name: [:0]const u16,
+    response_timeout_ms: u64,
 ) !?[]u8 {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         // Both mean "no instance we can reach"; see `connectToIpcPipe`.
@@ -1106,7 +1108,7 @@ fn sendListWindowsIpc(
     return try win32_ipc.readDataResponseWithTimeout(
         alloc,
         pipe,
-        win32_ipc.automation_response_timeout_ms,
+        response_timeout_ms,
     );
 }
 
@@ -1115,6 +1117,7 @@ fn sendPerformActionIpc(
     pipe_name: [:0]const u16,
     target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
+    response_timeout_ms: u64,
 ) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         // Both mean "no instance we can reach"; see `connectToIpcPipe`.
@@ -1128,7 +1131,54 @@ fn sendPerformActionIpc(
     defer alloc.free(request);
 
     try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, win32_ipc.automation_response_timeout_ms);
+    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+}
+
+fn sendFocusIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+    target: apprt.ipc.AutomationTarget,
+    response_timeout_ms: u64,
+) !bool {
+    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    defer _ = windows.CloseHandle(pipe);
+
+    const request = try win32_ipc.encodeFocusRequest(alloc, target);
+    defer alloc.free(request);
+    try win32_ipc.writeAll(pipe, request);
+    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+}
+
+fn sendAutomationTextIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+    target: apprt.ipc.AutomationTarget,
+    value: []const u8,
+    response_timeout_ms: u64,
+) !bool {
+    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    defer _ = windows.CloseHandle(pipe);
+
+    const request = try win32_ipc.encodeSendTextRequest(alloc, target, value);
+    defer alloc.free(request);
+    try win32_ipc.writeAll(pipe, request);
+    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+}
+
+fn automationTextAllowed(text: []const u8) bool {
+    if (text.len == 0 or text.len > win32_ipc.max_action_text_len) return false;
+    const view = std.unicode.Utf8View.init(text) catch return false;
+    var it = view.iterator();
+    while (it.nextCodepoint()) |cp| {
+        if (cp <= 0x1F or cp == 0x7F or (cp >= 0x80 and cp <= 0x9F)) return false;
+    }
+    return win32_paste_protection.inspect(text).severity != .control_chars;
 }
 
 /// Configuration keys a forwarded `new_window` argv is allowed to set.
@@ -1391,6 +1441,7 @@ fn sendLaunchLayoutIpc(
     alloc: Allocator,
     pipe_name: [:0]const u16,
     name: []const u8,
+    response_timeout_ms: u64,
 ) !bool {
     // Validate before probing the pipe. The caller uses `false` as the cold
     // start fallback, so connecting first would let an invalid name spawn an
@@ -1406,7 +1457,7 @@ fn sendLaunchLayoutIpc(
     defer _ = windows.CloseHandle(pipe);
 
     try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, win32_ipc.automation_response_timeout_ms);
+    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
 }
 
 fn trySendStartupLaunchLayoutIpc(
@@ -1415,7 +1466,12 @@ fn trySendStartupLaunchLayoutIpc(
     name: ?[]const u8,
 ) !?bool {
     const layout_name = name orelse return null;
-    return try sendLaunchLayoutIpc(alloc, pipe_name, layout_name);
+    return try sendLaunchLayoutIpc(
+        alloc,
+        pipe_name,
+        layout_name,
+        win32_ipc.automation_response_timeout_ms,
+    );
 }
 
 const LaunchLayoutIpcArgument = union(enum) {
@@ -1887,6 +1943,14 @@ fn handleIpcClient(app: *App, pipe: windows.HANDLE) !win32_ipc.RequestKind {
             log.warn("failed to process win32 launch-layout IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
+        .focus => handleFocusIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation focus IPC request err={}", .{err});
+            try win32_ipc.writeAck(pipe, false);
+        },
+        .send_text => handleSendTextIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation send-text IPC request err={}", .{err});
+            try win32_ipc.writeAck(pipe, false);
+        },
     }
     return kind;
 }
@@ -1987,6 +2051,55 @@ fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
+fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    const target = win32_ipc.decodeFocusPayload(pipe) catch |err| switch (err) {
+        error.InvalidAutomationTarget => {
+            try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_target);
+            return;
+        },
+        else => return err,
+    };
+    requestAutomationCommand(app, .{ .focus = target }) catch |err| {
+        const status: u8 = switch (err) {
+            error.InvalidAutomationTarget => win32_ipc.ack_invalid_automation_target,
+            error.AutomationTargetNotFound => win32_ipc.ack_automation_target_not_found,
+            else => return err,
+        };
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    try win32_ipc.writeAck(pipe, true);
+}
+
+fn handleSendTextIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    var payload = win32_ipc.decodeSendTextPayload(app.core_app.alloc, pipe) catch |err| switch (err) {
+        error.InvalidAutomationText => {
+            try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
+            return;
+        },
+        error.InvalidAutomationTarget => {
+            try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_target);
+            return;
+        },
+        else => return err,
+    };
+    defer payload.deinit(app.core_app.alloc);
+    requestAutomationCommand(app, .{ .send_text = .{
+        .target = payload.target,
+        .text = payload.text,
+    } }) catch |err| {
+        const status: u8 = switch (err) {
+            error.InvalidAutomationTarget => win32_ipc.ack_invalid_automation_target,
+            error.AutomationTargetNotFound => win32_ipc.ack_automation_target_not_found,
+            error.AutomationPolicyRefused => win32_ipc.ack_automation_policy_refused,
+            else => return err,
+        };
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    try win32_ipc.writeAck(pipe, true);
+}
+
 fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
     const request = try CoreApp.Message.AutomationWindowListRequest.create(alloc);
     defer request.release();
@@ -2026,6 +2139,23 @@ fn requestAutomationAction(
         .mailbox = &app.core_app.mailbox,
     };
     if (mailbox.push(.{ .automation_action = request }, .{ .ns = win32_ipc.io_timeout_ms * std.time.ns_per_ms }) == 0) {
+        request.release();
+        return error.IPCFailed;
+    }
+
+    try waitForAutomationCompletion(app, &request.completed);
+    if (request.err) |err| return err;
+}
+
+fn requestAutomationCommand(app: *App, command: apprt.ipc.AutomationCommand) !void {
+    const request = try CoreApp.Message.AutomationCommandRequest.create(app.core_app.alloc, command);
+    defer request.release();
+    request.retain(); // Mailbox-consumer ownership.
+    const mailbox: CoreApp.Mailbox = .{
+        .rt_app = app,
+        .mailbox = &app.core_app.mailbox,
+    };
+    if (mailbox.push(.{ .automation_command = request }, .{ .ns = win32_ipc.io_timeout_ms * std.time.ns_per_ms }) == 0) {
         request.release();
         return error.IPCFailed;
     }
@@ -2369,6 +2499,13 @@ pub const App = struct {
     /// Test-only seam for automation snapshots built without a live core
     /// surface. Returned strings are owned by the caller.
     test_automation_pwd: ?*const fn (Allocator, *Surface) anyerror!?[]const u8 = null,
+    /// Test-only seam proving automation uses the protected paste encoder.
+    test_automation_paste: ?*const fn (
+        surface: *Surface,
+        state: apprt.ClipboardRequest,
+        text: [:0]const u8,
+        confirmed: bool,
+    ) anyerror!void = null,
     /// Test-only interleaving seam for the focus revision race between a
     /// structural split-close prepare and commit.
     test_before_split_undo_shell_commit: ?*const fn (
@@ -3981,6 +4118,7 @@ pub const App = struct {
             self.core_app.alloc,
             pipe_name,
             arguments,
+            win32_ipc.automation_response_timeout_ms,
         );
     }
 
@@ -5357,6 +5495,7 @@ pub const App = struct {
         target: apprt.ipc.Target,
         comptime action: apprt.ipc.Action.Key,
         value: apprt.ipc.Action.Value(action),
+        response_timeout_ms: u64,
     ) !bool {
         switch (action) {
             .new_window => {
@@ -5368,8 +5507,8 @@ pub const App = struct {
                 const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
                 defer alloc.free(pipe_name);
                 const forwarded = switch (launch_layout) {
-                    .none => try sendNewWindowIpc(alloc, pipe_name, value.arguments),
-                    .name => |name| try sendLaunchLayoutIpc(alloc, pipe_name, name),
+                    .none => try sendNewWindowIpc(alloc, pipe_name, value.arguments, response_timeout_ms),
+                    .name => |name| try sendLaunchLayoutIpc(alloc, pipe_name, name, response_timeout_ms),
                 };
                 if (forwarded) return true;
                 return try spawnWindowProcess(alloc, target, value);
@@ -5380,10 +5519,11 @@ pub const App = struct {
     pub fn queryAutomationWindowList(
         alloc: Allocator,
         target: apprt.ipc.Target,
+        response_timeout_ms: u64,
     ) !?[]u8 {
         const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
         defer alloc.free(pipe_name);
-        return try sendListWindowsIpc(alloc, pipe_name);
+        return try sendListWindowsIpc(alloc, pipe_name, response_timeout_ms);
     }
 
     pub fn performAutomationAction(
@@ -5391,10 +5531,74 @@ pub const App = struct {
         target: apprt.ipc.Target,
         action_target: apprt.ipc.AutomationActionTarget,
         action_text: []const u8,
+        response_timeout_ms: u64,
     ) !bool {
         const pipe_name = try resolveIpcPipeNameForTarget(alloc, target);
         defer alloc.free(pipe_name);
-        return try sendPerformActionIpc(alloc, pipe_name, action_target, action_text);
+        return try sendPerformActionIpc(alloc, pipe_name, action_target, action_text, response_timeout_ms);
+    }
+
+    pub fn focusAutomationTarget(
+        alloc: Allocator,
+        instance_target: apprt.ipc.Target,
+        automation_target: apprt.ipc.AutomationTarget,
+        response_timeout_ms: u64,
+    ) !bool {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, instance_target);
+        defer alloc.free(pipe_name);
+        return try sendFocusIpc(alloc, pipe_name, automation_target, response_timeout_ms);
+    }
+
+    pub fn sendAutomationText(
+        alloc: Allocator,
+        instance_target: apprt.ipc.Target,
+        automation_target: apprt.ipc.AutomationTarget,
+        text: []const u8,
+        response_timeout_ms: u64,
+    ) !bool {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, instance_target);
+        defer alloc.free(pipe_name);
+        return try sendAutomationTextIpc(
+            alloc,
+            pipe_name,
+            automation_target,
+            text,
+            response_timeout_ms,
+        );
+    }
+
+    pub fn performAutomationCommand(self: *App, command: apprt.ipc.AutomationCommand) !void {
+        switch (command) {
+            .focus => |target| {
+                const surface = switch (target) {
+                    .surface_id => |id| self.findSurfaceById(id),
+                    .window_id => |id| self.activeSurfaceForHost(id),
+                    .focused => return error.InvalidAutomationTarget,
+                } orelse return error.AutomationTargetNotFound;
+                self.activateSurface(surface);
+            },
+            .send_text => |value| {
+                const surface = switch (value.target) {
+                    .surface_id => |id| self.findSurfaceById(id),
+                    .focused, .window_id => return error.InvalidAutomationTarget,
+                } orelse return error.AutomationTargetNotFound;
+                if (!automationTextAllowed(value.text)) return error.AutomationPolicyRefused;
+
+                const text_z = try self.core_app.alloc.dupeZ(u8, value.text);
+                defer self.core_app.alloc.free(text_z);
+                if (self.test_automation_paste) |paste| {
+                    paste(surface, .paste, text_z, false) catch |err| switch (err) {
+                        error.UnsafePaste => return error.AutomationPolicyRefused,
+                        else => return err,
+                    };
+                } else {
+                    surface.core().completeClipboardRequest(.paste, text_z, false) catch |err| switch (err) {
+                        error.UnsafePaste => return error.AutomationPolicyRefused,
+                        else => return err,
+                    };
+                }
+            },
+        }
     }
 
     pub fn buildAutomationWindowListJson(
@@ -30974,6 +31178,144 @@ test "win32 IPC client authenticates the connected pipe descriptor" {
     // creatable from a test. Both are argued from the fail-closed structure
     // of `ipcPipeServerIsTrusted` (every error path returns false, and the
     // final comparison is `server_rid >= own_rid`), not observed.
+}
+
+test "automation focus selects exact targets without fallback" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    var app: App = undefined;
+    var host_a: Host = undefined;
+    var host_b: Host = undefined;
+    var surface_a: Surface = undefined;
+    var surface_b: Surface = undefined;
+    var surface_c: Surface = undefined;
+    var session: TestSession = .{};
+    try session.init(.{
+        .core_app = &core_app,
+        .app = &app,
+        .hosts = &.{
+            .{ .storage = &host_a, .id = 11, .register = true },
+            .{ .storage = &host_b, .id = 12, .register = true },
+        },
+        .surfaces = &.{
+            .{ .storage = &surface_a, .host = &host_a },
+            .{ .storage = &surface_b, .host = &host_a },
+            .{ .storage = &surface_c, .host = &host_b },
+        },
+        .tabs = &.{
+            .{ .host = &host_a, .surface = &surface_a, .id = 1 },
+            .{ .host = &host_a, .surface = &surface_b, .id = 2 },
+            .{ .host = &host_b, .surface = &surface_c, .id = 3 },
+        },
+    });
+    defer session.deinit();
+    surface_a.core_surface.id = 101;
+    surface_b.core_surface.id = 102;
+    surface_c.core_surface.id = 103;
+
+    try app.performAutomationCommand(.{ .focus = .{ .surface_id = 102 } });
+    try std.testing.expectEqual(@as(usize, 1), host_a.active_tab);
+    try app.performAutomationCommand(.{ .focus = .{ .window_id = 12 } });
+    try std.testing.expectEqual(&surface_c, host_b.activeSurface().?);
+    try std.testing.expectError(
+        error.AutomationTargetNotFound,
+        app.performAutomationCommand(.{ .focus = .{ .surface_id = 999 } }),
+    );
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        app.performAutomationCommand(.{ .focus = .focused }),
+    );
+}
+
+test "automation send text enforces receiver policy and protected paste path" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const Hook = struct {
+        var calls: usize = 0;
+        var expected: []const u8 = "";
+        var unsafe = false;
+        fn paste(
+            surface: *Surface,
+            state: apprt.ClipboardRequest,
+            text: [:0]const u8,
+            confirmed: bool,
+        ) !void {
+            try std.testing.expectEqual(@as(u64, 201), surface.core().id);
+            try std.testing.expectEqual(apprt.ClipboardRequest.paste, state);
+            try std.testing.expectEqualStrings(expected, text);
+            try std.testing.expect(!confirmed);
+            calls += 1;
+            if (unsafe) return error.UnsafePaste;
+        }
+    };
+
+    var core_app: CoreApp = undefined;
+    var app: App = undefined;
+    var host: Host = undefined;
+    var surface: Surface = undefined;
+    var session: TestSession = .{};
+    try session.init(.{
+        .core_app = &core_app,
+        .app = &app,
+        .hosts = &.{.{ .storage = &host, .register = true }},
+        .surfaces = &.{.{ .storage = &surface, .host = &host }},
+        .tabs = &.{.{ .host = &host, .surface = &surface, .id = 1 }},
+    });
+    defer session.deinit();
+    surface.core_surface.id = 201;
+    app.test_automation_paste = &Hook.paste;
+    Hook.calls = 0;
+
+    for ([_][]const u8{ "printable UTF-8: \xcf\x80", "$HOME && echo ok | more" }) |text| {
+        Hook.expected = text;
+        try app.performAutomationCommand(.{ .send_text = .{
+            .target = .{ .surface_id = 201 },
+            .text = text,
+        } });
+    }
+    try std.testing.expectEqual(@as(usize, 2), Hook.calls);
+    Hook.expected = "unsafe";
+    Hook.unsafe = true;
+    try std.testing.expectError(
+        error.AutomationPolicyRefused,
+        app.performAutomationCommand(.{ .send_text = .{
+            .target = .{ .surface_id = 201 },
+            .text = "unsafe",
+        } }),
+    );
+    Hook.unsafe = false;
+
+    const refused = [_][]const u8{
+        "\r",
+        "\n",
+        "\t",
+        "\x00",
+        "\x1b",
+        "\x7f",
+        "\xc2\x80",
+    };
+    for (refused) |text| {
+        try std.testing.expectError(
+            error.AutomationPolicyRefused,
+            app.performAutomationCommand(.{ .send_text = .{
+                .target = .{ .surface_id = 201 },
+                .text = text,
+            } }),
+        );
+    }
+    try std.testing.expectEqual(@as(usize, 3), Hook.calls);
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        app.performAutomationCommand(.{ .send_text = .{ .target = .focused, .text = "ok" } }),
+    );
+    try std.testing.expectError(
+        error.AutomationTargetNotFound,
+        app.performAutomationCommand(.{ .send_text = .{
+            .target = .{ .surface_id = 999 },
+            .text = "ok",
+        } }),
+    );
 }
 
 test "win32 IPC silent client read is bounded" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1171,12 +1171,9 @@ fn sendAutomationAckRequest(
         else => return err,
     };
     defer _ = windows.CloseHandle(pipe);
-    if (request.len < 13) return error.InvalidIpcRequest;
-    std.mem.writeInt(
-        u64,
-        request[5..13],
+    try win32_ipc.setAutomationRequestDeadline(
+        request,
         automationRequestDeadline(response_timeout_ms),
-        .little,
     );
     try win32_ipc.writeAll(pipe, request);
     return win32_ipc.readAckWithTimeout(pipe, std.math.maxInt(u64));
@@ -1543,11 +1540,9 @@ fn sendLaunchLayoutIpc(
     };
     defer _ = windows.CloseHandle(pipe);
 
-    std.mem.writeInt(
-        u64,
-        request[5..13],
+    try win32_ipc.setAutomationRequestDeadline(
+        request,
         automationRequestDeadline(response_timeout_ms),
-        .little,
     );
     try win32_ipc.writeAll(pipe, request);
     return try win32_ipc.readAckWithTimeout(pipe, std.math.maxInt(u64));

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4891,7 +4891,7 @@ pub const App = struct {
 
             .new_tab => {
                 const source = self.findSurfaceForTarget(target);
-                _ = try self.createNewTab(source, null);
+                _ = try self.createNewTab(source, null, false);
                 return true;
             },
 
@@ -5671,12 +5671,26 @@ pub const App = struct {
                 if (value.working_directory) |cwd| {
                     if (!automationWorkingDirectoryAllowed(cwd)) return error.AutomationPolicyRefused;
                 }
-                const source = switch (value.target) {
-                    .focused => self.focusedSurfaceForUndoRedo(),
-                    .window_id => |id| self.activeSurfaceForHost(id),
+                const resolved: struct {
+                    source: ?*Surface,
+                    explicit_window_target: bool,
+                } = switch (value.target) {
+                    .focused => .{
+                        .source = self.focusedSurfaceForUndoRedo(),
+                        .explicit_window_target = false,
+                    },
+                    .window_id => |id| .{
+                        .source = self.activeSurfaceForHost(id),
+                        .explicit_window_target = true,
+                    },
                     .surface_id => return error.InvalidAutomationTarget,
-                } orelse return error.AutomationTargetNotFound;
-                _ = try self.createNewTab(source, value.working_directory);
+                };
+                const source = resolved.source orelse return error.AutomationTargetNotFound;
+                _ = try self.createNewTab(
+                    source,
+                    value.working_directory,
+                    resolved.explicit_window_target,
+                );
             },
             .new_split => |value| {
                 if (value.working_directory) |cwd| {
@@ -6010,20 +6024,29 @@ pub const App = struct {
         return surface;
     }
 
-    fn createNewTab(self: *App, source: ?*Surface, working_directory: ?[]const u8) !*Surface {
+    fn createNewTab(
+        self: *App,
+        source: ?*Surface,
+        working_directory: ?[]const u8,
+        explicit_window_target: bool,
+    ) !*Surface {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .tab);
         defer config.deinit();
-        // `newConfig(.tab)` consults the globally focused surface. Reset and
-        // inherit from the exact requested host instead.
-        config.@"working-directory" = self.config.@"working-directory";
-        if (source) |surface| {
-            const split_inherit = config.@"split-inherit-working-directory";
-            {
-                defer config.@"split-inherit-working-directory" = split_inherit;
-                config.@"split-inherit-working-directory" = config.@"tab-inherit-working-directory";
-                _ = try applySplitWorkingDirectoryFromSource(self, &config, surface, self.startup_cwd);
+
+        if (explicit_window_target) {
+            // `newConfig(.tab)` consults the globally focused surface. Reset
+            // and inherit from the explicitly requested host instead.
+            config.@"working-directory" = self.config.@"working-directory";
+            if (source) |surface| {
+                const split_inherit = config.@"split-inherit-working-directory";
+                {
+                    defer config.@"split-inherit-working-directory" = split_inherit;
+                    config.@"split-inherit-working-directory" = config.@"tab-inherit-working-directory";
+                    _ = try applySplitWorkingDirectoryFromSource(self, &config, surface, self.startup_cwd);
+                }
             }
         }
+
         if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
         const surface = try self.createWindowSurface(&config, default_title, .{
             .host_id = if (source) |value| value.host_id else null,
@@ -27559,6 +27582,166 @@ test "win32 structural redo invalidation clears affected tab redo only" {
     try std.testing.expectEqual(@as(usize, 0), surface_b.undo_stack.redoDepth());
     try std.testing.expectEqual(@as(usize, 1), surface_c.undo_stack.undoDepth());
     try std.testing.expectEqual(@as(usize, 1), surface_c.undo_stack.redoDepth());
+}
+
+test "automation in-app new_tab action does not query source pwd" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    var app: App = undefined;
+    var host: Host = undefined;
+    var source: Surface = undefined;
+    var created: Surface = undefined;
+    var session: TestSession = .{};
+    try session.init(.{
+        .core_app = &core_app,
+        .app = &app,
+        .hosts = &.{.{ .storage = &host, .register = true, .next_tab_id = 2 }},
+        .surfaces = &.{
+            .{ .storage = &source, .host = &host, .register = true },
+            .{ .storage = &created, .host = &host, .window_visible = false, .host_active = false },
+        },
+        .tabs = &.{.{ .host = &host, .surface = &source, .id = 1 }},
+    });
+    defer session.deinit();
+
+    const Hook = struct {
+        var host_ref: *Host = undefined;
+        var created_ref: *Surface = undefined;
+        var pwd_calls: usize = 0;
+
+        fn queryPwd(_: Allocator, _: *Surface) !?[]const u8 {
+            pwd_calls += 1;
+            return error.UnexpectedPwdQuery;
+        }
+
+        fn createSurface(
+            hook_app: *App,
+            _: *const configpkg.Config,
+            _: LPCWSTR,
+            opts: SurfaceInitOptions,
+        ) anyerror!*Surface {
+            created_ref.app = hook_app;
+            created_ref.host = host_ref;
+            created_ref.host_id = host_ref.id;
+            try hook_app.windows.append(hook_app.core_app.alloc, created_ref);
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                opts.tab_insert_index.?,
+                try Tab.init(hook_app.core_app.alloc, host_ref.nextTabId(), created_ref),
+            );
+            return created_ref;
+        }
+    };
+
+    Hook.host_ref = &host;
+    Hook.created_ref = &created;
+    Hook.pwd_calls = 0;
+    app.test_automation_pwd = &Hook.queryPwd;
+    app.test_create_window_surface = &Hook.createSurface;
+
+    try std.testing.expect(try app.performAction(.app, .new_tab, {}));
+    try std.testing.expectEqual(@as(usize, 0), Hook.pwd_calls);
+}
+
+test "automation explicit-window new_tab reanchors inactive host cwd and override wins" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    var app: App = undefined;
+    var host_a: Host = undefined;
+    var host_b: Host = undefined;
+    var surface_a: Surface = undefined;
+    var surface_b: Surface = undefined;
+    var inherited: Surface = undefined;
+    var overridden: Surface = undefined;
+    var session: TestSession = .{};
+    try session.init(.{
+        .core_app = &core_app,
+        .app = &app,
+        .hosts = &.{
+            .{ .storage = &host_a, .id = 11, .register = true, .next_tab_id = 2 },
+            .{ .storage = &host_b, .id = 12, .register = true, .next_tab_id = 2 },
+        },
+        .surfaces = &.{
+            .{ .storage = &surface_a, .host = &host_a, .register = true, .window_focused = true },
+            .{ .storage = &surface_b, .host = &host_b, .register = true, .host_active = false },
+            .{ .storage = &inherited, .host = &host_b, .window_visible = false, .host_active = false },
+            .{ .storage = &overridden, .host = &host_b, .window_visible = false, .host_active = false },
+        },
+        .tabs = &.{
+            .{ .host = &host_a, .surface = &surface_a, .id = 1 },
+            .{ .host = &host_b, .surface = &surface_b, .id = 1 },
+        },
+    });
+    defer session.deinit();
+
+    const Hook = struct {
+        var host_ref: *Host = undefined;
+        var created_refs: [2]*Surface = undefined;
+        var create_calls: usize = 0;
+        var pwd_calls: usize = 0;
+
+        fn queryPwd(alloc: Allocator, source: *Surface) !?[]const u8 {
+            try std.testing.expectEqual(@as(u32, 12), source.host_id);
+            pwd_calls += 1;
+            return try alloc.dupe(u8, "C:\\inactive-host");
+        }
+
+        fn createSurface(
+            hook_app: *App,
+            config: *const configpkg.Config,
+            _: LPCWSTR,
+            opts: SurfaceInitOptions,
+        ) anyerror!*Surface {
+            const call_index = create_calls;
+            create_calls += 1;
+            try std.testing.expect(call_index < created_refs.len);
+            try std.testing.expectEqual(@as(?u32, host_ref.id), opts.host_id);
+            try std.testing.expect(opts.clone_state_from != null);
+            try std.testing.expectEqual(host_ref.id, opts.clone_state_from.?.host_id);
+
+            const expected = if (call_index == 0) "C:\\inactive-host" else "D:\\explicit-override";
+            const working_directory = config.@"working-directory" orelse
+                return error.MissingWorkingDirectory;
+            switch (working_directory) {
+                .path => |path| try std.testing.expectEqualStrings(expected, path),
+                .home, .inherit => return error.UnexpectedWorkingDirectory,
+            }
+
+            const created = created_refs[call_index];
+            created.app = hook_app;
+            created.host = host_ref;
+            created.host_id = host_ref.id;
+            try hook_app.windows.append(hook_app.core_app.alloc, created);
+            try host_ref.tabs.insert(
+                hook_app.core_app.alloc,
+                opts.tab_insert_index.?,
+                try Tab.init(hook_app.core_app.alloc, host_ref.nextTabId(), created),
+            );
+            return created;
+        }
+    };
+
+    Hook.host_ref = &host_b;
+    Hook.created_refs = .{ &inherited, &overridden };
+    Hook.create_calls = 0;
+    Hook.pwd_calls = 0;
+    app.test_automation_pwd = &Hook.queryPwd;
+    app.test_create_window_surface = &Hook.createSurface;
+
+    try std.testing.expect(!surface_b.host_active);
+    try app.performAutomationCommand(.{ .new_tab = .{
+        .target = .{ .window_id = host_b.id },
+        .working_directory = null,
+    } });
+    try app.performAutomationCommand(.{ .new_tab = .{
+        .target = .{ .window_id = host_b.id },
+        .working_directory = "D:\\explicit-override",
+    } });
+
+    try std.testing.expectEqual(@as(usize, 2), Hook.create_calls);
+    try std.testing.expectEqual(@as(usize, 2), Hook.pwd_calls);
 }
 
 test "win32 new_tab action inserts after the active tab by default, clears current tab redo, and activates the created tab" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -31924,7 +31924,12 @@ test "win32 launch-layout IPC validates names before cold fallback" {
 
     try std.testing.expectError(
         error.InvalidAutomationAction,
-        sendLaunchLayoutIpc(std.testing.allocator, pipe_name, "CON"),
+        sendLaunchLayoutIpc(
+            std.testing.allocator,
+            pipe_name,
+            "CON",
+            win32_ipc.automation_response_timeout_ms,
+        ),
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -6038,8 +6038,13 @@ pub const App = struct {
             // `newConfig(.tab)` consults the globally focused surface. Reset
             // and inherit from the explicitly requested host instead.
             config.@"working-directory" = self.config.@"working-directory";
-            if (source) |surface| {
-                inherited_profile_key = try applyProfileConfigFromSource(&config, surface);
+        }
+        if (source) |surface| {
+            // newConfig inherits only the focused surface's working directory;
+            // profile command selection is app-runtime state and must be
+            // applied for both focused and explicit-window automation.
+            inherited_profile_key = try applyProfileConfigFromSource(&config, surface);
+            if (explicit_window_target) {
                 const split_inherit = config.@"split-inherit-working-directory";
                 {
                     defer config.@"split-inherit-working-directory" = split_inherit;
@@ -27605,12 +27610,33 @@ test "automation in-app new_tab action does not query source pwd" {
         .app = &app,
         .hosts = &.{.{ .storage = &host, .register = true, .next_tab_id = 2 }},
         .surfaces = &.{
-            .{ .storage = &source, .host = &host, .register = true },
-            .{ .storage = &created, .host = &host, .window_visible = false, .host_active = false },
+            .{
+                .storage = &source,
+                .host = &host,
+                .register = true,
+                .free_launch_profile_key_on_deinit = true,
+            },
+            .{
+                .storage = &created,
+                .host = &host,
+                .window_visible = false,
+                .host_active = false,
+                .free_launch_profile_key_on_deinit = true,
+            },
         },
         .tabs = &.{.{ .host = &host, .surface = &source, .id = 1 }},
     });
     defer session.deinit();
+
+    const command = [_][:0]const u8{ "pwsh.exe", "-NoLogo" };
+    var profiles = [_]windows_shell.Profile{.{
+        .kind = .pwsh,
+        .key = "pwsh",
+        .label = "PowerShell",
+        .command = .{ .direct = &command },
+    }};
+    host.profiles = &profiles;
+    source.launch_profile_key = try core_app.alloc.dupeZ(u8, "pwsh");
 
     const Hook = struct {
         var host_ref: *Host = undefined;
@@ -27624,10 +27650,14 @@ test "automation in-app new_tab action does not query source pwd" {
 
         fn createSurface(
             hook_app: *App,
-            _: *const configpkg.Config,
+            config: *const configpkg.Config,
             _: LPCWSTR,
             opts: SurfaceInitOptions,
         ) anyerror!*Surface {
+            const direct = config.command.?.direct;
+            try std.testing.expectEqual(@as(usize, 2), direct.len);
+            try std.testing.expectEqualStrings("pwsh.exe", direct[0]);
+            try std.testing.expectEqualStrings("-NoLogo", direct[1]);
             created_ref.app = hook_app;
             created_ref.host = host_ref;
             created_ref.host_id = host_ref.id;
@@ -27649,6 +27679,7 @@ test "automation in-app new_tab action does not query source pwd" {
 
     try std.testing.expect(try app.performAction(.app, .new_tab, {}));
     try std.testing.expectEqual(@as(usize, 0), Hook.pwd_calls);
+    try std.testing.expectEqualStrings("pwsh", created.launch_profile_key.?);
 }
 
 test "automation explicit-window new_tab reanchors inactive host cwd and override wins" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -5676,7 +5676,7 @@ pub const App = struct {
                     explicit_window_target: bool,
                 } = switch (value.target) {
                     .focused => .{
-                        .source = self.focusedSurfaceForUndoRedo(),
+                        .source = self.automationDefaultSurface(),
                         .explicit_window_target = false,
                     },
                     .window_id => |id| .{
@@ -5697,7 +5697,7 @@ pub const App = struct {
                     if (!automationWorkingDirectoryAllowed(cwd)) return error.AutomationPolicyRefused;
                 }
                 const source = switch (value.target) {
-                    .focused => self.focusedSurfaceForUndoRedo(),
+                    .focused => self.automationDefaultSurface(),
                     .surface_id => |id| self.findSurfaceById(id),
                     .window_id => return error.InvalidAutomationTarget,
                 } orelse return error.AutomationTargetNotFound;
@@ -6041,9 +6041,10 @@ pub const App = struct {
         }
         if (source) |surface| {
             // newConfig inherits only the focused surface's working directory;
-            // profile command selection is app-runtime state and must be
-            // applied for both focused and explicit-window automation.
-            inherited_profile_key = try applyProfileConfigFromSource(&config, surface);
+            // Launch command selection is app-runtime state and must be
+            // inherited from the source snapshot rather than re-resolved from
+            // mutable global/profile configuration.
+            inherited_profile_key = try applyLaunchConfigFromSource(&config, surface);
             if (explicit_window_target) {
                 const split_inherit = config.@"split-inherit-working-directory";
                 {
@@ -6083,7 +6084,7 @@ pub const App = struct {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .split);
         defer config.deinit();
         config.@"working-directory" = self.config.@"working-directory";
-        const inherited_profile_key = try applyProfileConfigFromSource(&config, source);
+        const inherited_profile_key = try applyLaunchConfigFromSource(&config, source);
         _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
         if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
         const surface = try self.createWindowSurface(&config, default_title, .{
@@ -6115,10 +6116,17 @@ pub const App = struct {
         return surface;
     }
 
-    fn applyProfileConfigFromSource(
+    fn applyLaunchConfigFromSource(
         config: *configpkg.Config,
         source: *Surface,
     ) !?[]const u8 {
+        if (source.launch_command) |command| {
+            config.command = try command.clone(config._arena.?.allocator());
+            return source.launch_profile_key;
+        }
+
+        // Headless fixtures may not have a captured command. Preserve the
+        // previous profile fallback for those tests.
         const key = source.launch_profile_key orelse return null;
         const host = source.host orelse return null;
         const profile = (try host.profileForKey(key)) orelse return null;
@@ -6696,6 +6704,13 @@ pub const App = struct {
         }
 
         return null;
+    }
+
+    fn automationDefaultSurface(self: *App) ?*Surface {
+        if (self.core_app.focusedSurface()) |core_surface| {
+            if (self.findSurfaceByCore(core_surface)) |surface| return surface;
+        }
+        return self.focusedSurfaceForUndoRedo() orelse self.primarySurface();
     }
 
     fn undoRedoSurfaceForTarget(self: *App, target: apprt.Target) ?*Surface {
@@ -22615,6 +22630,7 @@ pub const Surface = struct {
     /// Recorded from the resolved profile kind at launch, so nothing downstream
     /// has to re-derive "is this SSH?" from the key text.
     launched_ssh: bool = false,
+    launch_command: ?configpkg.Command = null,
     mouse_shape: terminal.MouseShape = .text,
     mouse_visible: bool = true,
     hovered_link: ?[:0]const u8 = null,
@@ -22938,6 +22954,15 @@ pub const Surface = struct {
             session.pty.deinit();
             _ = windows.CloseHandle(session.client_process);
             self.adopted_session = null;
+        };
+        const launch_command = if (app.core_app.first)
+            config.@"initial-command" orelse config.command
+        else
+            config.command;
+        if (launch_command) |command| self.launch_command = try command.clone(app.core_app.alloc);
+        errdefer if (self.launch_command) |*command| {
+            command.deinit(app.core_app.alloc);
+            self.launch_command = null;
         };
         // The DropTarget's surface_ctx must be `self`, but we can't
         // initialise it until `self.*` has been fully assigned above
@@ -26359,6 +26384,10 @@ pub const Surface = struct {
         if (self.launch_profile_key) |value| {
             alloc.free(value);
             self.launch_profile_key = null;
+        }
+        if (self.launch_command) |*command| {
+            command.deinit(alloc);
+            self.launch_command = null;
         }
         if (self.key_table_name) |value| {
             alloc.free(value);
@@ -32405,31 +32434,54 @@ test "win32 session restore refuses ssh profiles regardless of key case" {
     try std.testing.expectEqualStrings("cmd.exe", clone.command.?.direct[0]);
 }
 
-test "win32 automation tab profile inheritance applies the source command" {
+test "win32 automation tab inheritance preserves the captured source command" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
     const command = [_][:0]const u8{ "pwsh.exe", "-NoLogo" };
+    const reloaded_command = [_][:0]const u8{"cmd.exe"};
     var profiles = [_]windows_shell.Profile{.{
         .kind = .pwsh,
         .key = "pwsh",
         .label = "PowerShell",
-        .command = .{ .direct = &command },
+        .command = .{ .direct = &reloaded_command },
     }};
     var host: Host = undefined;
     host.profiles = &profiles;
     var source: Surface = undefined;
     source.host = &host;
     source.launch_profile_key = "pwsh";
+    source.launch_command = .{ .direct = &command };
 
     var config = try configpkg.Config.default(std.testing.allocator);
     defer config.deinit();
-    const inherited = try App.applyProfileConfigFromSource(&config, &source);
+    const inherited = try App.applyLaunchConfigFromSource(&config, &source);
 
     try std.testing.expectEqualStrings("pwsh", inherited.?);
     const direct = config.command.?.direct;
     try std.testing.expectEqual(@as(usize, 2), direct.len);
     try std.testing.expectEqualStrings("pwsh.exe", direct[0]);
     try std.testing.expectEqualStrings("-NoLogo", direct[1]);
+}
+
+test "win32 automation omitted target falls back to the active surface" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var core_app: CoreApp = undefined;
+    var app: App = undefined;
+    var host: Host = undefined;
+    var surface: Surface = undefined;
+    var session: TestSession = .{};
+    try session.init(.{
+        .core_app = &core_app,
+        .app = &app,
+        .hosts = &.{.{ .storage = &host, .register = true }},
+        .surfaces = &.{.{ .storage = &surface, .host = &host, .register = true }},
+        .tabs = &.{.{ .host = &host, .surface = &surface, .id = 1 }},
+    });
+    defer session.deinit();
+
+    try std.testing.expect(!surface.window_focused);
+    try std.testing.expectEqual(@as(?*Surface, &surface), app.automationDefaultSurface());
 }
 
 test "win32 applyProfileConfigByKey applies saved first-pane profile before host exists" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2249,7 +2249,7 @@ fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
         return error.IPCFailed;
     }
 
-    try waitForAutomationCompletion(app, &request.completed);
+    try waitForAutomationCompletion(app, &request.lifecycle);
     if (request.err) |err| return err;
     return request.takeResult() orelse error.IPCFailed;
 }
@@ -2279,7 +2279,7 @@ fn requestAutomationAction(
         return error.IPCFailed;
     }
 
-    try waitForAutomationCompletion(app, &request.completed);
+    try waitForAutomationCompletion(app, &request.lifecycle);
     if (request.err) |err| return err;
 }
 
@@ -2296,15 +2296,31 @@ fn requestAutomationCommand(app: *App, command: apprt.ipc.AutomationCommand) !vo
         return error.IPCFailed;
     }
 
-    try waitForAutomationCompletion(app, &request.completed);
+    try waitForAutomationCompletion(app, &request.lifecycle);
     if (request.err) |err| return err;
 }
 
-fn waitForAutomationCompletion(app: *const App, completed: *const std.atomic.Value(bool)) !void {
+fn waitForAutomationCompletion(
+    app: *const App,
+    lifecycle: *CoreApp.Message.AutomationRequestLifecycle,
+) !void {
     const deadline_ms = sys.GetTickCount64() +| win32_ipc.automation_response_timeout_ms;
-    while (!completed.load(.acquire)) {
-        if (app.ipc_stop_requested.load(.acquire)) return error.IPCFailed;
-        if (sys.GetTickCount64() >= deadline_ms) return error.IpcTimeout;
+    while (true) {
+        switch (lifecycle.load()) {
+            .completed => return,
+            .cancelled => return error.IPCFailed,
+            .pending => {
+                if (app.ipc_stop_requested.load(.acquire)) {
+                    if (lifecycle.cancel()) return error.IPCFailed;
+                } else if (sys.GetTickCount64() >= deadline_ms) {
+                    if (lifecycle.cancel()) return error.IpcTimeout;
+                }
+            },
+            // Once the app thread has claimed a mutating request, the client
+            // waits for its actual outcome instead of reporting a timeout that
+            // could encourage a duplicate retry.
+            .claimed => {},
+        }
         std.Thread.sleep(std.time.ns_per_ms);
     }
 }
@@ -30850,16 +30866,17 @@ test "automation-window-list win32 json skips empty hosts kept alive for undo hi
     try std.testing.expect(pane.get("working_directory").? == .null);
 }
 
-test "win32 timed out automation request remains owned until consumption" {
+test "win32 timed out automation request stays owned and cannot be claimed" {
     const request = try CoreApp.Message.AutomationActionRequest.create(
         std.testing.allocator,
         .focused,
         "new_tab",
     );
     request.retain();
+    try std.testing.expect(request.lifecycle.cancel());
     request.release(); // Producer times out and drops its ownership.
     try std.testing.expectEqualStrings("new_tab", request.action_text);
-    request.completed.store(true, .release);
+    try std.testing.expect(!request.lifecycle.claim());
     request.release(); // Delayed mailbox consumer owns the final reference.
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1120,6 +1120,7 @@ fn sendListWindowsIpc(
     pipe_name: [:0]const u16,
     response_timeout_ms: u64,
 ) !?[]u8 {
+    const request_deadline_ms = automationRequestDeadline(response_timeout_ms);
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         // Both mean "no instance we can reach"; see `connectToIpcPipe`.
         error.FileNotFound, error.PipeUnreachable => return null,
@@ -1128,7 +1129,7 @@ fn sendListWindowsIpc(
     };
     defer _ = windows.CloseHandle(pipe);
 
-    const request = try win32_ipc.encodeListWindowsRequest(alloc);
+    const request = try win32_ipc.encodeListWindowsRequest(alloc, request_deadline_ms);
     defer alloc.free(request);
 
     try win32_ipc.writeAll(pipe, request);
@@ -1146,7 +1147,13 @@ fn sendPerformActionIpc(
     action_text: []const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const request = try win32_ipc.encodePerformActionRequest(alloc, target, action_text);
+    const request_deadline_ms = automationRequestDeadline(response_timeout_ms);
+    const request = try win32_ipc.encodePerformActionRequest(
+        alloc,
+        target,
+        action_text,
+        request_deadline_ms,
+    );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
@@ -1173,7 +1180,11 @@ fn sendFocusIpc(
     target: apprt.ipc.AutomationTarget,
     response_timeout_ms: u64,
 ) !bool {
-    const request = try win32_ipc.encodeFocusRequest(alloc, target);
+    const request = try win32_ipc.encodeFocusRequest(
+        alloc,
+        target,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
@@ -1185,7 +1196,12 @@ fn sendNewTabIpc(
     working_directory: ?[]const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const request = try win32_ipc.encodeNewTabRequest(alloc, target, working_directory);
+    const request = try win32_ipc.encodeNewTabRequest(
+        alloc,
+        target,
+        working_directory,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
@@ -1198,7 +1214,13 @@ fn sendNewSplitIpc(
     working_directory: ?[]const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const request = try win32_ipc.encodeNewSplitRequest(alloc, target, direction, working_directory);
+    const request = try win32_ipc.encodeNewSplitRequest(
+        alloc,
+        target,
+        direction,
+        working_directory,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
@@ -1210,9 +1232,18 @@ fn sendAutomationTextIpc(
     value: []const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const request = try win32_ipc.encodeSendTextRequest(alloc, target, value);
+    const request = try win32_ipc.encodeSendTextRequest(
+        alloc,
+        target,
+        value,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
+}
+
+fn automationRequestDeadline(response_timeout_ms: u64) u64 {
+    return sys.GetTickCount64() +| response_timeout_ms;
 }
 
 fn automationTextAllowed(text: []const u8) bool {
@@ -1490,7 +1521,11 @@ fn sendLaunchLayoutIpc(
     // Validate before probing the pipe. The caller uses `false` as the cold
     // start fallback, so connecting first would let an invalid name spawn an
     // otherwise ordinary window when no instance is listening.
-    const request = try win32_ipc.encodeLaunchLayoutRequest(alloc, name);
+    const request = try win32_ipc.encodeLaunchLayoutRequest(
+        alloc,
+        name,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
 
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
@@ -2083,7 +2118,12 @@ fn newWindowIpcArgumentsAccepted(arguments: ?[]const [:0]const u8) bool {
 }
 
 fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const json = try requestAutomationWindowListJson(app, app.core_app.alloc);
+    const deadline_ms = try win32_ipc.decodeListWindowsDeadline(pipe);
+    const json = try requestAutomationWindowListJson(
+        app,
+        app.core_app.alloc,
+        deadline_ms,
+    );
     defer app.core_app.alloc.free(json);
     try win32_ipc.writeDataResponse(pipe, true, json);
 }
@@ -2098,7 +2138,12 @@ fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
     };
     defer app.core_app.alloc.free(payload.action_text);
 
-    requestAutomationAction(app, payload.target, payload.action_text) catch |err| {
+    requestAutomationAction(
+        app,
+        payload.target,
+        payload.action_text,
+        payload.deadline_ms,
+    ) catch |err| {
         const status: u8 = switch (err) {
             error.InvalidAutomationAction => win32_ipc.ack_invalid_automation_action,
             error.UnsafeAutomationAction => win32_ipc.ack_unsafe_automation_action,
@@ -2113,22 +2158,27 @@ fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
 }
 
 fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const name = win32_ipc.decodeLaunchLayoutPayload(app.core_app.alloc, pipe) catch |err| {
+    const payload = win32_ipc.decodeLaunchLayoutPayload(app.core_app.alloc, pipe) catch |err| {
         log.warn("invalid win32 launch-layout IPC request err={}", .{err});
         try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_action);
         return;
     };
-    defer app.core_app.alloc.free(name);
+    defer app.core_app.alloc.free(payload.name);
 
     // Name validation restricts this to an unambiguous action payload.
     const action_text = try std.fmt.allocPrint(
         app.core_app.alloc,
         "launch_layout:{s}",
-        .{name},
+        .{payload.name},
     );
     defer app.core_app.alloc.free(action_text);
 
-    requestAutomationAction(app, .focused, action_text) catch |err| {
+    requestAutomationAction(
+        app,
+        .focused,
+        action_text,
+        payload.deadline_ms,
+    ) catch |err| {
         const status: u8 = switch (err) {
             error.InvalidAutomationAction => win32_ipc.ack_invalid_automation_action,
             error.UnsafeAutomationAction => win32_ipc.ack_unsafe_automation_action,
@@ -2143,14 +2193,18 @@ fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE) !void {
 }
 
 fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const target = win32_ipc.decodeFocusPayload(pipe) catch |err| switch (err) {
+    const payload = win32_ipc.decodeFocusPayload(pipe) catch |err| switch (err) {
         error.InvalidAutomationTarget => {
             try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_target);
             return;
         },
         else => return err,
     };
-    requestAutomationCommand(app, .{ .focus = target }) catch |err| {
+    requestAutomationCommand(
+        app,
+        .{ .focus = payload.target },
+        payload.deadline_ms,
+    ) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2171,10 +2225,14 @@ fn handleSendTextIpcClient(app: *App, pipe: windows.HANDLE) !void {
         else => return err,
     };
     defer payload.deinit(app.core_app.alloc);
-    requestAutomationCommand(app, .{ .send_text = .{
-        .target = payload.target,
-        .text = payload.text,
-    } }) catch |err| {
+    requestAutomationCommand(
+        app,
+        .{ .send_text = .{
+            .target = payload.target,
+            .text = payload.text,
+        } },
+        payload.deadline_ms,
+    ) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2202,10 +2260,14 @@ fn handleNewTabIpcClient(app: *App, pipe: windows.HANDLE) !void {
         try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
         return;
     };
-    requestAutomationCommand(app, .{ .new_tab = .{
-        .target = payload.target,
-        .working_directory = payload.working_directory,
-    } }) catch |err| {
+    requestAutomationCommand(
+        app,
+        .{ .new_tab = .{
+            .target = payload.target,
+            .working_directory = payload.working_directory,
+        } },
+        payload.deadline_ms,
+    ) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2224,11 +2286,15 @@ fn handleNewSplitIpcClient(app: *App, pipe: windows.HANDLE) !void {
         try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
         return;
     };
-    requestAutomationCommand(app, .{ .new_split = .{
-        .target = payload.target,
-        .direction = payload.direction,
-        .working_directory = payload.working_directory,
-    } }) catch |err| {
+    requestAutomationCommand(
+        app,
+        .{ .new_split = .{
+            .target = payload.target,
+            .direction = payload.direction,
+            .working_directory = payload.working_directory,
+        } },
+        payload.deadline_ms,
+    ) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2236,8 +2302,16 @@ fn handleNewSplitIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
-fn requestAutomationWindowListJson(app: *App, alloc: Allocator) ![]u8 {
-    const request = try CoreApp.Message.AutomationWindowListRequest.create(alloc);
+fn requestAutomationWindowListJson(
+    app: *App,
+    alloc: Allocator,
+    client_deadline_ms: u64,
+) ![]u8 {
+    const request = try CoreApp.Message.AutomationWindowListRequest.create(
+        alloc,
+        serverAutomationDeadline(client_deadline_ms),
+        automationNowMs,
+    );
     defer request.release();
     request.retain(); // Mailbox-consumer ownership.
     const mailbox: CoreApp.Mailbox = .{
@@ -2258,6 +2332,7 @@ fn requestAutomationAction(
     app: *App,
     target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
+    client_deadline_ms: u64,
 ) !void {
     if (action_text.len == 0 or action_text.len > win32_ipc.max_action_text_len) {
         return error.InvalidAutomationAction;
@@ -2267,6 +2342,8 @@ fn requestAutomationAction(
         app.core_app.alloc,
         target,
         action_text,
+        serverAutomationDeadline(client_deadline_ms),
+        automationNowMs,
     );
     defer request.release();
     request.retain(); // Mailbox-consumer ownership.
@@ -2283,8 +2360,17 @@ fn requestAutomationAction(
     if (request.err) |err| return err;
 }
 
-fn requestAutomationCommand(app: *App, command: apprt.ipc.AutomationCommand) !void {
-    const request = try CoreApp.Message.AutomationCommandRequest.create(app.core_app.alloc, command);
+fn requestAutomationCommand(
+    app: *App,
+    command: apprt.ipc.AutomationCommand,
+    client_deadline_ms: u64,
+) !void {
+    const request = try CoreApp.Message.AutomationCommandRequest.create(
+        app.core_app.alloc,
+        command,
+        serverAutomationDeadline(client_deadline_ms),
+        automationNowMs,
+    );
     defer request.release();
     request.retain(); // Mailbox-consumer ownership.
     const mailbox: CoreApp.Mailbox = .{
@@ -2304,7 +2390,6 @@ fn waitForAutomationCompletion(
     app: *const App,
     lifecycle: *CoreApp.Message.AutomationRequestLifecycle,
 ) !void {
-    const deadline_ms = sys.GetTickCount64() +| win32_ipc.automation_response_timeout_ms;
     while (true) {
         switch (lifecycle.load()) {
             .completed => return,
@@ -2312,7 +2397,7 @@ fn waitForAutomationCompletion(
             .pending => {
                 if (app.ipc_stop_requested.load(.acquire)) {
                     if (lifecycle.cancel()) return error.IPCFailed;
-                } else if (sys.GetTickCount64() >= deadline_ms) {
+                } else if (automationNowMs() >= lifecycle.deadline_ms) {
                     if (lifecycle.cancel()) return error.IpcTimeout;
                 }
             },
@@ -2323,6 +2408,17 @@ fn waitForAutomationCompletion(
         }
         std.Thread.sleep(std.time.ns_per_ms);
     }
+}
+
+fn automationNowMs() u64 {
+    return sys.GetTickCount64();
+}
+
+fn serverAutomationDeadline(client_deadline_ms: u64) u64 {
+    return @min(
+        client_deadline_ms,
+        automationNowMs() +| win32_ipc.automation_response_timeout_ms,
+    );
 }
 
 pub fn getProcAddress(name: [*:0]const u8) callconv(.c) ?*const anyopaque {
@@ -30871,6 +30967,8 @@ test "win32 timed out automation request stays owned and cannot be claimed" {
         std.testing.allocator,
         .focused,
         "new_tab",
+        std.math.maxInt(u64),
+        automationNowMs,
     );
     request.retain();
     try std.testing.expect(request.lifecycle.cancel());
@@ -31962,16 +32060,20 @@ test "win32 IPC silent synchronous client read is bounded" {
     );
 }
 
-test "win32 win32_ipc.encodeListWindowsRequest preserves legacy zero-argc trailer" {
+test "win32 win32_ipc.encodeListWindowsRequest carries the response deadline" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
-    const request = try win32_ipc.encodeListWindowsRequest(std.testing.allocator);
+    const deadline_ms: u64 = 0x0102030405060708;
+    const request = try win32_ipc.encodeListWindowsRequest(
+        std.testing.allocator,
+        deadline_ms,
+    );
     defer std.testing.allocator.free(request);
 
-    try std.testing.expectEqual(@as(usize, 9), request.len);
+    try std.testing.expectEqual(@as(usize, 13), request.len);
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
     try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.list_windows), request[4]);
-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, request[5..9], .little));
+    try std.testing.expectEqual(deadline_ms, std.mem.readInt(u64, request[5..13], .little));
 }
 
 test "automation-action win32 ipc encodes focused action request" {
@@ -31981,15 +32083,17 @@ test "automation-action win32 ipc encodes focused action request" {
         std.testing.allocator,
         .focused,
         "new_tab",
+        0x0102030405060708,
     );
     defer std.testing.allocator.free(request);
 
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
     try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action), request[4]);
-    try std.testing.expectEqual(@as(u8, 0), request[5]);
-    try std.testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, request[6..14], .little));
-    try std.testing.expectEqual(@as(u32, 7), std.mem.readInt(u32, request[14..18], .little));
-    try std.testing.expectEqualStrings("new_tab", request[18..]);
+    try std.testing.expectEqual(@as(u64, 0x0102030405060708), std.mem.readInt(u64, request[5..13], .little));
+    try std.testing.expectEqual(@as(u8, 0), request[13]);
+    try std.testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, request[14..22], .little));
+    try std.testing.expectEqual(@as(u32, 7), std.mem.readInt(u32, request[22..26], .little));
+    try std.testing.expectEqualStrings("new_tab", request[26..]);
 }
 
 test "win32 launch-layout IPC argument scan isolates the layout name" {
@@ -32061,15 +32165,17 @@ test "automation-action win32 ipc encodes surface action request" {
         std.testing.allocator,
         .{ .surface_id = 42 },
         "toggle_fullscreen",
+        0x0102030405060708,
     );
     defer std.testing.allocator.free(request);
 
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
     try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action), request[4]);
-    try std.testing.expectEqual(@as(u8, 1), request[5]);
-    try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, request[6..14], .little));
-    try std.testing.expectEqual(@as(u32, 17), std.mem.readInt(u32, request[14..18], .little));
-    try std.testing.expectEqualStrings("toggle_fullscreen", request[18..]);
+    try std.testing.expectEqual(@as(u64, 0x0102030405060708), std.mem.readInt(u64, request[5..13], .little));
+    try std.testing.expectEqual(@as(u8, 1), request[13]);
+    try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, request[14..22], .little));
+    try std.testing.expectEqual(@as(u32, 17), std.mem.readInt(u32, request[22..26], .little));
+    try std.testing.expectEqualStrings("toggle_fullscreen", request[26..]);
 }
 
 test "automation-action win32 ipc rejects oversized action before encode" {
@@ -32081,7 +32187,12 @@ test "automation-action win32 ipc rejects oversized action before encode" {
 
     try std.testing.expectError(
         error.InvalidAutomationAction,
-        win32_ipc.encodePerformActionRequest(std.testing.allocator, .focused, action_text),
+        win32_ipc.encodePerformActionRequest(
+            std.testing.allocator,
+            .focused,
+            action_text,
+            0x0102030405060708,
+        ),
     );
 }
 
@@ -32097,10 +32208,11 @@ test "automation-action win32 ipc rejects oversized decoded action" {
     });
     defer file.close();
 
-    var header: [13]u8 = undefined;
-    header[0] = 0;
-    std.mem.writeInt(u64, header[1..9], 0, .little);
-    std.mem.writeInt(u32, header[9..13], win32_ipc.max_action_text_len + 1, .little);
+    var header: [21]u8 = undefined;
+    std.mem.writeInt(u64, header[0..8], std.math.maxInt(u64), .little);
+    header[8] = 0;
+    std.mem.writeInt(u64, header[9..17], 0, .little);
+    std.mem.writeInt(u32, header[17..21], win32_ipc.max_action_text_len + 1, .little);
     try file.writeAll(&header);
     try file.seekTo(0);
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -717,6 +717,7 @@ fn shouldTreatWslSplitPwdAsStartupFallback(
 }
 
 fn applySplitWorkingDirectoryFromSource(
+    app: *App,
     config: *configpkg.Config,
     source: *Surface,
     startup_cwd: ?[]const u8,
@@ -724,7 +725,10 @@ fn applySplitWorkingDirectoryFromSource(
     if (!config.@"split-inherit-working-directory") return false;
 
     const alloc = config._arena.?.allocator();
-    const live_pwd = source.core().pwd(alloc) catch |err| blk: {
+    const live_pwd = (if (app.test_automation_pwd) |query|
+        query(alloc, source)
+    else
+        source.core().pwd(alloc)) catch |err| blk: {
         log.warn("win32 split cwd inheritance could not query live cwd err={}", .{err});
         break :blk null;
     };
@@ -1119,6 +1123,16 @@ fn sendPerformActionIpc(
     action_text: []const u8,
     response_timeout_ms: u64,
 ) !bool {
+    const request = try win32_ipc.encodePerformActionRequest(alloc, target, action_text);
+    defer alloc.free(request);
+    return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
+}
+
+fn sendAutomationAckRequest(
+    pipe_name: [:0]const u16,
+    request: []const u8,
+    response_timeout_ms: u64,
+) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         // Both mean "no instance we can reach"; see `connectToIpcPipe`.
         error.FileNotFound, error.PipeUnreachable => return false,
@@ -1126,12 +1140,8 @@ fn sendPerformActionIpc(
         else => return err,
     };
     defer _ = windows.CloseHandle(pipe);
-
-    const request = try win32_ipc.encodePerformActionRequest(alloc, target, action_text);
-    defer alloc.free(request);
-
     try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+    return win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
 }
 
 fn sendFocusIpc(
@@ -1140,16 +1150,34 @@ fn sendFocusIpc(
     target: apprt.ipc.AutomationTarget,
     response_timeout_ms: u64,
 ) !bool {
-    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
-        error.FileNotFound => return false,
-        else => return err,
-    };
-    defer _ = windows.CloseHandle(pipe);
-
     const request = try win32_ipc.encodeFocusRequest(alloc, target);
     defer alloc.free(request);
-    try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+    return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
+}
+
+fn sendNewTabIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+    target: apprt.ipc.AutomationTarget,
+    working_directory: ?[]const u8,
+    response_timeout_ms: u64,
+) !bool {
+    const request = try win32_ipc.encodeNewTabRequest(alloc, target, working_directory);
+    defer alloc.free(request);
+    return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
+}
+
+fn sendNewSplitIpc(
+    alloc: Allocator,
+    pipe_name: [:0]const u16,
+    target: apprt.ipc.AutomationTarget,
+    direction: apprt.ipc.AutomationSplitDirection,
+    working_directory: ?[]const u8,
+    response_timeout_ms: u64,
+) !bool {
+    const request = try win32_ipc.encodeNewSplitRequest(alloc, target, direction, working_directory);
+    defer alloc.free(request);
+    return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
 
 fn sendAutomationTextIpc(
@@ -1159,16 +1187,9 @@ fn sendAutomationTextIpc(
     value: []const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
-        error.FileNotFound => return false,
-        else => return err,
-    };
-    defer _ = windows.CloseHandle(pipe);
-
     const request = try win32_ipc.encodeSendTextRequest(alloc, target, value);
     defer alloc.free(request);
-    try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+    return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
 }
 
 fn automationTextAllowed(text: []const u8) bool {
@@ -1511,6 +1532,45 @@ fn scanLaunchLayoutIpcArgument(
 ///
 /// This function does not log, so that it stays a pure predicate over argv
 /// and can be unit tested; every caller logs the rejection it handles.
+fn automationWorkingDirectoryValue(value: []const u8) []const u8 {
+    var result = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (result.len >= 2 and result[0] == '"' and result[result.len - 1] == '"') {
+        result = std.mem.trim(u8, result[1 .. result.len - 1], &std.ascii.whitespace);
+    }
+    return result;
+}
+
+/// Mirrors #185's `forwardedWorkingDirectoryAllowed` on the receiver.
+fn automationWorkingDirectoryAllowed(value: []const u8) bool {
+    const path = automationWorkingDirectoryValue(value);
+    if (std.mem.eql(u8, path, "home") or std.mem.eql(u8, path, "inherit") or
+        std.mem.eql(u8, path, "~")) return true;
+    if (path.len >= 2 and path[0] == '~' and (path[1] == '/' or path[1] == '\\')) return true;
+    return path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
+        (path[2] == '/' or path[2] == '\\');
+}
+
+fn applyAutomationWorkingDirectory(config: *configpkg.Config, value: []const u8) !void {
+    if (!automationWorkingDirectoryAllowed(value)) return error.AutomationPolicyRefused;
+    const alloc = config._arena.?.allocator();
+    const path = automationWorkingDirectoryValue(value);
+    if (std.mem.eql(u8, path, "~")) {
+        config.@"working-directory" = .home;
+        return;
+    }
+    var working_directory: configpkg.WorkingDirectory = undefined;
+    if (path.len >= 2 and path[0] == '~' and path[1] == '\\') {
+        const normalized = try alloc.dupe(u8, path);
+        normalized[1] = '/';
+        working_directory = .{ .path = normalized };
+    } else {
+        working_directory = .home;
+        try working_directory.parseCLI(alloc, path);
+    }
+    try working_directory.finalize(alloc);
+    config.@"working-directory" = working_directory;
+}
+
 fn applyNewWindowArguments(
     alloc_gpa: Allocator,
     config: *configpkg.Config,
@@ -1943,6 +2003,14 @@ fn handleIpcClient(app: *App, pipe: windows.HANDLE) !win32_ipc.RequestKind {
             log.warn("failed to process win32 launch-layout IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
+        .new_tab => handleNewTabIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation new-tab IPC request err={}", .{err});
+            try win32_ipc.writeAck(pipe, false);
+        },
+        .new_split => handleNewSplitIpcClient(app, pipe) catch |err| {
+            log.warn("failed to process win32 automation new-split IPC request err={}", .{err});
+            try win32_ipc.writeAck(pipe, false);
+        },
         .focus => handleFocusIpcClient(app, pipe) catch |err| {
             log.warn("failed to process win32 automation focus IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
@@ -2060,11 +2128,7 @@ fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE) !void {
         else => return err,
     };
     requestAutomationCommand(app, .{ .focus = target }) catch |err| {
-        const status: u8 = switch (err) {
-            error.InvalidAutomationTarget => win32_ipc.ack_invalid_automation_target,
-            error.AutomationTargetNotFound => win32_ipc.ack_automation_target_not_found,
-            else => return err,
-        };
+        const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
     };
@@ -2088,12 +2152,61 @@ fn handleSendTextIpcClient(app: *App, pipe: windows.HANDLE) !void {
         .target = payload.target,
         .text = payload.text,
     } }) catch |err| {
-        const status: u8 = switch (err) {
-            error.InvalidAutomationTarget => win32_ipc.ack_invalid_automation_target,
-            error.AutomationTargetNotFound => win32_ipc.ack_automation_target_not_found,
-            error.AutomationPolicyRefused => win32_ipc.ack_automation_policy_refused,
-            else => return err,
-        };
+        const status = automationCommandAckStatus(err) orelse return err;
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    try win32_ipc.writeAck(pipe, true);
+}
+
+fn automationCommandAckStatus(err: anyerror) ?u8 {
+    return switch (err) {
+        error.InvalidAutomationTarget, error.InvalidAutomationDirection => win32_ipc.ack_invalid_automation_target,
+        error.AutomationTargetNotFound => win32_ipc.ack_automation_target_not_found,
+        error.AutomationPolicyRefused, error.InvalidAutomationWorkingDirectory => win32_ipc.ack_automation_policy_refused,
+        else => null,
+    };
+}
+
+fn handleNewTabIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    var payload = win32_ipc.decodeNewTabPayload(app.core_app.alloc, pipe) catch |err| {
+        const status = automationCommandAckStatus(err) orelse return err;
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    defer payload.deinit(app.core_app.alloc);
+    if (payload.working_directory) |cwd| if (!automationWorkingDirectoryAllowed(cwd)) {
+        try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
+        return;
+    };
+    requestAutomationCommand(app, .{ .new_tab = .{
+        .target = payload.target,
+        .working_directory = payload.working_directory,
+    } }) catch |err| {
+        const status = automationCommandAckStatus(err) orelse return err;
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    try win32_ipc.writeAck(pipe, true);
+}
+
+fn handleNewSplitIpcClient(app: *App, pipe: windows.HANDLE) !void {
+    var payload = win32_ipc.decodeNewSplitPayload(app.core_app.alloc, pipe) catch |err| {
+        const status = automationCommandAckStatus(err) orelse return err;
+        try win32_ipc.writeAckStatus(pipe, status);
+        return;
+    };
+    defer payload.deinit(app.core_app.alloc);
+    if (payload.working_directory) |cwd| if (!automationWorkingDirectoryAllowed(cwd)) {
+        try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
+        return;
+    };
+    requestAutomationCommand(app, .{ .new_split = .{
+        .target = payload.target,
+        .direction = payload.direction,
+        .working_directory = payload.working_directory,
+    } }) catch |err| {
+        const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
     };
@@ -4777,67 +4890,14 @@ pub const App = struct {
             },
 
             .new_tab => {
-                var config = try apprt.surface.newConfig(
-                    self.core_app,
-                    &self.config,
-                    .tab,
-                );
-                defer config.deinit();
                 const source = self.findSurfaceForTarget(target);
-                const surface = try self.createWindowSurface(&config, default_title, .{
-                    .host_id = if (source) |v| v.host_id else null,
-                    .tab_insert_index = if (source) |v| if (v.host) |host|
-                        windowNewTabInsertIndex(host, self.config.@"window-new-tab-position")
-                    else
-                        null else null,
-                    .clone_state_from = source,
-                });
-                if (source) |v| {
-                    v.invalidateRedoForUnsupportedTabStructuralAction();
-                }
-                self.activateSurface(surface);
+                _ = try self.createNewTab(source, null);
                 return true;
             },
 
             .new_split => {
-                var config = try apprt.surface.newConfig(
-                    self.core_app,
-                    &self.config,
-                    .split,
-                );
-                defer config.deinit();
                 const source = self.findSurfaceForTarget(target) orelse return false;
-                const tab_info = self.findTabForSurface(source) orelse return false;
-                const inherited_profile_key = try applySplitProfileConfigFromSource(&config, source);
-                if (shouldInheritSplitWorkingDirectory(source.launched_ssh)) {
-                    _ = try applySplitWorkingDirectoryFromSource(&config, source, self.startup_cwd);
-                }
-                const split_direction = splitDirectionFromAction(value);
-                const surface = try self.createWindowSurface(&config, default_title, .{
-                    .host_id = source.host_id,
-                    .tab_id = tab_info.tab.id,
-                    .clone_state_from = source,
-                    .split_direction = split_direction,
-                });
-                if (inherited_profile_key) |key| {
-                    try appendOwnedString(self.core_app.alloc, &surface.launch_profile_key, key);
-                    surface.launched_ssh = source.launched_ssh;
-                }
-                tab_info.tab.clearRedoHistory();
-                if (tab_info.host.pushStructuralUndo(.{
-                    .kind = .split_create,
-                    .timestamp_ms = sys.GetTickCount64(),
-                    .sequence_id = self.nextUndoSequence(),
-                    .payload = .{ .split_create = .{
-                        .source_surface = source,
-                        .created_surface = surface,
-                        .direction = split_direction,
-                    } },
-                })) |_| {} else |err| {
-                    log.warn("new_split undo snapshot failed err={}", .{err});
-                    _ = tab_info.host.clearStructuralRedo();
-                }
-                self.activateSurface(surface);
+                _ = try self.createNewSplit(source, splitDirectionFromAction(value), null);
                 return true;
             },
 
@@ -5549,6 +5609,44 @@ pub const App = struct {
         return try sendFocusIpc(alloc, pipe_name, automation_target, response_timeout_ms);
     }
 
+    pub fn newAutomationTab(
+        alloc: Allocator,
+        instance_target: apprt.ipc.Target,
+        automation_target: apprt.ipc.AutomationTarget,
+        working_directory: ?[]const u8,
+        response_timeout_ms: u64,
+    ) !bool {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, instance_target);
+        defer alloc.free(pipe_name);
+        return try sendNewTabIpc(
+            alloc,
+            pipe_name,
+            automation_target,
+            working_directory,
+            response_timeout_ms,
+        );
+    }
+
+    pub fn newAutomationSplit(
+        alloc: Allocator,
+        instance_target: apprt.ipc.Target,
+        automation_target: apprt.ipc.AutomationTarget,
+        direction: apprt.ipc.AutomationSplitDirection,
+        working_directory: ?[]const u8,
+        response_timeout_ms: u64,
+    ) !bool {
+        const pipe_name = try resolveIpcPipeNameForTarget(alloc, instance_target);
+        defer alloc.free(pipe_name);
+        return try sendNewSplitIpc(
+            alloc,
+            pipe_name,
+            automation_target,
+            direction,
+            working_directory,
+            response_timeout_ms,
+        );
+    }
+
     pub fn sendAutomationText(
         alloc: Allocator,
         instance_target: apprt.ipc.Target,
@@ -5569,6 +5667,34 @@ pub const App = struct {
 
     pub fn performAutomationCommand(self: *App, command: apprt.ipc.AutomationCommand) !void {
         switch (command) {
+            .new_tab => |value| {
+                if (value.working_directory) |cwd| {
+                    if (!automationWorkingDirectoryAllowed(cwd)) return error.AutomationPolicyRefused;
+                }
+                const source = switch (value.target) {
+                    .focused => self.focusedSurfaceForUndoRedo(),
+                    .window_id => |id| self.activeSurfaceForHost(id),
+                    .surface_id => return error.InvalidAutomationTarget,
+                } orelse return error.AutomationTargetNotFound;
+                _ = try self.createNewTab(source, value.working_directory);
+            },
+            .new_split => |value| {
+                if (value.working_directory) |cwd| {
+                    if (!automationWorkingDirectoryAllowed(cwd)) return error.AutomationPolicyRefused;
+                }
+                const source = switch (value.target) {
+                    .focused => self.focusedSurfaceForUndoRedo(),
+                    .surface_id => |id| self.findSurfaceById(id),
+                    .window_id => return error.InvalidAutomationTarget,
+                } orelse return error.AutomationTargetNotFound;
+                const direction: SplitTreeSurface.Split.Direction = switch (value.direction) {
+                    .left => .left,
+                    .right => .right,
+                    .up => .up,
+                    .down => .down,
+                };
+                _ = try self.createNewSplit(source, direction, value.working_directory);
+            },
             .focus => |target| {
                 const surface = switch (target) {
                     .surface_id => |id| self.findSurfaceById(id),
@@ -5881,6 +6007,76 @@ pub const App = struct {
 
         try surface.init(self, title, config, opts);
         if (opts.host_id == null) self.consumePendingToastActivation();
+        return surface;
+    }
+
+    fn createNewTab(self: *App, source: ?*Surface, working_directory: ?[]const u8) !*Surface {
+        var config = try apprt.surface.newConfig(self.core_app, &self.config, .tab);
+        defer config.deinit();
+        // `newConfig(.tab)` consults the globally focused surface. Reset and
+        // inherit from the exact requested host instead.
+        config.@"working-directory" = self.config.@"working-directory";
+        if (source) |surface| {
+            const split_inherit = config.@"split-inherit-working-directory";
+            {
+                defer config.@"split-inherit-working-directory" = split_inherit;
+                config.@"split-inherit-working-directory" = config.@"tab-inherit-working-directory";
+                _ = try applySplitWorkingDirectoryFromSource(self, &config, surface, self.startup_cwd);
+            }
+        }
+        if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
+        const surface = try self.createWindowSurface(&config, default_title, .{
+            .host_id = if (source) |value| value.host_id else null,
+            .tab_insert_index = if (source) |value| if (value.host) |host|
+                windowNewTabInsertIndex(host, self.config.@"window-new-tab-position")
+            else
+                null else null,
+            .clone_state_from = source,
+        });
+        if (source) |value| value.invalidateRedoForUnsupportedTabStructuralAction();
+        self.activateSurface(surface);
+        return surface;
+    }
+
+    fn createNewSplit(
+        self: *App,
+        source: *Surface,
+        direction: SplitTreeSurface.Split.Direction,
+        working_directory: ?[]const u8,
+    ) !*Surface {
+        const tab_info = self.findTabForSurface(source) orelse return error.AutomationTargetNotFound;
+        var config = try apprt.surface.newConfig(self.core_app, &self.config, .split);
+        defer config.deinit();
+        config.@"working-directory" = self.config.@"working-directory";
+        const inherited_profile_key = try applySplitProfileConfigFromSource(&config, source);
+        _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
+        if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
+        const surface = try self.createWindowSurface(&config, default_title, .{
+            .host_id = source.host_id,
+            .tab_id = tab_info.tab.id,
+            .clone_state_from = source,
+            .split_direction = direction,
+        });
+        if (inherited_profile_key) |key| try appendOwnedString(
+            self.core_app.alloc,
+            &surface.launch_profile_key,
+            key,
+        );
+        tab_info.tab.clearRedoHistory();
+        if (tab_info.host.pushStructuralUndo(.{
+            .kind = .split_create,
+            .timestamp_ms = sys.GetTickCount64(),
+            .sequence_id = self.nextUndoSequence(),
+            .payload = .{ .split_create = .{
+                .source_surface = source,
+                .created_surface = surface,
+                .direction = direction,
+            } },
+        })) |_| {} else |err| {
+            log.warn("new_split undo snapshot failed err={}", .{err});
+            _ = tab_info.host.clearStructuralRedo();
+        }
+        self.activateSurface(surface);
         return surface;
     }
 
@@ -31226,6 +31422,30 @@ test "automation focus selects exact targets without fallback" {
         error.InvalidAutomationTarget,
         app.performAutomationCommand(.{ .focus = .focused }),
     );
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        app.performAutomationCommand(.{ .new_tab = .{
+            .target = .{ .surface_id = 102 },
+            .working_directory = null,
+        } }),
+    );
+    try std.testing.expectError(
+        error.AutomationTargetNotFound,
+        app.performAutomationCommand(.{ .new_split = .{
+            .target = .{ .surface_id = 999 },
+            .direction = .right,
+            .working_directory = null,
+        } }),
+    );
+}
+
+test "automation working directory receiver policy mirrors forwarded syntax" {
+    for ([_][]const u8{ "home", "inherit", "~", "~/x", "~\\x", "C:\\x" }) |value| {
+        try std.testing.expect(automationWorkingDirectoryAllowed(value));
+    }
+    for ([_][]const u8{ "", "relative", "C:relative", "\\\\host\\share", "//host/share", "\\\\?\\C:\\x", "\\\\.\\x" }) |value| {
+        try std.testing.expect(!automationWorkingDirectoryAllowed(value));
+    }
 }
 
 test "automation send text enforces receiver policy and protected paste path" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1120,7 +1120,6 @@ fn sendListWindowsIpc(
     pipe_name: [:0]const u16,
     response_timeout_ms: u64,
 ) !?[]u8 {
-    const request_deadline_ms = automationRequestDeadline(response_timeout_ms);
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
         // Both mean "no instance we can reach"; see `connectToIpcPipe`.
         error.FileNotFound, error.PipeUnreachable => return null,
@@ -1129,7 +1128,10 @@ fn sendListWindowsIpc(
     };
     defer _ = windows.CloseHandle(pipe);
 
-    const request = try win32_ipc.encodeListWindowsRequest(alloc, request_deadline_ms);
+    const request = try win32_ipc.encodeListWindowsRequest(
+        alloc,
+        automationRequestDeadline(response_timeout_ms),
+    );
     defer alloc.free(request);
 
     try win32_ipc.writeAll(pipe, request);
@@ -1147,12 +1149,11 @@ fn sendPerformActionIpc(
     action_text: []const u8,
     response_timeout_ms: u64,
 ) !bool {
-    const request_deadline_ms = automationRequestDeadline(response_timeout_ms);
     const request = try win32_ipc.encodePerformActionRequest(
         alloc,
         target,
         action_text,
-        request_deadline_ms,
+        0,
     );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
@@ -1160,7 +1161,7 @@ fn sendPerformActionIpc(
 
 fn sendAutomationAckRequest(
     pipe_name: [:0]const u16,
-    request: []const u8,
+    request: []u8,
     response_timeout_ms: u64,
 ) !bool {
     const pipe = connectToIpcPipe(pipe_name) catch |err| switch (err) {
@@ -1170,6 +1171,13 @@ fn sendAutomationAckRequest(
         else => return err,
     };
     defer _ = windows.CloseHandle(pipe);
+    if (request.len < 13) return error.InvalidIpcRequest;
+    std.mem.writeInt(
+        u64,
+        request[5..13],
+        automationRequestDeadline(response_timeout_ms),
+        .little,
+    );
     try win32_ipc.writeAll(pipe, request);
     return win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
 }
@@ -1183,7 +1191,7 @@ fn sendFocusIpc(
     const request = try win32_ipc.encodeFocusRequest(
         alloc,
         target,
-        automationRequestDeadline(response_timeout_ms),
+        0,
     );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
@@ -1200,7 +1208,7 @@ fn sendNewTabIpc(
         alloc,
         target,
         working_directory,
-        automationRequestDeadline(response_timeout_ms),
+        0,
     );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
@@ -1219,7 +1227,7 @@ fn sendNewSplitIpc(
         target,
         direction,
         working_directory,
-        automationRequestDeadline(response_timeout_ms),
+        0,
     );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
@@ -1236,7 +1244,7 @@ fn sendAutomationTextIpc(
         alloc,
         target,
         value,
-        automationRequestDeadline(response_timeout_ms),
+        0,
     );
     defer alloc.free(request);
     return sendAutomationAckRequest(pipe_name, request, response_timeout_ms);
@@ -1524,7 +1532,7 @@ fn sendLaunchLayoutIpc(
     const request = try win32_ipc.encodeLaunchLayoutRequest(
         alloc,
         name,
-        automationRequestDeadline(response_timeout_ms),
+        0,
     );
     defer alloc.free(request);
 
@@ -1535,6 +1543,12 @@ fn sendLaunchLayoutIpc(
     };
     defer _ = windows.CloseHandle(pipe);
 
+    std.mem.writeInt(
+        u64,
+        request[5..13],
+        automationRequestDeadline(response_timeout_ms),
+        .little,
+    );
     try win32_ipc.writeAll(pipe, request);
     return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
 }
@@ -2049,31 +2063,59 @@ fn handleIpcClient(app: *App, pipe: windows.HANDLE) !win32_ipc.RequestKind {
             log.warn("failed to process win32 new-window IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .list_windows => handleListWindowsIpcClient(app, pipe) catch |err| {
+        .list_windows, .list_windows_timed => handleListWindowsIpcClient(
+            app,
+            pipe,
+            kind == .list_windows_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation list IPC request err={}", .{err});
             try win32_ipc.writeDataResponse(pipe, false, "");
         },
-        .perform_action => handlePerformActionIpcClient(app, pipe) catch |err| {
+        .perform_action, .perform_action_timed => handlePerformActionIpcClient(
+            app,
+            pipe,
+            kind == .perform_action_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation action IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .launch_layout => handleLaunchLayoutIpcClient(app, pipe) catch |err| {
+        .launch_layout, .launch_layout_timed => handleLaunchLayoutIpcClient(
+            app,
+            pipe,
+            kind == .launch_layout_timed,
+        ) catch |err| {
             log.warn("failed to process win32 launch-layout IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .new_tab => handleNewTabIpcClient(app, pipe) catch |err| {
+        .new_tab, .new_tab_timed => handleNewTabIpcClient(
+            app,
+            pipe,
+            kind == .new_tab_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation new-tab IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .new_split => handleNewSplitIpcClient(app, pipe) catch |err| {
+        .new_split, .new_split_timed => handleNewSplitIpcClient(
+            app,
+            pipe,
+            kind == .new_split_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation new-split IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .focus => handleFocusIpcClient(app, pipe) catch |err| {
+        .focus, .focus_timed => handleFocusIpcClient(
+            app,
+            pipe,
+            kind == .focus_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation focus IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
-        .send_text => handleSendTextIpcClient(app, pipe) catch |err| {
+        .send_text, .send_text_timed => handleSendTextIpcClient(
+            app,
+            pipe,
+            kind == .send_text_timed,
+        ) catch |err| {
             log.warn("failed to process win32 automation send-text IPC request err={}", .{err});
             try win32_ipc.writeAck(pipe, false);
         },
@@ -2117,8 +2159,8 @@ fn newWindowIpcArgumentsAccepted(arguments: ?[]const [:0]const u8) bool {
     };
 }
 
-fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const deadline_ms = try win32_ipc.decodeListWindowsDeadline(pipe);
+fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    const deadline_ms = try win32_ipc.decodeListWindowsDeadline(pipe, timed);
     const json = try requestAutomationWindowListJson(
         app,
         app.core_app.alloc,
@@ -2128,8 +2170,8 @@ fn handleListWindowsIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeDataResponse(pipe, true, json);
 }
 
-fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const payload = win32_ipc.decodePerformActionPayload(app.core_app.alloc, pipe) catch |err| switch (err) {
+fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    const payload = win32_ipc.decodePerformActionPayload(app.core_app.alloc, pipe, timed) catch |err| switch (err) {
         error.InvalidAutomationAction => {
             try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_action);
             return;
@@ -2157,8 +2199,8 @@ fn handlePerformActionIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
-fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const payload = win32_ipc.decodeLaunchLayoutPayload(app.core_app.alloc, pipe) catch |err| {
+fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    const payload = win32_ipc.decodeLaunchLayoutPayload(app.core_app.alloc, pipe, timed) catch |err| {
         log.warn("invalid win32 launch-layout IPC request err={}", .{err});
         try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_action);
         return;
@@ -2192,8 +2234,8 @@ fn handleLaunchLayoutIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
-fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    const payload = win32_ipc.decodeFocusPayload(pipe) catch |err| switch (err) {
+fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    const payload = win32_ipc.decodeFocusPayload(pipe, timed) catch |err| switch (err) {
         error.InvalidAutomationTarget => {
             try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_invalid_automation_target);
             return;
@@ -2212,8 +2254,8 @@ fn handleFocusIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
-fn handleSendTextIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    var payload = win32_ipc.decodeSendTextPayload(app.core_app.alloc, pipe) catch |err| switch (err) {
+fn handleSendTextIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    var payload = win32_ipc.decodeSendTextPayload(app.core_app.alloc, pipe, timed) catch |err| switch (err) {
         error.InvalidAutomationText => {
             try win32_ipc.writeAckStatus(pipe, win32_ipc.ack_automation_policy_refused);
             return;
@@ -2249,8 +2291,8 @@ fn automationCommandAckStatus(err: anyerror) ?u8 {
     };
 }
 
-fn handleNewTabIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    var payload = win32_ipc.decodeNewTabPayload(app.core_app.alloc, pipe) catch |err| {
+fn handleNewTabIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    var payload = win32_ipc.decodeNewTabPayload(app.core_app.alloc, pipe, timed) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2275,8 +2317,8 @@ fn handleNewTabIpcClient(app: *App, pipe: windows.HANDLE) !void {
     try win32_ipc.writeAck(pipe, true);
 }
 
-fn handleNewSplitIpcClient(app: *App, pipe: windows.HANDLE) !void {
-    var payload = win32_ipc.decodeNewSplitPayload(app.core_app.alloc, pipe) catch |err| {
+fn handleNewSplitIpcClient(app: *App, pipe: windows.HANDLE, timed: bool) !void {
+    var payload = win32_ipc.decodeNewSplitPayload(app.core_app.alloc, pipe, timed) catch |err| {
         const status = automationCommandAckStatus(err) orelse return err;
         try win32_ipc.writeAckStatus(pipe, status);
         return;
@@ -2397,7 +2439,7 @@ fn waitForAutomationCompletion(
             .pending => {
                 if (app.ipc_stop_requested.load(.acquire)) {
                     if (lifecycle.cancel()) return error.IPCFailed;
-                } else if (automationNowMs() >= lifecycle.deadline_ms) {
+                } else if (automationNowMs() > lifecycle.deadline_ms) {
                     if (lifecycle.cancel()) return error.IpcTimeout;
                 }
             },
@@ -32072,7 +32114,7 @@ test "win32 win32_ipc.encodeListWindowsRequest carries the response deadline" {
 
     try std.testing.expectEqual(@as(usize, 13), request.len);
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
-    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.list_windows), request[4]);
+    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.list_windows_timed), request[4]);
     try std.testing.expectEqual(deadline_ms, std.mem.readInt(u64, request[5..13], .little));
 }
 
@@ -32088,7 +32130,7 @@ test "automation-action win32 ipc encodes focused action request" {
     defer std.testing.allocator.free(request);
 
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
-    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action), request[4]);
+    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action_timed), request[4]);
     try std.testing.expectEqual(@as(u64, 0x0102030405060708), std.mem.readInt(u64, request[5..13], .little));
     try std.testing.expectEqual(@as(u8, 0), request[13]);
     try std.testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, request[14..22], .little));
@@ -32170,7 +32212,7 @@ test "automation-action win32 ipc encodes surface action request" {
     defer std.testing.allocator.free(request);
 
     try std.testing.expectEqual(win32_ipc.wire_version, std.mem.readInt(u32, request[0..4], .little));
-    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action), request[4]);
+    try std.testing.expectEqual(@intFromEnum(win32_ipc.RequestKind.perform_action_timed), request[4]);
     try std.testing.expectEqual(@as(u64, 0x0102030405060708), std.mem.readInt(u64, request[5..13], .little));
     try std.testing.expectEqual(@as(u8, 1), request[13]);
     try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, request[14..22], .little));
@@ -32218,7 +32260,7 @@ test "automation-action win32 ipc rejects oversized decoded action" {
 
     try std.testing.expectError(
         error.InvalidAutomationAction,
-        win32_ipc.decodePerformActionPayload(std.testing.allocator, file.handle),
+        win32_ipc.decodePerformActionPayload(std.testing.allocator, file.handle, true),
     );
 }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -5711,7 +5711,7 @@ pub const App = struct {
             },
             .focus => |target| {
                 const surface = switch (target) {
-                    .surface_id => |id| self.findSurfaceById(id),
+                    .surface_id => |id| self.findLiveSurfaceById(id),
                     .window_id => |id| self.activeSurfaceForHost(id),
                     .focused => return error.InvalidAutomationTarget,
                 } orelse return error.AutomationTargetNotFound;
@@ -5719,7 +5719,7 @@ pub const App = struct {
             },
             .send_text => |value| {
                 const surface = switch (value.target) {
-                    .surface_id => |id| self.findSurfaceById(id),
+                    .surface_id => |id| self.findLiveSurfaceById(id),
                     .focused, .window_id => return error.InvalidAutomationTarget,
                 } orelse return error.AutomationTargetNotFound;
                 if (!automationTextAllowed(value.text)) return error.AutomationPolicyRefused;
@@ -6663,6 +6663,12 @@ pub const App = struct {
         }
 
         return null;
+    }
+
+    fn findLiveSurfaceById(self: *App, surface_id: u64) ?*Surface {
+        const surface = self.findSurfaceById(surface_id) orelse return null;
+        _ = self.findTabForSurface(surface) orelse return null;
+        return surface;
     }
 
     fn inheritHostWindowState(_: *App, destination: *Host, source: *Host) !void {
@@ -31636,6 +31642,7 @@ test "automation focus selects exact targets without fallback" {
     var surface_a: Surface = undefined;
     var surface_b: Surface = undefined;
     var surface_c: Surface = undefined;
+    var detached_surface: Surface = undefined;
     var session: TestSession = .{};
     try session.init(.{
         .core_app = &core_app,
@@ -31648,6 +31655,7 @@ test "automation focus selects exact targets without fallback" {
             .{ .storage = &surface_a, .host = &host_a },
             .{ .storage = &surface_b, .host = &host_a },
             .{ .storage = &surface_c, .host = &host_b },
+            .{ .storage = &detached_surface, .host = &host_a, .register = true },
         },
         .tabs = &.{
             .{ .host = &host_a, .surface = &surface_a, .id = 1 },
@@ -31659,6 +31667,10 @@ test "automation focus selects exact targets without fallback" {
     surface_a.core_surface.id = 101;
     surface_b.core_surface.id = 102;
     surface_c.core_surface.id = 103;
+    detached_surface.core_surface.id = 104;
+
+    try std.testing.expectEqual(@as(?*Surface, &surface_a), app.findLiveSurfaceById(101));
+    try std.testing.expect(app.findLiveSurfaceById(104) == null);
 
     try app.performAutomationCommand(.{ .focus = .{ .surface_id = 102 } });
     try std.testing.expectEqual(@as(usize, 1), host_a.active_tab);
@@ -31667,6 +31679,10 @@ test "automation focus selects exact targets without fallback" {
     try std.testing.expectError(
         error.AutomationTargetNotFound,
         app.performAutomationCommand(.{ .focus = .{ .surface_id = 999 } }),
+    );
+    try std.testing.expectError(
+        error.AutomationTargetNotFound,
+        app.performAutomationCommand(.{ .focus = .{ .surface_id = 104 } }),
     );
     try std.testing.expectError(
         error.InvalidAutomationTarget,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -2366,6 +2366,9 @@ pub const App = struct {
         title: LPCWSTR,
         opts: SurfaceInitOptions,
     ) anyerror!*Surface = null,
+    /// Test-only seam for automation snapshots built without a live core
+    /// surface. Returned strings are owned by the caller.
+    test_automation_pwd: ?*const fn (Allocator, *Surface) anyerror!?[]const u8 = null,
     /// Test-only interleaving seam for the focus revision race between a
     /// structural split-close prepare and commit.
     test_before_split_undo_shell_commit: ?*const fn (
@@ -2382,6 +2385,8 @@ pub const App = struct {
     wheel_settings: SystemWheelSettings = .{},
     system_dynamic_scrollbars: bool = true,
     ipc_pipe_name: ?[:0]const u16 = null,
+    /// Effective sanitized namespace captured when the IPC server starts.
+    ipc_namespace: ?[]const u8 = null,
     ipc_thread: ?std.Thread = null,
     ipc_stop_requested: std.atomic.Value(bool) = .init(false),
     global_hotkeys: std.ArrayListUnmanaged(RegisteredGlobalHotkey) = .empty,
@@ -3983,7 +3988,13 @@ pub const App = struct {
         if (self.config.@"single-instance" != .true) return;
         if (self.ipc_thread != null) return;
 
-        self.ipc_pipe_name = try self.resolveIpcPipeName(self.core_app.alloc);
+        self.ipc_namespace = try sanitizeIpcNamespace(self.core_app.alloc, self.config.class);
+        errdefer {
+            if (self.ipc_namespace) |namespace| self.core_app.alloc.free(namespace);
+            self.ipc_namespace = null;
+        }
+
+        self.ipc_pipe_name = try allocIpcPipeName(self.core_app.alloc, self.ipc_namespace);
         errdefer {
             if (self.ipc_pipe_name) |pipe_name| self.core_app.alloc.free(pipe_name);
             self.ipc_pipe_name = null;
@@ -4012,6 +4023,10 @@ pub const App = struct {
         if (self.ipc_pipe_name) |pipe_name| {
             self.core_app.alloc.free(pipe_name);
             self.ipc_pipe_name = null;
+        }
+        if (self.ipc_namespace) |namespace| {
+            self.core_app.alloc.free(namespace);
+            self.ipc_namespace = null;
         }
         self.ipc_stop_requested.store(false, .release);
     }
@@ -5399,6 +5414,19 @@ pub const App = struct {
         self: *App,
         alloc: Allocator,
     ) !apprt.ipc.AutomationWindowList {
+        const namespace = self.ipc_namespace orelse return error.IpcServerNotStarted;
+        var instance: apprt.ipc.AutomationInstance = instance: {
+            const version = try alloc.dupe(u8, build_config.version_string);
+            errdefer alloc.free(version);
+            const namespace_copy = try alloc.dupe(u8, namespace);
+            break :instance .{
+                .pid = sys.GetCurrentProcessId(),
+                .version = version,
+                .class = namespace_copy,
+            };
+        };
+        errdefer instance.deinit(alloc);
+
         const window_entries = try alloc.alloc(apprt.ipc.AutomationWindow, self.automationWindowCount());
         var built: usize = 0;
         errdefer {
@@ -5408,11 +5436,11 @@ pub const App = struct {
 
         for (self.hosts.items) |host| {
             if (host.tabs.items.len == 0) continue;
-            window_entries[built] = try buildAutomationWindow(alloc, host);
+            window_entries[built] = try self.buildAutomationWindow(alloc, host);
             built += 1;
         }
 
-        return .{ .windows = window_entries };
+        return .{ .instance = instance, .windows = window_entries };
     }
 
     fn automationWindowCount(self: *const App) usize {
@@ -5425,6 +5453,7 @@ pub const App = struct {
     }
 
     fn buildAutomationWindow(
+        self: *App,
         alloc: Allocator,
         host: *Host,
     ) !apprt.ipc.AutomationWindow {
@@ -5438,13 +5467,16 @@ pub const App = struct {
         var active_tab_id: ?u32 = null;
         for (host.tabs.items, 0..) |*tab, i| {
             const active = i == host.active_tab;
-            tabs[i] = try buildAutomationTab(alloc, tab, active);
+            tabs[i] = try self.buildAutomationTab(alloc, tab, active);
             if (active) active_tab_id = tab.id;
             built += 1;
         }
 
+        const title = try alloc.dupe(u8, host.cached_window_title orelse "noctty");
+
         return .{
             .window_id = host.id,
+            .title = title,
             .focused = if (host.activeSurface()) |surface| surface.window_focused else false,
             .active_tab_id = active_tab_id,
             .tab_count = @intCast(tabs.len),
@@ -5454,18 +5486,36 @@ pub const App = struct {
     }
 
     fn buildAutomationTab(
+        self: *App,
         alloc: Allocator,
         tab: *const Tab,
         active: bool,
     ) !apprt.ipc.AutomationTab {
         var panes: std.ArrayList(apprt.ipc.AutomationPane) = .empty;
+        // Registration order matters: `defer` and `errdefer` run LIFO, so the
+        // per-pane string cleanup must be registered AFTER the list teardown
+        // in order to run BEFORE it. The reverse order reads `panes.items`
+        // after `deinit` has freed the backing buffer.
         defer panes.deinit(alloc);
+        errdefer for (panes.items) |*pane| pane.deinit(alloc);
 
         const focused_surface = tab.focusedSurface();
         var it = tab.tree.iterator();
         while (it.next()) |entry| {
+            const title = if (entry.view.effectiveTitle()) |value|
+                try alloc.dupe(u8, value)
+            else
+                null;
+            errdefer if (title) |value| alloc.free(value);
+            const working_directory = if (self.test_automation_pwd) |query|
+                try query(alloc, entry.view)
+            else
+                try entry.view.core().pwd(alloc);
+            errdefer if (working_directory) |value| alloc.free(value);
             try panes.append(alloc, .{
                 .surface_id = entry.view.core().id,
+                .title = title,
+                .working_directory = working_directory,
                 .focused = if (focused_surface) |surface| surface == entry.view else false,
                 // True only for the focused pane in the active tab, not every
                 // tab-local focused pane.
@@ -29863,6 +29913,17 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     var app: App = undefined;
     app.windows = .empty;
     app.hosts = .empty;
+    app.ipc_namespace = "lane_9";
+    app.test_automation_pwd = &struct {
+        fn query(alloc: Allocator, surface: *Surface) !?[]const u8 {
+            return switch (surface.core().id) {
+                701 => null,
+                702 => try alloc.dupe(u8, "C:\\work\\\"quote\"\t\r\n"),
+                703 => try alloc.dupe(u8, "home"),
+                else => error.UnexpectedSurface,
+            };
+        }
+    }.query;
     defer app.windows.deinit(std.testing.allocator);
     defer app.hosts.deinit(std.testing.allocator);
 
@@ -29870,6 +29931,7 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     host.id = 17;
     host.tabs = .empty;
     host.active_tab = 1;
+    host.cached_window_title = "host \"quote\"\\slash\t\r\n";
     defer {
         for (host.tabs.items) |*tab| tab.deinit();
         host.tabs.deinit(std.testing.allocator);
@@ -29880,6 +29942,9 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     tab0_surface.core_surface.id = 701;
     tab0_surface.host = &host;
     tab0_surface.host_id = host.id;
+    tab0_surface.title = null;
+    tab0_surface.title_override = null;
+    tab0_surface.tab_title_override = null;
 
     var tab1_primary: Surface = undefined;
     tab1_primary.core_surface = undefined;
@@ -29887,12 +29952,18 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     tab1_primary.host = &host;
     tab1_primary.host_id = host.id;
     tab1_primary.window_focused = true;
+    tab1_primary.title = "terminal title";
+    tab1_primary.title_override = "surface title";
+    tab1_primary.tab_title_override = "tab \"title\"\\\t\r\n";
 
     var tab1_split: Surface = undefined;
     tab1_split.core_surface = undefined;
     tab1_split.core_surface.id = 703;
     tab1_split.host = &host;
     tab1_split.host_id = host.id;
+    tab1_split.title = "split title";
+    tab1_split.title_override = null;
+    tab1_split.tab_title_override = null;
 
     try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 3, &tab0_surface));
     try host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 4, &tab1_primary));
@@ -29921,10 +29992,58 @@ test "automation-window-list win32 json includes host tab and pane ids" {
     const json = try app.buildAutomationWindowListJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
 
-    try std.testing.expectEqualStrings(
-        "{\"schema\":\"noctty.windows.v2\",\"api_version\":2,\"windows\":[{\"window_id\":17,\"focused\":true,\"active_tab_id\":4,\"tab_count\":2,\"pane_count\":3,\"tabs\":[{\"tab_id\":3,\"active\":false,\"focused_surface_id\":701,\"pane_count\":1,\"panes\":[{\"surface_id\":701,\"focused\":true,\"active\":false}]},{\"tab_id\":4,\"active\":true,\"focused_surface_id\":702,\"pane_count\":2,\"panes\":[{\"surface_id\":703,\"focused\":false,\"active\":false},{\"surface_id\":702,\"focused\":true,\"active\":true}]}]}]}",
-        json,
-    );
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try std.testing.expectEqualStrings("noctty.windows.v3", apprt.ipc.automation_window_list_schema);
+    try std.testing.expectEqual(@as(u32, 3), apprt.ipc.automation_window_list_api_version);
+    try std.testing.expectEqualStrings("noctty.windows.v3", root.get("schema").?.string);
+    try std.testing.expectEqual(@as(i64, 3), root.get("api_version").?.integer);
+    const instance = root.get("instance").?.object;
+    try std.testing.expectEqual(@as(i64, sys.GetCurrentProcessId()), instance.get("pid").?.integer);
+    try std.testing.expectEqualStrings(build_config.version_string, instance.get("version").?.string);
+    try std.testing.expectEqualStrings("lane_9", instance.get("class").?.string);
+
+    const windows_json = root.get("windows").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), windows_json.len);
+    const window = windows_json[0].object;
+    try std.testing.expectEqual(@as(i64, 17), window.get("window_id").?.integer);
+    try std.testing.expectEqualStrings("host \"quote\"\\slash\t\r\n", window.get("title").?.string);
+    try std.testing.expect(window.get("focused").?.bool);
+    try std.testing.expectEqual(@as(i64, 4), window.get("active_tab_id").?.integer);
+    try std.testing.expectEqual(@as(i64, 2), window.get("tab_count").?.integer);
+    try std.testing.expectEqual(@as(i64, 3), window.get("pane_count").?.integer);
+    const tabs = window.get("tabs").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), tabs.len);
+    try std.testing.expectEqual(@as(i64, 3), tabs[0].object.get("tab_id").?.integer);
+    try std.testing.expect(!tabs[0].object.get("active").?.bool);
+    try std.testing.expectEqual(@as(i64, 701), tabs[0].object.get("focused_surface_id").?.integer);
+    try std.testing.expectEqual(@as(i64, 1), tabs[0].object.get("pane_count").?.integer);
+    const null_pane = tabs[0].object.get("panes").?.array.items[0].object;
+    try std.testing.expectEqual(@as(i64, 701), null_pane.get("surface_id").?.integer);
+    try std.testing.expect(null_pane.get("focused").?.bool);
+    try std.testing.expect(!null_pane.get("active").?.bool);
+    try std.testing.expect(null_pane.get("title").? == .null);
+    try std.testing.expect(null_pane.get("working_directory").? == .null);
+    const active_panes = tabs[1].object.get("panes").?.array.items;
+    try std.testing.expectEqual(@as(i64, 4), tabs[1].object.get("tab_id").?.integer);
+    try std.testing.expect(tabs[1].object.get("active").?.bool);
+    try std.testing.expectEqual(@as(i64, 702), tabs[1].object.get("focused_surface_id").?.integer);
+    try std.testing.expectEqual(@as(i64, 2), tabs[1].object.get("pane_count").?.integer);
+    try std.testing.expectEqual(@as(usize, 2), active_panes.len);
+    try std.testing.expectEqual(@as(i64, 703), active_panes[0].object.get("surface_id").?.integer);
+    try std.testing.expectEqualStrings("split title", active_panes[0].object.get("title").?.string);
+    try std.testing.expectEqualStrings("home", active_panes[0].object.get("working_directory").?.string);
+    try std.testing.expectEqual(@as(i64, 702), active_panes[1].object.get("surface_id").?.integer);
+    try std.testing.expectEqualStrings("tab \"title\"\\\t\r\n", active_panes[1].object.get("title").?.string);
+    try std.testing.expectEqualStrings("C:\\work\\\"quote\"\t\r\n", active_panes[1].object.get("working_directory").?.string);
+    try std.testing.expect(active_panes[1].object.get("focused").?.bool);
+    try std.testing.expect(active_panes[1].object.get("active").?.bool);
+    try std.testing.expect(active_panes[1].object.get("pid") == null);
+
+    for ([_][]const u8{ "grid", "scrollback", "selection", "clipboard", "shell_input" }) |key| {
+        try std.testing.expect(std.mem.indexOf(u8, json, key) == null);
+    }
 }
 
 test "automation-window-list win32 json skips empty hosts kept alive for undo history" {
@@ -29933,6 +30052,12 @@ test "automation-window-list win32 json skips empty hosts kept alive for undo hi
     var app: App = undefined;
     app.windows = .empty;
     app.hosts = .empty;
+    app.ipc_namespace = "empty-host-test";
+    app.test_automation_pwd = &struct {
+        fn query(_: Allocator, _: *Surface) !?[]const u8 {
+            return null;
+        }
+    }.query;
     defer app.windows.deinit(std.testing.allocator);
     defer app.hosts.deinit(std.testing.allocator);
 
@@ -29949,6 +30074,7 @@ test "automation-window-list win32 json skips empty hosts kept alive for undo hi
     live_host.id = 17;
     live_host.tabs = .empty;
     live_host.active_tab = 0;
+    live_host.cached_window_title = null;
     defer {
         for (live_host.tabs.items) |*tab| tab.deinit();
         live_host.tabs.deinit(std.testing.allocator);
@@ -29960,6 +30086,9 @@ test "automation-window-list win32 json skips empty hosts kept alive for undo hi
     surface.host = &live_host;
     surface.host_id = live_host.id;
     surface.window_focused = true;
+    surface.title = null;
+    surface.title_override = null;
+    surface.tab_title_override = null;
 
     try live_host.tabs.append(std.testing.allocator, try Tab.init(std.testing.allocator, 5, &surface));
     try app.hosts.append(std.testing.allocator, &empty_host);
@@ -29969,10 +30098,16 @@ test "automation-window-list win32 json skips empty hosts kept alive for undo hi
     const json = try app.buildAutomationWindowListJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
 
-    try std.testing.expectEqualStrings(
-        "{\"schema\":\"noctty.windows.v2\",\"api_version\":2,\"windows\":[{\"window_id\":17,\"focused\":true,\"active_tab_id\":5,\"tab_count\":1,\"pane_count\":1,\"tabs\":[{\"tab_id\":5,\"active\":true,\"focused_surface_id\":801,\"pane_count\":1,\"panes\":[{\"surface_id\":801,\"focused\":true,\"active\":true}]}]}]}",
-        json,
-    );
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const windows_json = parsed.value.object.get("windows").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), windows_json.len);
+    const window = windows_json[0].object;
+    try std.testing.expectEqual(@as(i64, 17), window.get("window_id").?.integer);
+    try std.testing.expectEqualStrings("noctty", window.get("title").?.string);
+    const pane = window.get("tabs").?.array.items[0].object.get("panes").?.array.items[0].object;
+    try std.testing.expect(pane.get("title").? == .null);
+    try std.testing.expect(pane.get("working_directory").? == .null);
 }
 
 test "win32 timed out automation request remains owned until consumption" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -6032,12 +6032,14 @@ pub const App = struct {
     ) !*Surface {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .tab);
         defer config.deinit();
+        var inherited_profile_key: ?[]const u8 = null;
 
         if (explicit_window_target) {
             // `newConfig(.tab)` consults the globally focused surface. Reset
             // and inherit from the explicitly requested host instead.
             config.@"working-directory" = self.config.@"working-directory";
             if (source) |surface| {
+                inherited_profile_key = try applyProfileConfigFromSource(&config, surface);
                 const split_inherit = config.@"split-inherit-working-directory";
                 {
                     defer config.@"split-inherit-working-directory" = split_inherit;
@@ -6056,6 +6058,11 @@ pub const App = struct {
                 null else null,
             .clone_state_from = source,
         });
+        if (inherited_profile_key) |key| try appendOwnedString(
+            self.core_app.alloc,
+            &surface.launch_profile_key,
+            key,
+        );
         if (source) |value| value.invalidateRedoForUnsupportedTabStructuralAction();
         self.activateSurface(surface);
         return surface;
@@ -6071,7 +6078,7 @@ pub const App = struct {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .split);
         defer config.deinit();
         config.@"working-directory" = self.config.@"working-directory";
-        const inherited_profile_key = try applySplitProfileConfigFromSource(&config, source);
+        const inherited_profile_key = try applyProfileConfigFromSource(&config, source);
         _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
         if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
         const surface = try self.createWindowSurface(&config, default_title, .{
@@ -6103,7 +6110,7 @@ pub const App = struct {
         return surface;
     }
 
-    fn applySplitProfileConfigFromSource(
+    fn applyProfileConfigFromSource(
         config: *configpkg.Config,
         source: *Surface,
     ) !?[]const u8 {
@@ -32365,6 +32372,33 @@ test "win32 session restore refuses ssh profiles regardless of key case" {
     defer clone.deinit();
     try std.testing.expect(try applyProfileConfigByKey(&clone, &profiles, "CMD.EXE"));
     try std.testing.expectEqualStrings("cmd.exe", clone.command.?.direct[0]);
+}
+
+test "win32 automation tab profile inheritance applies the source command" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const command = [_][:0]const u8{ "pwsh.exe", "-NoLogo" };
+    var profiles = [_]windows_shell.Profile{.{
+        .kind = .pwsh,
+        .key = "pwsh",
+        .label = "PowerShell",
+        .command = .{ .direct = &command },
+    }};
+    var host: Host = undefined;
+    host.profiles = &profiles;
+    var source: Surface = undefined;
+    source.host = &host;
+    source.launch_profile_key = "pwsh";
+
+    var config = try configpkg.Config.default(std.testing.allocator);
+    defer config.deinit();
+    const inherited = try App.applyProfileConfigFromSource(&config, &source);
+
+    try std.testing.expectEqualStrings("pwsh", inherited.?);
+    const direct = config.command.?.direct;
+    try std.testing.expectEqual(@as(usize, 2), direct.len);
+    try std.testing.expectEqualStrings("pwsh.exe", direct[0]);
+    try std.testing.expectEqualStrings("-NoLogo", direct[1]);
 }
 
 test "win32 applyProfileConfigByKey applies saved first-pane profile before host exists" {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -4891,7 +4891,7 @@ pub const App = struct {
 
             .new_tab => {
                 const source = self.findSurfaceForTarget(target);
-                _ = try self.createNewTab(source, null, false);
+                _ = try self.createNewTab(source, null, false, false);
                 return true;
             },
 
@@ -5690,6 +5690,7 @@ pub const App = struct {
                     source,
                     value.working_directory,
                     resolved.explicit_window_target,
+                    true,
                 );
             },
             .new_split => |value| {
@@ -6029,6 +6030,7 @@ pub const App = struct {
         source: ?*Surface,
         working_directory: ?[]const u8,
         explicit_window_target: bool,
+        inherit_launch_config: bool,
     ) !*Surface {
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .tab);
         defer config.deinit();
@@ -6044,7 +6046,9 @@ pub const App = struct {
             // Launch command selection is app-runtime state and must be
             // inherited from the source snapshot rather than re-resolved from
             // mutable global/profile configuration.
-            inherited_profile_key = try applyLaunchConfigFromSource(&config, surface);
+            if (inherit_launch_config) {
+                inherited_profile_key = try applyLaunchConfigFromSource(&config, surface);
+            }
             if (explicit_window_target) {
                 const split_inherit = config.@"split-inherit-working-directory";
                 {
@@ -6069,6 +6073,9 @@ pub const App = struct {
             &surface.launch_profile_key,
             key,
         );
+        if (inherit_launch_config) {
+            if (source) |value| surface.launched_ssh = value.launched_ssh;
+        }
         if (source) |value| value.invalidateRedoForUnsupportedTabStructuralAction();
         self.activateSurface(surface);
         return surface;
@@ -6085,7 +6092,9 @@ pub const App = struct {
         defer config.deinit();
         config.@"working-directory" = self.config.@"working-directory";
         const inherited_profile_key = try applyLaunchConfigFromSource(&config, source);
-        _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
+        if (shouldInheritSplitWorkingDirectory(source.launched_ssh)) {
+            _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
+        }
         if (working_directory) |cwd| try applyAutomationWorkingDirectory(&config, cwd);
         const surface = try self.createWindowSurface(&config, default_title, .{
             .host_id = source.host_id,
@@ -6098,6 +6107,7 @@ pub const App = struct {
             &surface.launch_profile_key,
             key,
         );
+        surface.launched_ssh = source.launched_ssh;
         tab_info.tab.clearRedoHistory();
         if (tab_info.host.pushStructuralUndo(.{
             .kind = .split_create,

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1138,7 +1138,7 @@ fn sendListWindowsIpc(
     return try win32_ipc.readDataResponseWithTimeout(
         alloc,
         pipe,
-        response_timeout_ms,
+        std.math.maxInt(u64),
     );
 }
 
@@ -1179,7 +1179,7 @@ fn sendAutomationAckRequest(
         .little,
     );
     try win32_ipc.writeAll(pipe, request);
-    return win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+    return win32_ipc.readAckWithTimeout(pipe, std.math.maxInt(u64));
 }
 
 fn sendFocusIpc(
@@ -1550,7 +1550,7 @@ fn sendLaunchLayoutIpc(
         .little,
     );
     try win32_ipc.writeAll(pipe, request);
-    return try win32_ipc.readAckWithTimeout(pipe, response_timeout_ms);
+    return try win32_ipc.readAckWithTimeout(pipe, std.math.maxInt(u64));
 }
 
 fn trySendStartupLaunchLayoutIpc(

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -649,6 +649,10 @@ fn applyProfileLaunchConfig(
     try applyProfileCommandConfig(config, profile);
     if (profile.kind != .ssh) return;
 
+    try applySshLaunchHardening(config);
+}
+
+fn applySshLaunchHardening(config: *configpkg.Config) !void {
     // Shell integration injection rewrites the two-element ssh argv into a
     // space-joined, unquoted `cmd.exe /C` string. A remote session cannot use
     // it anyway: the integration scripts run locally.
@@ -760,6 +764,14 @@ fn applySplitWorkingDirectoryFromSource(
 
 fn shouldInheritSplitWorkingDirectory(source_launched_ssh: bool) bool {
     return !source_launched_ssh;
+}
+
+fn shouldResetNewTabWorkingDirectory(
+    explicit_window_target: bool,
+    inherit_launch_config: bool,
+    source_launched_ssh: bool,
+) bool {
+    return explicit_window_target or (inherit_launch_config and source_launched_ssh);
 }
 
 fn defaultIpcNamespace() []const u8 {
@@ -4908,7 +4920,7 @@ pub const App = struct {
 
             .new_split => {
                 const source = self.findSurfaceForTarget(target) orelse return false;
-                _ = try self.createNewSplit(source, splitDirectionFromAction(value), null);
+                _ = try self.createNewSplit(source, splitDirectionFromAction(value), null, false);
                 return true;
             },
 
@@ -5719,7 +5731,7 @@ pub const App = struct {
                     .up => .up,
                     .down => .down,
                 };
-                _ = try self.createNewSplit(source, direction, value.working_directory);
+                _ = try self.createNewSplit(source, direction, value.working_directory, true);
             },
             .focus => |target| {
                 const surface = switch (target) {
@@ -6054,9 +6066,14 @@ pub const App = struct {
         defer config.deinit();
         var inherited_profile_key: ?[]const u8 = null;
 
-        if (explicit_window_target) {
+        if (shouldResetNewTabWorkingDirectory(
+            explicit_window_target,
+            inherit_launch_config,
+            if (source) |surface| surface.launched_ssh else false,
+        )) {
             // `newConfig(.tab)` consults the globally focused surface. Reset
-            // and inherit from the explicitly requested host instead.
+            // and inherit from the explicitly requested host instead. An SSH
+            // source also needs the reset because its live cwd is remote.
             config.@"working-directory" = self.config.@"working-directory";
         }
         if (source) |surface| {
@@ -6067,7 +6084,7 @@ pub const App = struct {
             if (inherit_launch_config) {
                 inherited_profile_key = try applyLaunchConfigFromSource(&config, surface);
             }
-            if (explicit_window_target) {
+            if (explicit_window_target and shouldInheritSplitWorkingDirectory(surface.launched_ssh)) {
                 const split_inherit = config.@"split-inherit-working-directory";
                 {
                     defer config.@"split-inherit-working-directory" = split_inherit;
@@ -6104,12 +6121,16 @@ pub const App = struct {
         source: *Surface,
         direction: SplitTreeSurface.Split.Direction,
         working_directory: ?[]const u8,
+        inherit_launch_config: bool,
     ) !*Surface {
         const tab_info = self.findTabForSurface(source) orelse return error.AutomationTargetNotFound;
         var config = try apprt.surface.newConfig(self.core_app, &self.config, .split);
         defer config.deinit();
         config.@"working-directory" = self.config.@"working-directory";
-        const inherited_profile_key = try applyLaunchConfigFromSource(&config, source);
+        const inherited_profile_key = if (inherit_launch_config)
+            try applyLaunchConfigFromSource(&config, source)
+        else
+            try applySplitProfileConfigFromSource(&config, source);
         if (shouldInheritSplitWorkingDirectory(source.launched_ssh)) {
             _ = try applySplitWorkingDirectoryFromSource(self, &config, source, self.startup_cwd);
         }
@@ -6125,7 +6146,9 @@ pub const App = struct {
             &surface.launch_profile_key,
             key,
         );
-        surface.launched_ssh = source.launched_ssh;
+        if (inherit_launch_config or inherited_profile_key != null) {
+            surface.launched_ssh = source.launched_ssh;
+        }
         tab_info.tab.clearRedoHistory();
         if (tab_info.host.pushStructuralUndo(.{
             .kind = .split_create,
@@ -6150,11 +6173,23 @@ pub const App = struct {
     ) !?[]const u8 {
         if (source.launch_command) |command| {
             config.command = try command.clone(config._arena.?.allocator());
+            if (source.launched_ssh) try applySshLaunchHardening(config);
             return source.launch_profile_key;
         }
 
         // Headless fixtures may not have a captured command. Preserve the
         // previous profile fallback for those tests.
+        const key = source.launch_profile_key orelse return null;
+        const host = source.host orelse return null;
+        const profile = (try host.profileForKey(key)) orelse return null;
+        try applyProfileLaunchConfig(config, profile);
+        return profile.key;
+    }
+
+    fn applySplitProfileConfigFromSource(
+        config: *configpkg.Config,
+        source: *Surface,
+    ) !?[]const u8 {
         const key = source.launch_profile_key orelse return null;
         const host = source.host orelse return null;
         const profile = (try host.profileForKey(key)) orelse return null;
@@ -32425,6 +32460,9 @@ test "win32 ssh split and session state drop remote cwd" {
 
     try std.testing.expect(!shouldInheritSplitWorkingDirectory(true));
     try std.testing.expect(shouldInheritSplitWorkingDirectory(false));
+    try std.testing.expect(shouldResetNewTabWorkingDirectory(false, true, true));
+    try std.testing.expect(shouldResetNewTabWorkingDirectory(true, true, false));
+    try std.testing.expect(!shouldResetNewTabWorkingDirectory(false, false, true));
 
     var surface: Surface = undefined;
     surface.pwd = "C:\\remote-controlled";
@@ -32532,6 +32570,39 @@ test "win32 automation tab inheritance preserves the captured source command" {
     try std.testing.expectEqual(@as(usize, 2), direct.len);
     try std.testing.expectEqualStrings("pwsh.exe", direct[0]);
     try std.testing.expectEqualStrings("-NoLogo", direct[1]);
+}
+
+test "win32 automation ssh inheritance preserves command and hardening" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const command = [_][:0]const u8{ "C:\\Windows\\System32\\OpenSSH\\ssh.exe", "production" };
+    var source: Surface = undefined;
+    source.launch_command = .{ .direct = &command };
+    source.launch_profile_key = "ssh:production";
+    source.launched_ssh = true;
+
+    var config = try configpkg.Config.default(std.testing.allocator);
+    defer config.deinit();
+    config.@"shell-integration" = .bash;
+    const inherited = try App.applyLaunchConfigFromSource(&config, &source);
+
+    try std.testing.expectEqualStrings("ssh:production", inherited.?);
+    try std.testing.expectEqual(configpkg.Config.ShellIntegration.none, config.@"shell-integration");
+    try std.testing.expectEqualStrings(command[0], config.command.?.direct[0]);
+    try std.testing.expectEqualStrings(command[1], config.command.?.direct[1]);
+}
+
+test "win32 ordinary split ignores a captured one-shot command" {
+    const one_shot = [_][:0]const u8{ "cmd.exe", "/c", "one-shot.cmd" };
+    var source: Surface = undefined;
+    source.launch_command = .{ .direct = &one_shot };
+    source.launch_profile_key = null;
+    source.host = null;
+
+    var config = try configpkg.Config.default(std.testing.allocator);
+    defer config.deinit();
+    try std.testing.expect((try App.applySplitProfileConfigFromSource(&config, &source)) == null);
+    try std.testing.expect(config.command == null);
 }
 
 test "win32 automation omitted target falls back to the active surface" {

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -463,6 +463,22 @@ pub extern "kernel32" fn ConnectNamedPipe(
     lpOverlapped: ?*anyopaque,
 ) callconv(.winapi) BOOL;
 
+pub extern "kernel32" fn SetNamedPipeHandleState(
+    hNamedPipe: windows.HANDLE,
+    lpMode: ?*DWORD,
+    lpMaxCollectionCount: ?*DWORD,
+    lpCollectDataTimeout: ?*DWORD,
+) callconv(.winapi) BOOL;
+
+pub extern "kernel32" fn PeekNamedPipe(
+    hNamedPipe: windows.HANDLE,
+    lpBuffer: ?*anyopaque,
+    nBufferSize: DWORD,
+    lpBytesRead: ?*DWORD,
+    lpTotalBytesAvail: ?*DWORD,
+    lpBytesLeftThisMessage: ?*DWORD,
+) callconv(.winapi) BOOL;
+
 /// `SID_AND_ATTRIBUTES`/`TOKEN_USER` as returned by `GetTokenInformation`
 /// with `TokenUser`. Only the SID pointer is used; the SID itself lives in
 /// the caller-provided buffer.
@@ -641,6 +657,8 @@ pub extern "shell32" fn DragFinish(hDrop: *anyopaque) callconv(.winapi) void;
 pub extern "user32" fn EnableWindow(hWnd: HWND, bEnable: BOOL) callconv(.winapi) BOOL;
 
 pub extern "user32" fn GetParent(hWnd: HWND) callconv(.winapi) ?HWND;
+
+pub extern "user32" fn GetForegroundWindow() callconv(.winapi) ?HWND;
 
 pub extern "user32" fn IsChild(hWndParent: HWND, hWnd: HWND) callconv(.winapi) BOOL;
 

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -1025,7 +1025,10 @@ test "win32 IPC silent client read is bounded" {
         null,
     );
     try std.testing.expect(server != windows.INVALID_HANDLE_VALUE);
-    defer _ = windows.CloseHandle(server);
+    var server_open = true;
+    defer {
+        if (server_open) _ = windows.CloseHandle(server);
+    }
 
     try std.testing.expectEqual(@as(BOOL, 0), sys.ConnectNamedPipe(server, null));
     try std.testing.expectEqual(windows.Win32Error.PIPE_LISTENING, windows.kernel32.GetLastError());
@@ -1056,6 +1059,24 @@ test "win32 IPC silent client read is bounded" {
     try writeAll(client, "x");
     try readExactWithTimeout(server, &byte, 0);
     try std.testing.expectEqual(@as(u8, 'x'), byte[0]);
+
+    const DelayedWriter = struct {
+        fn run(pipe: windows.HANDLE) void {
+            std.Thread.sleep(20 * std.time.ns_per_ms);
+            writeAll(pipe, "y") catch unreachable;
+        }
+    };
+    const writer = try std.Thread.spawn(.{}, DelayedWriter.run, .{server});
+    defer writer.join();
+    try readExactWithTimeout(client, &byte, std.math.maxInt(u64));
+    try std.testing.expectEqual(@as(u8, 'y'), byte[0]);
+
+    _ = windows.CloseHandle(server);
+    server_open = false;
+    try std.testing.expectError(
+        error.EndOfStream,
+        readExactWithTimeout(client, &byte, std.math.maxInt(u64)),
+    );
 }
 
 test "win32 IPC pending pipe states remain retryable" {

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -587,12 +587,10 @@ fn readExactUntil(
     deadline_ms: u64,
 ) !void {
     var offset: usize = 0;
-    var attempted = false;
     while (offset < dst.len) {
         // A zero timeout is a nonblocking poll, not an automatic failure.
-        // Always attempt one ReadFile so an already-buffered response wins.
-        if (attempted and sys.GetTickCount64() >= deadline_ms) return error.IpcTimeout;
-        attempted = true;
+        // Keep consuming immediately available bytes even after partial
+        // progress; enforce the deadline only when the pipe has no data.
         var read_len: u32 = 0;
         if (windows.kernel32.ReadFile(
             pipe,

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -33,6 +33,8 @@ pub const RequestKind = enum(u8) {
     new_window = 1,
     list_windows = 2,
     perform_action = 3,
+    new_tab = 4,
+    new_split = 5,
     focus = 6,
     send_text = 7,
     launch_layout = 8,
@@ -49,6 +51,24 @@ pub const SendTextPayload = struct {
 
     pub fn deinit(self: *@This(), alloc: Allocator) void {
         alloc.free(self.text);
+        self.* = undefined;
+    }
+};
+
+pub const NewTabPayload = struct {
+    target: apprt.ipc.AutomationTarget,
+    working_directory: ?[]u8,
+    pub fn deinit(self: *@This(), alloc: Allocator) void {
+        if (self.working_directory) |value| alloc.free(value);
+        self.* = undefined;
+    }
+};
+pub const NewSplitPayload = struct {
+    target: apprt.ipc.AutomationTarget,
+    direction: apprt.ipc.AutomationSplitDirection,
+    working_directory: ?[]u8,
+    pub fn deinit(self: *@This(), alloc: Allocator) void {
+        if (self.working_directory) |value| alloc.free(value);
         self.* = undefined;
     }
 };
@@ -90,6 +110,40 @@ fn decodeAutomationTarget(src: *const [9]u8) !apprt.ipc.AutomationTarget {
             error.InvalidAutomationTarget,
         else => error.InvalidAutomationTarget,
     };
+}
+
+fn appendWorkingDirectory(dst: *std.ArrayList(u8), alloc: Allocator, value: ?[]const u8) !void {
+    const cwd = value orelse return appendU32(dst, alloc, 0);
+    if (cwd.len == 0 or cwd.len > max_new_window_arg_len or
+        !std.unicode.utf8ValidateSlice(cwd) or std.mem.indexOfScalar(u8, cwd, 0) != null)
+    {
+        return error.InvalidAutomationWorkingDirectory;
+    }
+    try appendU32(dst, alloc, @intCast(cwd.len));
+    try dst.appendSlice(alloc, cwd);
+}
+
+fn decodeWorkingDirectory(alloc: Allocator, pipe: windows.HANDLE, deadline_ms: u64) !?[]u8 {
+    var len_buf: [4]u8 = undefined;
+    try readExactUntil(pipe, &len_buf, deadline_ms);
+    const len = readU32(&len_buf);
+    if (len == 0) return null;
+    if (len > max_new_window_arg_len) return error.InvalidAutomationWorkingDirectory;
+    const cwd = try alloc.alloc(u8, len);
+    errdefer alloc.free(cwd);
+    try readExactUntil(pipe, cwd, deadline_ms);
+    if (!std.unicode.utf8ValidateSlice(cwd) or std.mem.indexOfScalar(u8, cwd, 0) != null) {
+        return error.InvalidAutomationWorkingDirectory;
+    }
+    return cwd;
+}
+
+fn validateLaunchTarget(target: apprt.ipc.AutomationTarget, window: bool) !void {
+    switch (target) {
+        .focused => {},
+        .surface_id => if (window) return error.InvalidAutomationTarget,
+        .window_id => if (!window) return error.InvalidAutomationTarget,
+    }
 }
 
 fn readU32(src: []const u8) u32 {
@@ -190,6 +244,43 @@ pub fn encodeLaunchLayoutRequest(
     try appendU32(&encoded, alloc, @intCast(name.len));
     try encoded.appendSlice(alloc, name);
     return try encoded.toOwnedSlice(alloc);
+}
+
+fn encodeLaunchRequest(
+    alloc: Allocator,
+    kind: RequestKind,
+    target: apprt.ipc.AutomationTarget,
+    direction: ?apprt.ipc.AutomationSplitDirection,
+    working_directory: ?[]const u8,
+) ![]u8 {
+    var encoded: std.ArrayList(u8) = .empty;
+    errdefer encoded.deinit(alloc);
+    try appendU32(&encoded, alloc, wire_version);
+    try encoded.append(alloc, @intFromEnum(kind));
+    try appendAutomationTarget(&encoded, alloc, target);
+    if (direction) |value| try encoded.append(alloc, switch (value) {
+        .left => 1,
+        .right => 2,
+        .up => 3,
+        .down => 4,
+    });
+    try appendWorkingDirectory(&encoded, alloc, working_directory);
+    return try encoded.toOwnedSlice(alloc);
+}
+
+pub fn encodeNewTabRequest(alloc: Allocator, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8) ![]u8 {
+    try validateLaunchTarget(target, true);
+    return encodeLaunchRequest(alloc, .new_tab, target, null, cwd);
+}
+
+pub fn encodeNewSplitRequest(
+    alloc: Allocator,
+    target: apprt.ipc.AutomationTarget,
+    direction: apprt.ipc.AutomationSplitDirection,
+    cwd: ?[]const u8,
+) ![]u8 {
+    try validateLaunchTarget(target, false);
+    return encodeLaunchRequest(alloc, .new_split, target, direction, cwd);
 }
 
 pub fn encodeFocusRequest(
@@ -327,6 +418,32 @@ fn validateLaunchLayoutName(name: []const u8) !void {
     if (!std.unicode.utf8ValidateSlice(name)) return error.InvalidAutomationAction;
     if (std.mem.indexOfScalar(u8, name, 0) != null) return error.InvalidAutomationAction;
     win32_layouts.validateName(name) catch return error.InvalidAutomationAction;
+}
+
+pub fn decodeNewTabPayload(alloc: Allocator, pipe: windows.HANDLE) !NewTabPayload {
+    const deadline_ms = deadline();
+    var encoded: [9]u8 = undefined;
+    try readExactUntil(pipe, &encoded, deadline_ms);
+    const target = try decodeAutomationTarget(&encoded);
+    try validateLaunchTarget(target, true);
+    return .{ .target = target, .working_directory = try decodeWorkingDirectory(alloc, pipe, deadline_ms) };
+}
+
+pub fn decodeNewSplitPayload(alloc: Allocator, pipe: windows.HANDLE) !NewSplitPayload {
+    const deadline_ms = deadline();
+    var encoded: [10]u8 = undefined;
+    try readExactUntil(pipe, &encoded, deadline_ms);
+    const target = try decodeAutomationTarget(encoded[0..9]);
+    try validateLaunchTarget(target, false);
+    const direction: apprt.ipc.AutomationSplitDirection = switch (encoded[9]) {
+        1 => .left,
+        2 => .right,
+        3 => .up,
+        4 => .down,
+        else => return error.InvalidAutomationDirection,
+    };
+    const cwd = try decodeWorkingDirectory(alloc, pipe, deadline_ms);
+    return .{ .target = target, .direction = direction, .working_directory = cwd };
 }
 
 pub fn decodeFocusPayload(pipe: windows.HANDLE) !apprt.ipc.AutomationTarget {
@@ -528,15 +645,17 @@ fn automationTargetBytes(tag: u8, value: u64) [9]u8 {
     return encoded;
 }
 
-fn writeAutomationSendTextPayload(
+fn writeAutomationSizedPayload(
     file: *std.fs.File,
     target: [9]u8,
+    extra: []const u8,
     declared_len: u32,
     body: []const u8,
 ) !void {
     try file.setEndPos(0);
     try file.seekTo(0);
     try file.writeAll(&target);
+    try file.writeAll(extra);
     var len_buf: [4]u8 = undefined;
     std.mem.writeInt(u32, &len_buf, declared_len, .little);
     try file.writeAll(&len_buf);
@@ -544,187 +663,73 @@ fn writeAutomationSendTextPayload(
     try file.seekTo(0);
 }
 
-test "win32 automation wire and status numeric pins" {
-    try std.testing.expectEqual(@as(u32, 1), wire_version);
-    try std.testing.expectEqual(@as(u8, 1), @intFromEnum(RequestKind.new_window));
-    try std.testing.expectEqual(@as(u8, 2), @intFromEnum(RequestKind.list_windows));
-    try std.testing.expectEqual(@as(u8, 3), @intFromEnum(RequestKind.perform_action));
-    try std.testing.expectEqual(@as(u8, 6), @intFromEnum(RequestKind.focus));
-    try std.testing.expectEqual(@as(u8, 7), @intFromEnum(RequestKind.send_text));
-    try std.testing.expectEqual(@as(u8, 0), ack_success);
-    try std.testing.expectEqual(@as(u8, 1), ack_failure);
-    try std.testing.expectEqual(@as(u8, 2), ack_invalid_automation_action);
-    try std.testing.expectEqual(@as(u8, 3), ack_unsafe_automation_action);
-    try std.testing.expectEqual(@as(u8, 4), ack_invalid_automation_target);
-    try std.testing.expectEqual(@as(u8, 5), ack_no_automation_target);
-    try std.testing.expectEqual(@as(u8, 6), ack_automation_target_not_found);
-    try std.testing.expectEqual(@as(u8, 7), ack_automation_policy_refused);
+fn writeAutomationBytes(file: *std.fs.File, bytes: []const u8) !void {
+    try file.setEndPos(0);
+    try file.seekTo(0);
+    try file.writeAll(bytes);
+    try file.seekTo(0);
 }
 
-test "win32 automation focus request round trip" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
+test "win32 automation numeric pins" {
+    try std.testing.expectEqual(@as(u32, 1), wire_version);
+    for ([_]RequestKind{ .new_window, .list_windows, .perform_action, .new_tab, .new_split, .focus, .send_text }, 1..) |kind, value| {
+        try std.testing.expectEqual(@as(u8, @intCast(value)), @intFromEnum(kind));
+    }
+    const acks = [_]u8{ ack_success, ack_failure, ack_invalid_automation_action, ack_unsafe_automation_action, ack_invalid_automation_target, ack_no_automation_target, ack_automation_target_not_found, ack_automation_policy_refused };
+    for (acks, 0..) |ack, value| try std.testing.expectEqual(@as(u8, @intCast(value)), ack);
+    for ([_]apprt.ipc.AutomationSplitDirection{ .left, .right, .up, .down }, 1..) |direction, value| {
+        try std.testing.expectEqual(@as(u8, @intCast(value)), @intFromEnum(direction));
+        const request = try encodeNewSplitRequest(std.testing.allocator, .focused, direction, null);
+        defer std.testing.allocator.free(request);
+        try std.testing.expectEqual(@as(u8, @intCast(value)), request[14]);
+    }
+}
 
+test "win32 automation request and ack round trips" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var file = try tmp.dir.createFile("automation-focus.bin", .{ .read = true });
+    var file = try tmp.dir.createFile("automation-roundtrip.bin", .{ .read = true });
     defer file.close();
 
-    for ([_]apprt.ipc.AutomationTarget{
-        .{ .surface_id = 42 },
-        .{ .window_id = 17 },
-    }) |target| {
+    for ([_]apprt.ipc.AutomationTarget{ .{ .surface_id = 42 }, .{ .window_id = 17 } }) |target| {
         const request = try encodeFocusRequest(std.testing.allocator, target);
         defer std.testing.allocator.free(request);
-        try file.setEndPos(0);
-        try file.seekTo(0);
-        try file.writeAll(request);
-        try file.seekTo(0);
+        try writeAutomationBytes(&file, request);
         try std.testing.expectEqual(RequestKind.focus, try decodeRequestKind(file.handle));
         try std.testing.expectEqual(target, try decodeFocusPayload(file.handle));
     }
-}
 
-test "win32 automation send text request round trip" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    const target: apprt.ipc.AutomationTarget = .{ .surface_id = 0x1234 };
     const text = "printable £ ✓ ; | $(allowed) https://example.com mixed";
-    const request = try encodeSendTextRequest(std.testing.allocator, target, text);
-    defer std.testing.allocator.free(request);
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var file = try tmp.dir.createFile("automation-send-text.bin", .{ .read = true });
-    defer file.close();
-    try file.writeAll(request);
-    try file.seekTo(0);
-
+    const send = try encodeSendTextRequest(std.testing.allocator, .{ .surface_id = 0x1234 }, text);
+    defer std.testing.allocator.free(send);
+    try writeAutomationBytes(&file, send);
     try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
-    var payload = try decodeSendTextPayload(std.testing.allocator, file.handle);
-    defer payload.deinit(std.testing.allocator);
-    try std.testing.expectEqual(target, payload.target);
-    try std.testing.expectEqualStrings(text, payload.text);
-}
+    var sent = try decodeSendTextPayload(std.testing.allocator, file.handle);
+    defer sent.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(text, sent.text);
 
-test "win32 automation target tags reject invalid forms" {
-    try std.testing.expectEqual(
-        apprt.ipc.AutomationTarget.focused,
-        try decodeAutomationTarget(&automationTargetBytes(0, 0)),
-    );
-    try std.testing.expectEqual(
-        apprt.ipc.AutomationTarget{ .surface_id = 42 },
-        try decodeAutomationTarget(&automationTargetBytes(1, 42)),
-    );
-    try std.testing.expectEqual(
-        apprt.ipc.AutomationTarget{ .window_id = 17 },
-        try decodeAutomationTarget(&automationTargetBytes(2, 17)),
-    );
+    const cwd = try std.testing.allocator.alloc(u8, max_new_window_arg_len);
+    defer std.testing.allocator.free(cwd);
+    @memset(cwd, 'x');
+    const tab = try encodeNewTabRequest(std.testing.allocator, .{ .window_id = std.math.maxInt(u32) }, cwd);
+    defer std.testing.allocator.free(tab);
+    try writeAutomationBytes(&file, tab);
+    try std.testing.expectEqual(RequestKind.new_tab, try decodeRequestKind(file.handle));
+    var tab_payload = try decodeNewTabPayload(std.testing.allocator, file.handle);
+    defer tab_payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .window_id = std.math.maxInt(u32) }, tab_payload.target);
+    try std.testing.expectEqual(@as(usize, max_new_window_arg_len), tab_payload.working_directory.?.len);
 
-    for ([_][9]u8{
-        automationTargetBytes(0, 1),
-        automationTargetBytes(1, 0),
-        automationTargetBytes(2, 0),
-        automationTargetBytes(2, @as(u64, std.math.maxInt(u32)) + 1),
-        automationTargetBytes(3, 1),
-    }) |encoded| {
-        try std.testing.expectError(error.InvalidAutomationTarget, decodeAutomationTarget(&encoded));
-    }
-
-    try std.testing.expectError(
-        error.InvalidAutomationTarget,
-        encodeFocusRequest(std.testing.allocator, .{ .surface_id = 0 }),
-    );
-    try std.testing.expectError(
-        error.InvalidAutomationTarget,
-        encodeFocusRequest(std.testing.allocator, .{ .window_id = 0 }),
-    );
-}
-
-test "win32 automation send text codec enforces text contract" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    const target: apprt.ipc.AutomationTarget = .{ .surface_id = 42 };
-    const max_text = try std.testing.allocator.alloc(u8, max_action_text_len);
-    defer std.testing.allocator.free(max_text);
-    @memset(max_text, 'x');
-    const max_request = try encodeSendTextRequest(std.testing.allocator, target, max_text);
-    defer std.testing.allocator.free(max_request);
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var file = try tmp.dir.createFile("automation-send-text-contract.bin", .{ .read = true });
-    defer file.close();
-    try file.writeAll(max_request);
-    try file.seekTo(0);
-    try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
-    var max_payload = try decodeSendTextPayload(std.testing.allocator, file.handle);
-    defer max_payload.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, max_action_text_len), max_payload.text.len);
-
-    const over_text = try std.testing.allocator.alloc(u8, max_action_text_len + 1);
-    defer std.testing.allocator.free(over_text);
-    @memset(over_text, 'x');
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        encodeSendTextRequest(std.testing.allocator, target, ""),
-    );
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        encodeSendTextRequest(std.testing.allocator, target, over_text),
-    );
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        encodeSendTextRequest(std.testing.allocator, target, &.{0xFF}),
-    );
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        encodeSendTextRequest(std.testing.allocator, target, "a\x00b"),
-    );
-
-    const raw_target = automationTargetBytes(1, 42);
-    try writeAutomationSendTextPayload(&file, raw_target, 0, "");
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        decodeSendTextPayload(std.testing.allocator, file.handle),
-    );
-    try writeAutomationSendTextPayload(&file, raw_target, max_action_text_len + 1, "");
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        decodeSendTextPayload(std.testing.allocator, file.handle),
-    );
-    try writeAutomationSendTextPayload(&file, raw_target, 1, &.{0xFF});
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        decodeSendTextPayload(std.testing.allocator, file.handle),
-    );
-    try writeAutomationSendTextPayload(&file, raw_target, 3, "a\x00b");
-    try std.testing.expectError(
-        error.InvalidAutomationText,
-        decodeSendTextPayload(std.testing.allocator, file.handle),
-    );
-}
-
-test "win32 automation send text partial EOF frees allocation" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var file = try tmp.dir.createFile("automation-send-text-eof.bin", .{ .read = true });
-    defer file.close();
-    try writeAutomationSendTextPayload(&file, automationTargetBytes(1, 42), 3, "x");
-    try std.testing.expectError(
-        error.EndOfStream,
-        decodeSendTextPayload(std.testing.allocator, file.handle),
-    );
-}
-
-test "win32 automation ack maps target and policy statuses" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var file = try tmp.dir.createFile("automation-ack.bin", .{ .read = true });
-    defer file.close();
+    const split = try encodeNewSplitRequest(std.testing.allocator, .{ .surface_id = 42 }, .down, "C:\\x");
+    defer std.testing.allocator.free(split);
+    try writeAutomationBytes(&file, split);
+    try std.testing.expectEqual(RequestKind.new_split, try decodeRequestKind(file.handle));
+    var split_payload = try decodeNewSplitPayload(std.testing.allocator, file.handle);
+    defer split_payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .surface_id = 42 }, split_payload.target);
+    try std.testing.expectEqual(apprt.ipc.AutomationSplitDirection.down, split_payload.direction);
+    try std.testing.expectEqualStrings("C:\\x", split_payload.working_directory.?);
 
     for ([_]struct { status: u8, expected: anyerror }{
         .{ .status = ack_automation_target_not_found, .expected = error.AutomationTargetNotFound },
@@ -735,6 +740,69 @@ test "win32 automation ack maps target and policy statuses" {
         try writeAckStatus(file.handle, case.status);
         try file.seekTo(0);
         try std.testing.expectError(case.expected, readAck(file.handle));
+    }
+}
+
+test "win32 automation malformed codecs free allocations" {
+    const alloc = std.testing.allocator;
+    try std.testing.expectEqual(apprt.ipc.AutomationTarget.focused, try decodeAutomationTarget(&automationTargetBytes(0, 0)));
+    try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .surface_id = 42 }, try decodeAutomationTarget(&automationTargetBytes(1, 42)));
+    try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .window_id = 17 }, try decodeAutomationTarget(&automationTargetBytes(2, 17)));
+    for ([_][9]u8{ automationTargetBytes(0, 1), automationTargetBytes(1, 0), automationTargetBytes(2, 0), automationTargetBytes(2, @as(u64, std.math.maxInt(u32)) + 1), automationTargetBytes(3, 1) }) |encoded| {
+        try std.testing.expectError(error.InvalidAutomationTarget, decodeAutomationTarget(&encoded));
+    }
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .surface_id = 0 }));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .window_id = 0 }));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewTabRequest(alloc, .{ .surface_id = 1 }, null));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewSplitRequest(alloc, .{ .window_id = 1 }, .right, null));
+    for ([_][]const u8{ "", &.{0xFF}, "x\x00y" }) |value| {
+        try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, value));
+        try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, value));
+    }
+    const oversized = try alloc.alloc(u8, max_new_window_arg_len + 1);
+    defer alloc.free(oversized);
+    @memset(oversized, 'x');
+    try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, oversized[0 .. max_action_text_len + 1]));
+    try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, oversized));
+
+    const max_send = try encodeSendTextRequest(alloc, .{ .surface_id = 42 }, oversized[0..max_action_text_len]);
+    defer alloc.free(max_send);
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-invalid.bin", .{ .read = true });
+    defer file.close();
+    try writeAutomationBytes(&file, max_send);
+    _ = try decodeRequestKind(file.handle);
+    var max_payload = try decodeSendTextPayload(alloc, file.handle);
+    defer max_payload.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, max_action_text_len), max_payload.text.len);
+
+    const surface = automationTargetBytes(1, 42);
+    const window = automationTargetBytes(2, 42);
+    const bad_cases = [_]struct { len: u32, body: []const u8, expected: anyerror }{
+        .{ .len = 0, .body = "", .expected = error.InvalidAutomationText },
+        .{ .len = max_action_text_len + 1, .body = "", .expected = error.InvalidAutomationText },
+        .{ .len = 1, .body = &.{0xFF}, .expected = error.InvalidAutomationText },
+        .{ .len = 3, .body = "x\x00y", .expected = error.InvalidAutomationText },
+        .{ .len = 3, .body = "x", .expected = error.EndOfStream },
+    };
+    for (bad_cases) |case| {
+        try writeAutomationSizedPayload(&file, surface, "", case.len, case.body);
+        try std.testing.expectError(case.expected, decodeSendTextPayload(alloc, file.handle));
+    }
+    try writeAutomationSizedPayload(&file, surface, "", 0, "");
+    try std.testing.expectError(error.InvalidAutomationTarget, decodeNewTabPayload(alloc, file.handle));
+    try writeAutomationSizedPayload(&file, surface, &.{0}, 0, "");
+    try std.testing.expectError(error.InvalidAutomationDirection, decodeNewSplitPayload(alloc, file.handle));
+    for ([_]struct { len: u32, body: []const u8, expected: anyerror }{
+        .{ .len = 1, .body = &.{0xFF}, .expected = error.InvalidAutomationWorkingDirectory },
+        .{ .len = 3, .body = "x\x00y", .expected = error.InvalidAutomationWorkingDirectory },
+        .{ .len = max_new_window_arg_len + 1, .body = "", .expected = error.InvalidAutomationWorkingDirectory },
+        .{ .len = 3, .body = "x", .expected = error.EndOfStream },
+    }) |case| {
+        try writeAutomationSizedPayload(&file, window, "", case.len, case.body);
+        try std.testing.expectError(case.expected, decodeNewTabPayload(alloc, file.handle));
     }
 }
 

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -101,6 +101,11 @@ fn appendU64(dst: *std.ArrayList(u8), alloc: Allocator, value: u64) !void {
     try dst.appendSlice(alloc, &buf);
 }
 
+pub fn setAutomationRequestDeadline(encoded: []u8, deadline_ms: u64) !void {
+    if (encoded.len < 13) return error.InvalidIpcRequest;
+    std.mem.writeInt(u64, encoded[5..13], deadline_ms, .little);
+}
+
 fn appendAutomationTarget(
     dst: *std.ArrayList(u8),
     alloc: Allocator,
@@ -1067,9 +1072,10 @@ test "win32 IPC silent client read is bounded" {
         }
     };
     const writer = try std.Thread.spawn(.{}, DelayedWriter.run, .{server});
-    defer writer.join();
+    errdefer writer.join();
     try readExactWithTimeout(client, &byte, std.math.maxInt(u64));
     try std.testing.expectEqual(@as(u8, 'y'), byte[0]);
+    writer.join();
 
     _ = windows.CloseHandle(server);
     server_open = false;
@@ -1090,6 +1096,18 @@ test "win32 IPC request kind values remain stable" {
     try std.testing.expectEqual(@as(u8, 2), @intFromEnum(RequestKind.list_windows));
     try std.testing.expectEqual(@as(u8, 3), @intFromEnum(RequestKind.perform_action));
     try std.testing.expectEqual(@as(u8, 8), @intFromEnum(RequestKind.launch_layout));
+}
+
+test "win32 IPC deadline patching stays codec-owned" {
+    const request = try encodeFocusRequest(std.testing.allocator, .focused, 0);
+    defer std.testing.allocator.free(request);
+
+    try setAutomationRequestDeadline(request, test_deadline_ms);
+    try std.testing.expectEqual(test_deadline_ms, readU64(request[5..13]));
+    try std.testing.expectError(
+        error.InvalidIpcRequest,
+        setAutomationRequestDeadline(request[0..12], test_deadline_ms),
+    );
 }
 
 test "win32 launch-layout IPC encode decode round trip" {

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -587,8 +587,12 @@ fn readExactUntil(
     deadline_ms: u64,
 ) !void {
     var offset: usize = 0;
+    var attempted = false;
     while (offset < dst.len) {
-        if (sys.GetTickCount64() >= deadline_ms) return error.IpcTimeout;
+        // A zero timeout is a nonblocking poll, not an automatic failure.
+        // Always attempt one ReadFile so an already-buffered response wins.
+        if (attempted and sys.GetTickCount64() >= deadline_ms) return error.IpcTimeout;
+        attempted = true;
         var read_len: u32 = 0;
         if (windows.kernel32.ReadFile(
             pipe,
@@ -600,6 +604,7 @@ fn readExactUntil(
             const err = windows.kernel32.GetLastError();
             if (err == .BROKEN_PIPE) return error.EndOfStream;
             if (pipeIoPending(err)) {
+                if (sys.GetTickCount64() >= deadline_ms) return error.IpcTimeout;
                 std.Thread.sleep(poll_interval_ns);
                 continue;
             }
@@ -860,6 +865,10 @@ test "win32 IPC silent client read is bounded" {
         error.IpcTimeout,
         readExactWithTimeout(server, &byte, 10),
     );
+
+    try writeAll(client, "x");
+    try readExactWithTimeout(server, &byte, 0);
+    try std.testing.expectEqual(@as(u8, 'x'), byte[0]);
 }
 
 test "win32 IPC pending pipe states remain retryable" {

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -587,15 +587,34 @@ fn readExactUntil(
     deadline_ms: u64,
 ) !void {
     var offset: usize = 0;
+    var expired_buffered_budget: ?usize = null;
     while (offset < dst.len) {
-        // A zero timeout is a nonblocking poll, not an automatic failure.
-        // Keep consuming immediately available bytes even after partial
-        // progress; enforce the deadline only when the pipe has no data.
+        // A zero timeout is a nonblocking poll, not an automatic failure. At
+        // (or after) the deadline, snapshot the bytes already buffered and
+        // consume at most that snapshot. This permits a buffered multi-read
+        // response without letting a producer extend the deadline forever by
+        // continuously dribbling short reads.
+        if (expired_buffered_budget == null and sys.GetTickCount64() >= deadline_ms) {
+            var available: u32 = 0;
+            if (sys.PeekNamedPipe(pipe, null, 0, null, &available, null) == 0) {
+                const err = windows.kernel32.GetLastError();
+                if (err == .BROKEN_PIPE) return error.EndOfStream;
+                if (pipeIoPending(err)) return error.IpcTimeout;
+                return windows.unexpectedError(err);
+            }
+            if (available == 0) return error.IpcTimeout;
+            expired_buffered_budget = @min(@as(usize, available), dst.len - offset);
+        }
+
+        const read_cap = if (expired_buffered_budget) |budget|
+            @min(budget, dst.len - offset)
+        else
+            dst.len - offset;
         var read_len: u32 = 0;
         if (windows.kernel32.ReadFile(
             pipe,
             dst[offset..].ptr,
-            @intCast(dst.len - offset),
+            @intCast(read_cap),
             &read_len,
             null,
         ) == 0) {
@@ -611,6 +630,10 @@ fn readExactUntil(
 
         if (read_len == 0) return error.EndOfStream;
         offset += read_len;
+        if (expired_buffered_budget) |*budget| {
+            budget.* -= read_len;
+            if (budget.* == 0 and offset < dst.len) return error.IpcTimeout;
+        }
     }
 }
 

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -41,11 +41,18 @@ pub const RequestKind = enum(u8) {
 };
 
 pub const PerformActionPayload = struct {
+    deadline_ms: u64,
     target: apprt.ipc.AutomationActionTarget,
     action_text: []u8,
 };
 
+pub const FocusPayload = struct {
+    deadline_ms: u64,
+    target: apprt.ipc.AutomationTarget,
+};
+
 pub const SendTextPayload = struct {
+    deadline_ms: u64,
     target: apprt.ipc.AutomationTarget,
     text: []u8,
 
@@ -56,6 +63,7 @@ pub const SendTextPayload = struct {
 };
 
 pub const NewTabPayload = struct {
+    deadline_ms: u64,
     target: apprt.ipc.AutomationTarget,
     working_directory: ?[]u8,
     pub fn deinit(self: *@This(), alloc: Allocator) void {
@@ -64,6 +72,7 @@ pub const NewTabPayload = struct {
     }
 };
 pub const NewSplitPayload = struct {
+    deadline_ms: u64,
     target: apprt.ipc.AutomationTarget,
     direction: apprt.ipc.AutomationSplitDirection,
     working_directory: ?[]u8,
@@ -191,13 +200,13 @@ pub fn encodeNewWindowRequest(
     return try encoded.toOwnedSlice(alloc);
 }
 
-pub fn encodeListWindowsRequest(alloc: Allocator) ![]u8 {
+pub fn encodeListWindowsRequest(alloc: Allocator, deadline_ms: u64) ![]u8 {
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
 
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(RequestKind.list_windows));
-    try appendU32(&encoded, alloc, 0);
+    try appendU64(&encoded, alloc, deadline_ms);
 
     return try encoded.toOwnedSlice(alloc);
 }
@@ -206,6 +215,7 @@ pub fn encodePerformActionRequest(
     alloc: Allocator,
     target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
+    deadline_ms: u64,
 ) ![]u8 {
     if (action_text.len == 0 or action_text.len > max_action_text_len) {
         return error.InvalidAutomationAction;
@@ -216,6 +226,7 @@ pub fn encodePerformActionRequest(
 
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(RequestKind.perform_action));
+    try appendU64(&encoded, alloc, deadline_ms);
     try encoded.append(alloc, switch (target) {
         .focused => 0,
         .surface_id => 1,
@@ -233,6 +244,7 @@ pub fn encodePerformActionRequest(
 pub fn encodeLaunchLayoutRequest(
     alloc: Allocator,
     name: []const u8,
+    deadline_ms: u64,
 ) ![]u8 {
     try validateLaunchLayoutName(name);
 
@@ -241,6 +253,7 @@ pub fn encodeLaunchLayoutRequest(
 
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(RequestKind.launch_layout));
+    try appendU64(&encoded, alloc, deadline_ms);
     try appendU32(&encoded, alloc, @intCast(name.len));
     try encoded.appendSlice(alloc, name);
     return try encoded.toOwnedSlice(alloc);
@@ -252,11 +265,13 @@ fn encodeLaunchRequest(
     target: apprt.ipc.AutomationTarget,
     direction: ?apprt.ipc.AutomationSplitDirection,
     working_directory: ?[]const u8,
+    deadline_ms: u64,
 ) ![]u8 {
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(kind));
+    try appendU64(&encoded, alloc, deadline_ms);
     try appendAutomationTarget(&encoded, alloc, target);
     if (direction) |value| try encoded.append(alloc, switch (value) {
         .left => 1,
@@ -268,9 +283,14 @@ fn encodeLaunchRequest(
     return try encoded.toOwnedSlice(alloc);
 }
 
-pub fn encodeNewTabRequest(alloc: Allocator, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8) ![]u8 {
+pub fn encodeNewTabRequest(
+    alloc: Allocator,
+    target: apprt.ipc.AutomationTarget,
+    cwd: ?[]const u8,
+    deadline_ms: u64,
+) ![]u8 {
     try validateLaunchTarget(target, true);
-    return encodeLaunchRequest(alloc, .new_tab, target, null, cwd);
+    return encodeLaunchRequest(alloc, .new_tab, target, null, cwd, deadline_ms);
 }
 
 pub fn encodeNewSplitRequest(
@@ -278,19 +298,22 @@ pub fn encodeNewSplitRequest(
     target: apprt.ipc.AutomationTarget,
     direction: apprt.ipc.AutomationSplitDirection,
     cwd: ?[]const u8,
+    deadline_ms: u64,
 ) ![]u8 {
     try validateLaunchTarget(target, false);
-    return encodeLaunchRequest(alloc, .new_split, target, direction, cwd);
+    return encodeLaunchRequest(alloc, .new_split, target, direction, cwd, deadline_ms);
 }
 
 pub fn encodeFocusRequest(
     alloc: Allocator,
     target: apprt.ipc.AutomationTarget,
+    deadline_ms: u64,
 ) ![]u8 {
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(RequestKind.focus));
+    try appendU64(&encoded, alloc, deadline_ms);
     try appendAutomationTarget(&encoded, alloc, target);
     return try encoded.toOwnedSlice(alloc);
 }
@@ -299,6 +322,7 @@ pub fn encodeSendTextRequest(
     alloc: Allocator,
     target: apprt.ipc.AutomationTarget,
     text: []const u8,
+    deadline_ms: u64,
 ) ![]u8 {
     if (text.len == 0 or text.len > max_action_text_len or
         !std.unicode.utf8ValidateSlice(text) or std.mem.indexOfScalar(u8, text, 0) != null)
@@ -310,6 +334,7 @@ pub fn encodeSendTextRequest(
     errdefer encoded.deinit(alloc);
     try appendU32(&encoded, alloc, wire_version);
     try encoded.append(alloc, @intFromEnum(RequestKind.send_text));
+    try appendU64(&encoded, alloc, deadline_ms);
     try appendAutomationTarget(&encoded, alloc, target);
     try appendU32(&encoded, alloc, @intCast(text.len));
     try encoded.appendSlice(alloc, text);
@@ -364,20 +389,26 @@ pub fn decodeNewWindowPayload(
     return argv;
 }
 
+pub fn decodeListWindowsDeadline(pipe: windows.HANDLE) !u64 {
+    var encoded: [8]u8 = undefined;
+    try readExactUntil(pipe, &encoded, deadline());
+    return readU64(&encoded);
+}
+
 pub fn decodePerformActionPayload(
     alloc: Allocator,
     pipe: windows.HANDLE,
 ) !PerformActionPayload {
     const deadline_ms = deadline();
-    var header: [13]u8 = undefined;
+    var header: [21]u8 = undefined;
     try readExactUntil(pipe, &header, deadline_ms);
 
-    const target: apprt.ipc.AutomationActionTarget = switch (header[0]) {
+    const target: apprt.ipc.AutomationActionTarget = switch (header[8]) {
         0 => .focused,
-        1 => .{ .surface_id = readU64(header[1..9]) },
+        1 => .{ .surface_id = readU64(header[9..17]) },
         else => return error.InvalidIpcRequest,
     };
-    const len = readU32(header[9..13]);
+    const len = readU32(header[17..21]);
     if (len == 0 or len > max_action_text_len) {
         return error.InvalidAutomationAction;
     }
@@ -386,6 +417,7 @@ pub fn decodePerformActionPayload(
     errdefer alloc.free(action_text);
     try readExactUntil(pipe, action_text, deadline_ms);
     return .{
+        .deadline_ms = readU64(header[0..8]),
         .target = target,
         .action_text = action_text,
     };
@@ -394,12 +426,12 @@ pub fn decodePerformActionPayload(
 pub fn decodeLaunchLayoutPayload(
     alloc: Allocator,
     pipe: windows.HANDLE,
-) ![]u8 {
+) !struct { deadline_ms: u64, name: []u8 } {
     const deadline_ms = deadline();
-    var len_buf: [4]u8 = undefined;
-    try readExactUntil(pipe, &len_buf, deadline_ms);
+    var header: [12]u8 = undefined;
+    try readExactUntil(pipe, &header, deadline_ms);
 
-    const len = readU32(&len_buf);
+    const len = readU32(header[8..12]);
     if (len == 0 or len > max_layout_name_len) {
         return error.InvalidAutomationAction;
     }
@@ -408,7 +440,7 @@ pub fn decodeLaunchLayoutPayload(
     errdefer alloc.free(name);
     try readExactUntil(pipe, name, deadline_ms);
     try validateLaunchLayoutName(name);
-    return name;
+    return .{ .deadline_ms = readU64(header[0..8]), .name = name };
 }
 
 fn validateLaunchLayoutName(name: []const u8) !void {
@@ -422,20 +454,24 @@ fn validateLaunchLayoutName(name: []const u8) !void {
 
 pub fn decodeNewTabPayload(alloc: Allocator, pipe: windows.HANDLE) !NewTabPayload {
     const deadline_ms = deadline();
-    var encoded: [9]u8 = undefined;
+    var encoded: [17]u8 = undefined;
     try readExactUntil(pipe, &encoded, deadline_ms);
-    const target = try decodeAutomationTarget(&encoded);
+    const target = try decodeAutomationTarget(encoded[8..17]);
     try validateLaunchTarget(target, true);
-    return .{ .target = target, .working_directory = try decodeWorkingDirectory(alloc, pipe, deadline_ms) };
+    return .{
+        .deadline_ms = readU64(encoded[0..8]),
+        .target = target,
+        .working_directory = try decodeWorkingDirectory(alloc, pipe, deadline_ms),
+    };
 }
 
 pub fn decodeNewSplitPayload(alloc: Allocator, pipe: windows.HANDLE) !NewSplitPayload {
     const deadline_ms = deadline();
-    var encoded: [10]u8 = undefined;
+    var encoded: [18]u8 = undefined;
     try readExactUntil(pipe, &encoded, deadline_ms);
-    const target = try decodeAutomationTarget(encoded[0..9]);
+    const target = try decodeAutomationTarget(encoded[8..17]);
     try validateLaunchTarget(target, false);
-    const direction: apprt.ipc.AutomationSplitDirection = switch (encoded[9]) {
+    const direction: apprt.ipc.AutomationSplitDirection = switch (encoded[17]) {
         1 => .left,
         2 => .right,
         3 => .up,
@@ -443,13 +479,21 @@ pub fn decodeNewSplitPayload(alloc: Allocator, pipe: windows.HANDLE) !NewSplitPa
         else => return error.InvalidAutomationDirection,
     };
     const cwd = try decodeWorkingDirectory(alloc, pipe, deadline_ms);
-    return .{ .target = target, .direction = direction, .working_directory = cwd };
+    return .{
+        .deadline_ms = readU64(encoded[0..8]),
+        .target = target,
+        .direction = direction,
+        .working_directory = cwd,
+    };
 }
 
-pub fn decodeFocusPayload(pipe: windows.HANDLE) !apprt.ipc.AutomationTarget {
-    var encoded: [9]u8 = undefined;
+pub fn decodeFocusPayload(pipe: windows.HANDLE) !FocusPayload {
+    var encoded: [17]u8 = undefined;
     try readExactUntil(pipe, &encoded, deadline());
-    return try decodeAutomationTarget(&encoded);
+    return .{
+        .deadline_ms = readU64(encoded[0..8]),
+        .target = try decodeAutomationTarget(encoded[8..17]),
+    };
 }
 
 pub fn decodeSendTextPayload(
@@ -457,10 +501,10 @@ pub fn decodeSendTextPayload(
     pipe: windows.HANDLE,
 ) !SendTextPayload {
     const deadline_ms = deadline();
-    var header: [13]u8 = undefined;
+    var header: [21]u8 = undefined;
     try readExactUntil(pipe, &header, deadline_ms);
-    const target = try decodeAutomationTarget(header[0..9]);
-    const len = readU32(header[9..13]);
+    const target = try decodeAutomationTarget(header[8..17]);
+    const len = readU32(header[17..21]);
     if (len == 0 or len > max_action_text_len) return error.InvalidAutomationText;
 
     const text = try alloc.alloc(u8, len);
@@ -469,7 +513,11 @@ pub fn decodeSendTextPayload(
     if (!std.unicode.utf8ValidateSlice(text) or std.mem.indexOfScalar(u8, text, 0) != null) {
         return error.InvalidAutomationText;
     }
-    return .{ .target = target, .text = text };
+    return .{
+        .deadline_ms = readU64(header[0..8]),
+        .target = target,
+        .text = text,
+    };
 }
 
 pub fn writeAck(pipe: windows.HANDLE, success: bool) !void {
@@ -680,6 +728,9 @@ fn writeAutomationSizedPayload(
 ) !void {
     try file.setEndPos(0);
     try file.seekTo(0);
+    var deadline_buf: [8]u8 = undefined;
+    std.mem.writeInt(u64, &deadline_buf, test_deadline_ms, .little);
+    try file.writeAll(&deadline_buf);
     try file.writeAll(&target);
     try file.writeAll(extra);
     var len_buf: [4]u8 = undefined;
@@ -688,6 +739,8 @@ fn writeAutomationSizedPayload(
     try file.writeAll(body);
     try file.seekTo(0);
 }
+
+const test_deadline_ms: u64 = 0x0102030405060708;
 
 fn writeAutomationBytes(file: *std.fs.File, bytes: []const u8) !void {
     try file.setEndPos(0);
@@ -705,9 +758,15 @@ test "win32 automation numeric pins" {
     for (acks, 0..) |ack, value| try std.testing.expectEqual(@as(u8, @intCast(value)), ack);
     for ([_]apprt.ipc.AutomationSplitDirection{ .left, .right, .up, .down }, 1..) |direction, value| {
         try std.testing.expectEqual(@as(u8, @intCast(value)), @intFromEnum(direction));
-        const request = try encodeNewSplitRequest(std.testing.allocator, .focused, direction, null);
+        const request = try encodeNewSplitRequest(
+            std.testing.allocator,
+            .focused,
+            direction,
+            null,
+            test_deadline_ms,
+        );
         defer std.testing.allocator.free(request);
-        try std.testing.expectEqual(@as(u8, @intCast(value)), request[14]);
+        try std.testing.expectEqual(@as(u8, @intCast(value)), request[22]);
     }
 }
 
@@ -719,40 +778,61 @@ test "win32 automation request and ack round trips" {
     defer file.close();
 
     for ([_]apprt.ipc.AutomationTarget{ .{ .surface_id = 42 }, .{ .window_id = 17 } }) |target| {
-        const request = try encodeFocusRequest(std.testing.allocator, target);
+        const request = try encodeFocusRequest(std.testing.allocator, target, test_deadline_ms);
         defer std.testing.allocator.free(request);
         try writeAutomationBytes(&file, request);
         try std.testing.expectEqual(RequestKind.focus, try decodeRequestKind(file.handle));
-        try std.testing.expectEqual(target, try decodeFocusPayload(file.handle));
+        const payload = try decodeFocusPayload(file.handle);
+        try std.testing.expectEqual(test_deadline_ms, payload.deadline_ms);
+        try std.testing.expectEqual(target, payload.target);
     }
 
     const text = "printable £ ✓ ; | $(allowed) https://example.com mixed";
-    const send = try encodeSendTextRequest(std.testing.allocator, .{ .surface_id = 0x1234 }, text);
+    const send = try encodeSendTextRequest(
+        std.testing.allocator,
+        .{ .surface_id = 0x1234 },
+        text,
+        test_deadline_ms,
+    );
     defer std.testing.allocator.free(send);
     try writeAutomationBytes(&file, send);
     try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
     var sent = try decodeSendTextPayload(std.testing.allocator, file.handle);
     defer sent.deinit(std.testing.allocator);
+    try std.testing.expectEqual(test_deadline_ms, sent.deadline_ms);
     try std.testing.expectEqualStrings(text, sent.text);
 
     const cwd = try std.testing.allocator.alloc(u8, max_new_window_arg_len);
     defer std.testing.allocator.free(cwd);
     @memset(cwd, 'x');
-    const tab = try encodeNewTabRequest(std.testing.allocator, .{ .window_id = std.math.maxInt(u32) }, cwd);
+    const tab = try encodeNewTabRequest(
+        std.testing.allocator,
+        .{ .window_id = std.math.maxInt(u32) },
+        cwd,
+        test_deadline_ms,
+    );
     defer std.testing.allocator.free(tab);
     try writeAutomationBytes(&file, tab);
     try std.testing.expectEqual(RequestKind.new_tab, try decodeRequestKind(file.handle));
     var tab_payload = try decodeNewTabPayload(std.testing.allocator, file.handle);
     defer tab_payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(test_deadline_ms, tab_payload.deadline_ms);
     try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .window_id = std.math.maxInt(u32) }, tab_payload.target);
     try std.testing.expectEqual(@as(usize, max_new_window_arg_len), tab_payload.working_directory.?.len);
 
-    const split = try encodeNewSplitRequest(std.testing.allocator, .{ .surface_id = 42 }, .down, "C:\\x");
+    const split = try encodeNewSplitRequest(
+        std.testing.allocator,
+        .{ .surface_id = 42 },
+        .down,
+        "C:\\x",
+        test_deadline_ms,
+    );
     defer std.testing.allocator.free(split);
     try writeAutomationBytes(&file, split);
     try std.testing.expectEqual(RequestKind.new_split, try decodeRequestKind(file.handle));
     var split_payload = try decodeNewSplitPayload(std.testing.allocator, file.handle);
     defer split_payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(test_deadline_ms, split_payload.deadline_ms);
     try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .surface_id = 42 }, split_payload.target);
     try std.testing.expectEqual(apprt.ipc.AutomationSplitDirection.down, split_payload.direction);
     try std.testing.expectEqualStrings("C:\\x", split_payload.working_directory.?);
@@ -777,21 +857,21 @@ test "win32 automation malformed codecs free allocations" {
     for ([_][9]u8{ automationTargetBytes(0, 1), automationTargetBytes(1, 0), automationTargetBytes(2, 0), automationTargetBytes(2, @as(u64, std.math.maxInt(u32)) + 1), automationTargetBytes(3, 1) }) |encoded| {
         try std.testing.expectError(error.InvalidAutomationTarget, decodeAutomationTarget(&encoded));
     }
-    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .surface_id = 0 }));
-    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .window_id = 0 }));
-    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewTabRequest(alloc, .{ .surface_id = 1 }, null));
-    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewSplitRequest(alloc, .{ .window_id = 1 }, .right, null));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .surface_id = 0 }, test_deadline_ms));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeFocusRequest(alloc, .{ .window_id = 0 }, test_deadline_ms));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewTabRequest(alloc, .{ .surface_id = 1 }, null, test_deadline_ms));
+    try std.testing.expectError(error.InvalidAutomationTarget, encodeNewSplitRequest(alloc, .{ .window_id = 1 }, .right, null, test_deadline_ms));
     for ([_][]const u8{ "", &.{0xFF}, "x\x00y" }) |value| {
-        try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, value));
-        try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, value));
+        try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, value, test_deadline_ms));
+        try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, value, test_deadline_ms));
     }
     const oversized = try alloc.alloc(u8, max_new_window_arg_len + 1);
     defer alloc.free(oversized);
     @memset(oversized, 'x');
-    try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, oversized[0 .. max_action_text_len + 1]));
-    try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, oversized));
+    try std.testing.expectError(error.InvalidAutomationText, encodeSendTextRequest(alloc, .{ .surface_id = 1 }, oversized[0 .. max_action_text_len + 1], test_deadline_ms));
+    try std.testing.expectError(error.InvalidAutomationWorkingDirectory, encodeNewTabRequest(alloc, .focused, oversized, test_deadline_ms));
 
-    const max_send = try encodeSendTextRequest(alloc, .{ .surface_id = 42 }, oversized[0..max_action_text_len]);
+    const max_send = try encodeSendTextRequest(alloc, .{ .surface_id = 42 }, oversized[0..max_action_text_len], test_deadline_ms);
     defer alloc.free(max_send);
     if (builtin.os.tag != .windows) return error.SkipZigTest;
     var tmp = std.testing.tmpDir(.{});
@@ -908,7 +988,11 @@ test "win32 IPC request kind values remain stable" {
 test "win32 launch-layout IPC encode decode round trip" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
-    const request = try encodeLaunchLayoutRequest(std.testing.allocator, "Project Alpha");
+    const request = try encodeLaunchLayoutRequest(
+        std.testing.allocator,
+        "Project Alpha",
+        test_deadline_ms,
+    );
     defer std.testing.allocator.free(request);
 
     var tmp = std.testing.tmpDir(.{});
@@ -923,8 +1007,9 @@ test "win32 launch-layout IPC encode decode round trip" {
 
     try std.testing.expectEqual(RequestKind.launch_layout, try decodeRequestKind(file.handle));
     const decoded = try decodeLaunchLayoutPayload(std.testing.allocator, file.handle);
-    defer std.testing.allocator.free(decoded);
-    try std.testing.expectEqualStrings("Project Alpha", decoded);
+    defer std.testing.allocator.free(decoded.name);
+    try std.testing.expectEqual(test_deadline_ms, decoded.deadline_ms);
+    try std.testing.expectEqualStrings("Project Alpha", decoded.name);
 }
 
 test "win32 launch-layout IPC encoder rejects invalid names" {
@@ -945,7 +1030,7 @@ test "win32 launch-layout IPC encoder rejects invalid names" {
     };
     for (invalid_names) |name| try std.testing.expectError(
         error.InvalidAutomationAction,
-        encodeLaunchLayoutRequest(std.testing.allocator, name),
+        encodeLaunchLayoutRequest(std.testing.allocator, name, test_deadline_ms),
     );
 }
 
@@ -982,6 +1067,9 @@ test "win32 launch-layout IPC decoder rejects invalid names without leaks" {
         });
         defer file.close();
 
+        var deadline_buf: [8]u8 = undefined;
+        std.mem.writeInt(u64, &deadline_buf, test_deadline_ms, .little);
+        try file.writeAll(&deadline_buf);
         var len_buf: [4]u8 = undefined;
         std.mem.writeInt(u32, &len_buf, @intCast(name.len), .little);
         try file.writeAll(&len_buf);
@@ -1005,6 +1093,9 @@ test "win32 launch-layout IPC decoder cleans up on partial EOF" {
     });
     defer file.close();
 
+    var deadline_buf: [8]u8 = undefined;
+    std.mem.writeInt(u64, &deadline_buf, test_deadline_ms, .little);
+    try file.writeAll(&deadline_buf);
     var len_buf: [4]u8 = undefined;
     std.mem.writeInt(u32, &len_buf, 4, .little);
     try file.writeAll(&len_buf);
@@ -1016,16 +1107,16 @@ test "win32 launch-layout IPC decoder cleans up on partial EOF" {
     );
 }
 
-test "win32 encodeListWindowsRequest preserves legacy zero-argc trailer" {
+test "win32 encodeListWindowsRequest carries the response deadline" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
 
-    const request = try encodeListWindowsRequest(std.testing.allocator);
+    const request = try encodeListWindowsRequest(std.testing.allocator, test_deadline_ms);
     defer std.testing.allocator.free(request);
 
-    try std.testing.expectEqual(@as(usize, 9), request.len);
+    try std.testing.expectEqual(@as(usize, 13), request.len);
     try std.testing.expectEqual(wire_version, readU32(request[0..4]));
     try std.testing.expectEqual(@intFromEnum(RequestKind.list_windows), request[4]);
-    try std.testing.expectEqual(@as(u32, 0), readU32(request[5..9]));
+    try std.testing.expectEqual(test_deadline_ms, readU64(request[5..13]));
 }
 
 test "win32 decodeNewWindowPayload rejects oversized argument length before allocation" {

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -20,6 +20,8 @@ pub const ack_invalid_automation_action: u8 = 2;
 pub const ack_unsafe_automation_action: u8 = 3;
 pub const ack_invalid_automation_target: u8 = 4;
 pub const ack_no_automation_target: u8 = 5;
+pub const ack_automation_target_not_found: u8 = 6;
+pub const ack_automation_policy_refused: u8 = 7;
 pub const max_data_response_len: u32 = 16 * 1024 * 1024;
 pub const max_action_text_len: u32 = 16 * 1024;
 pub const max_new_window_argc: u32 = 4096;
@@ -31,13 +33,24 @@ pub const RequestKind = enum(u8) {
     new_window = 1,
     list_windows = 2,
     perform_action = 3,
-    // Values 4-7 are owned by PR #196 (issue #144).
+    focus = 6,
+    send_text = 7,
     launch_layout = 8,
 };
 
 pub const PerformActionPayload = struct {
     target: apprt.ipc.AutomationActionTarget,
     action_text: []u8,
+};
+
+pub const SendTextPayload = struct {
+    target: apprt.ipc.AutomationTarget,
+    text: []u8,
+
+    pub fn deinit(self: *@This(), alloc: Allocator) void {
+        alloc.free(self.text);
+        self.* = undefined;
+    }
 };
 
 fn appendU32(dst: *std.ArrayList(u8), alloc: Allocator, value: u32) !void {
@@ -50,6 +63,33 @@ fn appendU64(dst: *std.ArrayList(u8), alloc: Allocator, value: u64) !void {
     var buf: [8]u8 = undefined;
     std.mem.writeInt(u64, &buf, value, .little);
     try dst.appendSlice(alloc, &buf);
+}
+
+fn appendAutomationTarget(
+    dst: *std.ArrayList(u8),
+    alloc: Allocator,
+    target: apprt.ipc.AutomationTarget,
+) !void {
+    const tag: u8, const value: u64 = switch (target) {
+        .focused => .{ 0, 0 },
+        .surface_id => |id| if (id == 0) return error.InvalidAutomationTarget else .{ 1, id },
+        .window_id => |id| if (id == 0) return error.InvalidAutomationTarget else .{ 2, id },
+    };
+    try dst.append(alloc, tag);
+    try appendU64(dst, alloc, value);
+}
+
+fn decodeAutomationTarget(src: *const [9]u8) !apprt.ipc.AutomationTarget {
+    const value = readU64(src[1..9]);
+    return switch (src[0]) {
+        0 => if (value == 0) .focused else error.InvalidAutomationTarget,
+        1 => if (value != 0) .{ .surface_id = value } else error.InvalidAutomationTarget,
+        2 => if (value != 0 and value <= std.math.maxInt(u32))
+            .{ .window_id = @intCast(value) }
+        else
+            error.InvalidAutomationTarget,
+        else => error.InvalidAutomationTarget,
+    };
 }
 
 fn readU32(src: []const u8) u32 {
@@ -149,7 +189,39 @@ pub fn encodeLaunchLayoutRequest(
     try encoded.append(alloc, @intFromEnum(RequestKind.launch_layout));
     try appendU32(&encoded, alloc, @intCast(name.len));
     try encoded.appendSlice(alloc, name);
+    return try encoded.toOwnedSlice(alloc);
+}
 
+pub fn encodeFocusRequest(
+    alloc: Allocator,
+    target: apprt.ipc.AutomationTarget,
+) ![]u8 {
+    var encoded: std.ArrayList(u8) = .empty;
+    errdefer encoded.deinit(alloc);
+    try appendU32(&encoded, alloc, wire_version);
+    try encoded.append(alloc, @intFromEnum(RequestKind.focus));
+    try appendAutomationTarget(&encoded, alloc, target);
+    return try encoded.toOwnedSlice(alloc);
+}
+
+pub fn encodeSendTextRequest(
+    alloc: Allocator,
+    target: apprt.ipc.AutomationTarget,
+    text: []const u8,
+) ![]u8 {
+    if (text.len == 0 or text.len > max_action_text_len or
+        !std.unicode.utf8ValidateSlice(text) or std.mem.indexOfScalar(u8, text, 0) != null)
+    {
+        return error.InvalidAutomationText;
+    }
+
+    var encoded: std.ArrayList(u8) = .empty;
+    errdefer encoded.deinit(alloc);
+    try appendU32(&encoded, alloc, wire_version);
+    try encoded.append(alloc, @intFromEnum(RequestKind.send_text));
+    try appendAutomationTarget(&encoded, alloc, target);
+    try appendU32(&encoded, alloc, @intCast(text.len));
+    try encoded.appendSlice(alloc, text);
     return try encoded.toOwnedSlice(alloc);
 }
 
@@ -257,6 +329,32 @@ fn validateLaunchLayoutName(name: []const u8) !void {
     win32_layouts.validateName(name) catch return error.InvalidAutomationAction;
 }
 
+pub fn decodeFocusPayload(pipe: windows.HANDLE) !apprt.ipc.AutomationTarget {
+    var encoded: [9]u8 = undefined;
+    try readExactUntil(pipe, &encoded, deadline());
+    return try decodeAutomationTarget(&encoded);
+}
+
+pub fn decodeSendTextPayload(
+    alloc: Allocator,
+    pipe: windows.HANDLE,
+) !SendTextPayload {
+    const deadline_ms = deadline();
+    var header: [13]u8 = undefined;
+    try readExactUntil(pipe, &header, deadline_ms);
+    const target = try decodeAutomationTarget(header[0..9]);
+    const len = readU32(header[9..13]);
+    if (len == 0 or len > max_action_text_len) return error.InvalidAutomationText;
+
+    const text = try alloc.alloc(u8, len);
+    errdefer alloc.free(text);
+    try readExactUntil(pipe, text, deadline_ms);
+    if (!std.unicode.utf8ValidateSlice(text) or std.mem.indexOfScalar(u8, text, 0) != null) {
+        return error.InvalidAutomationText;
+    }
+    return .{ .target = target, .text = text };
+}
+
 pub fn writeAck(pipe: windows.HANDLE, success: bool) !void {
     return writeAckStatus(pipe, if (success) ack_success else ack_failure);
 }
@@ -283,6 +381,8 @@ pub fn readAckWithTimeout(pipe: windows.HANDLE, timeout_ms: u64) !bool {
         ack_unsafe_automation_action => error.UnsafeAutomationAction,
         ack_invalid_automation_target => error.InvalidAutomationTarget,
         ack_no_automation_target => error.NoAutomationTarget,
+        ack_automation_target_not_found => error.AutomationTargetNotFound,
+        ack_automation_policy_refused => error.AutomationPolicyRefused,
         else => error.InvalidIpcResponse,
     };
 }
@@ -418,6 +518,223 @@ pub fn writeAll(pipe: windows.HANDLE, src: []const u8) !void {
         }
         if (write_len == 0) return error.WriteFailed;
         offset += write_len;
+    }
+}
+
+fn automationTargetBytes(tag: u8, value: u64) [9]u8 {
+    var encoded: [9]u8 = undefined;
+    encoded[0] = tag;
+    std.mem.writeInt(u64, encoded[1..9], value, .little);
+    return encoded;
+}
+
+fn writeAutomationSendTextPayload(
+    file: *std.fs.File,
+    target: [9]u8,
+    declared_len: u32,
+    body: []const u8,
+) !void {
+    try file.setEndPos(0);
+    try file.seekTo(0);
+    try file.writeAll(&target);
+    var len_buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &len_buf, declared_len, .little);
+    try file.writeAll(&len_buf);
+    try file.writeAll(body);
+    try file.seekTo(0);
+}
+
+test "win32 automation wire and status numeric pins" {
+    try std.testing.expectEqual(@as(u32, 1), wire_version);
+    try std.testing.expectEqual(@as(u8, 1), @intFromEnum(RequestKind.new_window));
+    try std.testing.expectEqual(@as(u8, 2), @intFromEnum(RequestKind.list_windows));
+    try std.testing.expectEqual(@as(u8, 3), @intFromEnum(RequestKind.perform_action));
+    try std.testing.expectEqual(@as(u8, 6), @intFromEnum(RequestKind.focus));
+    try std.testing.expectEqual(@as(u8, 7), @intFromEnum(RequestKind.send_text));
+    try std.testing.expectEqual(@as(u8, 0), ack_success);
+    try std.testing.expectEqual(@as(u8, 1), ack_failure);
+    try std.testing.expectEqual(@as(u8, 2), ack_invalid_automation_action);
+    try std.testing.expectEqual(@as(u8, 3), ack_unsafe_automation_action);
+    try std.testing.expectEqual(@as(u8, 4), ack_invalid_automation_target);
+    try std.testing.expectEqual(@as(u8, 5), ack_no_automation_target);
+    try std.testing.expectEqual(@as(u8, 6), ack_automation_target_not_found);
+    try std.testing.expectEqual(@as(u8, 7), ack_automation_policy_refused);
+}
+
+test "win32 automation focus request round trip" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-focus.bin", .{ .read = true });
+    defer file.close();
+
+    for ([_]apprt.ipc.AutomationTarget{
+        .{ .surface_id = 42 },
+        .{ .window_id = 17 },
+    }) |target| {
+        const request = try encodeFocusRequest(std.testing.allocator, target);
+        defer std.testing.allocator.free(request);
+        try file.setEndPos(0);
+        try file.seekTo(0);
+        try file.writeAll(request);
+        try file.seekTo(0);
+        try std.testing.expectEqual(RequestKind.focus, try decodeRequestKind(file.handle));
+        try std.testing.expectEqual(target, try decodeFocusPayload(file.handle));
+    }
+}
+
+test "win32 automation send text request round trip" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const target: apprt.ipc.AutomationTarget = .{ .surface_id = 0x1234 };
+    const text = "printable £ ✓ ; | $(allowed) https://example.com mixed";
+    const request = try encodeSendTextRequest(std.testing.allocator, target, text);
+    defer std.testing.allocator.free(request);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-send-text.bin", .{ .read = true });
+    defer file.close();
+    try file.writeAll(request);
+    try file.seekTo(0);
+
+    try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
+    var payload = try decodeSendTextPayload(std.testing.allocator, file.handle);
+    defer payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(target, payload.target);
+    try std.testing.expectEqualStrings(text, payload.text);
+}
+
+test "win32 automation target tags reject invalid forms" {
+    try std.testing.expectEqual(
+        apprt.ipc.AutomationTarget.focused,
+        try decodeAutomationTarget(&automationTargetBytes(0, 0)),
+    );
+    try std.testing.expectEqual(
+        apprt.ipc.AutomationTarget{ .surface_id = 42 },
+        try decodeAutomationTarget(&automationTargetBytes(1, 42)),
+    );
+    try std.testing.expectEqual(
+        apprt.ipc.AutomationTarget{ .window_id = 17 },
+        try decodeAutomationTarget(&automationTargetBytes(2, 17)),
+    );
+
+    for ([_][9]u8{
+        automationTargetBytes(0, 1),
+        automationTargetBytes(1, 0),
+        automationTargetBytes(2, 0),
+        automationTargetBytes(2, @as(u64, std.math.maxInt(u32)) + 1),
+        automationTargetBytes(3, 1),
+    }) |encoded| {
+        try std.testing.expectError(error.InvalidAutomationTarget, decodeAutomationTarget(&encoded));
+    }
+
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        encodeFocusRequest(std.testing.allocator, .{ .surface_id = 0 }),
+    );
+    try std.testing.expectError(
+        error.InvalidAutomationTarget,
+        encodeFocusRequest(std.testing.allocator, .{ .window_id = 0 }),
+    );
+}
+
+test "win32 automation send text codec enforces text contract" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const target: apprt.ipc.AutomationTarget = .{ .surface_id = 42 };
+    const max_text = try std.testing.allocator.alloc(u8, max_action_text_len);
+    defer std.testing.allocator.free(max_text);
+    @memset(max_text, 'x');
+    const max_request = try encodeSendTextRequest(std.testing.allocator, target, max_text);
+    defer std.testing.allocator.free(max_request);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-send-text-contract.bin", .{ .read = true });
+    defer file.close();
+    try file.writeAll(max_request);
+    try file.seekTo(0);
+    try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
+    var max_payload = try decodeSendTextPayload(std.testing.allocator, file.handle);
+    defer max_payload.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, max_action_text_len), max_payload.text.len);
+
+    const over_text = try std.testing.allocator.alloc(u8, max_action_text_len + 1);
+    defer std.testing.allocator.free(over_text);
+    @memset(over_text, 'x');
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        encodeSendTextRequest(std.testing.allocator, target, ""),
+    );
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        encodeSendTextRequest(std.testing.allocator, target, over_text),
+    );
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        encodeSendTextRequest(std.testing.allocator, target, &.{0xFF}),
+    );
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        encodeSendTextRequest(std.testing.allocator, target, "a\x00b"),
+    );
+
+    const raw_target = automationTargetBytes(1, 42);
+    try writeAutomationSendTextPayload(&file, raw_target, 0, "");
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        decodeSendTextPayload(std.testing.allocator, file.handle),
+    );
+    try writeAutomationSendTextPayload(&file, raw_target, max_action_text_len + 1, "");
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        decodeSendTextPayload(std.testing.allocator, file.handle),
+    );
+    try writeAutomationSendTextPayload(&file, raw_target, 1, &.{0xFF});
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        decodeSendTextPayload(std.testing.allocator, file.handle),
+    );
+    try writeAutomationSendTextPayload(&file, raw_target, 3, "a\x00b");
+    try std.testing.expectError(
+        error.InvalidAutomationText,
+        decodeSendTextPayload(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 automation send text partial EOF frees allocation" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-send-text-eof.bin", .{ .read = true });
+    defer file.close();
+    try writeAutomationSendTextPayload(&file, automationTargetBytes(1, 42), 3, "x");
+    try std.testing.expectError(
+        error.EndOfStream,
+        decodeSendTextPayload(std.testing.allocator, file.handle),
+    );
+}
+
+test "win32 automation ack maps target and policy statuses" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-ack.bin", .{ .read = true });
+    defer file.close();
+
+    for ([_]struct { status: u8, expected: anyerror }{
+        .{ .status = ack_automation_target_not_found, .expected = error.AutomationTargetNotFound },
+        .{ .status = ack_automation_policy_refused, .expected = error.AutomationPolicyRefused },
+    }) |case| {
+        try file.setEndPos(0);
+        try file.seekTo(0);
+        try writeAckStatus(file.handle, case.status);
+        try file.seekTo(0);
+        try std.testing.expectError(case.expected, readAck(file.handle));
     }
 }
 

--- a/src/apprt/win32_ipc.zig
+++ b/src/apprt/win32_ipc.zig
@@ -38,6 +38,13 @@ pub const RequestKind = enum(u8) {
     focus = 6,
     send_text = 7,
     launch_layout = 8,
+    list_windows_timed = 9,
+    perform_action_timed = 10,
+    new_tab_timed = 11,
+    new_split_timed = 12,
+    focus_timed = 13,
+    send_text_timed = 14,
+    launch_layout_timed = 15,
 };
 
 pub const PerformActionPayload = struct {
@@ -205,7 +212,7 @@ pub fn encodeListWindowsRequest(alloc: Allocator, deadline_ms: u64) ![]u8 {
     errdefer encoded.deinit(alloc);
 
     try appendU32(&encoded, alloc, wire_version);
-    try encoded.append(alloc, @intFromEnum(RequestKind.list_windows));
+    try encoded.append(alloc, @intFromEnum(RequestKind.list_windows_timed));
     try appendU64(&encoded, alloc, deadline_ms);
 
     return try encoded.toOwnedSlice(alloc);
@@ -225,7 +232,7 @@ pub fn encodePerformActionRequest(
     errdefer encoded.deinit(alloc);
 
     try appendU32(&encoded, alloc, wire_version);
-    try encoded.append(alloc, @intFromEnum(RequestKind.perform_action));
+    try encoded.append(alloc, @intFromEnum(RequestKind.perform_action_timed));
     try appendU64(&encoded, alloc, deadline_ms);
     try encoded.append(alloc, switch (target) {
         .focused => 0,
@@ -252,7 +259,7 @@ pub fn encodeLaunchLayoutRequest(
     errdefer encoded.deinit(alloc);
 
     try appendU32(&encoded, alloc, wire_version);
-    try encoded.append(alloc, @intFromEnum(RequestKind.launch_layout));
+    try encoded.append(alloc, @intFromEnum(RequestKind.launch_layout_timed));
     try appendU64(&encoded, alloc, deadline_ms);
     try appendU32(&encoded, alloc, @intCast(name.len));
     try encoded.appendSlice(alloc, name);
@@ -290,7 +297,7 @@ pub fn encodeNewTabRequest(
     deadline_ms: u64,
 ) ![]u8 {
     try validateLaunchTarget(target, true);
-    return encodeLaunchRequest(alloc, .new_tab, target, null, cwd, deadline_ms);
+    return encodeLaunchRequest(alloc, .new_tab_timed, target, null, cwd, deadline_ms);
 }
 
 pub fn encodeNewSplitRequest(
@@ -301,7 +308,7 @@ pub fn encodeNewSplitRequest(
     deadline_ms: u64,
 ) ![]u8 {
     try validateLaunchTarget(target, false);
-    return encodeLaunchRequest(alloc, .new_split, target, direction, cwd, deadline_ms);
+    return encodeLaunchRequest(alloc, .new_split_timed, target, direction, cwd, deadline_ms);
 }
 
 pub fn encodeFocusRequest(
@@ -312,7 +319,7 @@ pub fn encodeFocusRequest(
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
     try appendU32(&encoded, alloc, wire_version);
-    try encoded.append(alloc, @intFromEnum(RequestKind.focus));
+    try encoded.append(alloc, @intFromEnum(RequestKind.focus_timed));
     try appendU64(&encoded, alloc, deadline_ms);
     try appendAutomationTarget(&encoded, alloc, target);
     return try encoded.toOwnedSlice(alloc);
@@ -333,7 +340,7 @@ pub fn encodeSendTextRequest(
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(alloc);
     try appendU32(&encoded, alloc, wire_version);
-    try encoded.append(alloc, @intFromEnum(RequestKind.send_text));
+    try encoded.append(alloc, @intFromEnum(RequestKind.send_text_timed));
     try appendU64(&encoded, alloc, deadline_ms);
     try appendAutomationTarget(&encoded, alloc, target);
     try appendU32(&encoded, alloc, @intCast(text.len));
@@ -389,35 +396,54 @@ pub fn decodeNewWindowPayload(
     return argv;
 }
 
-pub fn decodeListWindowsDeadline(pipe: windows.HANDLE) !u64 {
+fn decodeAutomationDeadline(
+    pipe: windows.HANDLE,
+    timed: bool,
+    io_deadline_ms: u64,
+) !u64 {
+    if (!timed) return std.math.maxInt(u64);
     var encoded: [8]u8 = undefined;
-    try readExactUntil(pipe, &encoded, deadline());
+    try readExactUntil(pipe, &encoded, io_deadline_ms);
     return readU64(&encoded);
+}
+
+pub fn decodeListWindowsDeadline(pipe: windows.HANDLE, timed: bool) !u64 {
+    const io_deadline_ms = deadline();
+    if (timed) return decodeAutomationDeadline(pipe, true, io_deadline_ms);
+
+    // Kind 2's original v1 payload was a zero u32 trailer. Keep accepting it
+    // so an older client can query a newer running instance.
+    var trailer: [4]u8 = undefined;
+    try readExactUntil(pipe, &trailer, io_deadline_ms);
+    if (readU32(&trailer) != 0) return error.InvalidIpcRequest;
+    return std.math.maxInt(u64);
 }
 
 pub fn decodePerformActionPayload(
     alloc: Allocator,
     pipe: windows.HANDLE,
+    timed: bool,
 ) !PerformActionPayload {
-    const deadline_ms = deadline();
-    var header: [21]u8 = undefined;
-    try readExactUntil(pipe, &header, deadline_ms);
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var header: [13]u8 = undefined;
+    try readExactUntil(pipe, &header, io_deadline_ms);
 
-    const target: apprt.ipc.AutomationActionTarget = switch (header[8]) {
+    const target: apprt.ipc.AutomationActionTarget = switch (header[0]) {
         0 => .focused,
-        1 => .{ .surface_id = readU64(header[9..17]) },
+        1 => .{ .surface_id = readU64(header[1..9]) },
         else => return error.InvalidIpcRequest,
     };
-    const len = readU32(header[17..21]);
+    const len = readU32(header[9..13]);
     if (len == 0 or len > max_action_text_len) {
         return error.InvalidAutomationAction;
     }
 
     const action_text = try alloc.alloc(u8, len);
     errdefer alloc.free(action_text);
-    try readExactUntil(pipe, action_text, deadline_ms);
+    try readExactUntil(pipe, action_text, io_deadline_ms);
     return .{
-        .deadline_ms = readU64(header[0..8]),
+        .deadline_ms = request_deadline_ms,
         .target = target,
         .action_text = action_text,
     };
@@ -426,21 +452,23 @@ pub fn decodePerformActionPayload(
 pub fn decodeLaunchLayoutPayload(
     alloc: Allocator,
     pipe: windows.HANDLE,
+    timed: bool,
 ) !struct { deadline_ms: u64, name: []u8 } {
-    const deadline_ms = deadline();
-    var header: [12]u8 = undefined;
-    try readExactUntil(pipe, &header, deadline_ms);
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var len_buf: [4]u8 = undefined;
+    try readExactUntil(pipe, &len_buf, io_deadline_ms);
 
-    const len = readU32(header[8..12]);
+    const len = readU32(&len_buf);
     if (len == 0 or len > max_layout_name_len) {
         return error.InvalidAutomationAction;
     }
 
     const name = try alloc.alloc(u8, len);
     errdefer alloc.free(name);
-    try readExactUntil(pipe, name, deadline_ms);
+    try readExactUntil(pipe, name, io_deadline_ms);
     try validateLaunchLayoutName(name);
-    return .{ .deadline_ms = readU64(header[0..8]), .name = name };
+    return .{ .deadline_ms = request_deadline_ms, .name = name };
 }
 
 fn validateLaunchLayoutName(name: []const u8) !void {
@@ -452,69 +480,75 @@ fn validateLaunchLayoutName(name: []const u8) !void {
     win32_layouts.validateName(name) catch return error.InvalidAutomationAction;
 }
 
-pub fn decodeNewTabPayload(alloc: Allocator, pipe: windows.HANDLE) !NewTabPayload {
-    const deadline_ms = deadline();
-    var encoded: [17]u8 = undefined;
-    try readExactUntil(pipe, &encoded, deadline_ms);
-    const target = try decodeAutomationTarget(encoded[8..17]);
+pub fn decodeNewTabPayload(alloc: Allocator, pipe: windows.HANDLE, timed: bool) !NewTabPayload {
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var encoded: [9]u8 = undefined;
+    try readExactUntil(pipe, &encoded, io_deadline_ms);
+    const target = try decodeAutomationTarget(&encoded);
     try validateLaunchTarget(target, true);
     return .{
-        .deadline_ms = readU64(encoded[0..8]),
+        .deadline_ms = request_deadline_ms,
         .target = target,
-        .working_directory = try decodeWorkingDirectory(alloc, pipe, deadline_ms),
+        .working_directory = try decodeWorkingDirectory(alloc, pipe, io_deadline_ms),
     };
 }
 
-pub fn decodeNewSplitPayload(alloc: Allocator, pipe: windows.HANDLE) !NewSplitPayload {
-    const deadline_ms = deadline();
-    var encoded: [18]u8 = undefined;
-    try readExactUntil(pipe, &encoded, deadline_ms);
-    const target = try decodeAutomationTarget(encoded[8..17]);
+pub fn decodeNewSplitPayload(alloc: Allocator, pipe: windows.HANDLE, timed: bool) !NewSplitPayload {
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var encoded: [10]u8 = undefined;
+    try readExactUntil(pipe, &encoded, io_deadline_ms);
+    const target = try decodeAutomationTarget(encoded[0..9]);
     try validateLaunchTarget(target, false);
-    const direction: apprt.ipc.AutomationSplitDirection = switch (encoded[17]) {
+    const direction: apprt.ipc.AutomationSplitDirection = switch (encoded[9]) {
         1 => .left,
         2 => .right,
         3 => .up,
         4 => .down,
         else => return error.InvalidAutomationDirection,
     };
-    const cwd = try decodeWorkingDirectory(alloc, pipe, deadline_ms);
+    const cwd = try decodeWorkingDirectory(alloc, pipe, io_deadline_ms);
     return .{
-        .deadline_ms = readU64(encoded[0..8]),
+        .deadline_ms = request_deadline_ms,
         .target = target,
         .direction = direction,
         .working_directory = cwd,
     };
 }
 
-pub fn decodeFocusPayload(pipe: windows.HANDLE) !FocusPayload {
-    var encoded: [17]u8 = undefined;
-    try readExactUntil(pipe, &encoded, deadline());
+pub fn decodeFocusPayload(pipe: windows.HANDLE, timed: bool) !FocusPayload {
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var encoded: [9]u8 = undefined;
+    try readExactUntil(pipe, &encoded, io_deadline_ms);
     return .{
-        .deadline_ms = readU64(encoded[0..8]),
-        .target = try decodeAutomationTarget(encoded[8..17]),
+        .deadline_ms = request_deadline_ms,
+        .target = try decodeAutomationTarget(&encoded),
     };
 }
 
 pub fn decodeSendTextPayload(
     alloc: Allocator,
     pipe: windows.HANDLE,
+    timed: bool,
 ) !SendTextPayload {
-    const deadline_ms = deadline();
-    var header: [21]u8 = undefined;
-    try readExactUntil(pipe, &header, deadline_ms);
-    const target = try decodeAutomationTarget(header[8..17]);
-    const len = readU32(header[17..21]);
+    const io_deadline_ms = deadline();
+    const request_deadline_ms = try decodeAutomationDeadline(pipe, timed, io_deadline_ms);
+    var header: [13]u8 = undefined;
+    try readExactUntil(pipe, &header, io_deadline_ms);
+    const target = try decodeAutomationTarget(header[0..9]);
+    const len = readU32(header[9..13]);
     if (len == 0 or len > max_action_text_len) return error.InvalidAutomationText;
 
     const text = try alloc.alloc(u8, len);
     errdefer alloc.free(text);
-    try readExactUntil(pipe, text, deadline_ms);
+    try readExactUntil(pipe, text, io_deadline_ms);
     if (!std.unicode.utf8ValidateSlice(text) or std.mem.indexOfScalar(u8, text, 0) != null) {
         return error.InvalidAutomationText;
     }
     return .{
-        .deadline_ms = readU64(header[0..8]),
+        .deadline_ms = request_deadline_ms,
         .target = target,
         .text = text,
     };
@@ -751,7 +785,23 @@ fn writeAutomationBytes(file: *std.fs.File, bytes: []const u8) !void {
 
 test "win32 automation numeric pins" {
     try std.testing.expectEqual(@as(u32, 1), wire_version);
-    for ([_]RequestKind{ .new_window, .list_windows, .perform_action, .new_tab, .new_split, .focus, .send_text }, 1..) |kind, value| {
+    for ([_]RequestKind{
+        .new_window,
+        .list_windows,
+        .perform_action,
+        .new_tab,
+        .new_split,
+        .focus,
+        .send_text,
+        .launch_layout,
+        .list_windows_timed,
+        .perform_action_timed,
+        .new_tab_timed,
+        .new_split_timed,
+        .focus_timed,
+        .send_text_timed,
+        .launch_layout_timed,
+    }, 1..) |kind, value| {
         try std.testing.expectEqual(@as(u8, @intCast(value)), @intFromEnum(kind));
     }
     const acks = [_]u8{ ack_success, ack_failure, ack_invalid_automation_action, ack_unsafe_automation_action, ack_invalid_automation_target, ack_no_automation_target, ack_automation_target_not_found, ack_automation_policy_refused };
@@ -770,6 +820,42 @@ test "win32 automation numeric pins" {
     }
 }
 
+test "win32 automation keeps legacy v1 kinds decodable" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile("automation-legacy-v1.bin", .{ .read = true });
+    defer file.close();
+
+    var list_request: [9]u8 = undefined;
+    std.mem.writeInt(u32, list_request[0..4], wire_version, .little);
+    list_request[4] = @intFromEnum(RequestKind.list_windows);
+    std.mem.writeInt(u32, list_request[5..9], 0, .little);
+    try writeAutomationBytes(&file, &list_request);
+    try std.testing.expectEqual(RequestKind.list_windows, try decodeRequestKind(file.handle));
+    try std.testing.expectEqual(
+        std.math.maxInt(u64),
+        try decodeListWindowsDeadline(file.handle, false),
+    );
+
+    const action_text = "new_tab";
+    var action_request: std.ArrayList(u8) = .empty;
+    defer action_request.deinit(std.testing.allocator);
+    try appendU32(&action_request, std.testing.allocator, wire_version);
+    try action_request.append(std.testing.allocator, @intFromEnum(RequestKind.perform_action));
+    try action_request.append(std.testing.allocator, 0);
+    try appendU64(&action_request, std.testing.allocator, 0);
+    try appendU32(&action_request, std.testing.allocator, @intCast(action_text.len));
+    try action_request.appendSlice(std.testing.allocator, action_text);
+    try writeAutomationBytes(&file, action_request.items);
+    try std.testing.expectEqual(RequestKind.perform_action, try decodeRequestKind(file.handle));
+    const payload = try decodePerformActionPayload(std.testing.allocator, file.handle, false);
+    defer std.testing.allocator.free(payload.action_text);
+    try std.testing.expectEqual(std.math.maxInt(u64), payload.deadline_ms);
+    try std.testing.expectEqual(apprt.ipc.AutomationActionTarget.focused, payload.target);
+    try std.testing.expectEqualStrings(action_text, payload.action_text);
+}
+
 test "win32 automation request and ack round trips" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
     var tmp = std.testing.tmpDir(.{});
@@ -781,8 +867,8 @@ test "win32 automation request and ack round trips" {
         const request = try encodeFocusRequest(std.testing.allocator, target, test_deadline_ms);
         defer std.testing.allocator.free(request);
         try writeAutomationBytes(&file, request);
-        try std.testing.expectEqual(RequestKind.focus, try decodeRequestKind(file.handle));
-        const payload = try decodeFocusPayload(file.handle);
+        try std.testing.expectEqual(RequestKind.focus_timed, try decodeRequestKind(file.handle));
+        const payload = try decodeFocusPayload(file.handle, true);
         try std.testing.expectEqual(test_deadline_ms, payload.deadline_ms);
         try std.testing.expectEqual(target, payload.target);
     }
@@ -796,8 +882,8 @@ test "win32 automation request and ack round trips" {
     );
     defer std.testing.allocator.free(send);
     try writeAutomationBytes(&file, send);
-    try std.testing.expectEqual(RequestKind.send_text, try decodeRequestKind(file.handle));
-    var sent = try decodeSendTextPayload(std.testing.allocator, file.handle);
+    try std.testing.expectEqual(RequestKind.send_text_timed, try decodeRequestKind(file.handle));
+    var sent = try decodeSendTextPayload(std.testing.allocator, file.handle, true);
     defer sent.deinit(std.testing.allocator);
     try std.testing.expectEqual(test_deadline_ms, sent.deadline_ms);
     try std.testing.expectEqualStrings(text, sent.text);
@@ -813,8 +899,8 @@ test "win32 automation request and ack round trips" {
     );
     defer std.testing.allocator.free(tab);
     try writeAutomationBytes(&file, tab);
-    try std.testing.expectEqual(RequestKind.new_tab, try decodeRequestKind(file.handle));
-    var tab_payload = try decodeNewTabPayload(std.testing.allocator, file.handle);
+    try std.testing.expectEqual(RequestKind.new_tab_timed, try decodeRequestKind(file.handle));
+    var tab_payload = try decodeNewTabPayload(std.testing.allocator, file.handle, true);
     defer tab_payload.deinit(std.testing.allocator);
     try std.testing.expectEqual(test_deadline_ms, tab_payload.deadline_ms);
     try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .window_id = std.math.maxInt(u32) }, tab_payload.target);
@@ -829,8 +915,8 @@ test "win32 automation request and ack round trips" {
     );
     defer std.testing.allocator.free(split);
     try writeAutomationBytes(&file, split);
-    try std.testing.expectEqual(RequestKind.new_split, try decodeRequestKind(file.handle));
-    var split_payload = try decodeNewSplitPayload(std.testing.allocator, file.handle);
+    try std.testing.expectEqual(RequestKind.new_split_timed, try decodeRequestKind(file.handle));
+    var split_payload = try decodeNewSplitPayload(std.testing.allocator, file.handle, true);
     defer split_payload.deinit(std.testing.allocator);
     try std.testing.expectEqual(test_deadline_ms, split_payload.deadline_ms);
     try std.testing.expectEqual(apprt.ipc.AutomationTarget{ .surface_id = 42 }, split_payload.target);
@@ -880,7 +966,7 @@ test "win32 automation malformed codecs free allocations" {
     defer file.close();
     try writeAutomationBytes(&file, max_send);
     _ = try decodeRequestKind(file.handle);
-    var max_payload = try decodeSendTextPayload(alloc, file.handle);
+    var max_payload = try decodeSendTextPayload(alloc, file.handle, true);
     defer max_payload.deinit(alloc);
     try std.testing.expectEqual(@as(usize, max_action_text_len), max_payload.text.len);
 
@@ -895,12 +981,12 @@ test "win32 automation malformed codecs free allocations" {
     };
     for (bad_cases) |case| {
         try writeAutomationSizedPayload(&file, surface, "", case.len, case.body);
-        try std.testing.expectError(case.expected, decodeSendTextPayload(alloc, file.handle));
+        try std.testing.expectError(case.expected, decodeSendTextPayload(alloc, file.handle, true));
     }
     try writeAutomationSizedPayload(&file, surface, "", 0, "");
-    try std.testing.expectError(error.InvalidAutomationTarget, decodeNewTabPayload(alloc, file.handle));
+    try std.testing.expectError(error.InvalidAutomationTarget, decodeNewTabPayload(alloc, file.handle, true));
     try writeAutomationSizedPayload(&file, surface, &.{0}, 0, "");
-    try std.testing.expectError(error.InvalidAutomationDirection, decodeNewSplitPayload(alloc, file.handle));
+    try std.testing.expectError(error.InvalidAutomationDirection, decodeNewSplitPayload(alloc, file.handle, true));
     for ([_]struct { len: u32, body: []const u8, expected: anyerror }{
         .{ .len = 1, .body = &.{0xFF}, .expected = error.InvalidAutomationWorkingDirectory },
         .{ .len = 3, .body = "x\x00y", .expected = error.InvalidAutomationWorkingDirectory },
@@ -908,7 +994,7 @@ test "win32 automation malformed codecs free allocations" {
         .{ .len = 3, .body = "x", .expected = error.EndOfStream },
     }) |case| {
         try writeAutomationSizedPayload(&file, window, "", case.len, case.body);
-        try std.testing.expectError(case.expected, decodeNewTabPayload(alloc, file.handle));
+        try std.testing.expectError(case.expected, decodeNewTabPayload(alloc, file.handle, true));
     }
 }
 
@@ -1005,8 +1091,8 @@ test "win32 launch-layout IPC encode decode round trip" {
     try file.writeAll(request);
     try file.seekTo(0);
 
-    try std.testing.expectEqual(RequestKind.launch_layout, try decodeRequestKind(file.handle));
-    const decoded = try decodeLaunchLayoutPayload(std.testing.allocator, file.handle);
+    try std.testing.expectEqual(RequestKind.launch_layout_timed, try decodeRequestKind(file.handle));
+    const decoded = try decodeLaunchLayoutPayload(std.testing.allocator, file.handle, true);
     defer std.testing.allocator.free(decoded.name);
     try std.testing.expectEqual(test_deadline_ms, decoded.deadline_ms);
     try std.testing.expectEqualStrings("Project Alpha", decoded.name);
@@ -1077,7 +1163,7 @@ test "win32 launch-layout IPC decoder rejects invalid names without leaks" {
         try file.seekTo(0);
         try std.testing.expectError(
             error.InvalidAutomationAction,
-            decodeLaunchLayoutPayload(std.testing.allocator, file.handle),
+            decodeLaunchLayoutPayload(std.testing.allocator, file.handle, true),
         );
     }
 }
@@ -1103,7 +1189,7 @@ test "win32 launch-layout IPC decoder cleans up on partial EOF" {
     try file.seekTo(0);
     try std.testing.expectError(
         error.EndOfStream,
-        decodeLaunchLayoutPayload(std.testing.allocator, file.handle),
+        decodeLaunchLayoutPayload(std.testing.allocator, file.handle, true),
     );
 }
 
@@ -1115,7 +1201,7 @@ test "win32 encodeListWindowsRequest carries the response deadline" {
 
     try std.testing.expectEqual(@as(usize, 13), request.len);
     try std.testing.expectEqual(wire_version, readU32(request[0..4]));
-    try std.testing.expectEqual(@intFromEnum(RequestKind.list_windows), request[4]);
+    try std.testing.expectEqual(@intFromEnum(RequestKind.list_windows_timed), request[4]);
     try std.testing.expectEqual(test_deadline_ms, readU64(request[5..13]));
 }
 

--- a/src/cli/action.zig
+++ b/src/cli/action.zig
@@ -37,6 +37,11 @@ pub fn detectIter(
     var fallback: ?E = null;
     var pending: ?E = null;
     while (iter.next()) |arg| {
+        // Everything after the conventional delimiter belongs to the
+        // selected action or child command and must not be reinterpreted as
+        // another top-level action.
+        if (std.mem.eql(u8, arg, "--")) break;
+
         // Allow handling of special cases.
         if (@hasDecl(E, "detectSpecialCase")) special: {
             const special = E.detectSpecialCase(arg) orelse break :special;
@@ -125,6 +130,21 @@ test "detect multiple actions" {
         DetectError.MultipleActions,
         detectIter(Enum, &iter),
     );
+}
+
+test "detect stops at literal argument delimiter" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const Enum = enum { foo, bar, version };
+
+    for ([_][]const u8{
+        "+foo -- +bar",
+        "+foo -- --version",
+    }) |args_text| {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(alloc, args_text);
+        defer iter.deinit();
+        try testing.expectEqual(Enum.foo, (try detectIter(Enum, &iter)).?);
+    }
 }
 
 test "detect no match" {

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -1337,6 +1337,11 @@ pub fn ArgsIterator(comptime Iterator: type) type {
         /// values yet.
         index: usize = 0,
 
+        /// Once the conventional literal delimiter is observed, arguments
+        /// belong to the selected action and must no longer be filtered as
+        /// top-level +actions.
+        literal: bool = false,
+
         pub fn deinit(self: *Self) void {
             if (@hasDecl(Iterator, "deinit")) {
                 self.iterator.deinit();
@@ -1347,10 +1352,15 @@ pub fn ArgsIterator(comptime Iterator: type) type {
             const value = self.iterator.next() orelse return null;
             self.index += 1;
 
+            if (std.mem.eql(u8, value, "--")) {
+                self.literal = true;
+                return value;
+            }
+
             // We ignore any argument that starts with "+". This is used
             // to indicate actions and are expected to be parsed out before
             // this iterator is created.
-            if (value.len > 0 and value[0] == '+') return self.next();
+            if (!self.literal and value.len > 0 and value[0] == '+') return self.next();
 
             return value;
         }
@@ -1384,6 +1394,23 @@ test "ArgsIterator" {
     try testing.expectEqualStrings("--what", iter.next().?);
     try testing.expectEqualStrings("--a=42", iter.next().?);
     try testing.expectEqual(@as(?[]const u8, null), iter.next());
+    try testing.expectEqual(@as(?[]const u8, null), iter.next());
+}
+
+test "ArgsIterator preserves plus-prefixed values after literal delimiter" {
+    const testing = std.testing;
+
+    const child = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "+send-text --surface-id=42 -- +focus",
+    );
+    const Iter = ArgsIterator(@TypeOf(child));
+    var iter: Iter = .{ .iterator = child };
+    defer iter.deinit();
+
+    try testing.expectEqualStrings("--surface-id=42", iter.next().?);
+    try testing.expectEqualStrings("--", iter.next().?);
+    try testing.expectEqualStrings("+focus", iter.next().?);
     try testing.expectEqual(@as(?[]const u8, null), iter.next());
 }
 

--- a/src/cli/automation_test_support.zig
+++ b/src/cli/automation_test_support.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+/// Minimal argument iterator for automation CLI unit tests.
+pub const TestArgs = struct {
+    items: []const []const u8,
+    index: usize = 0,
+
+    /// Returns the next test argument, or null at the end of the input.
+    pub fn next(self: *@This()) ?[]const u8 {
+        if (self.index == self.items.len) {
+            return null;
+        }
+        defer self.index += 1;
+        return self.items[self.index];
+    }
+};
+
+/// Runs an injected automation CLI seam with in-memory arguments and stderr.
+pub fn testRun(comptime runner: anytype, items: []const []const u8, hook: anytype) !u8 {
+    var iter: TestArgs = .{ .items = items };
+    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stderr.deinit();
+
+    return runner(std.testing.allocator, &iter, &stderr.writer, hook);
+}
+
+/// Maps stable CLI exit codes to representative hook outcomes for tests.
+pub fn testOutcome(code: u8) !bool {
+    return switch (code) {
+        1 => error.InvalidAutomationTarget,
+        2 => false,
+        3 => error.AutomationTargetNotFound,
+        4 => error.AutomationPolicyRefused,
+        5 => error.IPCFailed,
+        else => true,
+    };
+}

--- a/src/cli/automation_working_directory.zig
+++ b/src/cli/automation_working_directory.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+/// Mirrors win32.forwardedWorkingDirectoryAllowed.
+pub fn allowed(value: []const u8) bool {
+    if (!std.unicode.utf8ValidateSlice(value) or std.mem.indexOfScalar(u8, value, 0) != null) return false;
+    var path = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (path.len >= 2 and path[0] == '"' and path[path.len - 1] == '"') {
+        path = std.mem.trim(u8, path[1 .. path.len - 1], &std.ascii.whitespace);
+    }
+    if (std.mem.eql(u8, path, "home") or std.mem.eql(u8, path, "inherit") or std.mem.eql(u8, path, "~")) return true;
+    if (path.len >= 2 and path[0] == '~' and (path[1] == '/' or path[1] == '\\')) return true;
+    return path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
+        (path[2] == '/' or path[2] == '\\');
+}
+pub const TestArgs = struct {
+    items: []const []const u8,
+    index: usize = 0,
+    pub fn next(self: *@This()) ?[]const u8 {
+        if (self.index == self.items.len) return null;
+        defer self.index += 1;
+        return self.items[self.index];
+    }
+};
+pub fn testRun(comptime runner: anytype, items: []const []const u8, hook: anytype) !u8 {
+    var iter: TestArgs = .{ .items = items };
+    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stderr.deinit();
+    return runner(std.testing.allocator, &iter, &stderr.writer, hook);
+}
+pub fn testOutcome(code: u8) !bool {
+    return switch (code) {
+        1 => error.InvalidAutomationTarget,
+        2 => false,
+        3 => error.AutomationTargetNotFound,
+        4 => error.AutomationPolicyRefused,
+        5 => error.IPCFailed,
+        else => true,
+    };
+}

--- a/src/cli/automation_working_directory.zig
+++ b/src/cli/automation_working_directory.zig
@@ -1,8 +1,13 @@
 const std = @import("std");
 
+/// Keep this in sync with win32_ipc.max_new_window_arg_len. This CLI module
+/// validates before platform dispatch so an oversized value is a usage error.
+const max_wire_bytes: usize = 32 * 1024;
+
 /// Mirrors win32.forwardedWorkingDirectoryAllowed.
 pub fn allowed(value: []const u8) bool {
-    if (!std.unicode.utf8ValidateSlice(value) or
+    if (value.len > max_wire_bytes or
+        !std.unicode.utf8ValidateSlice(value) or
         std.mem.indexOfScalar(u8, value, 0) != null)
     {
         return false;
@@ -29,4 +34,15 @@ pub fn allowed(value: []const u8) bool {
 
     return path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
         (path[2] == '/' or path[2] == '\\');
+}
+
+test "automation working directory enforces wire byte limit" {
+    const alloc = std.testing.allocator;
+    const path = try alloc.alloc(u8, max_wire_bytes + 1);
+    defer alloc.free(path);
+    @memset(path, 'x');
+    @memcpy(path[0..3], "C:\\");
+
+    try std.testing.expect(allowed(path[0..max_wire_bytes]));
+    try std.testing.expect(!allowed(path));
 }

--- a/src/cli/automation_working_directory.zig
+++ b/src/cli/automation_working_directory.zig
@@ -1,38 +1,32 @@
 const std = @import("std");
+
 /// Mirrors win32.forwardedWorkingDirectoryAllowed.
 pub fn allowed(value: []const u8) bool {
-    if (!std.unicode.utf8ValidateSlice(value) or std.mem.indexOfScalar(u8, value, 0) != null) return false;
+    if (!std.unicode.utf8ValidateSlice(value) or
+        std.mem.indexOfScalar(u8, value, 0) != null)
+    {
+        return false;
+    }
+
     var path = std.mem.trim(u8, value, &std.ascii.whitespace);
     if (path.len >= 2 and path[0] == '"' and path[path.len - 1] == '"') {
         path = std.mem.trim(u8, path[1 .. path.len - 1], &std.ascii.whitespace);
     }
-    if (std.mem.eql(u8, path, "home") or std.mem.eql(u8, path, "inherit") or std.mem.eql(u8, path, "~")) return true;
-    if (path.len >= 2 and path[0] == '~' and (path[1] == '/' or path[1] == '\\')) return true;
+
+    if (std.mem.eql(u8, path, "home") or
+        std.mem.eql(u8, path, "inherit") or
+        std.mem.eql(u8, path, "~"))
+    {
+        return true;
+    }
+
+    if (path.len >= 2 and
+        path[0] == '~' and
+        (path[1] == '/' or path[1] == '\\'))
+    {
+        return true;
+    }
+
     return path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
         (path[2] == '/' or path[2] == '\\');
-}
-pub const TestArgs = struct {
-    items: []const []const u8,
-    index: usize = 0,
-    pub fn next(self: *@This()) ?[]const u8 {
-        if (self.index == self.items.len) return null;
-        defer self.index += 1;
-        return self.items[self.index];
-    }
-};
-pub fn testRun(comptime runner: anytype, items: []const []const u8, hook: anytype) !u8 {
-    var iter: TestArgs = .{ .items = items };
-    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
-    defer stderr.deinit();
-    return runner(std.testing.allocator, &iter, &stderr.writer, hook);
-}
-pub fn testOutcome(code: u8) !bool {
-    return switch (code) {
-        1 => error.InvalidAutomationTarget,
-        2 => false,
-        3 => error.AutomationTargetNotFound,
-        4 => error.AutomationPolicyRefused,
-        5 => error.IPCFailed,
-        else => true,
-    };
 }

--- a/src/cli/focus.zig
+++ b/src/cli/focus.zig
@@ -4,10 +4,9 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const actionpkg = @import("action.zig");
 const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
-
+const support = @import("automation_working_directory.zig");
 pub const Options = struct {
     _arena: ?ArenaAllocator = null,
-    /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
     /// Response timeout in milliseconds, from 0 through 10000.
     timeout: u64 = 10_000,
@@ -15,7 +14,6 @@ pub const Options = struct {
     @"surface-id": ?u64 = null,
     /// Nonzero window ID from `+list-windows`.
     @"window-id": ?u32 = null,
-
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
@@ -24,11 +22,7 @@ pub const Options = struct {
         return actionpkg.help_error;
     }
 };
-
-/// Select a window or pane in a running local noctty instance. Exactly one of
-/// `--surface-id=<id>` or `--window-id=<id>` is required. `--class=<class>`
-/// selects an instance namespace and `--timeout=<ms>` sets the 0..10000 ms
-/// response timeout (default 10000). Foreground activation is best-effort.
+/// Select exactly one `--surface-id` or `--window-id`; supports `--class` and 0..10000 ms `--timeout`.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
@@ -38,18 +32,14 @@ pub fn run(alloc: Allocator) !u8 {
     try writer.interface.flush();
     return result;
 }
-
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithFocus(alloc, iter, stderr, focusAutomationTarget);
 }
-
 const FocusFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, u64) anyerror!bool;
-
 fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
     try stderr.writeAll(message);
     return code;
 }
-
 fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: FocusFn) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
@@ -65,7 +55,6 @@ fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hoo
         if (id == 0) return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
         break :target .{ .window_id = id };
     } else return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
-
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -78,11 +67,9 @@ fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hoo
     };
     return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
 }
-
 fn focusAutomationTarget(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, timeout: u64) !bool {
     return apprt.App.focusAutomationTarget(alloc, instance, target, timeout);
 }
-
 fn testRun(line: []const u8, hook: FocusFn) !u8 {
     var iter = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, line);
     defer iter.deinit();
@@ -90,7 +77,6 @@ fn testRun(line: []const u8, hook: FocusFn) !u8 {
     defer stderr.deinit();
     return runArgsWithFocus(std.testing.allocator, &iter, &stderr.writer, hook);
 }
-
 test "automation focus cli contract" {
     const testing = std.testing;
     const Forward = struct {
@@ -115,7 +101,6 @@ test "automation focus cli contract" {
         Forward.window = i == 1;
         try testing.expectEqual(@as(u8, 0), try testRun(line, &Forward.call));
     }
-
     const Invalid = struct {
         var called = false;
         fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
@@ -138,17 +123,10 @@ test "automation focus cli contract" {
         try testing.expectEqual(@as(u8, 1), try testRun(line, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
-
     const Exit = struct {
         var outcome: u8 = 0;
         fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
-            return switch (outcome) {
-                1 => error.InvalidAutomationTarget,
-                2 => false,
-                3 => error.AutomationTargetNotFound,
-                5 => error.IPCFailed,
-                else => true,
-            };
+            return support.testOutcome(outcome);
         }
     };
     for ([_]u8{ 0, 1, 2, 3, 5 }) |code| {

--- a/src/cli/focus.zig
+++ b/src/cli/focus.zig
@@ -4,57 +4,100 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const actionpkg = @import("action.zig");
 const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
-const support = @import("automation_working_directory.zig");
+const test_support = @import("automation_test_support.zig");
+
+/// Parsed options for the `+focus` command.
 pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
+
+    /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
+
     /// Response timeout in milliseconds, from 0 through 10000.
     timeout: u64 = 10_000,
+
     /// Nonzero pane ID from `+list-windows`.
     @"surface-id": ?u64 = null,
+
     /// Nonzero window ID from `+list-windows`.
     @"window-id": ?u32 = null,
+
+    /// Releases memory owned by the parsed options.
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
     }
+
+    /// Enables `-h` and `--help` to work.
     pub fn help(_: Options) !void {
         return actionpkg.help_error;
     }
 };
+
 /// Select exactly one `--surface-id` or `--window-id`; supports `--class` and 0..10000 ms `--timeout`.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
+
     var buf: [1024]u8 = undefined;
     var writer = std.fs.File.stderr().writer(&buf);
     const result = runArgs(alloc, &iter, &writer.interface);
+
     try writer.interface.flush();
     return result;
 }
+
+/// Dispatches parsed arguments through the production IPC implementation.
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithFocus(alloc, iter, stderr, focusAutomationTarget);
 }
-const FocusFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, u64) anyerror!bool;
+
+/// Injected IPC seam used by the command and its unit tests.
+const FocusFn = *const fn (
+    Allocator,
+    apprt.ipc.Target,
+    apprt.ipc.AutomationTarget,
+    u64,
+) anyerror!bool;
+
+/// Writes a stable diagnostic before returning an exit code.
 fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
     try stderr.writeAll(message);
     return code;
 }
-fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: FocusFn) !u8 {
+
+/// Parses and validates `+focus` before invoking the injected IPC seam.
+fn runArgsWithFocus(
+    alloc: Allocator,
+    iter: anytype,
+    stderr: *std.Io.Writer,
+    hook: FocusFn,
+) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
+
     args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
         error.ActionHelpRequested => return err,
         else => return report(stderr, 1, "Invalid +focus arguments.\n"),
     };
-    if (opts.timeout > 10_000) return report(stderr, 1, "Invalid --timeout.\n");
+
+    if (opts.timeout > 10_000) {
+        return report(stderr, 1, "Invalid --timeout.\n");
+    }
+
     const target: apprt.ipc.AutomationTarget = if (opts.@"surface-id") |id| target: {
-        if (id == 0 or opts.@"window-id" != null) return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        if (id == 0 or opts.@"window-id" != null) {
+            return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        }
         break :target .{ .surface_id = id };
     } else if (opts.@"window-id") |id| target: {
-        if (id == 0) return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        if (id == 0) {
+            return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        }
         break :target .{ .window_id = id };
     } else return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -65,23 +108,43 @@ fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hoo
         error.AutomationTargetNotFound, error.NoAutomationTarget => return report(stderr, 3, "Automation target not found.\n"),
         else => return report(stderr, 5, "Automation focus IPC failed.\n"),
     };
+
     return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
 }
-fn focusAutomationTarget(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, timeout: u64) !bool {
+
+/// Requests focus for an exact surface or window in the running instance.
+fn focusAutomationTarget(
+    alloc: Allocator,
+    instance: apprt.ipc.Target,
+    target: apprt.ipc.AutomationTarget,
+    timeout: u64,
+) !bool {
     return apprt.App.focusAutomationTarget(alloc, instance, target, timeout);
 }
+
+/// Runs the focus parser against a shell-like argument string in tests.
 fn testRun(line: []const u8, hook: FocusFn) !u8 {
     var iter = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, line);
     defer iter.deinit();
+
     var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer stderr.deinit();
+
     return runArgsWithFocus(std.testing.allocator, &iter, &stderr.writer, hook);
 }
+
 test "automation focus cli contract" {
     const testing = std.testing;
+
     const Forward = struct {
         var window = false;
-        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, timeout: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            instance: apprt.ipc.Target,
+            target: apprt.ipc.AutomationTarget,
+            timeout: u64,
+        ) !bool {
             if (window) {
                 try testing.expectEqual(apprt.ipc.Target.detect, instance);
                 try testing.expectEqual(std.math.maxInt(u32), target.window_id);
@@ -94,6 +157,7 @@ test "automation focus cli contract" {
             return true;
         }
     };
+
     for ([_][]const u8{
         "--class=lane9 --timeout=0 --surface-id=18446744073709551615",
         "--window-id=4294967295",
@@ -101,9 +165,16 @@ test "automation focus cli contract" {
         Forward.window = i == 1;
         try testing.expectEqual(@as(u8, 0), try testRun(line, &Forward.call));
     }
+
     const Invalid = struct {
         var called = false;
-        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: u64,
+        ) !bool {
             called = true;
             return true;
         }
@@ -123,12 +194,20 @@ test "automation focus cli contract" {
         try testing.expectEqual(@as(u8, 1), try testRun(line, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
+
     const Exit = struct {
         var outcome: u8 = 0;
-        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
-            return support.testOutcome(outcome);
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: u64,
+        ) !bool {
+            return test_support.testOutcome(outcome);
         }
     };
+
     for ([_]u8{ 0, 1, 2, 3, 5 }) |code| {
         Exit.outcome = code;
         try testing.expectEqual(code, try testRun("--surface-id=1", &Exit.call));

--- a/src/cli/focus.zig
+++ b/src/cli/focus.zig
@@ -11,6 +11,10 @@ pub const Options = struct {
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
 
+    /// Tracks explicitly supplied empty target values.
+    _surface_id_seen: bool = false,
+    _window_id_seen: bool = false,
+
     /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
 
@@ -22,6 +26,14 @@ pub const Options = struct {
 
     /// Nonzero window ID from `+list-windows`.
     @"window-id": ?u32 = null,
+
+    /// Records target-flag presence before the generic parser normalizes an
+    /// empty optional value to null.
+    pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
+        if (std.mem.startsWith(u8, arg, "--surface-id=")) self._surface_id_seen = true;
+        if (std.mem.startsWith(u8, arg, "--window-id=")) self._window_id_seen = true;
+        return true;
+    }
 
     /// Releases memory owned by the parsed options.
     pub fn deinit(self: *Options) void {
@@ -84,6 +96,12 @@ fn runArgsWithFocus(
 
     if (opts.timeout > 10_000) {
         return report(stderr, 1, "Invalid --timeout.\n");
+    }
+
+    if ((opts._surface_id_seen and opts.@"surface-id" == null) or
+        (opts._window_id_seen and opts.@"window-id" == null))
+    {
+        return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
     }
 
     const target: apprt.ipc.AutomationTarget = if (opts.@"surface-id") |id| target: {
@@ -183,6 +201,10 @@ test "automation focus cli contract" {
         "",
         "extra",
         "--surface-id=1 --window-id=2",
+        "--surface-id=",
+        "--window-id=",
+        "--surface-id= --window-id=17",
+        "--surface-id=17 --window-id=",
         "--surface-id=0",
         "--surface-id=18446744073709551616",
         "--window-id=0",

--- a/src/cli/focus.zig
+++ b/src/cli/focus.zig
@@ -1,0 +1,158 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+
+pub const Options = struct {
+    _arena: ?ArenaAllocator = null,
+    /// Select a custom single-instance namespace.
+    class: ?[:0]const u8 = null,
+    /// Response timeout in milliseconds, from 0 through 10000.
+    timeout: u64 = 10_000,
+    /// Nonzero pane ID from `+list-windows`.
+    @"surface-id": ?u64 = null,
+    /// Nonzero window ID from `+list-windows`.
+    @"window-id": ?u32 = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+    pub fn help(_: Options) !void {
+        return actionpkg.help_error;
+    }
+};
+
+/// Select a window or pane in a running local noctty instance. Exactly one of
+/// `--surface-id=<id>` or `--window-id=<id>` is required. `--class=<class>`
+/// selects an instance namespace and `--timeout=<ms>` sets the 0..10000 ms
+/// response timeout (default 10000). Foreground activation is best-effort.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+    var buf: [1024]u8 = undefined;
+    var writer = std.fs.File.stderr().writer(&buf);
+    const result = runArgs(alloc, &iter, &writer.interface);
+    try writer.interface.flush();
+    return result;
+}
+
+fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
+    return runArgsWithFocus(alloc, iter, stderr, focusAutomationTarget);
+}
+
+const FocusFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, u64) anyerror!bool;
+
+fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
+    try stderr.writeAll(message);
+    return code;
+}
+
+fn runArgsWithFocus(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: FocusFn) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+    args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
+        error.ActionHelpRequested => return err,
+        else => return report(stderr, 1, "Invalid +focus arguments.\n"),
+    };
+    if (opts.timeout > 10_000) return report(stderr, 1, "Invalid --timeout.\n");
+    const target: apprt.ipc.AutomationTarget = if (opts.@"surface-id") |id| target: {
+        if (id == 0 or opts.@"window-id" != null) return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        break :target .{ .surface_id = id };
+    } else if (opts.@"window-id") |id| target: {
+        if (id == 0) return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+        break :target .{ .window_id = id };
+    } else return report(stderr, 1, "+focus requires exactly one nonzero target.\n");
+
+    const ok = hook(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+        target,
+        opts.timeout,
+    ) catch |err| switch (err) {
+        error.InvalidAutomationTarget => return report(stderr, 1, "Invalid automation target.\n"),
+        error.AutomationTargetNotFound, error.NoAutomationTarget => return report(stderr, 3, "Automation target not found.\n"),
+        else => return report(stderr, 5, "Automation focus IPC failed.\n"),
+    };
+    return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
+}
+
+fn focusAutomationTarget(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, timeout: u64) !bool {
+    return apprt.App.focusAutomationTarget(alloc, instance, target, timeout);
+}
+
+fn testRun(line: []const u8, hook: FocusFn) !u8 {
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(std.testing.allocator, line);
+    defer iter.deinit();
+    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stderr.deinit();
+    return runArgsWithFocus(std.testing.allocator, &iter, &stderr.writer, hook);
+}
+
+test "automation focus cli contract" {
+    const testing = std.testing;
+    const Forward = struct {
+        var window = false;
+        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, timeout: u64) !bool {
+            if (window) {
+                try testing.expectEqual(apprt.ipc.Target.detect, instance);
+                try testing.expectEqual(std.math.maxInt(u32), target.window_id);
+                try testing.expectEqual(@as(u64, 10_000), timeout);
+            } else {
+                try testing.expectEqualStrings("lane9", instance.class);
+                try testing.expectEqual(std.math.maxInt(u64), target.surface_id);
+                try testing.expectEqual(@as(u64, 0), timeout);
+            }
+            return true;
+        }
+    };
+    for ([_][]const u8{
+        "--class=lane9 --timeout=0 --surface-id=18446744073709551615",
+        "--window-id=4294967295",
+    }, 0..) |line, i| {
+        Forward.window = i == 1;
+        try testing.expectEqual(@as(u8, 0), try testRun(line, &Forward.call));
+    }
+
+    const Invalid = struct {
+        var called = false;
+        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+    for ([_][]const u8{
+        "",
+        "extra",
+        "--surface-id=1 --window-id=2",
+        "--surface-id=0",
+        "--surface-id=18446744073709551616",
+        "--window-id=0",
+        "--window-id=4294967296",
+        "--timeout=10001 --surface-id=1",
+        "--timeout=18446744073709551616 --surface-id=1",
+    }) |line| {
+        Invalid.called = false;
+        try testing.expectEqual(@as(u8, 1), try testRun(line, &Invalid.call));
+        try testing.expect(!Invalid.called);
+    }
+
+    const Exit = struct {
+        var outcome: u8 = 0;
+        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: u64) !bool {
+            return switch (outcome) {
+                1 => error.InvalidAutomationTarget,
+                2 => false,
+                3 => error.AutomationTargetNotFound,
+                5 => error.IPCFailed,
+                else => true,
+            };
+        }
+    };
+    for ([_]u8{ 0, 1, 2, 3, 5 }) |code| {
+        Exit.outcome = code;
+        try testing.expectEqual(code, try testRun("--surface-id=1", &Exit.call));
+    }
+}

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -26,6 +26,8 @@ const register_default_terminal = @import("register_default_terminal.zig");
 const unregister_default_terminal = @import("unregister_default_terminal.zig");
 const focus = @import("focus.zig");
 const send_text = @import("send_text.zig");
+const new_tab = @import("new_tab.zig");
+const new_split = @import("new_split.zig");
 
 pub const Action = @import("ghostty_action.zig").Action;
 
@@ -81,6 +83,8 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .@"unregister-default-terminal" => try unregister_default_terminal.run(alloc),
         .focus => try focus.run(alloc),
         .@"send-text" => try send_text.run(alloc),
+        .@"new-tab" => try new_tab.run(alloc),
+        .@"new-split" => try new_split.run(alloc),
     };
 }
 
@@ -113,6 +117,8 @@ pub fn options(comptime self: Action) type {
             .@"unregister-default-terminal" => unregister_default_terminal.Options,
             .focus => focus.Options,
             .@"send-text" => send_text.Options,
+            .@"new-tab" => new_tab.Options,
+            .@"new-split" => new_split.Options,
         };
     }
 }

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -206,6 +206,20 @@ test "parse action plus" {
     }
 }
 
+test "parse send-text action ignores literal action-like payloads" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    for ([_][]const u8{
+        "+send-text --surface-id=42 -- --version",
+        "+send-text --surface-id=42 -- +focus",
+    }) |args_text| {
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(alloc, args_text);
+        defer iter.deinit();
+        try testing.expectEqual(Action.@"send-text", (try actionpkg.detectIter(Action, &iter)).?);
+    }
+}
+
 test "parse action plus ignores -e" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/cli/ghostty.zig
+++ b/src/cli/ghostty.zig
@@ -24,6 +24,8 @@ const list_windows = @import("list_windows.zig");
 const perform_action = @import("perform_action.zig");
 const register_default_terminal = @import("register_default_terminal.zig");
 const unregister_default_terminal = @import("unregister_default_terminal.zig");
+const focus = @import("focus.zig");
+const send_text = @import("send_text.zig");
 
 pub const Action = @import("ghostty_action.zig").Action;
 
@@ -77,6 +79,8 @@ fn runMain(self: Action, alloc: Allocator) !u8 {
         .@"perform-action" => try perform_action.run(alloc),
         .@"register-default-terminal" => try register_default_terminal.run(alloc),
         .@"unregister-default-terminal" => try unregister_default_terminal.run(alloc),
+        .focus => try focus.run(alloc),
+        .@"send-text" => try send_text.run(alloc),
     };
 }
 
@@ -107,6 +111,8 @@ pub fn options(comptime self: Action) type {
             .@"perform-action" => perform_action.Options,
             .@"register-default-terminal" => register_default_terminal.Options,
             .@"unregister-default-terminal" => unregister_default_terminal.Options,
+            .focus => focus.Options,
+            .@"send-text" => send_text.Options,
         };
     }
 }

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -69,6 +69,12 @@ pub const Action = enum {
     /// Restore the default-terminal selection saved by noctty.
     @"unregister-default-terminal",
 
+    // Focus a specific window or surface in the running noctty instance.
+    focus,
+
+    // Send policy-bounded printable text to a surface in the running instance.
+    @"send-text",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -75,6 +75,12 @@ pub const Action = enum {
     // Send policy-bounded printable text to a surface in the running instance.
     @"send-text",
 
+    // Create a tab in a running noctty instance.
+    @"new-tab",
+
+    // Create a split in a running noctty instance.
+    @"new-split",
+
     pub fn detectSpecialCase(arg: []const u8) ?SpecialCase(Action) {
         // If we see a "-e" and we haven't seen a command yet, then
         // we are done looking for commands. This special case enables

--- a/src/cli/ghostty_action.zig
+++ b/src/cli/ghostty_action.zig
@@ -111,6 +111,9 @@ pub const Action = enum {
     /// path from the root src/ directory.
     pub fn file(comptime self: Action) []const u8 {
         comptime {
+            // This conversion is instantiated once per action by helpgen.
+            // Keep enough quota as the Windows-only action set grows.
+            @setEvalBranchQuota(2_000);
             const filename = filename: {
                 const tag = @tagName(self);
                 var filename: [tag.len]u8 = undefined;

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -28,10 +28,10 @@ pub const Options = struct {
 /// The `list-windows` command prints a read-only automation snapshot for the
 /// matching local noctty instance as JSON.
 ///
-/// The current schema exposes only stable host/tab/pane identifiers, focus
-/// state, active-pane state, and structural counts. It does not expose
-/// terminal text, shell input, working directories, or any write/control
-/// actions.
+/// The current schema exposes instance metadata, stable host/tab/pane
+/// identifiers, titles, last-known working directories, focus state,
+/// active-pane state, and structural counts. It never exposes terminal text,
+/// scrollback, selection, clipboard data, or pending shell input.
 ///
 /// Flags:
 ///
@@ -130,7 +130,7 @@ test "automation-window-list cli prints json payload" {
                 .class => |class| try testing.allocator.dupe(u8, class),
                 .detect => return error.UnexpectedTarget,
             };
-            return try alloc.dupe(u8, "{\"schema\":\"noctty.windows.v2\",\"api_version\":2,\"windows\":[]}");
+            return try alloc.dupe(u8, "{\"schema\":\"noctty.windows.v3\",\"api_version\":3,\"instance\":{\"pid\":1,\"version\":\"test\",\"class\":\"lane9\"},\"windows\":[]}");
         }
     };
     defer if (Hook.seen_class) |value| testing.allocator.free(value);
@@ -157,7 +157,7 @@ test "automation-window-list cli prints json payload" {
 
     try testing.expectEqual(@as(u8, 0), exit_code);
     try testing.expectEqualStrings(
-        "{\"schema\":\"noctty.windows.v2\",\"api_version\":2,\"windows\":[]}\n",
+        "{\"schema\":\"noctty.windows.v3\",\"api_version\":3,\"instance\":{\"pid\":1,\"version\":\"test\",\"class\":\"lane9\"},\"windows\":[]}\n",
         stdout_buf.written(),
     );
     try testing.expectEqualStrings("", stderr_buf.written());

--- a/src/cli/list_windows.zig
+++ b/src/cli/list_windows.zig
@@ -5,6 +5,8 @@ const actionpkg = @import("action.zig");
 const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
 
+const Format = enum { json };
+
 pub const Options = struct {
     /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
@@ -12,6 +14,12 @@ pub const Options = struct {
     /// If set, query a custom single-instance namespace instead of the
     /// default local noctty instance.
     class: ?[:0]const u8 = null,
+
+    /// How long to wait for the running instance to respond.
+    timeout: u64 = 10_000,
+
+    /// The stable output format. JSON is the only supported value.
+    format: Format = .json,
 
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
@@ -37,6 +45,12 @@ pub const Options = struct {
 ///
 ///   * `--class=<class>`: Query a custom instance namespace instead of the
 ///     default local noctty instance.
+///
+///   * `--timeout=<ms>`: Response timeout in milliseconds, from 0 through
+///     10000. The default is 10000.
+///
+///   * `--format=json`: Select the stable JSON output contract. JSON is the
+///     default and only supported format.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
@@ -73,6 +87,7 @@ fn runArgs(
 const QueryAutomationWindowListFn = *const fn (
     alloc: Allocator,
     target: apprt.ipc.Target,
+    timeout_ms: u64,
 ) anyerror!?[]u8;
 
 fn runArgsWithQuery(
@@ -84,27 +99,31 @@ fn runArgsWithQuery(
 ) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
-    try args.parse(Options, alloc, &opts, args_iter);
+    args.parse(Options, alloc, &opts, args_iter) catch |err| switch (err) {
+        error.ActionHelpRequested => return err,
+        else => {
+            try stderr.print("Error parsing +list-windows arguments: {}\n", .{err});
+            return 1;
+        },
+    };
+    if (opts.timeout > 10_000) {
+        try stderr.print("--timeout must be between 0 and 10000 milliseconds.\n", .{});
+        return 1;
+    }
 
     const payload = queryAutomationWindowListFn(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
-    ) catch |err| switch (err) {
-        error.IPCFailed => {
-            try stderr.print("Listing automation windows via IPC failed.\n", .{});
-            return 1;
-        },
-        error.InvalidIpcResponse => {
-            try stderr.print("Listing automation windows via IPC failed: invalid response from the target instance.\n", .{});
-            return 1;
-        },
-        else => return err,
+        opts.timeout,
+    ) catch |err| {
+        try stderr.print("Listing automation windows via IPC failed: {}\n", .{err});
+        return 5;
     };
     defer if (payload) |bytes| alloc.free(bytes);
 
     const json = payload orelse {
         try stderr.print("No matching noctty instance is listening for automation queries.\n", .{});
-        return 1;
+        return 2;
     };
 
     try stdout.writeAll(json);
@@ -115,8 +134,9 @@ fn runArgsWithQuery(
 fn queryAutomationWindowList(
     alloc: Allocator,
     target: apprt.ipc.Target,
+    timeout_ms: u64,
 ) !?[]u8 {
-    return try apprt.App.queryAutomationWindowList(alloc, target);
+    return try apprt.App.queryAutomationWindowList(alloc, target, timeout_ms);
 }
 
 test "automation-window-list cli prints json payload" {
@@ -125,7 +145,8 @@ test "automation-window-list cli prints json payload" {
     const Hook = struct {
         var seen_class: ?[]u8 = null;
 
-        fn query(alloc: Allocator, target: apprt.ipc.Target) !?[]u8 {
+        fn query(alloc: Allocator, target: apprt.ipc.Target, timeout_ms: u64) !?[]u8 {
+            try testing.expectEqual(@as(u64, 42), timeout_ms);
             seen_class = switch (target) {
                 .class => |class| try testing.allocator.dupe(u8, class),
                 .detect => return error.UnexpectedTarget,
@@ -137,7 +158,7 @@ test "automation-window-list cli prints json payload" {
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         testing.allocator,
-        "--class=lane9",
+        "--class=lane9 --timeout=42 --format=json",
     );
     defer iter.deinit();
 
@@ -169,7 +190,7 @@ test "automation-window-list cli reports ipc failure" {
     const testing = std.testing;
 
     const Hook = struct {
-        fn query(_: Allocator, _: apprt.ipc.Target) !?[]u8 {
+        fn query(_: Allocator, _: apprt.ipc.Target, _: u64) !?[]u8 {
             return error.IPCFailed;
         }
     };
@@ -194,19 +215,16 @@ test "automation-window-list cli reports ipc failure" {
         &Hook.query,
     );
 
-    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqual(@as(u8, 5), exit_code);
     try testing.expectEqualStrings("", stdout_buf.written());
-    try testing.expectEqualStrings(
-        "Listing automation windows via IPC failed.\n",
-        stderr_buf.written(),
-    );
+    try testing.expect(std.mem.startsWith(u8, stderr_buf.written(), "Listing automation windows via IPC failed:"));
 }
 
 test "automation-window-list cli reports invalid ipc response" {
     const testing = std.testing;
 
     const Hook = struct {
-        fn query(_: Allocator, _: apprt.ipc.Target) !?[]u8 {
+        fn query(_: Allocator, _: apprt.ipc.Target, _: u64) !?[]u8 {
             return error.InvalidIpcResponse;
         }
     };
@@ -231,20 +249,18 @@ test "automation-window-list cli reports invalid ipc response" {
         &Hook.query,
     );
 
-    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqual(@as(u8, 5), exit_code);
     try testing.expectEqualStrings("", stdout_buf.written());
-    try testing.expectEqualStrings(
-        "Listing automation windows via IPC failed: invalid response from the target instance.\n",
-        stderr_buf.written(),
-    );
+    try testing.expect(std.mem.startsWith(u8, stderr_buf.written(), "Listing automation windows via IPC failed:"));
 }
 
 test "automation-window-list cli reports missing instance" {
     const testing = std.testing;
 
     const Hook = struct {
-        fn query(_: Allocator, target: apprt.ipc.Target) !?[]u8 {
+        fn query(_: Allocator, target: apprt.ipc.Target, timeout_ms: u64) !?[]u8 {
             try testing.expectEqual(apprt.ipc.Target.detect, target);
+            try testing.expectEqual(@as(u64, 10_000), timeout_ms);
             return null;
         }
     };
@@ -269,10 +285,49 @@ test "automation-window-list cli reports missing instance" {
         &Hook.query,
     );
 
-    try testing.expectEqual(@as(u8, 1), exit_code);
+    try testing.expectEqual(@as(u8, 2), exit_code);
     try testing.expectEqualStrings("", stdout_buf.written());
     try testing.expectEqualStrings(
         "No matching noctty instance is listening for automation queries.\n",
         stderr_buf.written(),
     );
+}
+
+test "automation-window-list cli rejects invalid arguments before ipc" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var called = false;
+
+        fn query(_: Allocator, _: apprt.ipc.Target, _: u64) !?[]u8 {
+            called = true;
+            return null;
+        }
+    };
+
+    for ([_][]const u8{
+        "--format=text",
+        "--timeout=10001",
+        "--timeout=18446744073709551616",
+        "unexpected",
+    }) |command_line| {
+        Hook.called = false;
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(testing.allocator, command_line);
+        defer iter.deinit();
+
+        var stdout_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stdout_buf.deinit();
+        var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr_buf.deinit();
+
+        try testing.expectEqual(@as(u8, 1), try runArgsWithQuery(
+            testing.allocator,
+            &iter,
+            &stdout_buf.writer,
+            &stderr_buf.writer,
+            &Hook.query,
+        ));
+        try testing.expect(!Hook.called);
+        try testing.expectEqualStrings("", stdout_buf.written());
+    }
 }

--- a/src/cli/new_split.zig
+++ b/src/cli/new_split.zig
@@ -15,6 +15,9 @@ pub const Options = struct {
     /// Tracks an explicitly supplied empty working-directory value.
     _working_directory_seen: bool = false,
 
+    /// Tracks an explicitly supplied empty surface target.
+    _surface_id_seen: bool = false,
+
     /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
 
@@ -34,6 +37,9 @@ pub const Options = struct {
     pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
         if (std.mem.startsWith(u8, arg, "--working-directory=")) {
             self._working_directory_seen = true;
+        }
+        if (std.mem.startsWith(u8, arg, "--surface-id=")) {
+            self._surface_id_seen = true;
         }
         return true;
     }
@@ -100,6 +106,7 @@ fn runArgsWithNewSplit(
     };
 
     if (opts.timeout > 10_000 or (opts.@"surface-id" orelse 1) == 0 or
+        (opts._surface_id_seen and opts.@"surface-id" == null) or
         (opts._working_directory_seen and opts.@"working-directory" == null))
     {
         return fail(stderr, 1);
@@ -206,6 +213,7 @@ test "automation new-split cli contract" {
 
     for ([_][]const []const u8{
         &.{"--surface-id=0"},
+        &.{"--surface-id="},
         &.{"--surface-id=18446744073709551616"},
         &.{"--timeout=10001"},
         &.{"--timeout=18446744073709551616"},

--- a/src/cli/new_split.zig
+++ b/src/cli/new_split.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+const working_directory = @import("automation_working_directory.zig");
+pub const Options = struct {
+    _arena: ?ArenaAllocator = null,
+    _working_directory_seen: bool = false,
+    class: ?[:0]const u8 = null,
+    timeout: u64 = 10_000,
+    @"surface-id": ?u64 = null,
+    direction: apprt.ipc.AutomationSplitDirection = .right,
+    @"working-directory": ?[:0]const u8 = null,
+    pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) self._working_directory_seen = true;
+        return true;
+    }
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+    pub fn help(_: Options) !void {
+        return actionpkg.help_error;
+    }
+};
+/// Split the focused/`--surface-id` pane by direction with only a safe working-directory override.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+    var buf: [512]u8 = undefined;
+    var writer = std.fs.File.stderr().writer(&buf);
+    const result = runArgs(alloc, &iter, &writer.interface);
+    try writer.interface.flush();
+    return result;
+}
+const NewSplitFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, apprt.ipc.AutomationSplitDirection, ?[]const u8, u64) anyerror!bool;
+fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
+    return runArgsWithNewSplit(alloc, iter, stderr, newAutomationSplit);
+}
+fn fail(stderr: *std.Io.Writer, code: u8) !u8 {
+    try stderr.writeAll("+new-split failed.\n");
+    return code;
+}
+fn runArgsWithNewSplit(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: NewSplitFn) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+    args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
+        error.ActionHelpRequested => return err,
+        else => return fail(stderr, 1),
+    };
+    if (opts.timeout > 10_000 or (opts.@"surface-id" orelse 1) == 0 or
+        (opts._working_directory_seen and opts.@"working-directory" == null)) return fail(stderr, 1);
+    const cwd = opts.@"working-directory";
+    if (cwd) |path| if (!working_directory.allowed(path)) return fail(stderr, 1);
+    const ok = hook(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+        if (opts.@"surface-id") |id| .{ .surface_id = id } else .focused,
+        opts.direction,
+        cwd,
+        opts.timeout,
+    ) catch |err| switch (err) {
+        error.InvalidAutomationTarget, error.InvalidWorkingDirectory => return fail(stderr, 1),
+        error.AutomationTargetNotFound, error.NoAutomationTarget => return fail(stderr, 3),
+        error.AutomationPolicyRefused => return fail(stderr, 4),
+        else => return fail(stderr, 5),
+    };
+    return if (ok) 0 else fail(stderr, 2);
+}
+fn newAutomationSplit(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, direction: apprt.ipc.AutomationSplitDirection, cwd: ?[]const u8, timeout: u64) !bool {
+    return apprt.App.newAutomationSplit(alloc, instance, target, direction, cwd, timeout);
+}
+test "automation new-split cli contract" {
+    const testing = std.testing;
+    const Hook = struct {
+        var expected = apprt.ipc.AutomationSplitDirection.right;
+        var exact = false;
+        var outcome: u8 = 0;
+        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, direction: apprt.ipc.AutomationSplitDirection, cwd: ?[]const u8, timeout: u64) !bool {
+            try testing.expectEqual(expected, direction);
+            if (exact) {
+                try testing.expectEqualStrings("lane9", instance.class);
+                try testing.expectEqual(std.math.maxInt(u64), target.surface_id);
+                try testing.expectEqualStrings("C:\\x", cwd.?);
+                try testing.expectEqual(@as(u64, 0), timeout);
+            } else {
+                try testing.expectEqual(apprt.ipc.Target.detect, instance);
+                try testing.expectEqual(apprt.ipc.AutomationTarget.focused, target);
+                try testing.expect(cwd == null);
+                try testing.expectEqual(@as(u64, 10_000), timeout);
+            }
+            return working_directory.testOutcome(outcome);
+        }
+    };
+    for ([_]apprt.ipc.AutomationSplitDirection{ .right, .left, .up, .down }) |direction| {
+        Hook.expected = direction;
+        Hook.exact = direction == .right;
+        Hook.outcome = 0;
+        const argv: []const []const u8 = if (direction == .right) &.{ "--class=lane9", "--timeout=0", "--surface-id=18446744073709551615", "--working-directory=C:\\x" } else switch (direction) {
+            .left => &.{"--direction=left"},
+            .up => &.{"--direction=up"},
+            .down => &.{"--direction=down"},
+            .right => unreachable,
+        };
+        try testing.expectEqual(@as(u8, 0), try working_directory.testRun(runArgsWithNewSplit, argv, &Hook.call));
+    }
+    const Reject = struct {
+        var called = false;
+        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: apprt.ipc.AutomationSplitDirection, _: ?[]const u8, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+    for ([_][]const []const u8{
+        &.{"--surface-id=0"},                 &.{"--surface-id=18446744073709551616"}, &.{"--timeout=10001"},                     &.{"--timeout=18446744073709551616"},
+        &.{"--working-directory="},           &.{"--direction=diagonal"},              &.{"--working-directory=\\\\host\\share"}, &.{"--working-directory=relative"},
+        &.{"--working-directory=C:relative"}, &.{"-e"},                                &.{"--title=x"},                           &.{"--command=x"},
+        &.{"positional"},
+    }) |argv| {
+        Reject.called = false;
+        try testing.expectEqual(@as(u8, 1), try working_directory.testRun(runArgsWithNewSplit, argv, &Reject.call));
+        try testing.expect(!Reject.called);
+    }
+    Hook.expected = .right;
+    Hook.exact = false;
+    for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
+        Hook.outcome = code;
+        try testing.expectEqual(code, try working_directory.testRun(runArgsWithNewSplit, &.{}, &Hook.call));
+    }
+}

--- a/src/cli/new_split.zig
+++ b/src/cli/new_split.zig
@@ -4,56 +4,114 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const actionpkg = @import("action.zig");
 const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
+const test_support = @import("automation_test_support.zig");
 const working_directory = @import("automation_working_directory.zig");
+
+/// Parsed options for the `+new-split` command.
 pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
+
+    /// Tracks an explicitly supplied empty working-directory value.
     _working_directory_seen: bool = false,
+
+    /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
+
+    /// Response timeout in milliseconds, from 0 through 10000.
     timeout: u64 = 10_000,
+
+    /// Optional nonzero pane ID from `+list-windows`.
     @"surface-id": ?u64 = null,
+
+    /// Direction of the new split, defaulting to right.
     direction: apprt.ipc.AutomationSplitDirection = .right,
+
+    /// Optional receiver-validated working-directory override.
     @"working-directory": ?[:0]const u8 = null,
+
+    /// Records whether the working-directory flag appeared before parsing.
     pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
-        if (std.mem.startsWith(u8, arg, "--working-directory=")) self._working_directory_seen = true;
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) {
+            self._working_directory_seen = true;
+        }
         return true;
     }
+
+    /// Releases memory owned by the parsed options.
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
     }
+
+    /// Enables `-h` and `--help` to work.
     pub fn help(_: Options) !void {
         return actionpkg.help_error;
     }
 };
+
 /// Split the focused/`--surface-id` pane by direction with only a safe working-directory override.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
+
     var buf: [512]u8 = undefined;
     var writer = std.fs.File.stderr().writer(&buf);
     const result = runArgs(alloc, &iter, &writer.interface);
+
     try writer.interface.flush();
     return result;
 }
-const NewSplitFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, apprt.ipc.AutomationSplitDirection, ?[]const u8, u64) anyerror!bool;
+
+/// Injected IPC seam used by the command and its unit tests.
+const NewSplitFn = *const fn (
+    Allocator,
+    apprt.ipc.Target,
+    apprt.ipc.AutomationTarget,
+    apprt.ipc.AutomationSplitDirection,
+    ?[]const u8,
+    u64,
+) anyerror!bool;
+
+/// Dispatches parsed arguments through the production IPC implementation.
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithNewSplit(alloc, iter, stderr, newAutomationSplit);
 }
+
+/// Writes the stable command diagnostic before returning an exit code.
 fn fail(stderr: *std.Io.Writer, code: u8) !u8 {
     try stderr.writeAll("+new-split failed.\n");
     return code;
 }
-fn runArgsWithNewSplit(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: NewSplitFn) !u8 {
+
+/// Parses and validates `+new-split` before invoking the injected IPC seam.
+fn runArgsWithNewSplit(
+    alloc: Allocator,
+    iter: anytype,
+    stderr: *std.Io.Writer,
+    hook: NewSplitFn,
+) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
+
     args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
         error.ActionHelpRequested => return err,
         else => return fail(stderr, 1),
     };
+
     if (opts.timeout > 10_000 or (opts.@"surface-id" orelse 1) == 0 or
-        (opts._working_directory_seen and opts.@"working-directory" == null)) return fail(stderr, 1);
+        (opts._working_directory_seen and opts.@"working-directory" == null))
+    {
+        return fail(stderr, 1);
+    }
+
     const cwd = opts.@"working-directory";
-    if (cwd) |path| if (!working_directory.allowed(path)) return fail(stderr, 1);
+    if (cwd) |path| {
+        if (!working_directory.allowed(path)) {
+            return fail(stderr, 1);
+        }
+    }
+
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -67,18 +125,38 @@ fn runArgsWithNewSplit(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, 
         error.AutomationPolicyRefused => return fail(stderr, 4),
         else => return fail(stderr, 5),
     };
+
     return if (ok) 0 else fail(stderr, 2);
 }
-fn newAutomationSplit(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, direction: apprt.ipc.AutomationSplitDirection, cwd: ?[]const u8, timeout: u64) !bool {
+
+/// Requests a new split relative to the selected running-instance surface.
+fn newAutomationSplit(
+    alloc: Allocator,
+    instance: apprt.ipc.Target,
+    target: apprt.ipc.AutomationTarget,
+    direction: apprt.ipc.AutomationSplitDirection,
+    cwd: ?[]const u8,
+    timeout: u64,
+) !bool {
     return apprt.App.newAutomationSplit(alloc, instance, target, direction, cwd, timeout);
 }
+
 test "automation new-split cli contract" {
     const testing = std.testing;
+
     const Hook = struct {
         var expected = apprt.ipc.AutomationSplitDirection.right;
         var exact = false;
         var outcome: u8 = 0;
-        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, direction: apprt.ipc.AutomationSplitDirection, cwd: ?[]const u8, timeout: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            instance: apprt.ipc.Target,
+            target: apprt.ipc.AutomationTarget,
+            direction: apprt.ipc.AutomationSplitDirection,
+            cwd: ?[]const u8,
+            timeout: u64,
+        ) !bool {
             try testing.expectEqual(expected, direction);
             if (exact) {
                 try testing.expectEqualStrings("lane9", instance.class);
@@ -91,42 +169,65 @@ test "automation new-split cli contract" {
                 try testing.expect(cwd == null);
                 try testing.expectEqual(@as(u64, 10_000), timeout);
             }
-            return working_directory.testOutcome(outcome);
+            return test_support.testOutcome(outcome);
         }
     };
+
     for ([_]apprt.ipc.AutomationSplitDirection{ .right, .left, .up, .down }) |direction| {
         Hook.expected = direction;
         Hook.exact = direction == .right;
         Hook.outcome = 0;
-        const argv: []const []const u8 = if (direction == .right) &.{ "--class=lane9", "--timeout=0", "--surface-id=18446744073709551615", "--working-directory=C:\\x" } else switch (direction) {
+        const argv: []const []const u8 = if (direction == .right)
+            &.{ "--class=lane9", "--timeout=0", "--surface-id=18446744073709551615", "--working-directory=C:\\x" }
+        else switch (direction) {
             .left => &.{"--direction=left"},
             .up => &.{"--direction=up"},
             .down => &.{"--direction=down"},
             .right => unreachable,
         };
-        try testing.expectEqual(@as(u8, 0), try working_directory.testRun(runArgsWithNewSplit, argv, &Hook.call));
+        try testing.expectEqual(@as(u8, 0), try test_support.testRun(runArgsWithNewSplit, argv, &Hook.call));
     }
+
     const Reject = struct {
         var called = false;
-        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: apprt.ipc.AutomationSplitDirection, _: ?[]const u8, _: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: apprt.ipc.AutomationSplitDirection,
+            _: ?[]const u8,
+            _: u64,
+        ) !bool {
             called = true;
             return true;
         }
     };
+
     for ([_][]const []const u8{
-        &.{"--surface-id=0"},                 &.{"--surface-id=18446744073709551616"}, &.{"--timeout=10001"},                     &.{"--timeout=18446744073709551616"},
-        &.{"--working-directory="},           &.{"--direction=diagonal"},              &.{"--working-directory=\\\\host\\share"}, &.{"--working-directory=relative"},
-        &.{"--working-directory=C:relative"}, &.{"-e"},                                &.{"--title=x"},                           &.{"--command=x"},
+        &.{"--surface-id=0"},
+        &.{"--surface-id=18446744073709551616"},
+        &.{"--timeout=10001"},
+        &.{"--timeout=18446744073709551616"},
+        &.{"--working-directory="},
+        &.{"--direction=diagonal"},
+        &.{"--working-directory=\\\\host\\share"},
+        &.{"--working-directory=relative"},
+        &.{"--working-directory=C:relative"},
+        &.{"-e"},
+        &.{"--title=x"},
+        &.{"--command=x"},
         &.{"positional"},
     }) |argv| {
         Reject.called = false;
-        try testing.expectEqual(@as(u8, 1), try working_directory.testRun(runArgsWithNewSplit, argv, &Reject.call));
+        try testing.expectEqual(@as(u8, 1), try test_support.testRun(runArgsWithNewSplit, argv, &Reject.call));
         try testing.expect(!Reject.called);
     }
+
     Hook.expected = .right;
     Hook.exact = false;
     for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
         Hook.outcome = code;
-        try testing.expectEqual(code, try working_directory.testRun(runArgsWithNewSplit, &.{}, &Hook.call));
+        try testing.expectEqual(code, try test_support.testRun(runArgsWithNewSplit, &.{}, &Hook.call));
     }
 }

--- a/src/cli/new_tab.zig
+++ b/src/cli/new_tab.zig
@@ -15,6 +15,9 @@ pub const Options = struct {
     /// Tracks an explicitly supplied empty working-directory value.
     _working_directory_seen: bool = false,
 
+    /// Tracks an explicitly supplied empty window target.
+    _window_id_seen: bool = false,
+
     /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
 
@@ -31,6 +34,9 @@ pub const Options = struct {
     pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
         if (std.mem.startsWith(u8, arg, "--working-directory=")) {
             self._working_directory_seen = true;
+        }
+        if (std.mem.startsWith(u8, arg, "--window-id=")) {
+            self._window_id_seen = true;
         }
         return true;
     }
@@ -96,6 +102,7 @@ fn runArgsWithNewTab(
     };
 
     if (opts.timeout > 10_000 or (opts.@"window-id" orelse 1) == 0 or
+        (opts._window_id_seen and opts.@"window-id" == null) or
         (opts._working_directory_seen and opts.@"working-directory" == null))
     {
         return fail(stderr, 1);
@@ -207,6 +214,7 @@ test "automation new-tab cli contract" {
 
     for ([_][]const []const u8{
         &.{"--window-id=0"},
+        &.{"--window-id="},
         &.{"--window-id=4294967296"},
         &.{"--timeout=10001"},
         &.{"--timeout=18446744073709551616"},

--- a/src/cli/new_tab.zig
+++ b/src/cli/new_tab.zig
@@ -4,55 +4,110 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const actionpkg = @import("action.zig");
 const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
+const test_support = @import("automation_test_support.zig");
 const working_directory = @import("automation_working_directory.zig");
+
+/// Parsed options for the `+new-tab` command.
 pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
+
+    /// Tracks an explicitly supplied empty working-directory value.
     _working_directory_seen: bool = false,
+
+    /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
+
+    /// Response timeout in milliseconds, from 0 through 10000.
     timeout: u64 = 10_000,
+
+    /// Optional nonzero window ID from `+list-windows`.
     @"window-id": ?u32 = null,
+
+    /// Optional receiver-validated working-directory override.
     @"working-directory": ?[:0]const u8 = null,
+
+    /// Records whether the working-directory flag appeared before parsing.
     pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
-        if (std.mem.startsWith(u8, arg, "--working-directory=")) self._working_directory_seen = true;
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) {
+            self._working_directory_seen = true;
+        }
         return true;
     }
+
+    /// Releases memory owned by the parsed options.
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
     }
+
+    /// Enables `-h` and `--help` to work.
     pub fn help(_: Options) !void {
         return actionpkg.help_error;
     }
 };
+
 /// Create a tab in the focused/`--window-id` window with only a safe `--working-directory` override.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
+
     var buf: [512]u8 = undefined;
     var writer = std.fs.File.stderr().writer(&buf);
     const result = runArgs(alloc, &iter, &writer.interface);
+
     try writer.interface.flush();
     return result;
 }
-const NewTabFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, ?[]const u8, u64) anyerror!bool;
+
+/// Injected IPC seam used by the command and its unit tests.
+const NewTabFn = *const fn (
+    Allocator,
+    apprt.ipc.Target,
+    apprt.ipc.AutomationTarget,
+    ?[]const u8,
+    u64,
+) anyerror!bool;
+
+/// Dispatches parsed arguments through the production IPC implementation.
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithNewTab(alloc, iter, stderr, newAutomationTab);
 }
+
+/// Writes the stable command diagnostic before returning an exit code.
 fn fail(stderr: *std.Io.Writer, code: u8) !u8 {
     try stderr.writeAll("+new-tab failed.\n");
     return code;
 }
-fn runArgsWithNewTab(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: NewTabFn) !u8 {
+
+/// Parses and validates `+new-tab` before invoking the injected IPC seam.
+fn runArgsWithNewTab(
+    alloc: Allocator,
+    iter: anytype,
+    stderr: *std.Io.Writer,
+    hook: NewTabFn,
+) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
+
     args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
         error.ActionHelpRequested => return err,
         else => return fail(stderr, 1),
     };
+
     if (opts.timeout > 10_000 or (opts.@"window-id" orelse 1) == 0 or
-        (opts._working_directory_seen and opts.@"working-directory" == null)) return fail(stderr, 1);
+        (opts._working_directory_seen and opts.@"working-directory" == null))
+    {
+        return fail(stderr, 1);
+    }
+
     const cwd = opts.@"working-directory";
-    if (cwd) |path| if (!working_directory.allowed(path)) return fail(stderr, 1);
+    if (cwd) |path| {
+        if (!working_directory.allowed(path)) {
+            return fail(stderr, 1);
+        }
+    }
+
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -65,21 +120,44 @@ fn runArgsWithNewTab(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, ho
         error.AutomationPolicyRefused => return fail(stderr, 4),
         else => return fail(stderr, 5),
     };
+
     return if (ok) 0 else fail(stderr, 2);
 }
-fn newAutomationTab(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8, timeout: u64) !bool {
+
+/// Requests a new tab in the selected running instance window.
+fn newAutomationTab(
+    alloc: Allocator,
+    instance: apprt.ipc.Target,
+    target: apprt.ipc.AutomationTarget,
+    cwd: ?[]const u8,
+    timeout: u64,
+) !bool {
     return apprt.App.newAutomationTab(alloc, instance, target, cwd, timeout);
 }
+
 test "automation new-tab cli contract" {
     const testing = std.testing;
+
     const Hook = struct {
         var called = false;
         var expected_cwd: ?[]const u8 = null;
         var window = false;
         var outcome: u8 = 0;
-        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8, timeout: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            instance: apprt.ipc.Target,
+            target: apprt.ipc.AutomationTarget,
+            cwd: ?[]const u8,
+            timeout: u64,
+        ) !bool {
             called = true;
-            if (expected_cwd) |expected| try testing.expectEqualStrings(expected, cwd.?) else try testing.expect(cwd == null);
+            if (expected_cwd) |expected| {
+                try testing.expectEqualStrings(expected, cwd.?);
+            } else {
+                try testing.expect(cwd == null);
+            }
+
             if (window) {
                 try testing.expectEqualStrings("lane9", instance.class);
                 try testing.expectEqual(std.math.maxInt(u32), target.window_id);
@@ -89,41 +167,71 @@ test "automation new-tab cli contract" {
                 try testing.expectEqual(apprt.ipc.AutomationTarget.focused, target);
                 try testing.expectEqual(@as(u64, 10_000), timeout);
             }
-            return working_directory.testOutcome(outcome);
+            return test_support.testOutcome(outcome);
         }
     };
-    for ([_]struct { cwd: ?[]const u8, argv: []const []const u8, window: bool = false }{
-        .{ .cwd = null, .argv = &.{} },                                                                                                           .{ .cwd = "home", .argv = &.{"--working-directory=home"} },
-        .{ .cwd = "inherit", .argv = &.{"--working-directory=inherit"} },                                                                         .{ .cwd = "~", .argv = &.{"--working-directory=~"} },
-        .{ .cwd = "~/x", .argv = &.{"--working-directory=~/x"} },                                                                                 .{ .cwd = "~\\x", .argv = &.{"--working-directory=~\\x"} },
+
+    for ([_]struct {
+        cwd: ?[]const u8,
+        argv: []const []const u8,
+        window: bool = false,
+    }{
+        .{ .cwd = null, .argv = &.{} },
+        .{ .cwd = "home", .argv = &.{"--working-directory=home"} },
+        .{ .cwd = "inherit", .argv = &.{"--working-directory=inherit"} },
+        .{ .cwd = "~", .argv = &.{"--working-directory=~"} },
+        .{ .cwd = "~/x", .argv = &.{"--working-directory=~/x"} },
+        .{ .cwd = "~\\x", .argv = &.{"--working-directory=~\\x"} },
         .{ .cwd = "C:\\x", .argv = &.{ "--class=lane9", "--timeout=0", "--window-id=4294967295", "--working-directory=C:\\x" }, .window = true },
     }) |case| {
         Hook.expected_cwd = case.cwd;
         Hook.window = case.window;
         Hook.outcome = 0;
-        try testing.expectEqual(@as(u8, 0), try working_directory.testRun(runArgsWithNewTab, case.argv, &Hook.call));
+        try testing.expectEqual(@as(u8, 0), try test_support.testRun(runArgsWithNewTab, case.argv, &Hook.call));
     }
+
     const Reject = struct {
         var called = false;
-        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: ?[]const u8, _: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: ?[]const u8,
+            _: u64,
+        ) !bool {
             called = true;
             return true;
         }
     };
+
     for ([_][]const []const u8{
-        &.{"--window-id=0"},                 &.{"--window-id=4294967296"},              &.{"--timeout=10001"},                  &.{"--timeout=18446744073709551616"},
-        &.{"--working-directory="},          &.{"--working-directory=\\\\host\\share"}, &.{"--working-directory=//host/share"}, &.{"--working-directory=\\\\?\\C:\\x"},
-        &.{"--working-directory=relative"},  &.{"--working-directory=C:relative"},      &.{"-e"},                               &.{"--title=x"},
-        &.{"--working-directory=C:\\x\x00"}, &.{"--working-directory=C:\\x\xFF"},       &.{"--command=x"},                      &.{"positional"},
+        &.{"--window-id=0"},
+        &.{"--window-id=4294967296"},
+        &.{"--timeout=10001"},
+        &.{"--timeout=18446744073709551616"},
+        &.{"--working-directory="},
+        &.{"--working-directory=\\\\host\\share"},
+        &.{"--working-directory=//host/share"},
+        &.{"--working-directory=\\\\?\\C:\\x"},
+        &.{"--working-directory=relative"},
+        &.{"--working-directory=C:relative"},
+        &.{"-e"},
+        &.{"--title=x"},
+        &.{"--working-directory=C:\\x\x00"},
+        &.{"--working-directory=C:\\x\xFF"},
+        &.{"--command=x"},
+        &.{"positional"},
     }) |argv| {
         Reject.called = false;
-        try testing.expectEqual(@as(u8, 1), try working_directory.testRun(runArgsWithNewTab, argv, &Reject.call));
+        try testing.expectEqual(@as(u8, 1), try test_support.testRun(runArgsWithNewTab, argv, &Reject.call));
         try testing.expect(!Reject.called);
     }
+
     Hook.expected_cwd = null;
     Hook.window = false;
     for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
         Hook.outcome = code;
-        try testing.expectEqual(code, try working_directory.testRun(runArgsWithNewTab, &.{}, &Hook.call));
+        try testing.expectEqual(code, try test_support.testRun(runArgsWithNewTab, &.{}, &Hook.call));
     }
 }

--- a/src/cli/new_tab.zig
+++ b/src/cli/new_tab.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+const working_directory = @import("automation_working_directory.zig");
+pub const Options = struct {
+    _arena: ?ArenaAllocator = null,
+    _working_directory_seen: bool = false,
+    class: ?[:0]const u8 = null,
+    timeout: u64 = 10_000,
+    @"window-id": ?u32 = null,
+    @"working-directory": ?[:0]const u8 = null,
+    pub fn parseManuallyHook(self: *Options, _: Allocator, arg: []const u8, _: anytype) !bool {
+        if (std.mem.startsWith(u8, arg, "--working-directory=")) self._working_directory_seen = true;
+        return true;
+    }
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+    pub fn help(_: Options) !void {
+        return actionpkg.help_error;
+    }
+};
+/// Create a tab in the focused/`--window-id` window with only a safe `--working-directory` override.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+    var buf: [512]u8 = undefined;
+    var writer = std.fs.File.stderr().writer(&buf);
+    const result = runArgs(alloc, &iter, &writer.interface);
+    try writer.interface.flush();
+    return result;
+}
+const NewTabFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, ?[]const u8, u64) anyerror!bool;
+fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
+    return runArgsWithNewTab(alloc, iter, stderr, newAutomationTab);
+}
+fn fail(stderr: *std.Io.Writer, code: u8) !u8 {
+    try stderr.writeAll("+new-tab failed.\n");
+    return code;
+}
+fn runArgsWithNewTab(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: NewTabFn) !u8 {
+    var opts: Options = .{};
+    defer opts.deinit();
+    args.parse(Options, alloc, &opts, iter) catch |err| switch (err) {
+        error.ActionHelpRequested => return err,
+        else => return fail(stderr, 1),
+    };
+    if (opts.timeout > 10_000 or (opts.@"window-id" orelse 1) == 0 or
+        (opts._working_directory_seen and opts.@"working-directory" == null)) return fail(stderr, 1);
+    const cwd = opts.@"working-directory";
+    if (cwd) |path| if (!working_directory.allowed(path)) return fail(stderr, 1);
+    const ok = hook(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+        if (opts.@"window-id") |id| .{ .window_id = id } else .focused,
+        cwd,
+        opts.timeout,
+    ) catch |err| switch (err) {
+        error.InvalidAutomationTarget, error.InvalidWorkingDirectory => return fail(stderr, 1),
+        error.AutomationTargetNotFound, error.NoAutomationTarget => return fail(stderr, 3),
+        error.AutomationPolicyRefused => return fail(stderr, 4),
+        else => return fail(stderr, 5),
+    };
+    return if (ok) 0 else fail(stderr, 2);
+}
+fn newAutomationTab(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8, timeout: u64) !bool {
+    return apprt.App.newAutomationTab(alloc, instance, target, cwd, timeout);
+}
+test "automation new-tab cli contract" {
+    const testing = std.testing;
+    const Hook = struct {
+        var called = false;
+        var expected_cwd: ?[]const u8 = null;
+        var window = false;
+        var outcome: u8 = 0;
+        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, cwd: ?[]const u8, timeout: u64) !bool {
+            called = true;
+            if (expected_cwd) |expected| try testing.expectEqualStrings(expected, cwd.?) else try testing.expect(cwd == null);
+            if (window) {
+                try testing.expectEqualStrings("lane9", instance.class);
+                try testing.expectEqual(std.math.maxInt(u32), target.window_id);
+                try testing.expectEqual(@as(u64, 0), timeout);
+            } else {
+                try testing.expectEqual(apprt.ipc.Target.detect, instance);
+                try testing.expectEqual(apprt.ipc.AutomationTarget.focused, target);
+                try testing.expectEqual(@as(u64, 10_000), timeout);
+            }
+            return working_directory.testOutcome(outcome);
+        }
+    };
+    for ([_]struct { cwd: ?[]const u8, argv: []const []const u8, window: bool = false }{
+        .{ .cwd = null, .argv = &.{} },                                                                                                           .{ .cwd = "home", .argv = &.{"--working-directory=home"} },
+        .{ .cwd = "inherit", .argv = &.{"--working-directory=inherit"} },                                                                         .{ .cwd = "~", .argv = &.{"--working-directory=~"} },
+        .{ .cwd = "~/x", .argv = &.{"--working-directory=~/x"} },                                                                                 .{ .cwd = "~\\x", .argv = &.{"--working-directory=~\\x"} },
+        .{ .cwd = "C:\\x", .argv = &.{ "--class=lane9", "--timeout=0", "--window-id=4294967295", "--working-directory=C:\\x" }, .window = true },
+    }) |case| {
+        Hook.expected_cwd = case.cwd;
+        Hook.window = case.window;
+        Hook.outcome = 0;
+        try testing.expectEqual(@as(u8, 0), try working_directory.testRun(runArgsWithNewTab, case.argv, &Hook.call));
+    }
+    const Reject = struct {
+        var called = false;
+        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: ?[]const u8, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+    for ([_][]const []const u8{
+        &.{"--window-id=0"},                 &.{"--window-id=4294967296"},              &.{"--timeout=10001"},                  &.{"--timeout=18446744073709551616"},
+        &.{"--working-directory="},          &.{"--working-directory=\\\\host\\share"}, &.{"--working-directory=//host/share"}, &.{"--working-directory=\\\\?\\C:\\x"},
+        &.{"--working-directory=relative"},  &.{"--working-directory=C:relative"},      &.{"-e"},                               &.{"--title=x"},
+        &.{"--working-directory=C:\\x\x00"}, &.{"--working-directory=C:\\x\xFF"},       &.{"--command=x"},                      &.{"positional"},
+    }) |argv| {
+        Reject.called = false;
+        try testing.expectEqual(@as(u8, 1), try working_directory.testRun(runArgsWithNewTab, argv, &Reject.call));
+        try testing.expect(!Reject.called);
+    }
+    Hook.expected_cwd = null;
+    Hook.window = false;
+    for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
+        Hook.outcome = code;
+        try testing.expectEqual(code, try working_directory.testRun(runArgsWithNewTab, &.{}, &Hook.call));
+    }
+}

--- a/src/cli/new_window.zig
+++ b/src/cli/new_window.zig
@@ -15,6 +15,9 @@ pub const Options = struct {
     /// If set, open up a new window in a custom instance of noctty.
     class: ?[:0]const u8 = null,
 
+    /// How long to wait for the running instance to respond.
+    timeout: u64 = 10_000,
+
     /// Did the user specify a `--working-directory` argument on the command line?
     _working_directory_seen: bool = false,
 
@@ -53,6 +56,12 @@ pub const Options = struct {
     fn checkArg(self: *Options, alloc: Allocator, arg: []const u8) (error{InvalidValue} || homedir.ExpandError || std.fs.Dir.RealPathAllocError || Allocator.Error)!?[:0]const u8 {
         if (lib.cutPrefix(u8, arg, "--class=")) |rest| {
             self.class = try alloc.dupeZ(u8, std.mem.trim(u8, rest, &std.ascii.whitespace));
+            return null;
+        }
+
+        if (lib.cutPrefix(u8, arg, "--timeout=")) |rest| {
+            self.timeout = std.fmt.parseInt(u64, rest, 10) catch return error.InvalidValue;
+            if (self.timeout > 10_000) return error.InvalidValue;
             return null;
         }
 
@@ -128,6 +137,9 @@ pub const Options = struct {
 ///     noctty. On Win32 this selects the IPC namespace and is also forwarded
 ///     to the fallback process launch path.
 ///
+///   * `--timeout=<ms>`: Response timeout in milliseconds, from 0 through
+///     10000. The default is 10000.
+///
 ///   * `--command`: The command to be executed in the first surface of the new window.
 ///
 ///   * `--working-directory=<directory>`: The working directory to pass to noctty.
@@ -160,6 +172,27 @@ fn runArgs(
     alloc_gpa: Allocator,
     argsIter: anytype,
     stderr: *std.Io.Writer,
+) !u8 {
+    return runArgsWithPerform(
+        alloc_gpa,
+        argsIter,
+        stderr,
+        performNewWindow,
+    );
+}
+
+const PerformNewWindowFn = *const fn (
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+    arguments: ?[][:0]const u8,
+    timeout_ms: u64,
+) anyerror!bool;
+
+fn runArgsWithPerform(
+    alloc_gpa: Allocator,
+    argsIter: anytype,
+    stderr: *std.Io.Writer,
+    performNewWindowFn: PerformNewWindowFn,
 ) !u8 {
     var opts: Options = .{};
     defer opts.deinit();
@@ -203,27 +236,140 @@ fn runArgs(
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    if (apprt.App.performIpc(
+    if (performNewWindowFn(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
-        .new_window,
-        .{
-            .arguments = if (opts._arguments.items.len == 0) null else opts._arguments.items,
-        },
-    ) catch |err| switch (err) {
-        error.IPCFailed => {
-            // The apprt should have printed a more specific error message
-            // already.
-            return 1;
-        },
-        else => {
-            try stderr.print("Sending the IPC failed: {}", .{err});
-            return 1;
-        },
+        if (opts._arguments.items.len == 0) null else opts._arguments.items,
+        opts.timeout,
+    ) catch |err| {
+        try stderr.print("Sending the IPC or fallback launch failed: {}\n", .{err});
+        return 5;
     }) return 0;
 
     try stderr.print("+new-window could not find or start a matching noctty instance.\n", .{});
-    return 1;
+    return 5;
+}
+
+fn performNewWindow(
+    alloc: Allocator,
+    target: apprt.ipc.Target,
+    arguments: ?[][:0]const u8,
+    timeout_ms: u64,
+) !bool {
+    return try apprt.App.performIpc(
+        alloc,
+        target,
+        .new_window,
+        .{ .arguments = arguments },
+        timeout_ms,
+    );
+}
+
+test "automation-new-window cli forwards class timeout and passthrough arguments" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var called = false;
+
+        fn perform(
+            _: Allocator,
+            target: apprt.ipc.Target,
+            arguments: ?[][:0]const u8,
+            timeout_ms: u64,
+        ) !bool {
+            called = true;
+            const class = switch (target) {
+                .class => |value| value,
+                .detect => return error.UnexpectedTarget,
+            };
+            try testing.expectEqualStrings("lane9", class);
+            try testing.expectEqual(@as(u64, 42), timeout_ms);
+            try testing.expect(arguments != null);
+            try testing.expectEqual(@as(usize, 2), arguments.?.len);
+            try testing.expect(std.mem.startsWith(u8, arguments.?[0], "--working-directory="));
+            try testing.expectEqualStrings("--title=kept", arguments.?[1]);
+            return true;
+        }
+    };
+    Hook.called = false;
+
+    var iter = try std.process.ArgIteratorGeneral(.{}).init(
+        testing.allocator,
+        "--class=lane9 --timeout=42 --working-directory=. --title=kept",
+    );
+    defer iter.deinit();
+
+    var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer stderr_buf.deinit();
+
+    try testing.expectEqual(@as(u8, 0), try runArgsWithPerform(
+        testing.allocator,
+        &iter,
+        &stderr_buf.writer,
+        &Hook.perform,
+    ));
+    try testing.expect(Hook.called);
+    try testing.expectEqualStrings("", stderr_buf.written());
+}
+
+test "automation-new-window cli rejects invalid timeout before ipc" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var called = false;
+
+        fn perform(_: Allocator, _: apprt.ipc.Target, _: ?[][:0]const u8, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+
+    for ([_][]const u8{ "--timeout=10001", "--timeout=18446744073709551616" }) |command_line| {
+        Hook.called = false;
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(testing.allocator, command_line);
+        defer iter.deinit();
+
+        var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr_buf.deinit();
+
+        try testing.expectEqual(@as(u8, 1), try runArgsWithPerform(
+            testing.allocator,
+            &iter,
+            &stderr_buf.writer,
+            &Hook.perform,
+        ));
+        try testing.expect(!Hook.called);
+    }
+}
+
+test "automation-new-window cli maps fallback and transport failures to five" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var fail_transport = false;
+
+        fn perform(_: Allocator, _: apprt.ipc.Target, _: ?[][:0]const u8, timeout_ms: u64) !bool {
+            try testing.expectEqual(@as(u64, 10_000), timeout_ms);
+            if (fail_transport) return error.IPCFailed;
+            return false;
+        }
+    };
+
+    for ([_]bool{ false, true }) |fail_transport| {
+        Hook.fail_transport = fail_transport;
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(testing.allocator, "--working-directory=.");
+        defer iter.deinit();
+
+        var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr_buf.deinit();
+
+        try testing.expectEqual(@as(u8, 5), try runArgsWithPerform(
+            testing.allocator,
+            &iter,
+            &stderr_buf.writer,
+            &Hook.perform,
+        ));
+    }
 }
 
 fn hasLaunchLayoutArgument(arguments: []const [:0]const u8) bool {

--- a/src/cli/perform_action.zig
+++ b/src/cli/perform_action.zig
@@ -15,6 +15,9 @@ pub const Options = struct {
     /// default local noctty instance.
     class: ?[:0]const u8 = null,
 
+    /// How long to wait for the running instance to respond.
+    timeout: u64 = 10_000,
+
     /// If set, perform the action against a specific surface from
     /// `+list-windows` instead of the focused surface.
     @"surface-id": ?u64 = null,
@@ -48,6 +51,15 @@ pub const Options = struct {
 /// `write_screen_file`, and `crash` are rejected by the running instance. New
 /// action variants are denied until explicitly added to the automation
 /// allowlist.
+///
+/// Flags:
+///
+///   * `--class=<class>`: Select a custom instance namespace.
+///
+///   * `--surface-id=<id>`: Target a nonzero pane ID from `+list-windows`.
+///
+///   * `--timeout=<ms>`: Response timeout in milliseconds, from 0 through
+///     10000. The default is 10000.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
@@ -79,6 +91,7 @@ const PerformAutomationActionFn = *const fn (
     target: apprt.ipc.Target,
     action_target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
+    timeout_ms: u64,
 ) anyerror!bool;
 
 fn runArgsWithPerform(
@@ -107,10 +120,26 @@ fn runArgsWithPerform(
             continue;
         }
         if (lib.cutPrefix(u8, arg, "--surface-id=")) |raw| {
-            opts.@"surface-id" = std.fmt.parseInt(u64, raw, 10) catch {
+            const id = std.fmt.parseInt(u64, raw, 10) catch {
                 try stderr.print("Invalid --surface-id value: {s}\n", .{raw});
                 return 1;
             };
+            if (id == 0) {
+                try stderr.print("--surface-id must be nonzero.\n", .{});
+                return 1;
+            }
+            opts.@"surface-id" = id;
+            continue;
+        }
+        if (lib.cutPrefix(u8, arg, "--timeout=")) |raw| {
+            opts.timeout = std.fmt.parseInt(u64, raw, 10) catch {
+                try stderr.print("Invalid --timeout value: {s}\n", .{raw});
+                return 1;
+            };
+            if (opts.timeout > 10_000) {
+                try stderr.print("--timeout must be between 0 and 10000 milliseconds.\n", .{});
+                return 1;
+            }
             continue;
         }
         if (std.mem.startsWith(u8, arg, "-")) {
@@ -150,6 +179,7 @@ fn runArgsWithPerform(
         if (opts.class) |class| .{ .class = class } else .detect,
         if (opts.@"surface-id") |id| .{ .surface_id = id } else .focused,
         action,
+        opts.timeout,
     ) catch |err| switch (err) {
         error.InvalidAutomationTarget => {
             try stderr.print("Invalid automation target for action: {s}\n", .{action});
@@ -157,7 +187,7 @@ fn runArgsWithPerform(
         },
         error.NoAutomationTarget => {
             try stderr.print("No matching automation target for action: {s}\n", .{action});
-            return 1;
+            return 3;
         },
         error.InvalidAutomationAction => {
             try stderr.print("Invalid action for +perform-action: {s}\n", .{action});
@@ -165,23 +195,18 @@ fn runArgsWithPerform(
         },
         error.UnsafeAutomationAction => {
             try stderr.print("Unsafe action rejected for +perform-action: {s}\n", .{action});
-            return 1;
+            return 4;
         },
-        error.IPCFailed => {
-            try stderr.print("Performing automation action via IPC failed.\n", .{});
-            return 1;
+        else => {
+            try stderr.print("Performing automation action via IPC failed: {}\n", .{err});
+            return 5;
         },
-        error.InvalidIpcResponse => {
-            try stderr.print("Performing automation action via IPC failed: invalid response from the target instance.\n", .{});
-            return 1;
-        },
-        else => return err,
     };
 
     if (ok) return 0;
 
     try stderr.print("No matching noctty instance is listening for automation actions.\n", .{});
-    return 1;
+    return 2;
 }
 
 fn performAutomationAction(
@@ -189,12 +214,14 @@ fn performAutomationAction(
     target: apprt.ipc.Target,
     action_target: apprt.ipc.AutomationActionTarget,
     action_text: []const u8,
+    timeout_ms: u64,
 ) !bool {
     return try apprt.App.performAutomationAction(
         alloc,
         target,
         action_target,
         action_text,
+        timeout_ms,
     );
 }
 
@@ -211,6 +238,7 @@ test "automation-action cli forwards class surface and action" {
             target: apprt.ipc.Target,
             action_target: apprt.ipc.AutomationActionTarget,
             action_text: []const u8,
+            timeout_ms: u64,
         ) !bool {
             seen_class = switch (target) {
                 .class => |class| try testing.allocator.dupe(u8, class),
@@ -221,6 +249,7 @@ test "automation-action cli forwards class surface and action" {
                 .focused => return error.UnexpectedTarget,
             };
             seen_action = try testing.allocator.dupe(u8, action_text);
+            try testing.expectEqual(@as(u64, 0), timeout_ms);
             return true;
         }
     };
@@ -229,7 +258,7 @@ test "automation-action cli forwards class surface and action" {
 
     var iter = try std.process.ArgIteratorGeneral(.{}).init(
         testing.allocator,
-        "--class=lane9 --surface-id=42 new_tab",
+        "--class=lane9 --surface-id=42 --timeout=0 new_tab",
     );
     defer iter.deinit();
 
@@ -259,6 +288,7 @@ test "automation-action cli rejects invalid action before ipc" {
             _: apprt.ipc.Target,
             _: apprt.ipc.AutomationActionTarget,
             _: []const u8,
+            _: u64,
         ) !bool {
             return error.UnexpectedIpc;
         }
@@ -296,6 +326,7 @@ test "automation-action cli rejects app action with surface id before ipc" {
             _: apprt.ipc.Target,
             _: apprt.ipc.AutomationActionTarget,
             _: []const u8,
+            _: u64,
         ) !bool {
             return error.UnexpectedIpc;
         }
@@ -333,6 +364,7 @@ test "automation-action cli reports invalid ipc response" {
             _: apprt.ipc.Target,
             _: apprt.ipc.AutomationActionTarget,
             _: []const u8,
+            _: u64,
         ) !bool {
             return error.InvalidIpcResponse;
         }
@@ -354,9 +386,79 @@ test "automation-action cli reports invalid ipc response" {
         &Hook.perform,
     );
 
-    try testing.expectEqual(@as(u8, 1), exit_code);
-    try testing.expectEqualStrings(
-        "Performing automation action via IPC failed: invalid response from the target instance.\n",
-        stderr_buf.written(),
-    );
+    try testing.expectEqual(@as(u8, 5), exit_code);
+    try testing.expect(std.mem.startsWith(u8, stderr_buf.written(), "Performing automation action via IPC failed:"));
+}
+
+test "automation-action cli rejects invalid arguments before ipc" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var called = false;
+
+        fn perform(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationActionTarget, _: []const u8, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+
+    for ([_][]const u8{
+        "--surface-id=0 new_tab",
+        "--surface-id=18446744073709551616 new_tab",
+        "--timeout=10001 new_tab",
+        "--timeout=18446744073709551616 new_tab",
+        "",
+        "new_tab close_tab",
+    }) |command_line| {
+        Hook.called = false;
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(testing.allocator, command_line);
+        defer iter.deinit();
+
+        var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr_buf.deinit();
+
+        try testing.expectEqual(@as(u8, 1), try runArgsWithPerform(
+            testing.allocator,
+            &iter,
+            &stderr_buf.writer,
+            &Hook.perform,
+        ));
+        try testing.expect(!Hook.called);
+    }
+}
+
+test "automation-action cli maps stable runtime exit codes" {
+    const testing = std.testing;
+
+    const Hook = struct {
+        var outcome: u8 = 0;
+
+        fn perform(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationActionTarget, _: []const u8, timeout_ms: u64) !bool {
+            try testing.expectEqual(@as(u64, 10_000), timeout_ms);
+            return switch (outcome) {
+                1 => error.InvalidAutomationTarget,
+                2 => false,
+                3 => error.NoAutomationTarget,
+                4 => error.UnsafeAutomationAction,
+                5 => error.IPCFailed,
+                else => true,
+            };
+        }
+    };
+
+    for ([_]u8{ 1, 2, 3, 4, 5 }) |expected| {
+        Hook.outcome = expected;
+        var iter = try std.process.ArgIteratorGeneral(.{}).init(testing.allocator, "new_tab");
+        defer iter.deinit();
+
+        var stderr_buf = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr_buf.deinit();
+
+        try testing.expectEqual(expected, try runArgsWithPerform(
+            testing.allocator,
+            &iter,
+            &stderr_buf.writer,
+            &Hook.perform,
+        ));
+    }
 }

--- a/src/cli/send_text.zig
+++ b/src/cli/send_text.zig
@@ -6,69 +6,122 @@ const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
 const lib = @import("../lib/main.zig");
 const paste_protection = @import("../apprt/win32_paste_protection.zig");
-const support = @import("automation_working_directory.zig");
+const test_support = @import("automation_test_support.zig");
+
+/// Maximum text payload accepted by the automation protocol.
 const max_text_len = 16 * 1024;
+
+/// Parsed options for the `+send-text` command.
 pub const Options = struct {
+    /// This is set by the CLI parser for deinit.
     _arena: ?ArenaAllocator = null,
+
     /// Select a custom single-instance namespace.
     class: ?[:0]const u8 = null,
+
     /// Response timeout in milliseconds, from 0 through 10000.
     timeout: u64 = 10_000,
+
     /// Required nonzero pane ID from `+list-windows`.
     @"surface-id": ?u64 = null,
+
+    /// Releases memory owned by the parsed options.
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
     }
+
+    /// Enables `-h` and `--help` to work.
     pub fn help(_: Options) !void {
         return actionpkg.help_error;
     }
 };
+
 /// Send printable UTF-8 to `--surface-id`; control input is refused and never prompts.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
+
     var buf: [1024]u8 = undefined;
     var writer = std.fs.File.stderr().writer(&buf);
     const result = runArgs(alloc, &iter, &writer.interface);
+
     try writer.interface.flush();
     return result;
 }
+
+/// Dispatches parsed arguments through the production IPC implementation.
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithSend(alloc, iter, stderr, sendAutomationText);
 }
-const SendFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, []const u8, u64) anyerror!bool;
-const TextPolicy = enum { allowed, invalid, refused };
+
+/// Injected IPC seam used by the command and its unit tests.
+const SendFn = *const fn (
+    Allocator,
+    apprt.ipc.Target,
+    apprt.ipc.AutomationTarget,
+    []const u8,
+    u64,
+) anyerror!bool;
+
+/// Result of validating a prospective automation text payload.
+const TextPolicy = enum {
+    allowed,
+    invalid,
+    refused,
+};
+
+/// Writes a stable diagnostic before returning an exit code.
 fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
     try stderr.writeAll(message);
     return code;
 }
-fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: SendFn) !u8 {
+
+/// Parses and validates `+send-text` before invoking the injected IPC seam.
+fn runArgsWithSend(
+    alloc: Allocator,
+    iter: anytype,
+    stderr: *std.Io.Writer,
+    hook: SendFn,
+) !u8 {
     var opts: Options = .{ ._arena = ArenaAllocator.init(alloc) };
     defer opts.deinit();
     const arena = opts._arena.?.allocator();
+
     var text: ?[]const u8 = null;
     while (iter.next()) |arg| {
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) return actionpkg.help_error;
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            return actionpkg.help_error;
+        }
+
         if (lib.cutPrefix(u8, arg, "--class=")) |value| {
             opts.class = try arena.dupeZ(u8, std.mem.trim(u8, value, &std.ascii.whitespace));
         } else if (lib.cutPrefix(u8, arg, "--surface-id=")) |value| {
-            if (opts.@"surface-id" != null) return report(stderr, 1, "Invalid +send-text arguments.\n");
+            if (opts.@"surface-id" != null) {
+                return report(stderr, 1, "Invalid +send-text arguments.\n");
+            }
             opts.@"surface-id" = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --surface-id.\n");
         } else if (lib.cutPrefix(u8, arg, "--timeout=")) |value| {
             opts.timeout = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --timeout.\n");
         } else if (std.mem.startsWith(u8, arg, "-") or text != null) {
             return report(stderr, 1, "Invalid +send-text arguments.\n");
-        } else text = arg;
+        } else {
+            text = arg;
+        }
     }
+
     const id = opts.@"surface-id" orelse return report(stderr, 1, "+send-text requires --surface-id.\n");
     const value = text orelse return report(stderr, 1, "+send-text requires one text argument.\n");
-    if (id == 0 or opts.timeout > 10_000) return report(stderr, 1, "Invalid +send-text arguments.\n");
+    if (id == 0 or opts.timeout > 10_000) {
+        return report(stderr, 1, "Invalid +send-text arguments.\n");
+    }
+
     switch (automationTextPolicy(value)) {
         .allowed => {},
         .invalid => return report(stderr, 1, "Invalid automation text.\n"),
         .refused => return report(stderr, 4, "Automation control input refused.\n"),
     }
+
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -81,36 +134,70 @@ fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook
         error.AutomationPolicyRefused => return report(stderr, 4, "Automation text refused.\n"),
         else => return report(stderr, 5, "Automation text IPC failed.\n"),
     };
+
     return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
 }
+
+/// Applies the CLI-side text policy before any IPC connection is attempted.
 fn automationTextPolicy(text: []const u8) TextPolicy {
-    if (text.len == 0 or text.len > max_text_len) return .invalid;
+    if (text.len == 0 or text.len > max_text_len) {
+        return .invalid;
+    }
+
     const view = std.unicode.Utf8View.init(text) catch return .invalid;
     var iter = view.iterator();
-    while (iter.nextCodepoint()) |cp| if (cp <= 0x1F or cp == 0x7F or (cp >= 0x80 and cp <= 0x9F)) return .refused;
-    if (paste_protection.inspect(text).severity == .control_chars) return .refused;
+
+    while (iter.nextCodepoint()) |cp| {
+        if (cp <= 0x1F or cp == 0x7F or (cp >= 0x80 and cp <= 0x9F)) {
+            return .refused;
+        }
+    }
+
+    if (paste_protection.inspect(text).severity == .control_chars) {
+        return .refused;
+    }
     return .allowed;
 }
-fn sendAutomationText(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, text: []const u8, timeout: u64) !bool {
+
+/// Sends validated automation text to the matching running instance.
+fn sendAutomationText(
+    alloc: Allocator,
+    instance: apprt.ipc.Target,
+    target: apprt.ipc.AutomationTarget,
+    text: []const u8,
+    timeout: u64,
+) !bool {
     return apprt.App.sendAutomationText(alloc, instance, target, text, timeout);
 }
+
 test "automation send-text cli contract and policy" {
     const testing = std.testing;
+
     const Hook = struct {
         var called = false;
         var expected: ?[]const u8 = null;
         var outcome: u8 = 0;
-        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, text: []const u8, timeout: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            instance: apprt.ipc.Target,
+            target: apprt.ipc.AutomationTarget,
+            text: []const u8,
+            timeout: u64,
+        ) !bool {
             called = true;
             try testing.expectEqualStrings(expected.?, text);
             try testing.expectEqual(@as(u64, 42), target.surface_id);
             if (std.mem.eql(u8, text, "caf\xc3\xa9 \xe2\x98\x95")) {
                 try testing.expectEqualStrings("lane9", instance.class);
                 try testing.expectEqual(@as(u64, 0), timeout);
-            } else try testing.expectEqual(@as(u64, 10_000), timeout);
-            return support.testOutcome(outcome);
+            } else {
+                try testing.expectEqual(@as(u64, 10_000), timeout);
+            }
+            return test_support.testOutcome(outcome);
         }
     };
+
     for ([_][]const u8{
         "caf\xc3\xa9 \xe2\x98\x95",
         "echo $env:Path; whoami | more",
@@ -122,15 +209,24 @@ test "automation send-text cli contract and policy" {
             &.{ "--class=lane9", "--timeout=0", "--surface-id=42", value }
         else
             &.{ "--surface-id=42", value };
-        try testing.expectEqual(@as(u8, 0), try support.testRun(runArgsWithSend, argv, &Hook.call));
+        try testing.expectEqual(@as(u8, 0), try test_support.testRun(runArgsWithSend, argv, &Hook.call));
     }
+
     const Invalid = struct {
         var called = false;
-        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: []const u8, _: u64) !bool {
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: []const u8,
+            _: u64,
+        ) !bool {
             called = true;
             return true;
         }
     };
+
     for ([_][]const []const u8{
         &.{},
         &.{"text"},
@@ -142,24 +238,36 @@ test "automation send-text cli contract and policy" {
         &.{ "--timeout=18446744073709551616", "--surface-id=1", "text" },
     }) |argv| {
         Invalid.called = false;
-        try testing.expectEqual(@as(u8, 1), try support.testRun(runArgsWithSend, argv, &Invalid.call));
+        try testing.expectEqual(@as(u8, 1), try test_support.testRun(runArgsWithSend, argv, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
-    for ([_][]const u8{ "before\r", "before\n", "before\t", "before\x00", "before\x1B", "before\x7F", "before\xC2\x80" }) |value| {
+
+    for ([_][]const u8{
+        "before\r",
+        "before\n",
+        "before\t",
+        "before\x00",
+        "before\x1B",
+        "before\x7F",
+        "before\xC2\x80",
+    }) |value| {
         Invalid.called = false;
-        try testing.expectEqual(@as(u8, 4), try support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expectEqual(@as(u8, 4), try test_support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
+
     const oversized = try testing.allocator.alloc(u8, max_text_len + 1);
     defer testing.allocator.free(oversized);
     @memset(oversized, 'x');
+
     for ([_][]const u8{ "", "\xFF", oversized }) |value| {
-        try testing.expectEqual(@as(u8, 1), try support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expectEqual(@as(u8, 1), try test_support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
+
     Hook.expected = "text";
     for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
         Hook.outcome = code;
-        try testing.expectEqual(code, try support.testRun(runArgsWithSend, &.{ "--surface-id=42", "text" }, &Hook.call));
+        try testing.expectEqual(code, try test_support.testRun(runArgsWithSend, &.{ "--surface-id=42", "text" }, &Hook.call));
     }
 }

--- a/src/cli/send_text.zig
+++ b/src/cli/send_text.zig
@@ -89,25 +89,42 @@ fn runArgsWithSend(
     const arena = opts._arena.?.allocator();
 
     var text: ?[]const u8 = null;
+    var literal = false;
     while (iter.next()) |arg| {
-        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            return actionpkg.help_error;
-        }
-
-        if (lib.cutPrefix(u8, arg, "--class=")) |value| {
-            opts.class = try arena.dupeZ(u8, std.mem.trim(u8, value, &std.ascii.whitespace));
-        } else if (lib.cutPrefix(u8, arg, "--surface-id=")) |value| {
-            if (opts.@"surface-id" != null) {
+        if (!literal) {
+            if (std.mem.eql(u8, arg, "--")) {
+                literal = true;
+                continue;
+            }
+            if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+                return actionpkg.help_error;
+            }
+            if (lib.cutPrefix(u8, arg, "--class=")) |value| {
+                opts.class = try arena.dupeZ(u8, std.mem.trim(u8, value, &std.ascii.whitespace));
+                continue;
+            }
+            if (lib.cutPrefix(u8, arg, "--surface-id=")) |value| {
+                if (opts.@"surface-id" != null) {
+                    return report(stderr, 1, "Invalid +send-text arguments.\n");
+                }
+                opts.@"surface-id" = std.fmt.parseInt(u64, value, 10) catch
+                    return report(stderr, 1, "Invalid --surface-id.\n");
+                continue;
+            }
+            if (lib.cutPrefix(u8, arg, "--timeout=")) |value| {
+                opts.timeout = std.fmt.parseInt(u64, value, 10) catch
+                    return report(stderr, 1, "Invalid --timeout.\n");
+                continue;
+            }
+            if (std.mem.startsWith(u8, arg, "-")) {
                 return report(stderr, 1, "Invalid +send-text arguments.\n");
             }
-            opts.@"surface-id" = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --surface-id.\n");
-        } else if (lib.cutPrefix(u8, arg, "--timeout=")) |value| {
-            opts.timeout = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --timeout.\n");
-        } else if (std.mem.startsWith(u8, arg, "-") or text != null) {
-            return report(stderr, 1, "Invalid +send-text arguments.\n");
-        } else {
-            text = arg;
         }
+
+        if (text != null) {
+            return report(stderr, 1, "Invalid +send-text arguments.\n");
+        }
+        text = arg;
     }
 
     const id = opts.@"surface-id" orelse return report(stderr, 1, "+send-text requires --surface-id.\n");
@@ -210,6 +227,19 @@ test "automation send-text cli contract and policy" {
         else
             &.{ "--surface-id=42", value };
         try testing.expectEqual(@as(u8, 0), try test_support.testRun(runArgsWithSend, argv, &Hook.call));
+    }
+
+    for ([_][]const u8{ "-n", "--version", "--help" }) |value| {
+        Hook.expected = value;
+        Hook.outcome = 0;
+        try testing.expectEqual(
+            @as(u8, 0),
+            try test_support.testRun(
+                runArgsWithSend,
+                &.{ "--surface-id=42", "--", value },
+                &Hook.call,
+            ),
+        );
     }
 
     const Invalid = struct {

--- a/src/cli/send_text.zig
+++ b/src/cli/send_text.zig
@@ -6,9 +6,8 @@ const apprt = @import("../apprt.zig");
 const args = @import("args.zig");
 const lib = @import("../lib/main.zig");
 const paste_protection = @import("../apprt/win32_paste_protection.zig");
-
+const support = @import("automation_working_directory.zig");
 const max_text_len = 16 * 1024;
-
 pub const Options = struct {
     _arena: ?ArenaAllocator = null,
     /// Select a custom single-instance namespace.
@@ -17,7 +16,6 @@ pub const Options = struct {
     timeout: u64 = 10_000,
     /// Required nonzero pane ID from `+list-windows`.
     @"surface-id": ?u64 = null,
-
     pub fn deinit(self: *Options) void {
         if (self._arena) |arena| arena.deinit();
         self.* = undefined;
@@ -26,10 +24,7 @@ pub const Options = struct {
         return actionpkg.help_error;
     }
 };
-
-/// Send one nonempty printable UTF-8 argument (at most 16 KiB) to the required
-/// `--surface-id`. Supports `--class` and a 0..10000 ms `--timeout`. Automation
-/// cannot send Enter, newline, or control input and never raises a paste prompt.
+/// Send printable UTF-8 to `--surface-id`; control input is refused and never prompts.
 pub fn run(alloc: Allocator) !u8 {
     var iter = try args.argsIterator(alloc);
     defer iter.deinit();
@@ -39,19 +34,15 @@ pub fn run(alloc: Allocator) !u8 {
     try writer.interface.flush();
     return result;
 }
-
 fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
     return runArgsWithSend(alloc, iter, stderr, sendAutomationText);
 }
-
 const SendFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, []const u8, u64) anyerror!bool;
 const TextPolicy = enum { allowed, invalid, refused };
-
 fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
     try stderr.writeAll(message);
     return code;
 }
-
 fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: SendFn) !u8 {
     var opts: Options = .{ ._arena = ArenaAllocator.init(alloc) };
     defer opts.deinit();
@@ -78,7 +69,6 @@ fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook
         .invalid => return report(stderr, 1, "Invalid automation text.\n"),
         .refused => return report(stderr, 4, "Automation control input refused.\n"),
     }
-
     const ok = hook(
         alloc,
         if (opts.class) |class| .{ .class = class } else .detect,
@@ -93,7 +83,6 @@ fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook
     };
     return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
 }
-
 fn automationTextPolicy(text: []const u8) TextPolicy {
     if (text.len == 0 or text.len > max_text_len) return .invalid;
     const view = std.unicode.Utf8View.init(text) catch return .invalid;
@@ -102,28 +91,9 @@ fn automationTextPolicy(text: []const u8) TextPolicy {
     if (paste_protection.inspect(text).severity == .control_chars) return .refused;
     return .allowed;
 }
-
 fn sendAutomationText(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, text: []const u8, timeout: u64) !bool {
     return apprt.App.sendAutomationText(alloc, instance, target, text, timeout);
 }
-
-const TestArgs = struct {
-    items: []const []const u8,
-    index: usize = 0,
-    fn next(self: *@This()) ?[]const u8 {
-        if (self.index == self.items.len) return null;
-        defer self.index += 1;
-        return self.items[self.index];
-    }
-};
-
-fn testRun(items: []const []const u8, hook: SendFn) !u8 {
-    var iter: TestArgs = .{ .items = items };
-    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
-    defer stderr.deinit();
-    return runArgsWithSend(std.testing.allocator, &iter, &stderr.writer, hook);
-}
-
 test "automation send-text cli contract and policy" {
     const testing = std.testing;
     const Hook = struct {
@@ -138,17 +108,9 @@ test "automation send-text cli contract and policy" {
                 try testing.expectEqualStrings("lane9", instance.class);
                 try testing.expectEqual(@as(u64, 0), timeout);
             } else try testing.expectEqual(@as(u64, 10_000), timeout);
-            return switch (outcome) {
-                1 => error.InvalidAutomationTarget,
-                2 => false,
-                3 => error.AutomationTargetNotFound,
-                4 => error.AutomationPolicyRefused,
-                5 => error.IPCFailed,
-                else => true,
-            };
+            return support.testOutcome(outcome);
         }
     };
-
     for ([_][]const u8{
         "caf\xc3\xa9 \xe2\x98\x95",
         "echo $env:Path; whoami | more",
@@ -160,9 +122,8 @@ test "automation send-text cli contract and policy" {
             &.{ "--class=lane9", "--timeout=0", "--surface-id=42", value }
         else
             &.{ "--surface-id=42", value };
-        try testing.expectEqual(@as(u8, 0), try testRun(argv, &Hook.call));
+        try testing.expectEqual(@as(u8, 0), try support.testRun(runArgsWithSend, argv, &Hook.call));
     }
-
     const Invalid = struct {
         var called = false;
         fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: []const u8, _: u64) !bool {
@@ -181,26 +142,24 @@ test "automation send-text cli contract and policy" {
         &.{ "--timeout=18446744073709551616", "--surface-id=1", "text" },
     }) |argv| {
         Invalid.called = false;
-        try testing.expectEqual(@as(u8, 1), try testRun(argv, &Invalid.call));
+        try testing.expectEqual(@as(u8, 1), try support.testRun(runArgsWithSend, argv, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
-
     for ([_][]const u8{ "before\r", "before\n", "before\t", "before\x00", "before\x1B", "before\x7F", "before\xC2\x80" }) |value| {
         Invalid.called = false;
-        try testing.expectEqual(@as(u8, 4), try testRun(&.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expectEqual(@as(u8, 4), try support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
     const oversized = try testing.allocator.alloc(u8, max_text_len + 1);
     defer testing.allocator.free(oversized);
     @memset(oversized, 'x');
     for ([_][]const u8{ "", "\xFF", oversized }) |value| {
-        try testing.expectEqual(@as(u8, 1), try testRun(&.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expectEqual(@as(u8, 1), try support.testRun(runArgsWithSend, &.{ "--surface-id=1", value }, &Invalid.call));
         try testing.expect(!Invalid.called);
     }
-
     Hook.expected = "text";
     for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
         Hook.outcome = code;
-        try testing.expectEqual(code, try testRun(&.{ "--surface-id=42", "text" }, &Hook.call));
+        try testing.expectEqual(code, try support.testRun(runArgsWithSend, &.{ "--surface-id=42", "text" }, &Hook.call));
     }
 }

--- a/src/cli/send_text.zig
+++ b/src/cli/send_text.zig
@@ -146,7 +146,8 @@ fn runArgsWithSend(
         value,
         opts.timeout,
     ) catch |err| switch (err) {
-        error.InvalidAutomationTarget, error.InvalidAutomationText => return report(stderr, 1, "Invalid automation text request.\n"),
+        error.InvalidAutomationTarget => return report(stderr, 1, "Invalid automation target.\n"),
+        error.InvalidAutomationText => return report(stderr, 1, "Invalid automation text request.\n"),
         error.AutomationTargetNotFound, error.NoAutomationTarget => return report(stderr, 3, "Automation target not found.\n"),
         error.AutomationPolicyRefused => return report(stderr, 4, "Automation text refused.\n"),
         else => return report(stderr, 5, "Automation text IPC failed.\n"),
@@ -299,5 +300,34 @@ test "automation send-text cli contract and policy" {
     for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
         Hook.outcome = code;
         try testing.expectEqual(code, try test_support.testRun(runArgsWithSend, &.{ "--surface-id=42", "text" }, &Hook.call));
+    }
+
+    const ErrorHook = struct {
+        var outcome: anyerror = error.InvalidAutomationTarget;
+
+        fn call(
+            _: Allocator,
+            _: apprt.ipc.Target,
+            _: apprt.ipc.AutomationTarget,
+            _: []const u8,
+            _: u64,
+        ) !bool {
+            return outcome;
+        }
+    };
+    for ([_]struct { outcome: anyerror, message: []const u8 }{
+        .{ .outcome = error.InvalidAutomationTarget, .message = "Invalid automation target.\n" },
+        .{ .outcome = error.InvalidAutomationText, .message = "Invalid automation text request.\n" },
+    }) |case| {
+        var iter: test_support.TestArgs = .{ .items = &.{ "--surface-id=42", "text" } };
+        var stderr = std.Io.Writer.Allocating.init(testing.allocator);
+        defer stderr.deinit();
+        ErrorHook.outcome = case.outcome;
+
+        try testing.expectEqual(
+            @as(u8, 1),
+            try runArgsWithSend(testing.allocator, &iter, &stderr.writer, &ErrorHook.call),
+        );
+        try testing.expectEqualStrings(case.message, stderr.written());
     }
 }

--- a/src/cli/send_text.zig
+++ b/src/cli/send_text.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const actionpkg = @import("action.zig");
+const apprt = @import("../apprt.zig");
+const args = @import("args.zig");
+const lib = @import("../lib/main.zig");
+const paste_protection = @import("../apprt/win32_paste_protection.zig");
+
+const max_text_len = 16 * 1024;
+
+pub const Options = struct {
+    _arena: ?ArenaAllocator = null,
+    /// Select a custom single-instance namespace.
+    class: ?[:0]const u8 = null,
+    /// Response timeout in milliseconds, from 0 through 10000.
+    timeout: u64 = 10_000,
+    /// Required nonzero pane ID from `+list-windows`.
+    @"surface-id": ?u64 = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+    pub fn help(_: Options) !void {
+        return actionpkg.help_error;
+    }
+};
+
+/// Send one nonempty printable UTF-8 argument (at most 16 KiB) to the required
+/// `--surface-id`. Supports `--class` and a 0..10000 ms `--timeout`. Automation
+/// cannot send Enter, newline, or control input and never raises a paste prompt.
+pub fn run(alloc: Allocator) !u8 {
+    var iter = try args.argsIterator(alloc);
+    defer iter.deinit();
+    var buf: [1024]u8 = undefined;
+    var writer = std.fs.File.stderr().writer(&buf);
+    const result = runArgs(alloc, &iter, &writer.interface);
+    try writer.interface.flush();
+    return result;
+}
+
+fn runArgs(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer) !u8 {
+    return runArgsWithSend(alloc, iter, stderr, sendAutomationText);
+}
+
+const SendFn = *const fn (Allocator, apprt.ipc.Target, apprt.ipc.AutomationTarget, []const u8, u64) anyerror!bool;
+const TextPolicy = enum { allowed, invalid, refused };
+
+fn report(stderr: *std.Io.Writer, code: u8, message: []const u8) !u8 {
+    try stderr.writeAll(message);
+    return code;
+}
+
+fn runArgsWithSend(alloc: Allocator, iter: anytype, stderr: *std.Io.Writer, hook: SendFn) !u8 {
+    var opts: Options = .{ ._arena = ArenaAllocator.init(alloc) };
+    defer opts.deinit();
+    const arena = opts._arena.?.allocator();
+    var text: ?[]const u8 = null;
+    while (iter.next()) |arg| {
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) return actionpkg.help_error;
+        if (lib.cutPrefix(u8, arg, "--class=")) |value| {
+            opts.class = try arena.dupeZ(u8, std.mem.trim(u8, value, &std.ascii.whitespace));
+        } else if (lib.cutPrefix(u8, arg, "--surface-id=")) |value| {
+            if (opts.@"surface-id" != null) return report(stderr, 1, "Invalid +send-text arguments.\n");
+            opts.@"surface-id" = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --surface-id.\n");
+        } else if (lib.cutPrefix(u8, arg, "--timeout=")) |value| {
+            opts.timeout = std.fmt.parseInt(u64, value, 10) catch return report(stderr, 1, "Invalid --timeout.\n");
+        } else if (std.mem.startsWith(u8, arg, "-") or text != null) {
+            return report(stderr, 1, "Invalid +send-text arguments.\n");
+        } else text = arg;
+    }
+    const id = opts.@"surface-id" orelse return report(stderr, 1, "+send-text requires --surface-id.\n");
+    const value = text orelse return report(stderr, 1, "+send-text requires one text argument.\n");
+    if (id == 0 or opts.timeout > 10_000) return report(stderr, 1, "Invalid +send-text arguments.\n");
+    switch (automationTextPolicy(value)) {
+        .allowed => {},
+        .invalid => return report(stderr, 1, "Invalid automation text.\n"),
+        .refused => return report(stderr, 4, "Automation control input refused.\n"),
+    }
+
+    const ok = hook(
+        alloc,
+        if (opts.class) |class| .{ .class = class } else .detect,
+        .{ .surface_id = id },
+        value,
+        opts.timeout,
+    ) catch |err| switch (err) {
+        error.InvalidAutomationTarget, error.InvalidAutomationText => return report(stderr, 1, "Invalid automation text request.\n"),
+        error.AutomationTargetNotFound, error.NoAutomationTarget => return report(stderr, 3, "Automation target not found.\n"),
+        error.AutomationPolicyRefused => return report(stderr, 4, "Automation text refused.\n"),
+        else => return report(stderr, 5, "Automation text IPC failed.\n"),
+    };
+    return if (ok) 0 else report(stderr, 2, "No matching noctty instance.\n");
+}
+
+fn automationTextPolicy(text: []const u8) TextPolicy {
+    if (text.len == 0 or text.len > max_text_len) return .invalid;
+    const view = std.unicode.Utf8View.init(text) catch return .invalid;
+    var iter = view.iterator();
+    while (iter.nextCodepoint()) |cp| if (cp <= 0x1F or cp == 0x7F or (cp >= 0x80 and cp <= 0x9F)) return .refused;
+    if (paste_protection.inspect(text).severity == .control_chars) return .refused;
+    return .allowed;
+}
+
+fn sendAutomationText(alloc: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, text: []const u8, timeout: u64) !bool {
+    return apprt.App.sendAutomationText(alloc, instance, target, text, timeout);
+}
+
+const TestArgs = struct {
+    items: []const []const u8,
+    index: usize = 0,
+    fn next(self: *@This()) ?[]const u8 {
+        if (self.index == self.items.len) return null;
+        defer self.index += 1;
+        return self.items[self.index];
+    }
+};
+
+fn testRun(items: []const []const u8, hook: SendFn) !u8 {
+    var iter: TestArgs = .{ .items = items };
+    var stderr = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stderr.deinit();
+    return runArgsWithSend(std.testing.allocator, &iter, &stderr.writer, hook);
+}
+
+test "automation send-text cli contract and policy" {
+    const testing = std.testing;
+    const Hook = struct {
+        var called = false;
+        var expected: ?[]const u8 = null;
+        var outcome: u8 = 0;
+        fn call(_: Allocator, instance: apprt.ipc.Target, target: apprt.ipc.AutomationTarget, text: []const u8, timeout: u64) !bool {
+            called = true;
+            try testing.expectEqualStrings(expected.?, text);
+            try testing.expectEqual(@as(u64, 42), target.surface_id);
+            if (std.mem.eql(u8, text, "caf\xc3\xa9 \xe2\x98\x95")) {
+                try testing.expectEqualStrings("lane9", instance.class);
+                try testing.expectEqual(@as(u64, 0), timeout);
+            } else try testing.expectEqual(@as(u64, 10_000), timeout);
+            return switch (outcome) {
+                1 => error.InvalidAutomationTarget,
+                2 => false,
+                3 => error.AutomationTargetNotFound,
+                4 => error.AutomationPolicyRefused,
+                5 => error.IPCFailed,
+                else => true,
+            };
+        }
+    };
+
+    for ([_][]const u8{
+        "caf\xc3\xa9 \xe2\x98\x95",
+        "echo $env:Path; whoami | more",
+        "please visit https://example.com right now",
+    }, 0..) |value, i| {
+        Hook.expected = value;
+        Hook.outcome = 0;
+        const argv: []const []const u8 = if (i == 0)
+            &.{ "--class=lane9", "--timeout=0", "--surface-id=42", value }
+        else
+            &.{ "--surface-id=42", value };
+        try testing.expectEqual(@as(u8, 0), try testRun(argv, &Hook.call));
+    }
+
+    const Invalid = struct {
+        var called = false;
+        fn call(_: Allocator, _: apprt.ipc.Target, _: apprt.ipc.AutomationTarget, _: []const u8, _: u64) !bool {
+            called = true;
+            return true;
+        }
+    };
+    for ([_][]const []const u8{
+        &.{},
+        &.{"text"},
+        &.{"--surface-id=1"},
+        &.{ "--surface-id=1", "one", "two" },
+        &.{ "--surface-id=0", "text" },
+        &.{ "--surface-id=18446744073709551616", "text" },
+        &.{ "--timeout=10001", "--surface-id=1", "text" },
+        &.{ "--timeout=18446744073709551616", "--surface-id=1", "text" },
+    }) |argv| {
+        Invalid.called = false;
+        try testing.expectEqual(@as(u8, 1), try testRun(argv, &Invalid.call));
+        try testing.expect(!Invalid.called);
+    }
+
+    for ([_][]const u8{ "before\r", "before\n", "before\t", "before\x00", "before\x1B", "before\x7F", "before\xC2\x80" }) |value| {
+        Invalid.called = false;
+        try testing.expectEqual(@as(u8, 4), try testRun(&.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expect(!Invalid.called);
+    }
+    const oversized = try testing.allocator.alloc(u8, max_text_len + 1);
+    defer testing.allocator.free(oversized);
+    @memset(oversized, 'x');
+    for ([_][]const u8{ "", "\xFF", oversized }) |value| {
+        try testing.expectEqual(@as(u8, 1), try testRun(&.{ "--surface-id=1", value }, &Invalid.call));
+        try testing.expect(!Invalid.called);
+    }
+
+    Hook.expected = "text";
+    for ([_]u8{ 0, 1, 2, 3, 4, 5 }) |code| {
+        Hook.outcome = code;
+        try testing.expectEqual(code, try testRun(&.{ "--surface-id=42", "text" }, &Hook.call));
+    }
+}

--- a/test/windows/cli-automation.ps1
+++ b/test/windows/cli-automation.ps1
@@ -44,8 +44,28 @@ function Invoke-AutomationCli {
 
     $script:automationInvocation++
     $stderr = Join-Path $layout.Logs ("cli-{0}.stderr.log" -f $script:automationInvocation)
-    $output = @(& $cli @Arguments 2> $stderr)
-    $exitCode = $LASTEXITCODE
+
+    # Every automation verb is a native command whose nonzero exits and stderr
+    # are DATA here, not failures: the exit code is the contract under test, and
+    # `Wait-AutomationState` deliberately polls before the server is listening.
+    # Under Windows PowerShell 5.1 -- which `Invoke-InteractiveWin11Bootstrap`
+    # bootstraps into -- a native command writing to stderr raises a terminating
+    # NativeCommandError while `$ErrorActionPreference` is 'Stop', which would
+    # kill the script on the first poll before the tolerant retry could run.
+    # Under PowerShell 7.3+ the equivalent hazard is
+    # `$PSNativeCommandUseErrorActionPreference`, which also keys off 'Stop'.
+    # Relaxing the preference around just this call defuses both, and matches
+    # `interactive-win11-pr-smoke.ps1`.
+    $originalErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = @(& $cli @Arguments 2> $stderr)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $originalErrorActionPreference
+    }
+
     [pscustomobject]@{
         ExitCode = $exitCode
         Output = $output -join [Environment]::NewLine

--- a/test/windows/cli-automation.ps1
+++ b/test/windows/cli-automation.ps1
@@ -1,0 +1,202 @@
+[CmdletBinding()]
+param([switch]$Rebuild, [switch]$ResetState, [int]$TimeoutSeconds = 35)
+
+$ErrorActionPreference = 'Stop'
+if ($TimeoutSeconds -le 0) { throw 'TimeoutSeconds must be positive.' }
+
+$launcher = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts\interactive-win11-lib.ps1')
+$forwardedArgs = @('-TimeoutSeconds', $TimeoutSeconds.ToString())
+if ($Rebuild) { $forwardedArgs += '-Rebuild' }
+if ($ResetState) { $forwardedArgs += '-ResetState' }
+Invoke-InteractiveWin11HarnessMain -RepoRoot $repoRoot -LauncherPath $launcher `
+    -EnvironmentVariable 'NOCTTY_CLI_AUTOMATION_BOOTSTRAPPED' -ArgumentList $forwardedArgs
+
+$harness = Initialize-InteractiveWin11Sandbox -RepoRoot $repoRoot -SandboxName 'cli-automation' `
+    -ResetState:$ResetState -IncludeResourcesDir
+$layout = $harness.Layout
+$exe = Get-InteractiveWin11ExePath -RepoRoot $repoRoot
+if ((Get-InteractiveWin11LaunchAction -ExePath $exe -Rebuild:$Rebuild `
+        -BuildInputs (Get-InteractiveWin11DefaultBuildInputs -RepoRoot $repoRoot)) -eq 'build') {
+    Invoke-InteractiveWin11Build -RepoRoot $repoRoot
+}
+Assert-InteractiveWin11ExeExists -ExePath $exe
+$cli = Join-Path (Split-Path -Parent $exe) 'noctty.com'
+if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) { throw "Missing automation CLI shim: $cli" }
+
+$stateDir = Join-Path $layout.LocalAppData 'noctty'
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+[IO.File]::WriteAllText(
+    (Join-Path $stateDir 'config.ghostty'),
+    "confirm-close-surface = false`r`nwindow-save-state = never`r`n",
+    [Text.UTF8Encoding]::new($false)
+)
+
+$instanceClass = "noctty-automation-$($layout.SandboxId)"
+$serverStdout = Join-Path $layout.Logs 'server.stdout.log'
+$serverStderr = Join-Path $layout.Logs 'server.stderr.log'
+$server = $null
+$script:automationInvocation = 0
+
+function Invoke-AutomationCli {
+    param([Parameter(Mandatory)] [string[]] $Arguments)
+
+    $script:automationInvocation++
+    $stderr = Join-Path $layout.Logs ("cli-{0}.stderr.log" -f $script:automationInvocation)
+    $output = @(& $cli @Arguments 2> $stderr)
+    $exitCode = $LASTEXITCODE
+    [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = $output -join [Environment]::NewLine
+        Stderr = if (Test-Path -LiteralPath $stderr) { Get-Content -LiteralPath $stderr -Raw } else { '' }
+    }
+}
+
+function Assert-AutomationExit {
+    param(
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [psobject] $Result,
+        [Parameter(Mandatory)] [int] $Expected
+    )
+
+    if ($Result.ExitCode -ne $Expected) {
+        throw "$Description returned $($Result.ExitCode), expected $Expected. stderr: $($Result.Stderr)"
+    }
+}
+
+function Convert-AutomationSnapshot {
+    param([Parameter(Mandatory)] [psobject] $Result)
+
+    Assert-AutomationExit -Description '+list-windows' -Result $Result -Expected 0
+    try { return $Result.Output | ConvertFrom-Json }
+    catch { throw "Automation JSON did not parse: $($_.Exception.Message); payload: $($Result.Output)" }
+}
+
+function Assert-AutomationV3Shape {
+    param([Parameter(Mandatory)] [psobject] $State, [Parameter(Mandatory)] [int] $ServerPid)
+
+    if ($State.schema -cne 'noctty.windows.v3' -or $State.api_version -ne 3 -or
+        $State.instance.pid -ne $ServerPid -or $State.instance.class -cne $instanceClass -or
+        [string]::IsNullOrWhiteSpace($State.instance.version)) {
+        throw "Automation instance/schema mismatch: $($State | ConvertTo-Json -Depth 8 -Compress)"
+    }
+    $window = @($State.windows)[0]
+    $pane = @($window.tabs)[0].panes[0]
+    if ($null -eq $window -or $null -eq $pane -or
+        'title' -cnotin @($window.PSObject.Properties.Name) -or
+        'title' -cnotin @($pane.PSObject.Properties.Name) -or
+        'working_directory' -cnotin @($pane.PSObject.Properties.Name)) {
+        throw "Automation v3 window/pane shape mismatch: $($State | ConvertTo-Json -Depth 8 -Compress)"
+    }
+}
+
+function Wait-AutomationState {
+    param(
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [DateTime] $Deadline,
+        [Parameter(Mandatory)] [scriptblock] $Condition
+    )
+
+    $last = $null
+    do {
+        $result = Invoke-AutomationCli @('+list-windows', "--class=$instanceClass", '--format=json', '--timeout=1000')
+        if ($result.ExitCode -eq 0) {
+            $last = Convert-AutomationSnapshot $result
+            if (& $Condition $last) { return $last }
+        }
+        else { $last = $result }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $Deadline)
+    throw "Timed out waiting for $Description. Last state: $($last | ConvertTo-Json -Depth 8 -Compress)"
+}
+
+try {
+    $server = Start-Process -FilePath $exe -ArgumentList @(
+        Get-InteractiveWin11ContainmentArguments
+        '--single-instance=true'
+        "--class=$instanceClass"
+    ) -WorkingDirectory $repoRoot -RedirectStandardOutput $serverStdout `
+        -RedirectStandardError $serverStderr -PassThru
+    $serverPid = $server.Id
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+
+    $state = Wait-AutomationState -Description 'initial v3 snapshot' -Deadline $deadline -Condition {
+        param($candidate) @($candidate.windows).Count -eq 1
+    }
+    Assert-AutomationV3Shape -State $state -ServerPid $serverPid
+    $firstWindow = @($state.windows)[0]
+    $firstWindowId = [uint32]$firstWindow.window_id
+
+    $result = Invoke-AutomationCli @('+new-window', "--class=$instanceClass", '--timeout=10000')
+    Assert-AutomationExit -Description '+new-window' -Result $result -Expected 0
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $state = Wait-AutomationState -Description 'second window' -Deadline $deadline -Condition {
+        param($candidate) @($candidate.windows).Count -eq 2
+    }
+
+    $beforeTabCount = @($state.windows | Where-Object window_id -eq $firstWindowId)[0].tab_count
+    $result = Invoke-AutomationCli @(
+        '+new-tab', "--class=$instanceClass", "--window-id=$firstWindowId",
+        "--working-directory=$($layout.Temp)", '--timeout=10000'
+    )
+    Assert-AutomationExit -Description '+new-tab' -Result $result -Expected 0
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $state = Wait-AutomationState -Description 'new tab' -Deadline $deadline -Condition {
+        param($candidate)
+        @($candidate.windows | Where-Object window_id -eq $firstWindowId)[0].tab_count -eq ($beforeTabCount + 1)
+    }
+    $targetWindow = @($state.windows | Where-Object window_id -eq $firstWindowId)[0]
+    $targetTab = @($targetWindow.tabs | Where-Object active)[0]
+    $originalSurfaceId = [uint64]$targetTab.focused_surface_id
+    $beforePaneCount = $targetTab.pane_count
+
+    $result = Invoke-AutomationCli @(
+        '+new-split', "--class=$instanceClass", "--surface-id=$originalSurfaceId", '--direction=down',
+        "--working-directory=$($layout.Temp)", '--timeout=10000'
+    )
+    Assert-AutomationExit -Description '+new-split' -Result $result -Expected 0
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $state = Wait-AutomationState -Description 'new split' -Deadline $deadline -Condition {
+        param($candidate)
+        $window = @($candidate.windows | Where-Object window_id -eq $firstWindowId)[0]
+        @($window.tabs | Where-Object active)[0].pane_count -eq ($beforePaneCount + 1)
+    }
+
+    $result = Invoke-AutomationCli @(
+        '+focus', "--class=$instanceClass", "--surface-id=$originalSurfaceId", '--timeout=10000'
+    )
+    Assert-AutomationExit -Description '+focus' -Result $result -Expected 0
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $state = Wait-AutomationState -Description 'exact focused surface' -Deadline $deadline -Condition {
+        param($candidate)
+        $pane = @($candidate.windows.tabs.panes | Where-Object surface_id -eq $originalSurfaceId)[0]
+        $null -ne $pane -and $pane.focused -and $pane.active
+    }
+
+    $result = Invoke-AutomationCli @(
+        '+perform-action', "--class=$instanceClass", "--surface-id=$originalSurfaceId",
+        '--timeout=10000', 'scroll_to_bottom'
+    )
+    Assert-AutomationExit -Description '+perform-action' -Result $result -Expected 0
+
+    $result = Invoke-AutomationCli @(
+        '+send-text', "--class=$instanceClass", "--surface-id=$originalSurfaceId",
+        '--timeout=10000', "blocked`nline"
+    )
+    Assert-AutomationExit -Description '+send-text newline refusal' -Result $result -Expected 4
+    $result = Invoke-AutomationCli @(
+        '+send-text', "--class=$instanceClass", "--surface-id=$originalSurfaceId",
+        '--timeout=10000', 'echo $HOME & whoami'
+    )
+    Assert-AutomationExit -Description '+send-text printable text' -Result $result -Expected 0
+
+    $unusedClass = "noctty-unused-$([Guid]::NewGuid().ToString('N'))"
+    $result = Invoke-AutomationCli @('+list-windows', "--class=$unusedClass", '--timeout=0')
+    Assert-AutomationExit -Description '+list-windows unused class' -Result $result -Expected 2
+}
+finally {
+    if ($null -ne $server) { Stop-InteractiveWin11Process -Process $server -Contained }
+}
+
+Write-Host "cli automation validation: PASS (server pid=$serverPid class=$instanceClass)"

--- a/test/windows/flagship/contracts/Contracts.71-CliAutomation.ps1
+++ b/test/windows/flagship/contracts/Contracts.71-CliAutomation.ps1
@@ -35,7 +35,14 @@ foreach ($requiredText in @(
         'Description ''+send-text printable text'' -Result $result -Expected 0',
         'Description ''+list-windows unused class'' -Result $result -Expected 2',
         'blocked`nline',
-        'Stop-InteractiveWin11Process -Process $server -Contained'
+        'Stop-InteractiveWin11Process -Process $server -Contained',
+        # The harness bootstraps into Windows PowerShell 5.1, where a native
+        # command writing to stderr terminates the script while the preference
+        # is 'Stop'. The first `+list-windows` poll does exactly that before the
+        # server listens, so the CLI invocation must relax and restore the
+        # preference around itself or the harness cannot pass.
+        '$ErrorActionPreference = ''Continue''',
+        '$ErrorActionPreference = $originalErrorActionPreference'
     )) {
     if (-not $cliAutomationText.Contains($requiredText, [StringComparison]::Ordinal)) {
         throw "CLI automation harness contract is missing: $requiredText"

--- a/test/windows/flagship/contracts/Contracts.71-CliAutomation.ps1
+++ b/test/windows/flagship/contracts/Contracts.71-CliAutomation.ps1
@@ -1,0 +1,51 @@
+$cliAutomationHarness = Join-Path $repoRoot 'test\windows\cli-automation.ps1'
+if (-not (Test-Path -LiteralPath $cliAutomationHarness -PathType Leaf)) {
+    throw "CLI automation harness is missing: $cliAutomationHarness"
+}
+$cliAutomationText = Get-Content -LiteralPath $cliAutomationHarness -Raw
+$cliAutomationTokens = $null
+$cliAutomationErrors = $null
+$cliAutomationAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $cliAutomationText,
+    [ref]$cliAutomationTokens,
+    [ref]$cliAutomationErrors
+)
+if ($cliAutomationErrors.Count -ne 0) {
+    throw "CLI automation harness does not parse: $($cliAutomationErrors[0].Message)"
+}
+
+foreach ($requiredText in @(
+        'NOCTTY_CLI_AUTOMATION_BOOTSTRAPPED',
+        'noctty.windows.v3',
+        'ConvertFrom-Json',
+        '$serverPid = $server.Id',
+        '$State.instance.pid -ne $ServerPid',
+        '+new-window',
+        '+list-windows',
+        '+perform-action',
+        '+new-tab',
+        '+new-split',
+        '+focus',
+        '+send-text',
+        'Description ''second window''',
+        'Description ''new tab''',
+        'Description ''new split''',
+        'Description ''exact focused surface''',
+        'Description ''+send-text newline refusal'' -Result $result -Expected 4',
+        'Description ''+send-text printable text'' -Result $result -Expected 0',
+        'Description ''+list-windows unused class'' -Result $result -Expected 2',
+        'blocked`nline',
+        'Stop-InteractiveWin11Process -Process $server -Contained'
+    )) {
+    if (-not $cliAutomationText.Contains($requiredText, [StringComparison]::Ordinal)) {
+        throw "CLI automation harness contract is missing: $requiredText"
+    }
+}
+if ($cliAutomationText -match '(?i)\b(?:Stop-Process|taskkill(?:\.exe)?)\b') {
+    throw 'CLI automation cleanup must stop only its recorded process through the shared helper.'
+}
+
+$registrationPattern = "(?m)^Invoke-HarnessWithPassSentinel -ScriptName 'cli-automation\.ps1' -TimeoutSeconds 35$"
+if ([regex]::Matches($interactiveValidatorText, $registrationPattern).Count -ne 1) {
+    throw 'Interactive validation must register the CLI automation harness exactly once with its contract timeout.'
+}

--- a/test/windows/interactive-win11-validate.ps1
+++ b/test/windows/interactive-win11-validate.ps1
@@ -232,6 +232,7 @@ Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -Ti
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-key-input.ps1' -TimeoutSeconds 20 -AdditionalArguments @('-Key', 'unicode-escape') -ScenarioSlug 'control-escape'
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-ime-candidate.ps1' -TimeoutSeconds 20
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-new-tab.ps1' -TimeoutSeconds 20
+Invoke-HarnessWithPassSentinel -ScriptName 'cli-automation.ps1' -TimeoutSeconds 35
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-resize.ps1' -TimeoutSeconds 15
 Invoke-HarnessWithPassSentinel -ScriptName 'interactive-win11-undo.ps1' -TimeoutSeconds 35
 


### PR DESCRIPTION
## Summary  Turns noctty's ad-hoc automation entry points into a documented, PowerShell-friendly CLI verb set over the running instance: four new verbs (`+new-tab`, `+new-split`, `+focus`, `+send-text`), a versioned `noctty.windows.v3` JSON contract with instance/window/pane metadata, a stable 0-5 exit taxonomy, `--timeout` and `--format=json` on every verb, and `docs/automation.md` as the stability contract.  Deliberately narrow on the security side: **no verb can choose a program to run.** There is no `-e`, `--command` or `--title` on the launch verbs; `--working-directory` is the only launch override and is restricted to local, non-UNC forms, validated on both the client and the app thread.  Fixes #144  ## Dependencies integrated

The current head contains both prerequisite changes:

- #185 provides the current-user pipe DACL, remote-client rejection, integrity labeling, server authentication, and deny-by-default forwarded-argv policy used by every verb.
- #186 provides the dedicated named-layout routing that owns request kind 8.

This PR keeps the automation verbs on their narrow codecs and does not duplicate or bypass either dependency's policy.
## Changes  **Verbs** (`src/cli/`): new `focus.zig`, `send_text.zig`, `new_tab.zig`, `new_split.zig`, plus `automation_working_directory.zig` (shared path policy) and `automation_test_support.zig` (test-only helpers). `--class` and `--timeout=<0..10000>` on every verb; `--format=json` is the sole accepted format. Explicit IDs are opaque nonzero decimal integers; `0` is a usage error and an unknown ID on a live instance is exit 3, never a silent fallback to the focused target.  **Exit taxonomy**: 0 success / 1 usage / 2 no instance / 3 target not found / 4 policy refusal / 5 IPC failure or timeout. Each verb maps its own errors; nothing relies on the global exit-1 fallback. Pre-existing `list_windows` / `perform_action` tests asserting 1 for IPC failure and no-instance were updated to 5 and 2.  **Schema v3** (`src/apprt/ipc.zig`): `noctty.windows.v3` / `api_version = 3`, comptime suffix pin retained. Adds `instance {pid, version, class}` (class is the effective sanitized pipe namespace captured at server start, so it round-trips into `--class`), non-null `window.title` from the cached host caption, and nullable `pane.title` / `pane.working_directory`. Nullable fields are emitted as `null`, never omitted. `pane.pid` is deliberately not exposed. Terminal grid text, scrollback, selection, clipboard contents and pending shell input remain absent from the payload.  **Wire protocol** (`src/apprt/win32_ipc.zig`): `wire_version` stays 1 and kinds 1-3 are byte-for-byte unchanged; appends `new_tab=4`, `new_split=5`, `focus=6`, `send_text=7`, with 8 reserved by comment for `launch_layout` under #133. Split direction is an explicit wire value (1-4), never an internal enum ordinal. Decoders reject invalid UTF-8, interior NUL, unknown target tags and unknown directions, and free what they allocated on every error path.  **`+send-text` policy**, enforced identically in the CLI before connecting and again on the app thread after decode: non-empty valid UTF-8 up to 16 KiB, every Unicode `Cc` code point refused (`0x00..0x1F` including TAB/CR/LF, `0x7F`, `U+0080..U+009F`), plus refusal when `win32_paste_protection.inspect(text).severity` is `.control_chars` (matched by tag name, not ordinal). Shell metacharacters and mixed content stay allowed and are pinned by a test. Delivery is exclusively `completeClipboardRequest(.paste, text_z, false)`; `UnsafePaste` maps to exit 4. There is no raw or bypass mode. The guarantee is stated narrowly: automation cannot transmit Enter, newline or control input and never raises a paste-confirm prompt — printable text can still be acted on by a TUI or a pending prompt.  **Docs**: new `docs/automation.md`; `docs/windows.md`'s duplicated `## Automation` detail replaced by a summary and link; links added from `README.md` and `docs/getting-started.md`; `docs/status.md` and the `docs/windows-capability-matrix.md` "Local automation" row updated.  **Tests**: `test/windows/cli-automation.ps1` end-to-end harness, registered in `test/windows/interactive-win11-validate.ps1` and pinned by `test/windows/flagship/contracts/Contracts.71-CliAutomation.ps1`.  ## Validation  Every result below was produced by running the command on this branch at `a5a0e4f2a` and reading the output. Nothing here is reported second-hand.  | Command | Result | | --- | --- | | `zig fmt --check src` | exit 1, sole output `src\build\uucode_tables.zig` — the pre-existing generated-file exception. `git diff --stat 5220df49e -- src/build/uucode_tables.zig` is empty, so this branch does not touch it. | | `zig build -Demit-exe=true` | exit 0 | | `zig build test -Dtest-filter=automation` | exit 0 | | `zig build -Demit-test-exe=true` then `./zig-out/bin/ghostty-test.exe` | exit 0 — **`3789 passed; 70 skipped; 0 failed`** | | `pwsh -NoProfile -File scripts/check-source-format.ps1` | exit 0 — `PowerShell syntax and JSON validity checks passed.` | | `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` | exit 0 — `flagship verification contracts: PASS (2 scenarios)` |  All six were re-run after the harness fix at `fb3bb84c4`, with identical results.  The full suite mattered: a filtered `-Dtest-filter=automation` run was green while the full suite segfaulted at test 92/3859. Factoring the `.new_tab` action body into a reusable `createNewTab` had also changed that action's behavior, adding a `source.core().pwd()` call the original never made. Fixed in `a5a0e4f2a` by scoping the cwd re-anchor to the case it exists for — an explicit automation `--window-id` — so the in-app action and the focused automation target now use `newConfig(.tab)` unchanged. Both halves are pinned by new regression tests.  ## Live validation on a real desktop  The verbs were exercised against a running instance, asserting on observed state rather than on exit codes alone. Artifacts under `evidence/144/`.  - Payload is `noctty.windows.v3` / `api_version = 3`, with `instance.pid` matching the server process. - `+new-tab` moved the window's **tab count 1 -> 2**. - `+new-split` moved the tab's **pane count 1 -> 2**. - `+focus` reported the target pane `focused = True`, `active = True`. - **Foreground activation genuinely crosses applications.** The first attempt proved nothing because   noctty already held foreground, so it was re-run with a decoy Notepad in front: BEFORE   `pid=47844 'Untitled - Notepad'`, AFTER `pid=55172` == noctty. The docs previously undersold this   as "best-effort"; the wording is now tightened to say activation does cross application   boundaries, while still noting that exit 0 guarantees *selection*, since foreground-lock rules can   refuse the activation half when the requesting process holds no foreground rights. - Exit codes **0, 1, 2, 3 and 4 were all observed**, including 3 for unknown surface and window IDs.  **The `+send-text` security contract holds under live test.** Every Unicode `Cc` control was refused with exit 4 and `Automation control input refused.` — LF (the Enter case), CR, CRLF, TAB, VT, FF, ESC, DEL, BEL, C1 NEL `0x85`, C1 CSI `0x9B`, and a lone LF — while printable content still passed, including `a|b;c>d&e`, `echo $HOME & whoami` and non-ASCII text. **Automation cannot transmit Enter.**  ## Documented gaps in that validation  - **Exit 5 was not exercised.** It needs an induced transport fault that a healthy machine will not   produce. Recorded as a gap, not as a pass. - **NUL was not driven end to end, by construction rather than by omission.** A Win32 command line is   a NUL-terminated string, so an embedded NUL truncates the argument and the verb only ever receives   the printable prefix — the path is unreachable over argv. The check is not redundant: it still   guards the app-thread half against a direct pipe client, which is not bound by that argv   limitation. This reasoning is now stated in `docs/automation.md`.  ## Harness defect found and fixed  Live validation found one real defect, and it was in the harness, not the verbs: **as originally shipped, `test/windows/cli-automation.ps1` could not pass.** It sets `$ErrorActionPreference = 'Stop'` and bootstraps through `Invoke-InteractiveWin11Bootstrap`, which hard-codes `powershell.exe` — Windows PowerShell 5.1 — where a native command writing to stderr raises a terminating `NativeCommandError`. `Wait-AutomationState` is deliberately written to tolerate a nonzero exit while the server starts, but the very first `+list-windows` poll prints `No matching noctty instance is listening` to stderr and killed the script before that tolerance could run.  Every assertion in the harness was correct; only the shell it bootstraps into was wrong. Fixed in `fb3bb84c4` by relaxing and restoring the preference around just the CLI invocation — the same pattern `test/windows/interactive-win11-pr-smoke.ps1:21-28` already uses for its native build call, which is why this was chosen over switching the shared bootstrap to `pwsh` (that line is used by ~20 harnesses and changing it would put all of them back in scope). It also covers `$PSNativeCommandUseErrorActionPreference` on PowerShell 7.3+, which keys off the same `'Stop'`. Both halves are now pinned in `Contracts.71-CliAutomation.ps1` so the invocation cannot regress to a bare native call.  Verified headlessly against an unused `--class`, reproducing the exact first-poll condition (`evidence/144/harness-fix-verify.txt`):  | Shell | Pre-fix body | Post-fix body | | --- | --- | --- | | Windows PowerShell 5.1.26100.9168 | **TERMINATED** by EAP=Stop | SURVIVED, exit 2, preference restored | | PowerShell 7.6.5 | SURVIVED, exit 2 | SURVIVED, exit 2, preference restored |  The unfixed harness had already been confirmed green end to end under `pwsh 7` (`cli automation validation: PASS`), so this change makes the bootstrapped shell match the shell it was proven under, without altering a single assertion.  ## Residuals / user steps  - The harness has not been re-run end to end *after* the shell fix. The fix is verified in isolation   under both shells as tabled above, and no assertion changed, but one confirming interactive run is   worth doing before this is marked ready. - Exit 5 remains unexercised (see the gap above). - New verbs against an older running instance fail generically with exit 5. There is no capability   negotiation, by design. - Not fixed here, needs its own issue: `+new-window`'s `home` / `inherit` `_working_directory_seen`   bug. It changes existing `+new-window` behavior and is out of scope for #144. - Deliberately not built: `+launch-layout` (named layouts do not exist in this tree; wire kind 8 is   reserved for #133), `+query-state` (superseded by `instance` in the v3 payload), `--format=text`,   and `pane.pid`.  ## Summary by Sourcery  Document and standardize the Windows automation interface around a versioned metadata-rich JSON contract.  New Features: - Expose instance, window, and pane metadata through the versioned `noctty.windows.v3` automation snapshot, including titles and working directories.  Bug Fixes: - Update automation snapshot handling and tests to correctly manage newly exposed metadata and preserve existing behavior.  Enhancements: - Document the expanded Windows automation contract and update related user-facing documentation links and capability references.  Documentation: - Add comprehensive Windows automation documentation and link it from the relevant project guides.  Tests: - Add Windows end-to-end automation coverage and verification contracts for the v3 JSON payload and CLI behavior.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows CLI automation for listing windows, opening tabs and splits, focusing targets, performing actions, and sending text.
  * Added versioned JSON output with instance, window, tab, and pane metadata.
  * Added configurable request timeouts and stable exit-code reporting.
  * Added validation and safety policies for text input and working directories.
* **Documentation**
  * Added comprehensive automation documentation and updated related Windows references.
* **Bug Fixes**
  * Improved argument handling after `--` and strengthened timeout and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->