### PR TITLE
test(win11): handle unavailable toast setting

### DIFF
--- a/test/windows/flagship/contracts/Contracts.40-ShellCommand.ps1
+++ b/test/windows/flagship/contracts/Contracts.40-ShellCommand.ps1
@@ -218,8 +218,15 @@ Invoke-ContractTable -Contracts @(
     @{
         File = $commandFinishHarness
         Content = { $commandFinishHarnessText }
-        Pattern = '(?ms)\$setting = \$notifier\.Setting.*?\$settingAvailable = \$null -ne \$setting.*?Unavailable.*?\$toastFailure -and -not \$notifierDisabledFallback.*?-not \$settingAvailable -and -not \$toastFailure'
+        Pattern = '(?ms)function Get-CommandFinishValidationDecision.*?\$ExitCode -ne 0.*?\$UnexpectedToastFailureCount -gt 0.*?\$NotificationsEnabled -or \$NotifierDisabledFallback -or -not \$SettingAvailable.*?Get-CommandFinishValidationDecision `'
         Kind = 'Text'
-        Description = 'command-finish validation handles unavailable WinRT settings while rejecting unexpected toast failures'
+        Description = 'command-finish harness routes live results through the reviewed validation policy'
     }
 )
+$commandFinishPolicyOutput = @(
+    & pwsh -NoProfile -File $commandFinishHarness -PolicySelfTest 2>&1
+)
+if ($LASTEXITCODE -ne 0 -or
+    @($commandFinishPolicyOutput | Where-Object { [string]$_ -eq 'command-finish validation policy tests: PASS' }).Count -ne 1) {
+    throw "Command-finish validation policy tests failed: $($commandFinishPolicyOutput -join [Environment]::NewLine)"
+}

--- a/test/windows/flagship/contracts/Contracts.40-ShellCommand.ps1
+++ b/test/windows/flagship/contracts/Contracts.40-ShellCommand.ps1
@@ -211,3 +211,15 @@ Assert-CommandResolutionContract -Ast $cliShellAst -Tokens $cliShellTokens -Cont
     '& $cmdExe /d /c "set ""PATH=$envPath""&& where noctty"'
     '& $powershellExe -NoProfile -Command "(Get-Command noctty).Source"'
 )
+
+$commandFinishHarness = Join-Path $repoRoot 'test\windows\interactive-win11-command-finish.ps1'
+$commandFinishHarnessText = Get-Content -LiteralPath $commandFinishHarness -Raw
+Invoke-ContractTable -Contracts @(
+    @{
+        File = $commandFinishHarness
+        Content = { $commandFinishHarnessText }
+        Pattern = '(?ms)\$setting = \$notifier\.Setting.*?\$settingAvailable = \$null -ne \$setting.*?Unavailable.*?\$toastFailure -and -not \$notifierDisabledFallback.*?-not \$settingAvailable -and -not \$toastFailure'
+        Kind = 'Text'
+        Description = 'command-finish validation handles unavailable WinRT settings while rejecting unexpected toast failures'
+    }
+)

--- a/test/windows/interactive-win11-command-finish.ps1
+++ b/test/windows/interactive-win11-command-finish.ps1
@@ -71,8 +71,10 @@ Add-Type -AssemblyName System.Runtime.WindowsRuntime
 $aumid = 'io.github.amanthanvi.noctty'
 $toastMgr = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType=WindowsRuntime]
 $notifier = $toastMgr::CreateToastNotifier($aumid)
-$settingValue = [int] $notifier.Setting
-$settingText = $notifier.Setting.ToString()
+$setting = $notifier.Setting
+$settingAvailable = $null -ne $setting
+$settingValue = if ($settingAvailable) { [int] $setting } else { -1 }
+$settingText = if ($settingAvailable) { $setting.ToString() } else { 'Unavailable' }
 $notificationsEnabled = $settingText -eq 'Enabled'
 
 Remove-Item -LiteralPath $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
@@ -124,13 +126,17 @@ try {
             $failureReason = "unexpected WinRT toast failure while notifier setting is Enabled ($settingText)"
             break
         }
