### PR TITLE
ci: raise the palette-match p99 budget to the measured runner floor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           zig build bench:vt-throughput -- --workload=scroll --bytes=4194304 --seed=121 --runs=5 --rows=45 --cols=140 --min-mb-s=50
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          zig build bench:palette-match -- --entries=5000 --keystrokes=5000 --budget-us=1000
+          zig build bench:palette-match -- --entries=5000 --keystrokes=5000 --budget-us=2500
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Zig formatting

--- a/docs/windows-benchmark-methodology.md
+++ b/docs/windows-benchmark-methodology.md
@@ -57,10 +57,15 @@ dependencies into a nominally `ReleaseFast` benchmark, which under-reports
 throughput by 25-46x — far below any of these floors on either machine.
 
 The palette baseline used 5,000 entries and 5,000 deterministic keystrokes on
-the same machine: p50 89 us and p99 128 us. CI uses a conservative 1,000 us p99
-ceiling. These wide tolerances are catastrophic-regression guards for a pinned
-Windows runner image and Zig toolchain; they are not a claim that different CI
-hardware has comparable absolute performance.
+the same machine: p50 89 us and p99 128 us. CI uses a 2,500 us p99 ceiling. The
+earlier 1,000 us ceiling was measured against the `windows-2025` runner on
+2026-09-03 across 26 runs of identical code: p99 ranged from 433 us to
+1,995 us with a median of 864 us, and four unrelated pull requests plus one
+`main` push failed the gate on noise alone. The ceiling still catches the
+failure class it exists for (a Debug-linked benchmark is 25-46x slower). These
+wide tolerances are catastrophic-regression guards for a pinned Windows runner
+image and Zig toolchain; they are not a claim that different CI hardware has
+comparable absolute performance.
 
 Reproduce the headless gates:
 
@@ -69,7 +74,7 @@ zig build bench:vt-throughput -- --workload=ascii --bytes=4194304 --seed=121 --r
 zig build bench:vt-throughput -- --workload=utf8 --bytes=4194304 --seed=121 --runs=5 --rows=45 --cols=140 --min-mb-s=35
 zig build bench:vt-throughput -- --workload=osc --bytes=4194304 --seed=121 --runs=5 --rows=45 --cols=140 --min-mb-s=3
 zig build bench:vt-throughput -- --workload=scroll --bytes=4194304 --seed=121 --runs=5 --rows=45 --cols=140 --min-mb-s=50
-zig build bench:palette-match -- --entries=5000 --keystrokes=5000 --budget-us=1000
+zig build bench:palette-match -- --entries=5000 --keystrokes=5000 --budget-us=2500
 ```
 
 ## Measured interactive baseline

--- a/test/windows/flagship/contracts/Contracts.95-Benchmark.ps1
+++ b/test/windows/flagship/contracts/Contracts.95-Benchmark.ps1
@@ -55,7 +55,7 @@ Invoke-ContractTable -Contracts @(
         Content = {
             (Get-YamlJobText -Content $testWorkflowText -Name 'windows' -Source $testWorkflow)
         }
-        Pattern = '(?ms)- name: Headless benchmark regression gates.*?--workload=ascii.*?--min-mb-s=50.*?--workload=utf8.*?--min-mb-s=35.*?--workload=osc.*?--min-mb-s=3.*?--workload=scroll.*?--min-mb-s=50.*?bench:palette-match.*?--budget-us=1000'
+        Pattern = '(?ms)- name: Headless benchmark regression gates.*?--workload=ascii.*?--min-mb-s=50.*?--workload=utf8.*?--min-mb-s=35.*?--workload=osc.*?--min-mb-s=3.*?--workload=scroll.*?--min-mb-s=50.*?bench:palette-match.*?--budget-us=2500'
         Kind = 'Text'
         Description = 'CI runs every headless throughput floor and the palette budget'
     }


### PR DESCRIPTION
## Summary

`bench:palette-match` has been failing CI on noise. Across 26 runs on the `windows-2025` runner today with identical benchmark code, p99 ranged from 433 us to 1,995 us (median 864 us) against a 1,000 us ceiling; the gate failed on #211, #173, #156, #168 and once on a `main` push, all of which passed on rerun. Raises the ceiling to 2,500 us.

The gate's documented purpose is to catch a build-graph mistake that links Debug dependencies into the benchmark (25-46x slower). A 2,500 us ceiling still catches that.

## Changes

- `.github/workflows/test.yml`: `--budget-us=2500`.
- `test/windows/flagship/contracts/Contracts.95-Benchmark.ps1`: contract pin updated to match.
- `docs/windows-benchmark-methodology.md`: records the measured runner distribution and why the ceiling moved; the reproduction command updated.

## Validation

- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`: PASS (2 scenarios)
- `pwsh -NoProfile -File scripts/check-source-format.ps1`: passed
- No Zig touched.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); the run statistics were collected from this repository's own workflow logs.

## Summary by Sourcery

Raise the Windows palette-match benchmark budget to accommodate measured runner variability without weakening catastrophic-regression detection.

Bug Fixes:
- Reduce false CI failures from normal Windows runner variability in the palette-match benchmark gate.

Enhancements:
- Raise the palette-match p99 performance budget to 2,500 microseconds while retaining protection against severe benchmark regressions.
- Document the measured runner performance distribution and update the benchmark reproduction guidance.

CI:
- Update the Windows CI benchmark contract to enforce the revised palette-match budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false benchmark failures by raising the Windows palette-match performance threshold from 1,000 µs to 2,500 µs.
* **Documentation**
  * Updated the Windows benchmark methodology and reproduction instructions to reflect the revised threshold.
* **Tests**
  * Updated benchmark validation to enforce the new 2,500 µs limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->