### PR TITLE
fix(site): verify Pages 404 cache policy

### DIFF
--- a/scripts/build-site-assets.mjs
+++ b/scripts/build-site-assets.mjs
@@ -118,6 +118,8 @@ export function getHeaderContract(directory = siteRoot) {
     )
     .join("; ");
   const cacheControl = "public, max-age=0, must-revalidate";
+  // Cloudflare Pages overrides custom 404 responses with this stricter policy.
+  const notFoundCacheControl = "no-store";
   const permissionsPolicy =
     "accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), " +
     "magnetometer=(), microphone=(), payment=(), usb=()";
@@ -145,7 +147,7 @@ export function getHeaderContract(directory = siteRoot) {
       referrer_policy: "strict-origin-when-cross-origin",
       permissions_policy: permissionsPolicy,
     },
-    not_found: { cache_control: cacheControl },
+    not_found: { cache_control: notFoundCacheControl },
   };
 }
 

--- a/site/tests/build-site-assets.test.mjs
+++ b/site/tests/build-site-assets.test.mjs
@@ -58,13 +58,13 @@ test("the generated CSP keeps stylesheet and font origins self-only", () => {
   assert.match(policy, /style-src 'self'; font-src 'self';/);
 });
 
-test("the generated catch-all cache policy covers root and not-found responses", () => {
+test("the header contract records Pages' stricter not-found cache policy", () => {
   const contract = getHeaderContract();
   assert.equal(
     contract.root.cache_control,
     "public, max-age=0, must-revalidate",
   );
-  assert.equal(contract.not_found.cache_control, contract.root.cache_control);
+  assert.equal(contract.not_found.cache_control, "no-store");
 });
 
 for (const [name, scripts] of [

--- a/test/windows/flagship/contracts/Contracts.92-Site.ps1
+++ b/test/windows/flagship/contracts/Contracts.92-Site.ps1
@@ -863,8 +863,8 @@ if ([string]$siteHeaderContractObject.root.content_security_policy -cne
 }
 $siteCacheControl = [string]$siteHeaderContractObject.root.cache_control
 if ($siteCacheControl -cne 'public, max-age=0, must-revalidate' -or
-    [string]$siteHeaderContractObject.not_found.cache_control -cne $siteCacheControl) {
-    throw 'Central site header contract must apply the emitted catch-all revalidation policy to root and generated 404 responses.'
+    [string]$siteHeaderContractObject.not_found.cache_control -cne 'no-store') {
+    throw 'Central site header contract must record the emitted root policy and the Pages 404 override.'
 }
 Invoke-ContractTable -Contracts @(
     @{
@@ -1224,7 +1224,7 @@ Invoke-ContractTable -Contracts @(
         }
         Pattern = '(?ms)ExpectedStatus = 404.*?ExpectedCache = \[string\]\$Contract\.not_found\.cache_control.*?Test-EquivalentCacheControl.*?-Actual \$cacheControl.*?-Expected \$probe\.ExpectedCache'
         Kind = 'Text'
-        Description = 'published headers compare exact cache directive sets and apply the catch-all revalidation policy to generated 404 responses'
+        Description = 'published headers compare exact cache directive sets and apply the Pages no-store policy to generated 404 responses'
     }
     @{
         File = "$cloudflarePagesVerifier :: Assert-PublicHeaderContract"


### PR DESCRIPTION
## Summary
- record Cloudflare Pages' `no-store` override for generated 404 responses in the machine-readable header contract
- keep the authored catch-all `_headers` policy and all security-header verification unchanged
- update unit and flagship contracts to enforce the distinct root and 404 cache policies

## Root cause
Cloudflare Pages serves the uploaded custom 404 bytes and security headers correctly, but overrides `Cache-Control` to `no-store` for a 404 response on both immutable preview and production origins. The verifier expected the authored successful-response policy (`public, max-age=0, must-revalidate`) and blocked production after the canary payload bytes had already passed.

## Validation
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`
- `node --test "site/tests/**/*.test.mjs"` (42 passed)
- `node scripts/build-site-assets.mjs --check`
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`
- live immutable-canary probe: HTTP `404`, actual and expected `Cache-Control: no-store`
- `git diff --check`

## Summary by Sourcery

Record and verify Cloudflare Pages’ distinct cache policy for generated 404 responses.

Bug Fixes:
- Align the site header contract and verification checks with Cloudflare Pages' `no-store` policy for generated 404 responses.

Enhancements:
- Keep separate cache policies for successful root responses and generated 404 responses across unit and flagship contracts.

Tests:
- Update site and flagship contract tests to enforce the distinct root and 404 cache policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Cloudflare Pages custom 404 responses to use a stricter `no-store` cache policy.
  * Root site responses continue using the existing revalidation cache policy.
  * Updated automated checks to validate the corrected caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->