### PR TITLE
fix(win32): never block the UI thread on the renderer lock for UIA

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -19823,7 +19823,12 @@ fn terminalAccessibilityCapture(
     const surface: *Surface = @ptrCast(@alignCast(ctx));
     if (!surface.core_initialized) return error.SurfaceNotInitialized;
 
-    surface.core_surface.renderer_state.mutex.lock();
+    // This runs on the UI thread, reached from `windowProc` via WM_GETOBJECT,
+    // and UIA can re-enter `windowProc` while the UI thread already holds the
+    // renderer lock. Blocking here stops the message loop for as long as the
+    // lock is held -- indefinitely in the re-entrant case. Take the lock only
+    // if it is free and let the caller keep its cached snapshot otherwise.
+    if (!surface.core_surface.renderer_state.mutex.tryLock()) return error.WouldBlock;
     const snapshot = win32_uia.snapshotTerminalAccessiblePlainText(
         alloc,
         surface.core_surface.renderer_state.terminal,

--- a/src/apprt/win32_terminal_accessibility.zig
+++ b/src/apprt/win32_terminal_accessibility.zig
@@ -75,6 +75,11 @@ pub const TerminalAccessibilitySession = struct {
     query_refresh_post_pending: std.atomic.Value(bool) = .init(false),
     last_refresh_ms: u64 = 0,
     refresh_timer_active: bool = false,
+    /// Set when a refresh was skipped because the renderer lock was held. The
+    /// retry has to run even for a client that registers no events and has not
+    /// queried recently, which `publishPolicy` would otherwise filter out, so
+    /// it is treated like `force` for the refresh gates below.
+    contention_retry_pending: bool = false,
     cached_text: []u8,
     cached_name: [256]u8 = undefined,
     cached_name_len: usize = 0,
@@ -336,8 +341,12 @@ pub const TerminalAccessibilitySession = struct {
             win32_uia.events.clientsAreListening(),
             queryRecentlyActive(self.last_query_ms.load(.acquire), now_ms),
         );
-        if (!force and !policy.refresh_snapshot) return;
-        if (!force and !refreshDue(self.last_refresh_ms, now_ms)) {
+        // `handleTimer` cancels the timer before publishing, so a contention
+        // retry that lost the policy gate here would have nothing left to
+        // reschedule it. Let it through instead.
+        const force_refresh = force or self.contention_retry_pending;
+        if (!force_refresh and !policy.refresh_snapshot) return;
+        if (!force_refresh and !refreshDue(self.last_refresh_ms, now_ms)) {
             if (!self.refresh_timer_active) {
                 const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
                 if (sys.SetTimer(hwnd, self.timer_id, refreshDelay(self.last_refresh_ms, now_ms), null) != 0) {
@@ -347,6 +356,8 @@ pub const TerminalAccessibilitySession = struct {
             return;
         }
         self.cancelTimer();
+        // Consumed. If this refresh contends again, `armContentionRetry` re-sets it.
+        self.contention_retry_pending = false;
         const started_ms = now_ms;
         const is_focused = self.cached_focused.load(.acquire);
         const speech_mode: SpeechMode = if (requested_speech_mode == .discard or !is_focused)
@@ -603,6 +614,7 @@ pub const TerminalAccessibilitySession = struct {
     /// renderer lock was held. Without this the snapshot stays as it was until
     /// some unrelated output, focus, or query event happens to publish again.
     fn armContentionRetry(self: *TerminalAccessibilitySession) void {
+        self.contention_retry_pending = true;
         if (self.refresh_timer_active) return;
         const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
         if (sys.SetTimer(hwnd, self.timer_id, refresh_interval_ms, null) != 0) {

--- a/src/apprt/win32_terminal_accessibility.zig
+++ b/src/apprt/win32_terminal_accessibility.zig
@@ -136,13 +136,16 @@ pub const TerminalAccessibilitySession = struct {
         // the provider with the snapshot we already have rather than block.
         if (self.provider) |provider| {
             _ = self.refresh(.discard, false) catch |err| switch (err) {
-                error.WouldBlock => RefreshResult{ .change = .unchanged },
+                error.WouldBlock => {
+                    self.armContentionRetry();
+                    return provider;
+                },
                 else => return err,
             };
             return provider;
         }
-        _ = self.refresh(.discard, false) catch |err| switch (err) {
-            error.WouldBlock => RefreshResult{ .change = .unchanged },
+        const contended = if (self.refresh(.discard, false)) |_| false else |err| switch (err) {
+            error.WouldBlock => true,
             else => return err,
         };
         const hwnd = self.ops.hwnd(self.ops.ctx) orelse return error.NoWindow;
@@ -151,6 +154,9 @@ pub const TerminalAccessibilitySession = struct {
             hwnd,
             self.state(),
         );
+        // The cache is still empty on this path, so the provider would serve an
+        // empty document until something else published. Retry from the timer.
+        if (contended) self.armContentionRetry();
         return self.provider.?;
     }
 
@@ -361,11 +367,7 @@ pub const TerminalAccessibilitySession = struct {
             // The renderer lock was held. Skipping is the correct outcome on
             // the UI thread: keep the cached snapshot and retry from the timer.
             if (err == error.WouldBlock) {
-                if (self.refresh_timer_active) return;
-                const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
-                if (sys.SetTimer(hwnd, self.timer_id, refresh_interval_ms, null) != 0) {
-                    self.refresh_timer_active = true;
-                }
+                self.armContentionRetry();
                 return;
             }
             std.log.warn("win32 terminal UIA snapshot refresh failed err={}", .{err});
@@ -594,6 +596,17 @@ pub const TerminalAccessibilitySession = struct {
             self.pending_announcement_omitted[index] = false;
             self.pending_announcement_count += 1;
             remaining = remaining[chunk_len..];
+        }
+    }
+
+    /// Arm the periodic refresh timer after a refresh was skipped because the
+    /// renderer lock was held. Without this the snapshot stays as it was until
+    /// some unrelated output, focus, or query event happens to publish again.
+    fn armContentionRetry(self: *TerminalAccessibilitySession) void {
+        if (self.refresh_timer_active) return;
+        const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
+        if (sys.SetTimer(hwnd, self.timer_id, refresh_interval_ms, null) != 0) {
+            self.refresh_timer_active = true;
         }
     }
 

--- a/src/apprt/win32_terminal_accessibility.zig
+++ b/src/apprt/win32_terminal_accessibility.zig
@@ -131,11 +131,20 @@ pub const TerminalAccessibilitySession = struct {
     }
 
     pub fn acquireProvider(self: *TerminalAccessibilitySession) !*win32_uia.TerminalProvider {
+        // Refreshing here only freshens the cache. `error.WouldBlock` means the
+        // renderer lock is held, and this runs on the UI thread, so hand back
+        // the provider with the snapshot we already have rather than block.
         if (self.provider) |provider| {
-            _ = try self.refresh(.discard, false);
+            _ = self.refresh(.discard, false) catch |err| switch (err) {
+                error.WouldBlock => RefreshResult{ .change = .unchanged },
+                else => return err,
+            };
             return provider;
         }
-        _ = try self.refresh(.discard, false);
+        _ = self.refresh(.discard, false) catch |err| switch (err) {
+            error.WouldBlock => RefreshResult{ .change = .unchanged },
+            else => return err,
+        };
         const hwnd = self.ops.hwnd(self.ops.ctx) orelse return error.NoWindow;
         self.provider = try win32_uia.TerminalProvider.create(
             self.alloc,
@@ -349,6 +358,16 @@ pub const TerminalAccessibilitySession = struct {
             std.log.warn("win32 terminal UIA snapshot slow elapsed_ms={d}", .{completed_ms -| started_ms});
         }
         const refresh_result = result catch |err| {
+            // The renderer lock was held. Skipping is the correct outcome on
+            // the UI thread: keep the cached snapshot and retry from the timer.
+            if (err == error.WouldBlock) {
+                if (self.refresh_timer_active) return;
+                const hwnd = self.ops.hwnd(self.ops.ctx) orelse return;
+                if (sys.SetTimer(hwnd, self.timer_id, refresh_interval_ms, null) != 0) {
+                    self.refresh_timer_active = true;
+                }
+                return;
+            }
             std.log.warn("win32 terminal UIA snapshot refresh failed err={}", .{err});
             return;
         };


### PR DESCRIPTION
## Problem

noctty hangs during normal use: the window stops responding, output stops, and only a kill recovers it. `src/apprt/win32.zig` upstream #145 (Accessibility: finish UIA) is the related open item.

`terminalAccessibilityCapture` takes `renderer_state.mutex` with a blocking `lock()` and holds it while snapshotting the whole accessible terminal text. It runs on the **UI thread**, reached from `windowProc` via WM_GETOBJECT, so the message loop stops for as long as the lock is held.

A full dump captured from a hung session (no exception stream, 157 threads) shows three threads parked on the same SRWLock with identical innermost frames:

```
ZwWaitForAlertByThreadId+0x14
  RtlSleepConditionVariableSRW+0x71b
    RtlAcquireSRWLockExclusive+0x4d      <- std.Thread.Mutex on Windows
```

| thread | frame above the lock |
|---|---|
| **UI** | `terminalAccessibilityCapture` (`src/apprt/win32.zig`) via `refresh` (`src/apprt/win32_terminal_accessibility.zig`) |
| renderer | `updateFrame` (`src/renderer/generic.zig`) via `renderOnce` |
| IO | `processOutput` (`src/termio/Termio.zig`) |

`UIAutomationCore.DLL` is loaded and one of its threads is running, so a UIA client is mid-query. No thread holds the lock and is runnable, which points at the UI thread waiting on a lock it already owns in an outer frame: `noteTextQuery` sends a synchronous `SendMessageTimeoutW` to its own window, and Win32 message dispatch re-enters `windowProc` from there.

**That last step is inference, not proof.** A Windows SRWLOCK stores no owner thread id, so a dump cannot name the holder — I scanned every thread's stack and found no runnable thread with noctty frames. The fix does not depend on which explanation is right: whether the lock is held by the UI thread itself or by the renderer for a frame, the UI thread must not wait on it.

## Fix

Take the lock with `tryLock()` and return `error.WouldBlock` when it is busy.

- `acquireProvider` only freshens the cache, so it proceeds with the snapshot it already has.
- `publishAndRefresh` re-arms the existing 100 ms refresh timer instead of logging a warning — a busy lock is an expected outcome, not a failure.

The four other `refresh` call sites are in tests, which use a mock `Ops` that never returns this error.

## Validation

A/B on the same machine, same load, same UIA client (3 event handlers registered, 1500 ms query interval, window kept focused), measured by timing each UIA text query from an external poller.

| | `main` (unpatched) | this branch |
|---|---|---|
| survived | **hung after ~3 min** (n=126 queries) | **23 min, healthy to the end** (n=907, run stopped by me) |
| worst query | **78,168 ms** | **156 ms** (min 15, median 67) |
| hang detections | 1 | **0** |
| snapshot fetch failures | yes | **0 of 90 samples** |
| auto-captured dump | 782 MB, 3 threads on the SRWLock | none |

The last row matters: `tryLock` means a refresh can be skipped, so the risk is a stale accessible snapshot. It did not happen — the snapshot text updated on every one of the 90 samples across the whole run, so the UIA client sees the same freshness it did before.

- `zig build -Doptimize=ReleaseSafe -Demit-exe=true` with Zig 0.15.2, MSVC ABI — clean, no warnings.
- `zig build test` — **1896 passed, 4 skipped, 0 failed** (41/41 steps).
- Environment: Windows 11, WSL2 profile.

**Not covered:** no unit test for this path. The behavior is "a UI-thread callback must not block", which needs the real renderer lock and a real UIA client to exercise; the mock `Ops` in the existing tests cannot express it. The A/B above is the evidence instead. Happy to add a test if you have a shape in mind.

## AI assistance

Investigation and patch were produced with Claude Code assistance, per `AI_POLICY.md`. Note that an earlier round of this same investigation misattributed these hangs to a libxev IOCP race; that was wrong, and the dump analysis above is what corrected it. The `SendMessageTimeoutW` re-entrancy is likewise presented as inference rather than fact, because the dump cannot prove it.

## Summary by Sourcery

Prevent UIA accessibility operations from blocking the Win32 UI thread on the renderer lock while maintaining snapshot freshness through deferred retries.

Bug Fixes:
- Prevent Win32 UIA accessibility callbacks from blocking the UI thread when the renderer lock is busy, avoiding application hangs and unresponsive windows.
- Preserve the existing accessibility snapshot and schedule a retry when a refresh cannot acquire the renderer lock.

Enhancements:
- Treat renderer-lock contention as an expected refresh outcome while ensuring skipped snapshots are retried independently of normal refresh-policy gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows accessibility responsiveness by preventing UI operations from becoming blocked during re-entrant requests.
  * Accessibility content now remains available while updates are retried automatically when the interface is busy.
  * Reduced unnecessary failure reporting during temporary contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->