### PR TITLE
fix(termio): arm the sync-reset watchdog only when the completion is dead

### DIFF
--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -77,7 +77,13 @@ coalesce_data: Coalesce = .{},
 /// the terminal doesn't freeze with a bad actor.
 sync_reset: xev.Timer,
 sync_reset_c: xev.Completion = .{},
-sync_reset_cancel_c: xev.Completion = .{},
+/// The most recent request to restart the synchronized-output watchdog. We
+/// keep this as logical state instead of resetting the xev completion: on
+/// IOCP a completed timer remains `.active` until its callback is popped, so
+/// reusing it from another callback can corrupt libxev's intrusive completion
+/// queue and lose the timer entirely. Mirrors `cursor_blink_reset_at` in
+/// src/renderer/Thread.zig.
+sync_reset_at: ?std.time.Instant = null,
 
 flags: packed struct {
     /// This is set to true only when an abnormal exit is detected. It
@@ -369,11 +375,24 @@ fn drainMailbox(
 }
 
 fn startSynchronizedOutput(self: *Thread, cb: *CallbackData) void {
-    self.sync_reset.reset(
+    // Record the deadline and let the timer's own callback honor it. Calling
+    // `reset()` here would re-initialize a completion that libxev may still
+    // own, which on IOCP loses the watchdog: synchronized output is then
+    // never released and the terminal stops presenting for good.
+    self.sync_reset_at = std.time.Instant.now() catch null;
+    self.armSyncResetTimerIfDead(cb, sync_reset_ms);
+}
+
+/// Arm the synchronized-output watchdog only when libxev no longer owns the
+/// completion. `.active` can mean "already completed but still queued for its
+/// callback" on IOCP, so callers must never reset or reinitialize an active
+/// completion; the pending callback re-arms from the logical deadline instead.
+fn armSyncResetTimerIfDead(self: *Thread, cb: *CallbackData, delay_ms: u64) void {
+    if (self.sync_reset_c.state() != .dead) return;
+    self.sync_reset.run(
         &self.loop,
         &self.sync_reset_c,
-        &self.sync_reset_cancel_c,
-        sync_reset_ms,
+        delay_ms,
         CallbackData,
         cb,
         syncResetCallback,
@@ -414,6 +433,20 @@ fn syncResetCallback(
     };
 
     const cb = cb_ orelse return .disarm;
+
+    // A newer `2026h` may have arrived while this completion was queued.
+    // Honor the remaining logical delay here, from the timer's own callback,
+    // rather than resetting the queued object.
+    if (cb.self.sync_reset_at) |reset_at| honor: {
+        const now = std.time.Instant.now() catch break :honor;
+        const elapsed_ms = now.since(reset_at) / std.time.ns_per_ms;
+        if (elapsed_ms < sync_reset_ms) {
+            cb.self.armSyncResetTimerIfDead(cb, sync_reset_ms - elapsed_ms);
+            return .disarm;
+        }
+    }
+
+    cb.self.sync_reset_at = null;
     cb.io.resetSynchronizedOutput();
     return .disarm;
 }


### PR DESCRIPTION
## Problem

`startSynchronizedOutput` re-arms the synchronized-output watchdog with a bare `sync_reset.reset()` on every `ESC[?2026h`, without checking the completion's state:

```zig
fn startSynchronizedOutput(self: *Thread, cb: *CallbackData) void {
    self.sync_reset.reset(&self.loop, &self.sync_reset_c, &self.sync_reset_cancel_c, sync_reset_ms, ...);
}
```

On the IOCP backend a timer that has already fired stays `.active` until its callback is popped, so re-initialising the completion from another callback can corrupt libxev's intrusive completion queue and lose the watchdog. Synchronized output would then never be released and the terminal stops presenting.

**noctty already fixes this exact bug class on the renderer side.** `3f0a928c5` (#93) replaced the same `reset()` pattern for the cursor blink timer with `cursor_blink_reset_at` + `armCursorTimerIfDead`, which only arms when `state() == .dead`. `startSynchronizedOutput` is the remaining unguarded `reset()` in the tree.

## Fix

Apply the same shape to the sync-reset timer: record the deadline as logical state (`sync_reset_at`) and re-arm from the timer's own callback only when the completion is dead. A `2026h` that arrives while the completion is queued is honoured by the pending callback via the remaining delay, rather than by reinitialising an object libxev may still own.

This removes `sync_reset_cancel_c`, which existed only to serve `reset()`.

## Validation

- `zig build -Doptimize=ReleaseSafe -Demit-exe=true` with Zig 0.15.2, MSVC ABI — clean.
- `zig build test` — 1896 passed, 4 skipped, 0 failed.
- The watchdog still fires: a dump taken during a heavy synchronized-output run shows termio in `syncResetCallback` -> `resetSynchronizedOutput` -> `modes.set`, i.e. the 1 s release path still runs with the new arming logic.
- Used as the daily driver on Windows 11 (WSL2 profile) without regressions in synchronized-output behavior.

**This is hardening, not a fix for an observed failure — please weigh it accordingly.** I have not reproduced a lost watchdog in noctty. I have seen the underlying libxev IOCP completion-reuse race crash a different Ghostty fork (three WER minidumps sharing one exception signature, fixed there by a libxev guard), and this call site has the same shape, but I cannot demonstrate it firing here.

To be explicit about what this is *not*: while investigating hangs in noctty I initially suspected this libxev race and was wrong — those hangs were UIA re-entrancy (#198). This PR is not a fix for them. It stands only on consistency with the guard #93 already established for the same pattern.

## AI assistance

Investigation and patch were produced with Claude Code assistance, per `AI_POLICY.md`.

## Summary by Sourcery

Enhancements:
- Harden synchronized-output watchdog scheduling against unsafe timer completion reuse by tracking the logical reset deadline and rearming only dead completions.