### PR TITLE
fix(win32): recreate tab button on close undo

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -10035,6 +10035,7 @@ const Host = struct {
         // assistive clients receive the event from a live provider.
         self.prepareActiveTabVisibility(self.active_tab);
         self.layout() catch |err| log.warn("tab restore layout sync failed err={}", .{err});
+        self.refreshChrome() catch |err| log.warn("tab restore chrome sync failed err={}", .{err});
         self.notifyActiveTabUiaSelectionChanged(previous_tab_id);
         self.app.auditShellNativeMapping("tab-restore");
         return self.activeSurface() != null;


### PR DESCRIPTION
## Root cause

Close-tab undo restored the tab model and terminal surface, but `restoreClosedTabEntry` only ran `layout()`. Tab-button HWND creation lives in `refreshChrome()` / `syncTabButtons()`, so the restored tab had no native button and the release interactive harness timed out waiting for two visible tabs.

## Fix

Run best-effort `refreshChrome()` after the restored tab is made active and laid out, before raising the UIA selection notification.

## Validation

- `pwsh -NoProfile -File test/windows/interactive-win11-undo.ps1 -Rebuild -ResetState -TimeoutSeconds 15` -> PASS
- `zig build test -Demit-test-exe=true` -> PASS
- `pwsh -NoProfile -File scripts/check-zig-format.ps1` -> PASS
- `pwsh -NoProfile -File scripts/check-source-format.ps1` -> PASS
- `git diff --check` -> PASS

The original release Test run `33588610932` and its retry both failed at `Timed out waiting for undo restored closed tab`; the standalone 15-second command reproduced red before this fix and passed afterward.

## Summary by Sourcery

Bug Fixes:
- Ensure undoing a closed tab recreates its native tab button so the restored tab is visible and interactive on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab restoration by refreshing the window chrome after the layout is synchronized.
  * Added warning logging when the chrome refresh cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->