### PR TITLE
fix(win32): show a window for handed-off default-terminal sessions (#130)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -151,10 +151,12 @@ Win32-validated VT protocol coverage is tracked in
 
 `+register-default-terminal` and `+unregister-default-terminal` implement
 per-user registration and exact selection restore, using Windows Terminal
-1.24 or newer OpenConsole for console delegation. The runtime handoff does
-not work yet: live validation reaches noctty, but the adopted session closes
-before a visible window appears. Do not select noctty as your normal default
-terminal yet. Details in [windows.md](windows.md#default-terminal).
+1.24 or newer OpenConsole for console delegation. A delegated console
+application is adopted into a visible noctty window, verified live on
+Windows 11 26200. Still missing: noctty cannot appear in the Windows Settings
+picker without package identity, and it implements no `IConsoleHandoff`, so
+Windows Terminal must stay selected as the console half. Details in
+[windows.md](windows.md#default-terminal).
 
 ### Windows UI Automation (accessibility)
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -132,10 +132,10 @@ Explorer or clear the icon cache before assuming the build is broken.
 ## Default terminal
 
 > [!WARNING]
-> Default-terminal registration is experimental and not ready for normal use.
-> Live validation of this revision reaches the handoff server, but the adopted
-> session closes before a visible noctty window appears. Register only on a
-> disposable test account or machine, and unregister immediately after testing.
+> Default-terminal registration is experimental. A delegated console
+> application is now adopted into a visible noctty window, but noctty cannot
+> appear in the Windows Settings picker and ships no console half of its own.
+> Register only on a machine you can restore, and unregister after testing.
 
 ```powershell
 noctty +register-default-terminal
@@ -171,13 +171,16 @@ window.
 
 noctty is an unpackaged application, so it does not appear in the Windows
 Settings default-terminal picker; the registration command writes the
-per-user registry values directly. Delegated applications do not yet survive
-adoption into a visible noctty window.
+per-user registry values directly. Candidate enumeration accepts a console
+and terminal pair only when both come from the same package, and selecting
+anything in the picker overwrites noctty's pair. Package identity would be
+required to fix this.
 
-For a one-run handoff failure trace, set `NOCTTY_HANDOFF_TRACE=1` before
-launching the delegated console application. noctty appends the rejection
-reason and HRESULT to `%LOCALAPPDATA%\noctty\handoff.log`. The opt-in file is
-truncated before an append would exceed 1 MiB.
+For a handoff trace, set `NOCTTY_HANDOFF_TRACE=1` before launching the
+delegated console application. noctty appends `event=` milestone lines and
+`reason=`/HRESULT rejection lines to `%LOCALAPPDATA%\noctty\handoff.log`,
+which distinguishes "never activated" from "adopted, then lost on the way to
+a window". The opt-in file is truncated before an append would exceed 1 MiB.
 
 ### Security properties of registration
 
@@ -202,13 +205,14 @@ access-control boundary. A same-user medium-integrity process can create an
 equivalent HKCU mapping to the installer-published proxy class and activate
 the handoff class directly, even before the registration command has run.
 
-The handoff class is registered in a single-threaded apartment, and that is
-load-bearing. `EstablishPtyHandoff` returns raw pty-side handles and the UI
-thread closes noctty's copies later, which is safe only because the STA stub
-marshals the `[out]` handles on the same thread before returning to the
-message pump. Moving the class to an MTA, or running a nested modal loop
-while a handoff message is dispatched, would close the handles before
-conhost duplicates them and silently break every console launch.
+`EstablishPtyHandoff` returns the two OpenConsole-side pipe ends as
+`[out] system_handle(sh_pipe)` parameters, and that marshaling transfers
+ownership: once the method returns `S_OK` the RPC stub duplicates each handle
+into the client and closes noctty's original. noctty therefore drops those
+two handles at the point of return and never closes them again. Closing them
+afterwards is a double close, and `std.os.windows.CloseHandle` asserts that
+`NtClose` succeeded, so it aborts the process before the adopted session can
+become a window.
 
 ## Taskbar jump list
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -377,19 +377,6 @@ fn windowData(comptime T: type, hwnd: HWND) ?*T {
 
 const RTL_OSVERSIONINFOW = sys.RTL_OSVERSIONINFOW;
 
-/// True when the calling thread is in a single-threaded apartment.
-///
-/// The terminal handoff depends on this: the STA stub marshals the returned
-/// system handles to the caller before returning to the message pump, which is
-/// what makes it safe to close noctty's copies when the queued handoff message
-/// is later dispatched on this same thread.
-fn currentApartmentIsSta() bool {
-    var apartment: sys.APTTYPE = sys.APTTYPE_CURRENT;
-    var qualifier: sys.APTTYPEQUALIFIER = 0;
-    if (sys.CoGetApartmentType(&apartment, &qualifier) < 0) return false;
-    return apartment == sys.APTTYPE_STA or apartment == sys.APTTYPE_MAINSTA;
-}
-
 /// Probe the Windows build number once; cache on `App.os_build`. Build
 /// 22000+ is Win11 (integrated titlebar / Snap Layouts); 22621+ supports
 /// `DWMWA_SYSTEMBACKDROP_TYPE`. Failure returns 0 so downstream gates
@@ -3748,6 +3735,7 @@ pub const App = struct {
             // reachable from the very first handoff.
             self.terminal_handoff_server = &terminal_handoff_server.?;
             try terminal_handoff_server.?.register();
+            win32_terminal_handoff.appendHandoffMilestone(self.core_app.alloc, "server_registered");
             self.startTerminalHandoffIdleTimer();
         }
 
@@ -3874,21 +3862,12 @@ pub const App = struct {
                     self.core_app.alloc.destroy(pending);
                 }
                 self.stopTerminalHandoffIdleTimer();
-                // This same-STA message runs only after the COM stub has
-                // marshaled the returned system handles into OpenConsole.
-                //
-                // That ordering is the entire reason closing here is safe, and
-                // it holds only while the handoff class lives in an STA. Under
-                // an MTA the stub can still be marshaling when this runs, and
-                // closing would break every console launch in a way that looks
-                // like an unrelated pipe bug. Refuse to close rather than
-                // silently corrupt the handoff.
-                if (currentApartmentIsSta()) {
-                    pending.closeMarshaledPipeCopies();
-                } else {
-                    log.err("terminal handoff dispatched outside an STA; leaving marshaled pipe copies open", .{});
-                }
+                // Nothing to close here: `EstablishPtyHandoff` already released
+                // the two OpenConsole-side pipe ends, because returning S_OK
+                // transfers them to the RPC stub. See
+                // `Pty.releaseHandoffPipeCopies`.
                 self.createAdoptedWindow(pending) catch |err| {
+                    win32_terminal_handoff.appendHandoffMilestone(self.core_app.alloc, "adopted_window_failed");
                     log.err("terminal handoff surface creation failed err={}", .{err});
                     if (self.embedding_mode and self.windows.items.len == 0) {
                         if (self.exitEmbeddingServerIfIdle()) {
@@ -7376,6 +7355,7 @@ pub const App = struct {
         const title_w = try std.unicode.utf8ToUtf16LeAllocZ(self.core_app.alloc, pending.title);
         defer self.core_app.alloc.free(title_w);
         _ = try self.createWindowSurface(&config, title_w.ptr, .{ .adopted_session = pending });
+        win32_terminal_handoff.appendHandoffMilestone(self.core_app.alloc, "adopted_window_created");
     }
 
     fn refreshSystemWheelSettings(self: *App) void {

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -409,16 +409,6 @@ pub extern "ole32" fn CoInitializeEx(pvReserved: ?*anyopaque, dwCoInit: u32) cal
 
 pub extern "ole32" fn CoUninitialize() callconv(.winapi) void;
 
-pub const APTTYPE = i32;
-pub const APTTYPEQUALIFIER = i32;
-pub const APTTYPE_CURRENT: APTTYPE = -1;
-pub const APTTYPE_STA: APTTYPE = 0;
-pub const APTTYPE_MTA: APTTYPE = 1;
-pub const APTTYPE_NA: APTTYPE = 2;
-pub const APTTYPE_MAINSTA: APTTYPE = 3;
-
-pub extern "ole32" fn CoGetApartmentType(pAptType: *APTTYPE, pAptQualifier: *APTTYPEQUALIFIER) callconv(.winapi) i32;
-
 pub extern "ntdll" fn RtlGetVersion(lpVersionInformation: *RTL_OSVERSIONINFOW) callconv(.winapi) i32;
 
 /// Atomic replace of an existing file. Used by the settings save path

--- a/src/apprt/win32_terminal_handoff.zig
+++ b/src/apprt/win32_terminal_handoff.zig
@@ -226,10 +226,6 @@ pub const PendingSession = struct {
     adopted: ?ptypkg.AdoptedSession,
     title: []u8,
 
-    pub fn closeMarshaledPipeCopies(self: *PendingSession) void {
-        if (self.adopted) |*session| session.pty.closeHandoffPipeCopies();
-    }
-
     pub fn takeAdopted(self: *PendingSession) ptypkg.AdoptedSession {
         const result = self.adopted.?;
         self.adopted = null;
@@ -646,7 +642,20 @@ const TerminalHandoff = struct {
             self.server.alloc.destroy(pending);
             return self.fail("adopted_pty_handles_unavailable", E_FAIL);
         };
+        // Returning S_OK hands both pipe ends to the RPC stub, which
+        // duplicates them into the client and closes this process's originals.
+        // Drop them from the Pty before the session becomes reachable from any
+        // other thread: after `queue_session` the UI thread owns `pending`, and
+        // a close from there would be a double close that aborts the process
+        // (`std.os.windows.CloseHandle` asserts `NtClose` succeeded) before the
+        // adopted session can become a window.
+        pending.adopted.?.pty.releaseHandoffPipeCopies();
+
         if (!self.server.queue_session(self.server.queue_ctx, pending)) {
+            // This call fails, so nothing is marshaled and the two released
+            // ends are still ours to close.
+            _ = windows.CloseHandle(handles.input);
+            _ = windows.CloseHandle(handles.output);
             pending.deinit();
             self.server.alloc.destroy(pending);
             return self.fail("queue_pending_session_failed", E_FAIL);
@@ -654,6 +663,7 @@ const TerminalHandoff = struct {
 
         input.* = handles.input;
         output.* = handles.output;
+        appendHandoffMilestone(self.server.alloc, "handoff_accepted");
         return com.S_OK;
     }
 
@@ -868,6 +878,26 @@ fn handoffIntegrityFailureReason(authorization: HandoffIntegrityAuthorization) [
 const handoff_trace_max_bytes: u64 = 1024 * 1024;
 
 fn appendHandoffFailureTrace(alloc: Allocator, reason: []const u8, hr: HRESULT) void {
+    var line_buffer: [256]u8 = undefined;
+    const line = std.fmt.bufPrint(
+        &line_buffer,
+        "reason={s} hr=0x{x:0>8}",
+        .{ reason, @as(u32, @bitCast(hr)) },
+    ) catch return;
+    appendHandoffTrace(alloc, line);
+}
+
+/// Record a milestone the handoff reached. Only failures used to be traced,
+/// which cannot distinguish "never activated" from "activated, adopted, then
+/// lost on the way to a window" - the shape of the defect this trace was added
+/// to find. Milestones make that difference visible without a debugger.
+pub fn appendHandoffMilestone(alloc: Allocator, event: []const u8) void {
+    var line_buffer: [256]u8 = undefined;
+    const line = std.fmt.bufPrint(&line_buffer, "event={s}", .{event}) catch return;
+    appendHandoffTrace(alloc, line);
+}
+
+fn appendHandoffTrace(alloc: Allocator, line: []const u8) void {
     if (!std.process.hasNonEmptyEnvVarConstant("NOCTTY_HANDOFF_TRACE")) return;
 
     const local_app_data = std.process.getEnvVarOwned(alloc, "LOCALAPPDATA") catch return;
@@ -878,26 +908,21 @@ fn appendHandoffFailureTrace(alloc: Allocator, reason: []const u8, hr: HRESULT) 
     const log_path = std.fs.path.join(alloc, &.{ dir_path, "handoff.log" }) catch return;
     defer alloc.free(log_path);
 
-    appendHandoffFailureTraceAtPath(log_path, reason, hr) catch return;
+    appendHandoffTraceAtPath(log_path, line) catch return;
 }
 
-fn appendHandoffFailureTraceAtPath(log_path: []const u8, reason: []const u8, hr: HRESULT) !void {
+fn appendHandoffTraceAtPath(log_path: []const u8, line: []const u8) !void {
     const file = try std.fs.createFileAbsolute(log_path, .{ .truncate = false });
     defer file.close();
-    var line_buffer: [256]u8 = undefined;
-    const line = try std.fmt.bufPrint(
-        &line_buffer,
-        "reason={s} hr=0x{x:0>8}\r\n",
-        .{ reason, @as(u32, @bitCast(hr)) },
-    );
     const current_size = try file.getEndPos();
-    if (current_size + line.len > handoff_trace_max_bytes) {
+    if (current_size + line.len + 2 > handoff_trace_max_bytes) {
         try file.setEndPos(0);
         try file.seekTo(0);
     } else {
         try file.seekTo(current_size);
     }
     try file.writeAll(line);
+    try file.writeAll("\r\n");
     try file.sync();
 }
 
@@ -2080,7 +2105,7 @@ test "handoff failure trace stays within its byte budget" {
     const path = try tmp.dir.realpathAlloc(std.testing.allocator, "handoff.log");
     defer std.testing.allocator.free(path);
 
-    try appendHandoffFailureTraceAtPath(path, "bounded_failure", E_FAIL);
+    try appendHandoffTraceAtPath(path, "reason=bounded_failure hr=0x80004005");
     const stat = try std.fs.cwd().statFile(path);
     try std.testing.expect(stat.size <= handoff_trace_max_bytes);
     const contents = try std.fs.cwd().readFileAlloc(

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -516,19 +516,21 @@ const WindowsPty = struct {
         };
     }
 
-    /// The COM proxy duplicates these into OpenConsole after the handoff
-    /// method returns. The embedding UI posts session adoption to itself, so
-    /// this runs only after COM has finished marshaling the returned handles.
-    pub fn closeHandoffPipeCopies(self: *Pty) void {
+    /// Give up the OpenConsole-side ends of an adopted session's pipes without
+    /// closing them, because this process no longer owns them.
+    ///
+    /// `ITerminalHandoff3::EstablishPtyHandoff` returns those two ends as
+    /// `[out] system_handle(sh_pipe)` parameters. That marshaling transfers
+    /// ownership: once the method returns `S_OK` the RPC stub duplicates each
+    /// handle into the client and closes this process's original. Closing them
+    /// again afterwards is not a leak fix, it is a double close, and
+    /// `std.os.windows.CloseHandle` asserts that `NtClose` succeeded, so the
+    /// second close aborts the process before the adopted session can ever
+    /// become a window.
+    pub fn releaseHandoffPipeCopies(self: *Pty) void {
         if (!self.isAdopted()) return;
-        if (self.in_pipe_pty) |handle| {
-            _ = windows.CloseHandle(handle);
-            self.in_pipe_pty = null;
-        }
-        if (self.out_pipe_pty) |handle| {
-            _ = windows.CloseHandle(handle);
-            self.out_pipe_pty = null;
-        }
+        self.in_pipe_pty = null;
+        self.out_pipe_pty = null;
     }
 
     /// Closing the signal pipe asks OpenConsole to begin orderly shutdown.
@@ -546,11 +548,24 @@ const WindowsPty = struct {
         }
     }
 
+    /// Close a pipe handle that a caller may already have taken from this
+    /// process.
+    ///
+    /// `std.os.windows.CloseHandle` asserts that `NtClose` succeeded, which
+    /// turns an ownership mistake into an abort of the whole terminal. A pty's
+    /// pipe ends are reachable by COM handle marshaling, so an external caller
+    /// must not be able to decide whether this process lives. Report instead.
+    fn closePipeHandle(handle: windows.HANDLE) void {
+        if (std.os.windows.ntdll.NtClose(handle) != .SUCCESS) {
+            log.warn("pty pipe handle was not owned by this process", .{});
+        }
+    }
+
     fn closePipes(self: *Pty) void {
-        if (self.in_pipe_pty) |handle| _ = windows.CloseHandle(handle);
-        _ = windows.CloseHandle(self.in_pipe);
-        if (self.out_pipe_pty) |handle| _ = windows.CloseHandle(handle);
-        _ = windows.CloseHandle(self.out_pipe);
+        if (self.in_pipe_pty) |handle| closePipeHandle(handle);
+        closePipeHandle(self.in_pipe);
+        if (self.out_pipe_pty) |handle| closePipeHandle(handle);
+        closePipeHandle(self.out_pipe);
         self.in_pipe_pty = null;
         self.out_pipe_pty = null;
     }
@@ -618,6 +633,56 @@ const WindowsPty = struct {
         return null;
     }
 };
+
+test "handoff release drops the marshaled pipe ends without closing them" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const process = std.os.windows.GetCurrentProcess();
+    var signal_read: windows.HANDLE = undefined;
+    var signal_write: windows.HANDLE = undefined;
+    try std.testing.expect(windows.exp.kernel32.CreatePipe(&signal_read, &signal_write, null, 0) != 0);
+    defer _ = windows.CloseHandle(signal_read);
+
+    // `openAdopted` takes ownership of all three control handles, and `deinit`
+    // closes them, so they have to be real closable handles.
+    var server_process: windows.HANDLE = undefined;
+    var reference: windows.HANDLE = undefined;
+    for ([_]*windows.HANDLE{ &server_process, &reference }) |slot| {
+        try std.testing.expect(windows.kernel32.DuplicateHandle(
+            process,
+            process,
+            process,
+            slot,
+            0,
+            windows.FALSE,
+            std.os.windows.DUPLICATE_SAME_ACCESS,
+        ) != 0);
+    }
+
+    var pty = try Pty.openAdopted(.{}, signal_write, server_process, reference);
+    const handles = pty.handoffHandles().?;
+
+    // Returning S_OK from `EstablishPtyHandoff` transfers these two ends to the
+    // RPC stub, which duplicates them into the client and closes our originals.
+    // Releasing must therefore only forget them.
+    pty.releaseHandoffPipeCopies();
+    try std.testing.expect(pty.handoffHandles() == null);
+    pty.deinit();
+
+    // Standing in for the stub: the ends are still live after the pty is gone,
+    // so exactly one close each succeeds. When the pty closed them itself, the
+    // stub's close was the second one, and `std.os.windows.CloseHandle` asserts
+    // `NtClose` succeeded, which aborted the process before the adopted session
+    // could become a window.
+    try std.testing.expectEqual(
+        std.os.windows.NTSTATUS.SUCCESS,
+        std.os.windows.ntdll.NtClose(handles.input),
+    );
+    try std.testing.expectEqual(
+        std.os.windows.NTSTATUS.SUCCESS,
+        std.os.windows.ntdll.NtClose(handles.output),
+    );
+}
 
 test "handoff resize writes one exact signal packet" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;


### PR DESCRIPTION
## Summary

Fixes residual #1 of #188: a handed-off default-terminal session now becomes a real, visible noctty window instead of being adopted and immediately torn down.

The defect was a **double close of the handles that `ITerminalHandoff3::EstablishPtyHandoff` returns**.

`Refs #130`

## Root cause

`EstablishPtyHandoff` returns the two OpenConsole-side pipe ends as `[out] system_handle(sh_pipe)` parameters. That marshaling **transfers ownership**: once the method returns `S_OK`, the RPC stub duplicates each handle into the client and closes this process's original. #188 read the ordering the other way round — it posted a message to noctty's own UI thread to close "noctty's copies" _after_ marshaling, guarded by an STA check whose comment asserted that ordering was "the entire reason closing here is safe".

`std.os.windows.CloseHandle` is `assert(ntdll.NtClose(h) == .SUCCESS)`, so the second close was not a harmless failure: it panicked the embedding process from inside the handoff message handler, before `createAdoptedWindow` ever ran. That is the whole reported symptom — no window, and `cmd.exe` exiting on its own because its terminal had just died.

### Evidence

Live on Windows 11 26200 with `Microsoft.WindowsTerminal 1.24.11911.0` as the console half, driving the real pipeline by launching `cmd.exe` with noctty registered.

Milestone tracing through the embedding process showed the handoff was fully accepted and the wake-up message was received, then execution stopped inside the close:

```
=== process start pid=72564 ===
App.init pid=72564 embedding=true
class object registered
EstablishPtyHandoff enter pid=72564
queueTerminalHandoff ui_thread_id=3260
EstablishPtyHandoff S_OK queued
msg=0x8007 hwnd=0x0            <- WM_WINHOSTTY_TERMINAL_HANDOFF received
WM handoff: took pending
WM handoff: idle timer stopped sta=true
probe in=0x708 valid=0 err=.INVALID_HANDLE | out=0x714 valid=0 err=.INVALID_HANDLE
```

The last line is a non-destructive `GetHandleInformation` probe taken immediately before the close: **both handles were already invalid**, i.e. the stub had already transferred and closed them. Nothing after that line ever executed.

Two secondary observations from the same instrumentation, both of which retire leads recorded in #188:

- The SCM appends `-Embedding` verbatim, `isEmbeddingProcess` returns true, and the `-Embedding` branch does **not** fall through into normal startup or single-instance forwarding. Lead (a) is not the cause.
- The "two noctty processes" were the panicking server plus a short-lived child of it that never reaches `main` (no process-start trace line). Both are gone with the fix: the live run below shows exactly one process.

## Changes

- **`src/pty.zig`** — `closeHandoffPipeCopies` becomes `releaseHandoffPipeCopies`, which only forgets the two ends. Adds `closePipeHandle`, so the Windows pty closes its pipe handles via `NtClose` with a logged failure rather than `std.os.windows.CloseHandle`: those handles are reachable by COM handle marshaling, and an external caller must not be able to decide whether this process lives.
- **`src/apprt/win32_terminal_handoff.zig`** — `EstablishPtyHandoff` releases the two ends at the point of return, before `queue_session` publishes the session to the UI thread, so there is no window in which another thread could close them. On the `queue_session` failure path nothing is marshaled, so the two ends are closed explicitly there. `PendingSession.closeMarshaledPipeCopies` is gone.
- **`src/apprt/win32.zig`** — the handoff message handler no longer closes anything. `currentApartmentIsSta` is deleted: the apartment dependency existed only to make the deferred close safe.
- **`src/apprt/win32/sys.zig`** — `CoGetApartmentType` and the `APTTYPE*` constants are removed; that helper was their only user.
- **Trace** — `NOCTTY_HANDOFF_TRACE=1` now records `event=` milestones alongside the existing `reason=`/HRESULT rejections. Only failures were traced before, which cannot distinguish "never activated" from "adopted, then lost on the way to a window" — exactly the shape of this defect. Verified that the variable does reach the SCM-activated process.
- **Docs** — `docs/windows.md` and `docs/status.md` updated to what now works and what still does not. The old `docs/windows.md` paragraph claiming the STA ordering made the deferred close safe is replaced by the actual ownership rule, so the wrong invariant is not re-derived later.

## Validation

Gates, on this branch rebased onto `origin/main` `3b8c12ba5`:

| Gate | Result |
| --- | --- |
| `zig build -Demit-exe=true` | exit 0 |
| `zig build test -Demit-test-exe=true` | exit 0 — **4169 passed, 71 skipped, 0 failed** (41/41 steps) |
| `pwsh -File scripts/check-zig-format.ps1` | exit 0, 696 tracked sources |
| `pwsh -File scripts/check-source-format.ps1` | exit 0 |
| `pwsh -File test/windows/flagship/Test-VerificationContracts.ps1` | exit 0, baseline probes PASS, contracts PASS (2 scenarios) |
| `prettier@3 --check docs/windows.md docs/status.md` | exit 0 |
| targeted `-Dtest-filter=`: `handoff release drops`, `handoff resize`, `handoff embedding`, `handoff failure trace`, `pty` | all exit 0 |

### Regression test

`handoff release drops the marshaled pipe ends without closing them` (`src/pty.zig`) builds a real adopted pty, releases it, deinits the pty, and then asserts that `NtClose` on each end still returns `SUCCESS` — i.e. the ends were still live for the stub to take. Before this change the pty had already closed them, and the stub's close was the second one.

### Live verification

Registered per-user, launched `cmd.exe`, then read the result back through UI Automation rather than a screenshot:

```
noctty pids: 70244
UIA top-level windows for pid 70244: 1
  name='C:\WINDOWS\System32\cmd.exe' class='noctty.win32.host'
  MARKER FOUND in terminal text
  text: NOCTTY_HANDOFF_MARKER_7391 | C:\Users\...\handoff-lane>
handoff.log: event=server_registered / event=handoff_accepted / event=adopted_window_created
```

One process, one window, correct title from `TERMINAL_STARTUP_INFO`, and the adopted `cmd.exe`'s own output and live prompt rendering inside it. The window survives past the 5 s idle timeout. The `DelegationConsole` / `DelegationTerminal` values were captured before registration and verified identical afterwards on every run, including the failed ones.

## Residuals

1. **No Settings picker entry.** Candidate enumeration accepts a console/terminal pair only when both come from the same package, so an unpackaged noctty can be selected by registry but cannot appear in the Windows Settings or Windows Terminal picker, and selecting anything there overwrites the pair. Package identity would be required; not attempted.
2. **No `IConsoleHandoff`.** noctty implements the terminal half only, so a Windows Terminal OpenConsole must stay selected as the console half.
3. **`ITerminalHandoff3` only**, unchanged from #188; v1 and v2 are refused with `E_NOINTERFACE`.
4. **Not verified here:** ReleaseFast behaviour of the fixed path (the assert that made the old bug fatal fires in Debug and the safe release modes; in ReleaseFast the old code would have silently closed a handle it did not own rather than aborting, so the release-mode symptom may have differed), ARM64, and the #188 residual that the proxy DLL still ships without release-gate verification — that remains a blocker on #164 and is untouched here.
5. **Same-user activation surface** and the integrity-mismatch rejection are unchanged; the security section in `docs/windows.md` still applies.

## Stacked on

Nothing — branched from `main`, rebased onto `3b8c12ba5`. No conflicts.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Fix Windows terminal handoff ownership so delegated sessions reliably become visible noctty windows.

Bug Fixes:
- Fix Windows default-terminal handoff sessions so delegated console applications are adopted into visible noctty windows instead of terminating during handoff.

Enhancements:
- Clarify ownership handling for marshaled handoff pipe handles and prevent invalid-handle closes from aborting the process.
- Add milestone events to optional handoff tracing to distinguish activation, adoption, and window-creation failures.

Documentation:
- Update Windows documentation and project status to reflect working delegated-session adoption and remaining default-terminal limitations.

Tests:
- Add regression coverage verifying that marshaled handoff pipe handles remain available for RPC ownership transfer.

Chores:
- Remove obsolete COM apartment-type handling that was only needed for deferred handoff-handle closure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows terminal handoff so delegated console applications now open in a visible noctty window.
  - Improved handoff reliability by correctly managing transferred resources and handling failed window adoption without crashes.
  - Added clearer handoff milestones and rejection details to help distinguish activation failures from sessions that were adopted and later lost.

- **Documentation**
  - Updated Windows guidance and status information to reflect the working handoff flow and remaining limitations, including Windows Settings picker availability and the need to keep Windows Terminal selected as the console component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->