### PR TITLE
release: RFC3161 timestamping and a preflight timestamp gate (#137)

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -147,7 +147,9 @@ Required for the GitHub `Release` workflow:
 Optional:
 
 - Environment or repo variable: `WINDOWS_CODESIGN_TIMESTAMP_URL`
-  Default: `http://timestamp.digicert.com`
+  Default: `http://timestamp.digicert.com` (RFC 3161). Optional only while
+  `WINDOWS_CODESIGN_TRUST_SELF_SIGNED` is `true`; preflight otherwise
+  requires an explicit http(s) URL.
 - Environment or repo variable: `WINDOWS_CODESIGN_TRUST_SELF_SIGNED`
   Default: unset / false
 

--- a/docs/adr/0005-pin-updater-publisher-public-keys.md
+++ b/docs/adr/0005-pin-updater-publisher-public-keys.md
@@ -39,6 +39,16 @@ and require timestamping, then (3) remove the retired pin only after the overlap
 release is broadly deployed. Until then, the updater pin is the narrow trust
 anchor and public copy must continue to warn that SmartScreen may intervene.
 
+Timestamping (2026-09-02). Release signing requests an RFC 3161 SHA-256
+timestamp (`signtool /tr <url> /td SHA256`) whenever a timestamp URL is in
+effect, never the legacy `/t` countersignature. Self-signed releases are still
+not timestamped: the updater and the verifier accept them only through the SPKI
+pin, which ignores certificate expiry, and the public timestamp authority
+stalled packaging for hours on 2026-04-30. Preflight therefore accepts a missing
+`WINDOWS_CODESIGN_TIMESTAMP_URL` only while `WINDOWS_CODESIGN_TRUST_SELF_SIGNED`
+is `true`; for any other signer it fails closed unless that variable holds an
+absolute http(s) URL, which is what makes migration step 2 enforceable.
+
 The staged installer and its containing stage directory must remain open
 without delete sharing from hash and Authenticode verification until the
 elevated launch handoff returns. The verifier rejects reparse points and

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -338,7 +338,9 @@ function Invoke-SignFile {
     )
 
     if (-not [string]::IsNullOrWhiteSpace($SigningConfig.TimestampUrl)) {
-        $signArgs += @("/t", $SigningConfig.TimestampUrl)
+        # RFC 3161 timestamp (not legacy Authenticode /t) so the signature
+        # stays verifiable after the signing certificate expires.
+        $signArgs += @("/tr", $SigningConfig.TimestampUrl, "/td", "SHA256")
     }
 
     $signArgs += @(
@@ -451,7 +453,9 @@ try {
         Write-Host "Code signing : enabled"
         if ($signingConfig.TrustSelfSigned) {
             Write-Host "Signing trust: validating self-signed signatures by expected signer thumbprint"
-            Write-Host "Timestamping : disabled for self-signed signing"
+            Write-Host "Timestamping : disabled for self-signed signing (ADR-0005: pin-based verification ignores expiry; public TSA stalled packaging on 2026-04-30)"
+        } else {
+            Write-Host "Timestamping : RFC 3161 via $($signingConfig.TimestampUrl) (/tr, /td SHA256)"
         }
     } else {
         Write-Host "Code signing : disabled"

--- a/scripts/release-preflight.ps1
+++ b/scripts/release-preflight.ps1
@@ -255,10 +255,28 @@ if ($patch -lt $firstForkPatch) {
     throw "Release patch '$patch' is below the configured firstForkPatch '$firstForkPatch'. noctty fork releases on line $versionLine must start at $versionLine.$firstForkPatch or later."
 }
 
-$timestampUrl = if (Test-EnvPresent -Name "WINDOWS_CODESIGN_TIMESTAMP_URL") {
-    Get-EnvValue -Name "WINDOWS_CODESIGN_TIMESTAMP_URL"
-} else {
-    "http://timestamp.digicert.com"
+$trustSelfSigned = ([string](Get-OptionalEnvValue -Name "WINDOWS_CODESIGN_TRUST_SELF_SIGNED")).Trim().ToLowerInvariant() -in @('true', '1', 'yes', 'on')
+
+function Assert-TimestampUrlConfigured {
+    param([bool]$TrustSelfSigned)
+
+    # Self-signed signatures are validated by updater SPKI pin, which ignores
+    # certificate expiry, and package-windows.ps1 skips the TSA in that mode.
+    # A CA-issued signature stays valid past NotAfter only through an RFC 3161
+    # timestamp, so that mode must name a TSA before the PFX is even loaded.
+    if ($TrustSelfSigned) {
+        return "disabled (WINDOWS_CODESIGN_TRUST_SELF_SIGNED is set)"
+    }
+    if (-not (Test-EnvPresent -Name "WINDOWS_CODESIGN_TIMESTAMP_URL")) {
+        throw "WINDOWS_CODESIGN_TIMESTAMP_URL must be set to an RFC 3161 timestamp service when WINDOWS_CODESIGN_TRUST_SELF_SIGNED is not true; signatures from a CA-issued certificate must be timestamped."
+    }
+    $timestampUrl = Get-EnvValue -Name "WINDOWS_CODESIGN_TIMESTAMP_URL"
+    $parsedTimestampUrl = $null
+    if (-not [Uri]::TryCreate($timestampUrl, [UriKind]::Absolute, [ref]$parsedTimestampUrl) -or
+        $parsedTimestampUrl.Scheme -notin @('http', 'https')) {
+        throw "WINDOWS_CODESIGN_TIMESTAMP_URL must be an absolute http(s) URL, got '$timestampUrl'."
+    }
+    return $timestampUrl
 }
 
 Write-Status -Label "Version" -Value $Version
@@ -323,6 +341,7 @@ function Assert-WingetArchitectureCoverage {
 }
 
 if ($RequireSigning) {
+    $timestampStatus = Assert-TimestampUrlConfigured -TrustSelfSigned $trustSelfSigned
     $hasPfxBase64 = Test-EnvPresent -Name "WINDOWS_CODESIGN_PFX_BASE64"
     $hasPfxPath = Test-EnvPresent -Name "WINDOWS_CODESIGN_PFX_PATH"
     if ($hasPfxBase64 -and $hasPfxPath) {
@@ -363,7 +382,7 @@ if ($RequireSigning) {
     Write-Status -Label "Signer expires" -Value $signingPolicy.NotAfter.ToString('o')
     Write-Status -Label "Signer validity left" -Value "$($signingPolicy.RemainingValidityDays) days"
     Write-Status -Label "Signer identity" -Value $(if ($signingPolicy.SelfSigned) { 'self-signed; updater-pin constrained' } else { 'CA-issued; updater-pin constrained' })
-    Write-Status -Label "Timestamp URL" -Value $timestampUrl
+    Write-Status -Label "Timestamp URL" -Value $timestampStatus
 } else {
     Write-Status -Label "Code signing" -Value "not required"
 }

--- a/test/windows/flagship/contracts/Contracts.81-ReleaseSigning.ps1
+++ b/test/windows/flagship/contracts/Contracts.81-ReleaseSigning.ps1
@@ -289,6 +289,109 @@ Invoke-ContractTable -Contracts @(
     }
 )
 
+# Authenticode timestamping: every signtool invocation must request an RFC 3161
+# timestamp (/tr + /td SHA256); the legacy Authenticode /t countersignature is
+# forbidden because it cannot carry a SHA-256 digest policy.
+$signToolInvocationPattern = '(?ms)function Invoke-SignFile.*?"/fd", "SHA256".*?"/tr", \$SigningConfig\.TimestampUrl, "/td", "SHA256".*?& \$SigningConfig\.SignToolPath @signArgs'
+Invoke-ContractTable -Contracts @(
+    @{
+        File = $windowsPackager
+        Content = { $windowsPackagerText }
+        Pattern = $signToolInvocationPattern
+        Kind = 'Text'
+        Description = 'packaging signs with SHA-256 file digests and RFC 3161 SHA-256 timestamps (/tr, /td SHA256)'
+    }
+    @{
+        File = $releasePreflight
+        Content = { Get-Content -LiteralPath $releasePreflight -Raw }
+        Pattern = '(?ms)function Assert-TimestampUrlConfigured.*?if \(\$TrustSelfSigned\) \{.*?return .*?\}.*?Test-EnvPresent -Name "WINDOWS_CODESIGN_TIMESTAMP_URL".*?throw "WINDOWS_CODESIGN_TIMESTAMP_URL must be set.*?\[Uri\]::TryCreate\(.*?\[UriKind\]::Absolute.*?Scheme -notin @\(''http'', ''https''\).*?throw "WINDOWS_CODESIGN_TIMESTAMP_URL must be an absolute http\(s\) URL.*?if \(\$RequireSigning\) \{\s*\$timestampStatus = Assert-TimestampUrlConfigured -TrustSelfSigned \$trustSelfSigned'
+        Kind = 'Text'
+        Description = 'release preflight requires an absolute http(s) RFC 3161 timestamp URL whenever signing is not self-signed'
+    }
+)
+$signToolInvocationText = [regex]::Match(
+    $windowsPackagerText,
+    '(?ms)function Invoke-SignFile.*?& \$SigningConfig\.SignToolPath @signArgs'
+).Value
+if ([string]::IsNullOrEmpty($signToolInvocationText) -or
+    $signToolInvocationText -match '"/t",' -or
+    $signToolInvocationText -match '(?m)^\s*/t\s') {
+    throw 'Packaging must never pass the legacy Authenticode /t timestamp switch to signtool.'
+}
+
+# The preflight timestamp gate is executed, not just pattern-matched: with the
+# signing environment cleared it must fail closed on the timestamp URL before it
+# reaches the PFX checks, and the self-signed mode must bypass that gate.
+function Invoke-PreflightTimestampProbe {
+    param(
+        [Parameter(Mandatory)] [hashtable] $Environment
+    )
+
+    $signingVariables = @(
+        'WINDOWS_CODESIGN_TRUST_SELF_SIGNED',
+        'WINDOWS_CODESIGN_TIMESTAMP_URL',
+        'WINDOWS_CODESIGN_PFX_BASE64',
+        'WINDOWS_CODESIGN_PFX_PATH',
+        'WINDOWS_CODESIGN_PFX_PASSWORD',
+        'WINDOWS_CODESIGN_MIN_VALIDITY_DAYS'
+    )
+    $saved = @{}
+    foreach ($name in $signingVariables) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name)
+        [Environment]::SetEnvironmentVariable($name, $null)
+    }
+    foreach ($entry in $Environment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+    }
+    try {
+        $output = @(& pwsh -NoProfile -File $releasePreflight -Version 1.3.100 -RequireSigning 2>&1)
+        return [pscustomobject]@{
+            ExitCode = $LASTEXITCODE
+            Text = ($output | ForEach-Object { [string]$_ }) -join "`n"
+        }
+    }
+    finally {
+        foreach ($name in $signingVariables) {
+            [Environment]::SetEnvironmentVariable($name, $saved[$name])
+        }
+    }
+}
+
+$preflightTimestampProbes = [ordered] @{
+    'CA-issued mode without a timestamp URL' = [pscustomobject]@{
+        Environment = @{}
+        ExpectedExitCode = 1
+        MustMatch = 'WINDOWS_CODESIGN_TIMESTAMP_URL must be set'
+        MustNotMatch = 'Required code-signing certificate was not configured'
+    }
+    'CA-issued mode with a non-http timestamp URL' = [pscustomobject]@{
+        Environment = @{ WINDOWS_CODESIGN_TIMESTAMP_URL = 'ftp://timestamp.invalid' }
+        ExpectedExitCode = 1
+        MustMatch = 'must be an absolute http\(s\) URL'
+        MustNotMatch = 'Required code-signing certificate was not configured'
+    }
+    'CA-issued mode with an http timestamp URL' = [pscustomobject]@{
+        Environment = @{ WINDOWS_CODESIGN_TIMESTAMP_URL = 'http://timestamp.invalid/rfc3161' }
+        ExpectedExitCode = 1
+        MustMatch = 'Required code-signing certificate was not configured'
+        MustNotMatch = 'WINDOWS_CODESIGN_TIMESTAMP_URL must'
+    }
+    'self-signed mode without a timestamp URL' = [pscustomobject]@{
+        Environment = @{ WINDOWS_CODESIGN_TRUST_SELF_SIGNED = 'true' }
+        ExpectedExitCode = 1
+        MustMatch = 'Required code-signing certificate was not configured'
+        MustNotMatch = 'WINDOWS_CODESIGN_TIMESTAMP_URL must'
+    }
+}
+foreach ($probe in $preflightTimestampProbes.GetEnumerator()) {
+    $result = Invoke-PreflightTimestampProbe -Environment $probe.Value.Environment
+    if ($result.ExitCode -ne $probe.Value.ExpectedExitCode -or
+        $result.Text -notmatch $probe.Value.MustMatch -or
+        $result.Text -match $probe.Value.MustNotMatch) {
+        throw "Release preflight timestamp gate misbehaved for $($probe.Key) (exit $($result.ExitCode)): $($result.Text)"
+    }
+}
+
 $portableManifestVerifier = Join-Path $repoRoot 'scripts\portable-manifest-verification.ps1'
 $portableManifestVerifierText = Get-Content -LiteralPath $portableManifestVerifier -Raw
 Invoke-ContractTable -Contracts @(


### PR DESCRIPTION
Refs #137

Code follow-up from the #137 signing assessment. Certificate, secrets, pins, `release.yml` publish steps, and Chocolatey are deliberately untouched.

## What changed

- `scripts/package-windows.ps1`: `Invoke-SignFile` now passes `/tr <url> /td SHA256` (RFC 3161) instead of the legacy `/t <url>`; `/fd SHA256` unchanged. Self-signed releases stay untimestamped (existing `TimestampUrl = $null` when `TRUST_SELF_SIGNED`), and the banner now says why. Edit is limited to the signtool argument block and the banner so the #173 rebase stays trivial.
- `scripts/release-preflight.ps1`: new `Assert-TimestampUrlConfigured`. When `WINDOWS_CODESIGN_TRUST_SELF_SIGNED` is not true and `-RequireSigning` is set, `WINDOWS_CODESIGN_TIMESTAMP_URL` must be an absolute http(s) URL or preflight throws before the PFX is loaded. No network call added. The silent DigiCert default in preflight is gone (it only printed a URL and enforced nothing); packaging keeps its own default.
- `test/windows/flagship/contracts/Contracts.81-ReleaseSigning.ps1`: text contract that `Invoke-SignFile` contains `/fd SHA256` + `/tr` + `/td SHA256`, a hard reject of any bare `/t`, a text contract on the preflight gate, and an executed probe running `release-preflight.ps1 -RequireSigning` in four environments (no URL, ftp URL, http URL, self-signed without URL) asserting exit code and which error fires first.
- `docs/adr/0005-pin-updater-publisher-public-keys.md`: dated paragraph recording the self-signed-era decision. `PACKAGING.md`: one sentence on when the URL is optional.

## Why self-signed releases are still not timestamped

The brief suggested timestamping self-signed signatures too. I tested it locally (signtool 10.0.26100 against `timestamp.digicert.com`, self-signed cert with a 100 s lifetime): the timestamp is applied and `Get-AuthenticodeSignature` reports the DigiCert TSA, but before and after expiry every repo verifier returns the same result for the timestamped and untimestamped PE (`Get-AuthenticodeSignature`=UnknownError, updater-style `WinVerifyTrust`=0x800B0109, `Test-SelfSignedTrustStatus`=True, `Assert-ReleaseSignature` accepts). The self-signed path is accepted through the SPKI pin (ADR-0005; `src/update/github_releases.zig:732` accepts only `0` or `CERT_E_UNTRUSTEDROOT`), which does not consult NotAfter, so a timestamp buys nothing today. The 2026-04-30 AGENTS.md entry (`a5e98473e`) records the public TSA wedging `Package Windows artifacts` for hours. Net: no benefit, one known outage risk, so the existing behaviour is kept and documented rather than changed.

## Verifier impact

`scripts/signing-trust.ps1`, `release-verify-artifacts.ps1`, `verify-published-release.ps1`: nothing asserts "no timestamp"; the probe above shows a timestamped self-signed PE and a timestamped `.ps1` manifest pass `Assert-ReleaseSignature`. No changes needed.

## Validation (head `26ac9da53`, base `origin/main` `e3a38268e`)

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | 4072 passed / 70 skipped / 0 failed |
| `scripts/check-zig-format.ps1` | pass (693 sources) |
| `scripts/check-source-format.ps1` | pass |
| `prettier@3 --check` (PACKAGING.md, ADR-0005) | pass |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios) |
| Contract mutants (legacy `/t`, `/tr` without `/td`, `/td SHA1`) | each rejected |
| `release-preflight.ps1 -RequireSigning` matrix | no URL → exit 1 on timestamp; ftp/garbage URL → exit 1 on URL shape; http URL → proceeds to PFX check; self-signed no URL → proceeds to PFX check; without `-RequireSigning` → exit 0 |

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Enforce reliable RFC 3161 timestamping for CA-issued Windows releases and fail signing preflight early when its timestamp service is not configured.

New Features:
- Use RFC 3161 SHA-256 timestamping for CA-issued Windows signatures.
- Add release preflight validation requiring an explicit absolute HTTP(S) timestamp URL when signing is not self-signed.

Enhancements:
- Preserve untimestamped self-signed releases while documenting the rationale and configuration behavior.

Documentation:
- Document RFC 3161 timestamping requirements and the self-signed exception in packaging guidance and the signing trust ADR.

Tests:
- Add contract and executed preflight-matrix tests covering timestamp arguments, legacy switch rejection, URL validation, and self-signed bypass.