### PR TITLE
fix(site): verify canonical Pages HTML routes

### DIFF
--- a/scripts/verify-cloudflare-pages.ps1
+++ b/scripts/verify-cloudflare-pages.ps1
@@ -326,7 +326,15 @@ function New-PublicAssetUri {
     } elseif ($RelativePath -ceq '404.html') {
         $path = "/__noctty_missing_$($Commit.Substring(0, 12))/nested/page"
     } else {
-        $escapedSegments = $RelativePath.Split('/') |
+        $publicPath = if ($RelativePath.EndsWith(
+                '.html',
+                [StringComparison]::Ordinal
+            )) {
+            $RelativePath.Substring(0, $RelativePath.Length - '.html'.Length)
+        } else {
+            $RelativePath
+        }
+        $escapedSegments = $publicPath.Split('/') |
             ForEach-Object { [Uri]::EscapeDataString($_) }
         $path = '/' + ($escapedSegments -join '/')
     }

--- a/test/windows/flagship/contracts/Contracts.92-Site.ps1
+++ b/test/windows/flagship/contracts/Contracts.92-Site.ps1
@@ -735,6 +735,23 @@ foreach ($expectedWrapper in $expectedPublicVerificationWrappers) {
             "-StaticOnly:`$StaticOnly to $($expectedWrapper.Inner)."
     }
 }
+$publicAssetUriFunction = Get-PowerShellBlockText `
+    -Content $cloudflarePagesVerifierText `
+    -HeaderPattern '^function\s+New-PublicAssetUri(?=\s|\{)'
+$publicAssetUriProbe = & ([scriptblock]::Create(
+        $publicAssetUriFunction + @'
+New-PublicAssetUri `
+    -Origin ([Uri]'https://11111111.noctty.pages.dev/') `
+    -RelativePath 'why-noctty.html' `
+    -Id '11111111-1d01-4095-9774-6f8cfe7d7d1e' `
+    -Commit '0123456789abcdef0123456789abcdef01234567'
+'@
+    ))
+if ($publicAssetUriProbe.AbsolutePath -cne '/why-noctty' -or
+    $publicAssetUriProbe.Query -cne
+        '?noctty_deployment=11111111-1d01-4095-9774-6f8cfe7d7d1e') {
+    throw 'Pages public HTML asset URLs must use the extensionless canonical route.'
+}
 Invoke-ContractTable -Contracts @(
     @{
         File = "$cloudflarePagesVerifier :: Test-PublicPayloadOnce"


### PR DESCRIPTION
## Summary
- map non-root `.html` payload files to Cloudflare Pages' extensionless canonical route
- keep redirect handling disabled and continue hashing the immutable deployment response bytes
- add a direct contract probe for the canonical public asset URL

## Root cause
Cloudflare Pages returns `308` with an empty body for `/why-noctty.html` and serves the uploaded bytes at `/why-noctty`. The verifier hashed the redirect response and reported a false payload mismatch, blocking every site deployment after the trust page was added.

## Validation
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- `node --test "site/tests/**/*.test.mjs"`
- `node scripts/build-site-assets.mjs --check`
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`
- deterministic `build-site-payload.ps1` double-build comparison
- live immutable-canary fetch of `/why-noctty` returned HTTP 200 with SHA-256 `ec6901dff50e2c1a13f5ee7281436d742d37916cb5762d8f5d76e810871be83c`, matching `why-noctty.html`

## Summary by Sourcery

Correct Cloudflare Pages asset verification to resolve HTML payloads through their canonical extensionless URLs.

Bug Fixes:
- Verify non-root HTML payloads against Cloudflare Pages’ extensionless canonical routes to avoid hashing redirect responses as deployment content.

Enhancements:
- Add a contract probe ensuring canonical public URLs are generated for HTML assets while preserving deployment query parameters.

Tests:
- Extend site verification contracts to cover canonical routing for the public trust-page asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloudflare Pages now generates extensionless canonical URLs for HTML pages, such as `/why-noctty`, instead of including the `.html` suffix.
  - Page URLs continue to include the deployment identifier required for correct asset resolution.

- **Tests**
  - Added coverage to verify canonical HTML page paths and deployment query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->