### PR TITLE
fix: don't feed URL-like strings to path resolution on Windows

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2277,6 +2277,19 @@ fn resolvePathForOpening(
     path: []const u8,
 ) Allocator.Error!?[]const u8 {
     if (!std.fs.path.isAbsolute(path)) {
+        // A URL-like string must never reach path resolution on Windows.
+        // Resolving e.g. "https://example.com" against the terminal pwd
+        // yields "C:\Users\me\https:\example.com", and a ':' inside a path
+        // component makes NT return OBJECT_NAME_INVALID, which
+        // `std.posix.faccessatW` maps to `unreachable`. That is a safety
+        // panic the `catch` below cannot recover from.
+        //
+        // Windows only uses ':' as a drive separator, and drive-absolute
+        // paths already returned above, so handing anything else that
+        // contains ':' to the URL opener is safe here.
+        if (builtin.os.tag == .windows and
+            std.mem.indexOfScalar(u8, path, ':') != null) return null;
+
         const terminal_pwd = self.io.terminal.getPwd() orelse {
             return null;
         };

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2309,10 +2309,16 @@ fn resolvePathForOpening(
 /// Whether Windows can address `path`, which must be the output of
 /// `std.fs.path.resolve`.
 ///
-/// `<>"|?*` are never legal in a Windows path. `:` is legal only in a leading
-/// drive prefix and as the alternate-data-stream separator in the final
-/// component; anywhere else it names a directory Windows cannot address.
+/// `<>"|?*` and the C0 control characters are never legal in a Windows path.
+/// `:` is legal only in a leading drive prefix and as the alternate-data-stream
+/// separator in the final component; anywhere else it names a directory Windows
+/// cannot address.
 fn windowsPathIsRepresentable(path: []const u8) bool {
+    // C0 is rejected everywhere, including inside the extended-length prefix
+    // region, so screen for it before stepping over anything. DEL is not
+    // rejected: NT accepts it in a name, so it resolves like any other byte.
+    for (path) |c| if (c < 0x20) return false;
+
     var rest = path;
 
     // The extended-length prefix is legal and `std.fs.path.resolve` preserves
@@ -2355,6 +2361,13 @@ test "windowsPathIsRepresentable" {
     try testing.expect(windowsPathIsRepresentable("\\\\?\\UNC\\server\\share\\file"));
     try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\https:\\example.com"));
     try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\a*b"));
+
+    // C0 aborts in `faccessatW` exactly like a stray ':', wherever it appears.
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\bad\x01name\\leaf"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\leaf\x1f"));
+    try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\bad\x01name\\leaf"));
+    // DEL is legal in a Windows name, so it must keep resolving.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\leaf\x7f"));
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2277,24 +2277,23 @@ fn resolvePathForOpening(
     path: []const u8,
 ) Allocator.Error!?[]const u8 {
     if (!std.fs.path.isAbsolute(path)) {
-        // A URL-like string must never reach path resolution on Windows.
-        // Resolving e.g. "https://example.com" against the terminal pwd
-        // yields "C:\Users\me\https:\example.com", and a ':' inside a path
-        // component makes NT return OBJECT_NAME_INVALID, which
-        // `std.posix.faccessatW` maps to `unreachable`. That is a safety
-        // panic the `catch` below cannot recover from.
-        //
-        // Windows only uses ':' as a drive separator, and drive-absolute
-        // paths already returned above, so handing anything else that
-        // contains ':' to the URL opener is safe here.
-        if (builtin.os.tag == .windows and
-            std.mem.indexOfScalar(u8, path, ':') != null) return null;
-
         const terminal_pwd = self.io.terminal.getPwd() orelse {
             return null;
         };
 
         const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
+
+        // Link text is arbitrary, so resolution can produce a string Windows
+        // cannot represent as a path: "https://example.com" becomes
+        // "C:\Users\me\https:\example.com". `accessAbsolute` does not merely
+        // fail on such a path -- NT returns STATUS_OBJECT_NAME_INVALID and
+        // `std.posix.faccessatW` maps that status to `unreachable`, so the
+        // process aborts and the `catch` below cannot recover. Screen the
+        // result before handing it to the filesystem.
+        if (builtin.os.tag == .windows and !windowsPathIsRepresentable(resolved)) {
+            self.alloc.free(resolved);
+            return null;
+        }
 
         std.fs.accessAbsolute(resolved, .{}) catch {
             self.alloc.free(resolved);
@@ -2305,6 +2304,42 @@ fn resolvePathForOpening(
     }
 
     return null;
+}
+
+/// Whether Windows can address `path`, which must be the output of
+/// `std.fs.path.resolve`.
+///
+/// `<>"|?*` are never legal in a Windows path. `:` is legal only in a leading
+/// drive prefix and as the alternate-data-stream separator in the final
+/// component; anywhere else it names a directory Windows cannot address.
+fn windowsPathIsRepresentable(path: []const u8) bool {
+    if (std.mem.indexOfAny(u8, path, "<>\"|?*") != null) return false;
+
+    var rest = path;
+    if (rest.len >= 2 and rest[1] == ':' and std.ascii.isAlphabetic(rest[0])) {
+        rest = rest[2..];
+    }
+    const last_sep = std.mem.lastIndexOfAny(u8, rest, "/\\") orelse return true;
+    return std.mem.indexOfScalar(u8, rest[0..last_sep], ':') == null;
+}
+
+test "windowsPathIsRepresentable" {
+    const testing = std.testing;
+
+    // Ordinary paths resolve as before.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\Documents"));
+    try testing.expect(windowsPathIsRepresentable("\\\\server\\share\\file"));
+    // Drive-relative input ("C:foo") resolves to a plain path.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\foo"));
+    // ':' in the final component is an alternate data stream.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\file.txt:stream"));
+
+    // A URL resolved against the pwd puts ':' in a directory component.
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\https:\\example.com"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\foo\\bar:baz\\qux"));
+    // Wildcards are never legal, wherever they appear.
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\magnet:?xt=urn"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\a*b"));
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2309,16 +2309,12 @@ fn resolvePathForOpening(
 /// Whether Windows can address `path`, which must be the output of
 /// `std.fs.path.resolve`.
 ///
-/// `<>"|?*` and the C0 control characters are never legal in a Windows path.
-/// `:` is legal only in a leading drive prefix and as the alternate-data-stream
-/// separator in the final component; anywhere else it names a directory Windows
-/// cannot address.
+/// Deliberately conservative. Anything this lets through that NT considers
+/// malformed does not merely fail: `std.posix.faccessatW` maps
+/// `STATUS_OBJECT_NAME_INVALID` to `unreachable`, so the process aborts and
+/// the caller cannot recover. Shapes we cannot cheaply prove safe are
+/// rejected, which only costs the link its file-path interpretation.
 fn windowsPathIsRepresentable(path: []const u8) bool {
-    // C0 is rejected everywhere, including inside the extended-length prefix
-    // region, so screen for it before stepping over anything. DEL is not
-    // rejected: NT accepts it in a name, so it resolves like any other byte.
-    for (path) |c| if (c < 0x20) return false;
-
     var rest = path;
 
     // The extended-length prefix is legal and `std.fs.path.resolve` preserves
@@ -2327,14 +2323,46 @@ fn windowsPathIsRepresentable(path: []const u8) bool {
         rest = rest[4..];
         if (std.ascii.startsWithIgnoreCase(rest, "UNC\\")) rest = rest[4..];
     }
-
-    if (std.mem.indexOfAny(u8, rest, "<>\"|?*") != null) return false;
-
     if (rest.len >= 2 and rest[1] == ':' and std.ascii.isAlphabetic(rest[0])) {
         rest = rest[2..];
     }
-    const last_sep = std.mem.lastIndexOfAny(u8, rest, "/\\") orelse return true;
-    return std.mem.indexOfScalar(u8, rest[0..last_sep], ':') == null;
+
+    const leaf_start = if (std.mem.lastIndexOfAny(u8, rest, "/\\")) |i| i + 1 else 0;
+    const dirs = rest[0..leaf_start];
+    const leaf = rest[leaf_start..];
+
+    // Outside the leaf a ':' names a directory Windows cannot address, which
+    // is the shape a URL takes once it is resolved against the terminal pwd.
+    if (std.mem.indexOfScalar(u8, dirs, ':') != null) return false;
+    if (!windowsNameIsAddressable(dirs)) return false;
+
+    // The leaf may carry one alternate-data-stream separator. NT accepts any
+    // character in a stream name, control characters included, but both sides
+    // of the ':' must be non-empty, and a second ':' introduces a stream
+    // *type* that NT validates against a fixed set ("$DATA" and friends).
+    // Rather than model that set we admit a single separator only.
+    const ads = std.mem.indexOfScalar(u8, leaf, ':') orelse
+        return windowsNameIsAddressable(leaf);
+    const name = leaf[0..ads];
+    const stream = leaf[ads + 1 ..];
+    if (name.len == 0 or stream.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, stream, ':') != null) return false;
+    // A NUL would truncate in `faccessatW`, so the existence check would run
+    // against a shorter path than the one we hand back to be opened.
+    if (std.mem.indexOfScalar(u8, stream, 0) != null) return false;
+    return windowsNameIsAddressable(name);
+}
+
+/// Whether `name` uses only characters NT accepts in a file name. It may
+/// contain path separators, but no drive prefix and no stream separator.
+///
+/// `<>"|?*` are never legal, and neither are the C0 controls. DEL is legal:
+/// NT treats 0x7f like any other byte, so `std.ascii.isControl` would be too
+/// broad here.
+fn windowsNameIsAddressable(name: []const u8) bool {
+    if (std.mem.indexOfAny(u8, name, "<>\"|?*") != null) return false;
+    for (name) |c| if (c < 0x20) return false;
+    return true;
 }
 
 test "windowsPathIsRepresentable" {
@@ -2345,15 +2373,13 @@ test "windowsPathIsRepresentable" {
     try testing.expect(windowsPathIsRepresentable("\\\\server\\share\\file"));
     // Drive-relative input ("C:foo") resolves to a plain path.
     try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\foo"));
-    // ':' in the final component is an alternate data stream.
-    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\file.txt:stream"));
 
     // A URL resolved against the pwd puts ':' in a directory component.
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\https:\\example.com"));
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\foo\\bar:baz\\qux"));
-    // Wildcards are never legal, wherever they appear.
-    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\magnet:?xt=urn"));
+    // Wildcards are never legal in a directory or file name.
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\a*b"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\dir*x\\leaf"));
 
     // The extended-length prefix survives resolution and its `?` is not a
     // wildcard, but the rest of such a path is screened as usual.
@@ -2362,12 +2388,30 @@ test "windowsPathIsRepresentable" {
     try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\https:\\example.com"));
     try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\a*b"));
 
-    // C0 aborts in `faccessatW` exactly like a stray ':', wherever it appears.
+    // C0 aborts in a directory or file name, wherever it appears.
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\bad\x01name\\leaf"));
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\leaf\x1f"));
     try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\bad\x01name\\leaf"));
     // DEL is legal in a Windows name, so it must keep resolving.
     try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\leaf\x7f"));
+
+    // One ':' in the leaf is an alternate data stream. NT accepts anything in
+    // the stream name, so the file-name screens must not reach into it.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\file.txt:stream"));
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\file.txt:str\x01eam"));
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\file.txt:str?eam"));
+    // A scheme with no path separator after it lands here too, and resolves
+    // safely to a missing stream rather than aborting.
+    try testing.expect(windowsPathIsRepresentable("C:\\Users\\me\\magnet:?xt=urn"));
+
+    // Both sides of the separator must be non-empty, and a second ':' names a
+    // stream type NT validates against a fixed set.
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\a:"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\:stream"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\a:b:c"));
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\magnet:?xt=urn:btih:0000"));
+    // A NUL would truncate the existence check to a shorter path.
+    try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\file.txt:str\x00eam"));
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2313,9 +2313,17 @@ fn resolvePathForOpening(
 /// drive prefix and as the alternate-data-stream separator in the final
 /// component; anywhere else it names a directory Windows cannot address.
 fn windowsPathIsRepresentable(path: []const u8) bool {
-    if (std.mem.indexOfAny(u8, path, "<>\"|?*") != null) return false;
-
     var rest = path;
+
+    // The extended-length prefix is legal and `std.fs.path.resolve` preserves
+    // it, so step over it before screening. Its own `?` is not a wildcard.
+    if (std.mem.startsWith(u8, rest, "\\\\?\\")) {
+        rest = rest[4..];
+        if (std.ascii.startsWithIgnoreCase(rest, "UNC\\")) rest = rest[4..];
+    }
+
+    if (std.mem.indexOfAny(u8, rest, "<>\"|?*") != null) return false;
+
     if (rest.len >= 2 and rest[1] == ':' and std.ascii.isAlphabetic(rest[0])) {
         rest = rest[2..];
     }
@@ -2340,6 +2348,13 @@ test "windowsPathIsRepresentable" {
     // Wildcards are never legal, wherever they appear.
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\magnet:?xt=urn"));
     try testing.expect(!windowsPathIsRepresentable("C:\\Users\\me\\a*b"));
+
+    // The extended-length prefix survives resolution and its `?` is not a
+    // wildcard, but the rest of such a path is screened as usual.
+    try testing.expect(windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\Documents"));
+    try testing.expect(windowsPathIsRepresentable("\\\\?\\UNC\\server\\share\\file"));
+    try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\https:\\example.com"));
+    try testing.expect(!windowsPathIsRepresentable("\\\\?\\C:\\Users\\me\\a*b"));
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)


### PR DESCRIPTION
## Problem

Ctrl+Click on any URL aborts noctty on Windows.

`processLinks` hands every `.open` link match to `resolvePathForOpening` (`src/Surface.zig:4639`), URLs included. A URL is not an absolute path, so it gets resolved against the terminal pwd:

```
"https://example.com" + pwd "C:\Users\me"  ->  "C:\Users\me\https:\example.com"
```

`std.fs.accessAbsolute` accepts that — `isAbsoluteWindows` returns `true` for a rooted path, so its assert passes — but NT rejects the `:` inside a path component with `STATUS_OBJECT_NAME_INVALID`, and `std.posix.faccessatW` maps that status to `unreachable`. The surrounding `catch` cannot recover from a safety panic.

| build mode | behavior |
|---|---|
| Debug / ReleaseSafe | aborts via `ExitProcess(3)`. No SEH, so no WER report and no crash dump — the window just vanishes |
| ReleaseFast (what releases ship) | undefined behavior. In my testing the call happened to return `error.Unexpected` / `error.FileNotFound` and got caught, but that is not guaranteed |

Two things that surprised me while narrowing this down:

- **No shell integration or OSC 7 is required.** `termio.Exec.initTerminal` (`src/termio/Exec.zig:125`) seeds the terminal pwd from the subprocess cwd, so `getPwd()` is non-null from the first prompt. The repro run logged `automatic shell integration not injected`.
- **It is not WSL-specific.** A native `C:\Users\...` pwd reproduces it identically; I initially assumed a POSIX pwd was needed.

## Reproduction

1. Build `main` with `-Doptimize=ReleaseSafe` (Debug works too).
2. Launch it so stderr is captured.
3. In the terminal: `echo 'https://example.com'`
4. Ctrl+Click the URL.

The window disappears immediately. stderr (paths shortened):

```
thread 58676 panic: reached unreachable code
<zig>\lib\std\fs\Dir.zig:2488:44: in access
<repo>\src\Surface.zig:4098:34: in mouseButtonCallback
            if (self.processLinks(pos)) |processed| {
<repo>\src\apprt\win32.zig:23253:50: in handleMouseButton
<repo>\src\apprt\win32.zig:19656:49: in windowProc
???: in USER32.dll
<repo>\src\apprt\win32.zig:1852:37: in run
<repo>\src\main_ghostty.zig:61:24: in main
<repo>\src\main_ghostty.zig:74:9: in WinMain
=== exit=3 ===
```

## Fix

Return early for non-absolute strings containing `:` on Windows, so they reach the URL opener instead of path resolution. Windows only uses `:` as a drive separator, and drive-absolute paths already return earlier via `isAbsolute`.

## Validation

- `zig build -Doptimize=ReleaseSafe -Demit-exe=true`, Zig 0.15.2, MSVC ABI — builds clean.
- **Before:** aborts on the first Ctrl+Click, 1/1. Trace above.
- **After:** the URL opens in the default browser, no abort. Same machine, same build settings, `main` + this commit only.
- Cross-checked against std directly with a standalone probe: `resolveWindows("C:\Users\me", "https://example.com")` → `C:\Users\me\https:\example.com`; `isAbsoluteWindows` → `true`; `accessAbsolute` → panic inside `faccessatW`. Same result for a POSIX pwd (`/home/me`).
- Environment: Windows 11, Zig 0.15.2, WSL2 profile and a native pwd — both reproduce.

**Not covered:** no regression test. `resolvePathForOpening` is a private method that reads `self.io.terminal` and `self.alloc`, so a unit test needs a `Surface` fixture. Happy to add one if you'd prefer that over the manual check.

**Scope:** this PR only stops URL-like strings from reaching path resolution. It does not touch the `openUrl` path or anything else.

## AI assistance

Investigation and patch were produced with Claude Code assistance, per `AI_POLICY.md`. The mechanism was confirmed independently of the model's explanation: an earlier draft of this change attributed the crash to the `accessAbsolute` assert, which turned out to be wrong — `isAbsoluteWindows` accepts rooted paths, so that assert never fires. The standalone std probe and the in-app trace above are what established `faccessatW`'s `unreachable` as the actual failure point.

## Summary by Sourcery

Prevent malformed Windows paths derived from link text from reaching filesystem access so URLs open safely instead of aborting the terminal.

Bug Fixes:
- Prevent URL-like link text from being treated as a Windows filesystem path, avoiding terminal crashes when opening links.
- Reject Windows paths that contain invalid filename characters or malformed alternate data stream syntax before filesystem access.

Tests:
- Add coverage for valid Windows paths, extended-length paths, URL-derived paths, invalid characters, control characters, and alternate data stream cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path validation before opening files.
  * Prevented invalid URL-like paths, wildcard-containing paths, control characters, embedded NULs, and unsupported colon placements from being treated as local filesystem paths.
  * Added safer handling for extended-length paths and valid alternate data streams.
  * Preserved support for Windows paths containing legal characters, including valid alternate data streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->