+        if ($toastFailure -and -not $notifierDisabledFallback) {
+            $failureReason = "unexpected WinRT toast failure while notifier setting is $settingText"
+            break
+        }
 
         if ($process.HasExited) {
             $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
 
             if ($launchStopwatch.ElapsedMilliseconds -lt $minimumRuntimeMs) {
                 $failureReason = "noctty exited too early for command-finish validation (exit code $exitCode, runtime $($launchStopwatch.ElapsedMilliseconds)ms)"
-            } elseif ($notificationsEnabled) {
+            } elseif ($notificationsEnabled -or (-not $settingAvailable -and -not $toastFailure)) {
                 $validated = $true
             } elseif ($notifierDisabledFallback) {
                 $validated = $true

--- a/test/windows/interactive-win11-command-finish.ps1
+++ b/test/windows/interactive-win11-command-finish.ps1
@@ -1,6 +1,7 @@
 param(
     [switch] $Rebuild,
     [switch] $ResetState,
+    [switch] $PolicySelfTest,
     [int] $TimeoutSeconds = 12
 )
 
@@ -10,6 +11,54 @@ $script:COMMAND_FINISH_POLL_MS = 250
 
 if ($TimeoutSeconds -le 0) {
     throw 'TimeoutSeconds must be greater than 0.'
+}
+
+function Get-CommandFinishValidationDecision {
+    param(
+        [Parameter(Mandatory)] [bool] $SettingAvailable,
+        [Parameter(Mandatory)] [bool] $NotificationsEnabled,
+        [Parameter(Mandatory)] [bool] $NotifierDisabledFallback,
+        [Parameter(Mandatory)] [int] $UnexpectedToastFailureCount,
+        [Parameter(Mandatory)] [int] $ExitCode,
+        [Parameter(Mandatory)] [long] $RuntimeMs,
+        [Parameter(Mandatory)] [long] $MinimumRuntimeMs,
+        [Parameter(Mandatory)] [string] $SettingText
+    )
+
+    if ($RuntimeMs -lt $MinimumRuntimeMs) {
+        return [pscustomobject]@{ Valid = $false; Reason = "noctty exited too early for command-finish validation (exit code $ExitCode, runtime $($RuntimeMs)ms)" }
+    }
+    if ($ExitCode -ne 0) {
+        return [pscustomobject]@{ Valid = $false; Reason = "noctty exited with code $ExitCode during command-finish validation" }
+    }
+    if ($UnexpectedToastFailureCount -gt 0) {
+        return [pscustomobject]@{ Valid = $false; Reason = "unexpected WinRT toast failure while notifier setting is $SettingText" }
+    }
+    if ($NotificationsEnabled -or $NotifierDisabledFallback -or -not $SettingAvailable) {
+        return [pscustomobject]@{ Valid = $true; Reason = $null }
+    }
+    return [pscustomobject]@{ Valid = $false; Reason = "expected explicit NotifierDisabled fallback while notifier setting is $SettingText" }
+}
+
+if ($PolicySelfTest) {
+    $cases = @(
+        @{ Label = 'unavailable clean'; Expected = $true; Args = @{ SettingAvailable = $false; NotificationsEnabled = $false; NotifierDisabledFallback = $false; UnexpectedToastFailureCount = 0; ExitCode = 0; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'Unavailable' } },
+        @{ Label = 'disabled fallback'; Expected = $true; Args = @{ SettingAvailable = $true; NotificationsEnabled = $false; NotifierDisabledFallback = $true; UnexpectedToastFailureCount = 0; ExitCode = 0; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'DisabledForApplication' } },
+        @{ Label = 'enabled clean'; Expected = $true; Args = @{ SettingAvailable = $true; NotificationsEnabled = $true; NotifierDisabledFallback = $false; UnexpectedToastFailureCount = 0; ExitCode = 0; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'Enabled' } },
+        @{ Label = 'mixed failures'; Expected = $false; Args = @{ SettingAvailable = $true; NotificationsEnabled = $false; NotifierDisabledFallback = $true; UnexpectedToastFailureCount = 1; ExitCode = 0; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'DisabledForApplication' } },
+        @{ Label = 'nonzero exit'; Expected = $false; Args = @{ SettingAvailable = $false; NotificationsEnabled = $false; NotifierDisabledFallback = $false; UnexpectedToastFailureCount = 0; ExitCode = 1; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'Unavailable' } },
+        @{ Label = 'disabled no fallback'; Expected = $false; Args = @{ SettingAvailable = $true; NotificationsEnabled = $false; NotifierDisabledFallback = $false; UnexpectedToastFailureCount = 0; ExitCode = 0; RuntimeMs = 5000; MinimumRuntimeMs = 5000; SettingText = 'DisabledForApplication' } },
+        @{ Label = 'short runtime'; Expected = $false; Args = @{ SettingAvailable = $false; NotificationsEnabled = $false; NotifierDisabledFallback = $false; UnexpectedToastFailureCount = 0; ExitCode = 0; RuntimeMs = 4999; MinimumRuntimeMs = 5000; SettingText = 'Unavailable' } }
+    )
+    foreach ($case in $cases) {
+        $caseArgs = $case.Args
+        $decision = Get-CommandFinishValidationDecision @caseArgs
+        if ($decision.Valid -ne $case.Expected) {
+            throw "Command-finish policy case failed: $($case.Label)"
+        }
+    }
+    Write-Host 'command-finish validation policy tests: PASS'
+    return
 }
 
 $launcherPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
@@ -114,8 +163,10 @@ try {
         Start-Sleep -Milliseconds $script:COMMAND_FINISH_POLL_MS
 
         $stderr = Get-InteractiveWin11TextFile -Path $stderrPath
-        $notifierDisabledFallback = $stderr -match 'winrt toast show failed err=.*NotifierDisabled; falling back to banner'
-        $toastFailure = $stderr -match 'winrt toast show failed'
+        $toastFailureLines = @($stderr -split '\r?\n' | Where-Object { $_ -match 'winrt toast show failed' })
+        $notifierDisabledFallback = @($toastFailureLines | Where-Object { $_ -match 'NotifierDisabled; falling back to banner' }).Count -gt 0
+        $unexpectedToastFailureCount = @($toastFailureLines | Where-Object { $_ -notmatch 'NotifierDisabled; falling back to banner' }).Count
+        $toastFailure = $toastFailureLines.Count -gt 0
 
         if ($stderr -match 'taskbar progress init failed|taskbar progress sync failed|panic: reached unreachable code') {
             $failureReason = 'unexpected runtime failure reported in stderr'
@@ -126,7 +177,7 @@ try {
             $failureReason = "unexpected WinRT toast failure while notifier setting is Enabled ($settingText)"
             break
         }
-        if ($toastFailure -and -not $notifierDisabledFallback) {
+        if ($unexpectedToastFailureCount -gt 0) {
             $failureReason = "unexpected WinRT toast failure while notifier setting is $settingText"
             break
         }
@@ -134,15 +185,17 @@ try {
         if ($process.HasExited) {
             $exitCode = Get-InteractiveWin11ProcessExitCode -Process $process -ProcessHandle $processHandle
 
-            if ($launchStopwatch.ElapsedMilliseconds -lt $minimumRuntimeMs) {
-                $failureReason = "noctty exited too early for command-finish validation (exit code $exitCode, runtime $($launchStopwatch.ElapsedMilliseconds)ms)"
-            } elseif ($notificationsEnabled -or (-not $settingAvailable -and -not $toastFailure)) {
-                $validated = $true
-            } elseif ($notifierDisabledFallback) {
-                $validated = $true
-            } else {
-                $failureReason = "expected explicit NotifierDisabled fallback while notifier setting is $settingText"
-            }
+            $decision = Get-CommandFinishValidationDecision `
+                -SettingAvailable $settingAvailable `
+                -NotificationsEnabled $notificationsEnabled `
+                -NotifierDisabledFallback $notifierDisabledFallback `
+                -UnexpectedToastFailureCount $unexpectedToastFailureCount `
+                -ExitCode $exitCode `
+                -RuntimeMs $launchStopwatch.ElapsedMilliseconds `
+                -MinimumRuntimeMs $minimumRuntimeMs `
+                -SettingText $settingText
+            $validated = $decision.Valid
+            $failureReason = $decision.Reason
 
             break
         }


### PR DESCRIPTION
## Root cause

PowerShell's WinRT projection can return `$null` for `ToastNotifier.Setting`. The release interactive harness called `.ToString()` unconditionally and failed before launching Noctty.

## Fix

Model a null setting as `Unavailable`. In that state, accept either a clean WinRT send or the explicit `NotifierDisabled` fallback, while rejecting every other toast failure. Add a flagship source contract for the null guard and failure policy.

## Validation

- `pwsh -NoProfile -File test/windows/interactive-win11-command-finish.ps1 -Rebuild -ResetState -TimeoutSeconds 12` -> PASS
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` -> PASS
- `pwsh -NoProfile -File scripts/check-source-format.ps1` -> PASS
- `git diff --check` -> PASS

The exact-main interactive run `33593897898` reproduced the pre-fix null dereference after runner provenance passed.

## Summary by Sourcery

Make Win11 interactive command-finish validation robust when the WinRT toast setting is unavailable.

Bug Fixes:
- Handle unavailable WinRT toast settings without dereferencing null values, allowing clean sends or explicit NotifierDisabled fallbacks while rejecting unexpected failures.

Enhancements:
- Centralize command-finish validation and add self-tests covering unavailable, enabled, disabled, failure, exit-code, and runtime cases.

Tests:
- Add a flagship source contract and executable policy self-test for the Windows command-finish harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command completion handling when toast notification settings are unavailable.
  * Command completion can now succeed without notification settings, provided no unexpected toast failure occurs.
  * Unexpected notification failures continue to be rejected, while the expected disabled-notifier fallback is handled correctly.

* **Tests**
  * Added coverage for command completion behavior across notification availability scenarios.
  * Added policy self-tests to verify command completion validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->