### PR TITLE
fix(win32): make tab labels follow the terminal title

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -22321,6 +22321,19 @@ fn runUiActionOrLog(comptime context: []const u8, action: anytype) void {
     _ = action catch |err| logUiActionError(context, err);
 }
 
+/// Run a chrome sync that reports "this changed", treating a failure as "no
+/// change". The sync helpers work on terminal-controlled data and can fail on
+/// it, and every `refreshChrome` call site already logs instead of
+/// propagating. Paths reached from `App.tick` need the same containment: the
+/// Win32 message loop calls `tick` with `try`, so an escaping error unwinds
+/// `App.run` and exits the process rather than dropping one chrome update.
+fn chromeSyncOrLog(comptime context: []const u8, sync: anytype) bool {
+    return sync catch |err| {
+        logUiActionError(context, err);
+        return false;
+    };
+}
+
 fn tabContainerProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT {
     if (getHost(hwnd)) |host| {
         if (msg == c.WM_GETOBJECT) {
@@ -28352,19 +28365,19 @@ pub const Surface = struct {
         // whatever title the shell emitted first until an unrelated event
         // (tab activation, focus change, tab reorder, split undo) refreshed
         // the whole chrome.
-        var invalidate = try host.syncWindowTitle();
+        //
+        // Neither sync propagates: see `chromeSyncOrLog`. Both are reachable
+        // only from title setters, which run under `App.tick`.
+        const caption_changed = chromeSyncOrLog(
+            "title window caption sync failed",
+            host.syncWindowTitle(),
+        );
+        const tabs_changed = chromeSyncOrLog(
+            "title tab label sync failed",
+            host.syncTabButtons(),
+        );
 
-        // Log rather than propagate, the way every `refreshChrome` caller
-        // already does. Chrome sync works on terminal-controlled data and
-        // can fail on it; a title path runs under `App.tick`, whose errors
-        // unwind the Win32 message loop and tear the process down.
-        const tabs_changed = host.syncTabButtons() catch |err| tabs: {
-            logUiActionError("title tab label sync failed", err);
-            break :tabs false;
-        };
-        invalidate = tabs_changed or invalidate;
-
-        if (invalidate) host.invalidateTopChromeText();
+        if (caption_changed or tabs_changed) host.invalidateTopChromeText();
     }
 
     fn invalidateStatusBarState(self: *Surface) void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -28343,10 +28343,28 @@ pub const Surface = struct {
     }
 
     fn refreshWindowTitle(self: *Surface) !void {
-        if (self.host) |host| {
-            if (try host.syncWindowTitle()) host.invalidateTopChromeText();
-            return;
-        }
+        const host = self.host orelse return;
+
+        // Two chrome elements show a surface title: the window caption,
+        // synced by `syncWindowTitle`, and the tab strip, synced by
+        // `syncTabButtons`. The latter is otherwise only reachable through
+        // `refreshChrome`, which no title path calls, so a tab label kept
+        // whatever title the shell emitted first until an unrelated event
+        // (tab activation, focus change, tab reorder, split undo) refreshed
+        // the whole chrome.
+        var invalidate = try host.syncWindowTitle();
+
+        // Log rather than propagate, the way every `refreshChrome` caller
+        // already does. Chrome sync works on terminal-controlled data and
+        // can fail on it; a title path runs under `App.tick`, whose errors
+        // unwind the Win32 message loop and tear the process down.
+        const tabs_changed = host.syncTabButtons() catch |err| tabs: {
+            logUiActionError("title tab label sync failed", err);
+            break :tabs false;
+        };
+        invalidate = tabs_changed or invalidate;
+
+        if (invalidate) host.invalidateTopChromeText();
     }
 
     fn invalidateStatusBarState(self: *Surface) void {

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -811,7 +811,22 @@ fn compactHostLabel(
 ) ![]u8 {
     if (value.len <= max_len) return try alloc.dupe(u8, value);
     if (max_len <= 3) return try alloc.dupe(u8, "...");
-    return try std.fmt.allocPrint(alloc, "{s}...", .{value[0 .. max_len - 3]});
+    const cut = utf8BoundaryFloor(value, max_len - 3);
+    return try std.fmt.allocPrint(alloc, "{s}...", .{value[0..cut]});
+}
+
+/// Round `len` down to a UTF-8 sequence boundary in `value`.
+///
+/// Labels are compacted against a byte budget but are later converted with
+/// `utf8ToUtf16LeAllocZ`, which rejects the result with `error.InvalidUtf8`
+/// when the cut landed inside a multi-byte codepoint. Any non-ASCII title --
+/// CJK, an emoji, an accented path -- hits that on the tab strip as soon as
+/// a tab is narrow enough to truncate.
+fn utf8BoundaryFloor(value: []const u8, len: usize) usize {
+    if (len >= value.len) return value.len;
+    var i = len;
+    while (i > 0 and value[i] & 0xC0 == 0x80) i -= 1;
+    return i;
 }
 
 fn compactHostLabelLen(value: []const u8, max_len: usize) usize {
@@ -2408,6 +2423,34 @@ test "win32 buildTabButtonLabel compacts long titles" {
     const title = try buildTabButtonLabel(std.testing.allocator, "this-is-a-very-long-terminal-title", 0, false, 1, 24, false);
     defer std.testing.allocator.free(title);
     try std.testing.expectEqualStrings("1: this-is-a-very-long-t...", title);
+}
+
+test "win32 compactHostLabel keeps the cut on a codepoint boundary" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // Three-byte codepoints: a byte-wise cut at `max_len - 3` == 8 would
+    // land on the last byte of the third character.
+    const label = try compactHostLabel(std.testing.allocator, "\u{3042}\u{3044}\u{3046}\u{3048}\u{304a}", 11);
+    defer std.testing.allocator.free(label);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(label));
+    try std.testing.expectEqualStrings("\u{3042}\u{3044}...", label);
+}
+
+test "win32 buildTabButtonLabel keeps narrow CJK titles valid UTF-8" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const title = try buildTabButtonLabel(
+        std.testing.allocator,
+        "\u{65e5}\u{672c}\u{8a9e}\u{306e}\u{30bf}\u{30a4}\u{30c8}\u{30eb}",
+        0,
+        false,
+        1,
+        9,
+        false,
+    );
+    defer std.testing.allocator.free(title);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(title));
+    try std.testing.expectEqualStrings("1: \u{65e5}\u{672c}...", title);
 }
 
 test "win32 buildTabButtonLabel drops pane count when tabs are narrow" {

--- a/src/apprt/win32/labels.zig
+++ b/src/apprt/win32/labels.zig
@@ -804,6 +804,11 @@ pub fn buildHostAwareBaseTitle(
     );
 }
 
+/// Compact `value` to `max_len` bytes, ending in an ellipsis when it had to
+/// cut. The budget is bytes, not codepoints: callers derive it from a pixel
+/// width at roughly one byte per drawn cell (see `hostTabLabelMaxLen`), so
+/// counting codepoints would let a CJK label overrun the space reserved for
+/// it. `compactHostLabelLen` reports the same length without allocating.
 fn compactHostLabel(
     alloc: Allocator,
     value: []const u8,
@@ -831,7 +836,11 @@ fn utf8BoundaryFloor(value: []const u8, len: usize) usize {
 
 fn compactHostLabelLen(value: []const u8, max_len: usize) usize {
     if (value.len <= max_len) return value.len;
-    return if (max_len <= 3) 3 else max_len;
+    if (max_len <= 3) return 3;
+    // Must track `compactHostLabel` exactly: `profileStatusBadgeTextLen`
+    // reserves chip width from this, and a cut rounded back off a multi-byte
+    // codepoint makes the real label shorter than the byte budget.
+    return utf8BoundaryFloor(value, max_len - 3) + 3;
 }
 
 pub fn hostTabLabelMaxLen(button_width: i32) usize {
@@ -2434,6 +2443,15 @@ test "win32 compactHostLabel keeps the cut on a codepoint boundary" {
     defer std.testing.allocator.free(label);
     try std.testing.expect(std.unicode.utf8ValidateSlice(label));
     try std.testing.expectEqualStrings("\u{3042}\u{3044}...", label);
+}
+
+test "win32 compactHostLabelLen matches the compacted label on a multi-byte cut" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const value = "\u{3042}\u{3044}\u{3046}\u{3048}\u{304a}";
+    const label = try compactHostLabel(std.testing.allocator, value, 11);
+    defer std.testing.allocator.free(label);
+    try std.testing.expectEqual(label.len, compactHostLabelLen(value, 11));
 }
 
 test "win32 buildTabButtonLabel keeps narrow CJK titles valid UTF-8" {


### PR DESCRIPTION
## Summary

Tab labels never followed the terminal title, and any non-ASCII title made the
label build fail outright. Two commits, root cause first.

**`fix(win32): keep compacted labels on a UTF-8 boundary`**

`compactHostLabel` truncates against a byte budget and sliced at `max_len - 3`
with no regard for codepoint boundaries. Every caller eventually hands the
result to `utf8ToUtf16LeAllocZ`, which rejects a split multi-byte sequence with
`error.InvalidUtf8`.

On the tab strip the budget is `hostTabLabelMaxLen(button_width)`, so a CJK or
emoji title starts failing as soon as a second tab halves the button width.
`syncTabButtons` returns the error to `refreshChrome`, whose callers log it and
move on, so the rest of that chrome pass is skipped and the labels stop
updating. In a real session it shows up as:

```
warning(win32): tab activation chrome refresh failed err=error.InvalidUtf8
```

`compactHostLabel` has 11 call sites (tab labels, the tab-overview banner,
profile labels, command palette rows), so this was never limited to the tab
strip.

**`fix(win32): sync tab labels when a surface title changes`**

`refreshWindowTitle` only called `syncWindowTitle` and
`invalidateTopChromeText`. Tab button labels are produced by `syncTabButtons`,
whose only caller is `refreshChrome`, and no title path reaches it;
`invalidateTopChromeText` marks the overlay, inspector and banner text dirty
and none of those consumers own a tab button. A tab label stayed frozen at
whatever title the shell emitted first until an unrelated event refreshed the
whole chrome: tab activation, focus change, tab reorder, split undo/redo. With
the integrated titlebar the tab strip is the title the user reads, so
refreshing only the caption is invisible to them.

Chrome sync errors are logged rather than propagated here, matching every
existing `refreshChrome` call site. That is load-bearing on this path:
`setTitle` and friends are reached from `App.tick`, and the message loop in
`App.run` calls it with `try`, so an escaping error unwinds `App.run` and takes
the process down instead of dropping one label update. I hit exactly that while
developing this change — an `error.InvalidUtf8` from a Japanese title unwound
the loop, and teardown then faulted.

Cost on the new hot path is bounded: `setTitle` returns early when the title is
unchanged, `syncTabButtons` skips every tab whose label inputs are unchanged,
and `layoutChromeForRect` only issues `SetWindowPos` when a placement actually
moves.

**Review follow-ups**

- `fix(win32): contain the window-caption sync error too` — `syncWindowTitle`
  was still called with a bare `try`, so the containment above covered only
  half the path. Both syncs now go through one `chromeSyncOrLog` helper, placed
  beside `runUiActionOrLog` so the rule is stated once.
- `fix(win32): keep compactHostLabelLen in step with the compacted label` —
  rounding the cut back to a codepoint boundary made the label shorter than its
  byte budget while the estimator still returned the budget, so
  `profileStatusBadgeTextLen` over-reserved for a multi-byte label. Both now
  share `utf8BoundaryFloor`, with a test covering the agreement.

## Validation

- [x] `zig build test -Dtest-filter=win32` — 1330 passed, 7 skipped, 0 failed
- [x] `zig build test -Dtest-filter=scroll` — 253 passed, 1 skipped, 0 failed
- [x] `zig build test -Dtest-filter=keybind` — 71 passed, 1 skipped, 0 failed
- [x] `zig build -Demit-exe=true` — ReleaseSafe, native MSVC target
- [x] Full suite `zig build test -Demit-test-exe=true` — 4131 passed, 75 skipped, 0 failed (3 new tests)

Manual Windows checks, per CONTRIBUTING for a window-chrome change. Windows 11
build 26200, integrated titlebar, shell is WSL, ReleaseSafe build used as a
daily driver:

- The tab label now tracks the running program's OSC title instead of staying
  on the shell's first title.
- Background tabs update too. `syncWindowTitle` only looks at
  `activeSurface()`, so before this a non-focused tab never updated at all.
- Japanese titles truncate cleanly instead of failing the label build.
- Opening more tabs shrinks the label budget without producing
  `error.InvalidUtf8` warnings any more.

## Risks / Follow-ups

- `compactHostLabel` can now return one character less than its byte budget. It
  never returns more, so no layout estimate (`compactHostLabelLen`,
  `hostTabLabelMaxLen`) is invalidated; non-ASCII labels are just marginally
  shorter.
- Pre-existing and untouched here: `Surface.destroy` dereferences `self.host`
  unconditionally for `cancelConfirmIfOwnedBy`, but `windowDestroyed` frees the
  `Host` through `removeHost` once its last tab is gone. During app teardown
  that read can land on freed memory. It usually survives because the heap page
  is still mapped; I have a WER minidump where it faulted with `0xC0000005` at
  `win32.zig:14430`. Happy to write that up separately if it is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
