### PR TITLE
fix(renderer): bound the preedit shaper-cell catch-up loop

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2993,8 +2993,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                     // Advance our index until we reach or pass
                     // our current x position in the shaper cells.
+                    //
+                    // A run can shape to fewer cells than it spans, so `x`
+                    // may be past the last shaped cell and this walks off
+                    // the end. Stopping at the end is what the caller
+                    // already expects: the `shaper_cells_i >= len` check
+                    // below picks up the next run for this same cell.
                     const shaper_cells_unwrapped = shaper_cells.?;
-                    while (run.offset + shaper_cells_unwrapped[shaper_cells_i].x < x) {
+                    while (shaper_cells_i < shaper_cells_unwrapped.len and
+                        run.offset + shaper_cells_unwrapped[shaper_cells_i].x < x)
+                    {
                         shaper_cells_i += 1;
                     }
                 }


### PR DESCRIPTION
## Summary

`rebuildRow`'s preedit block walks `shaper_cells_i` forward until the shaped
cell reaches the current `x`, with no upper bound. When a run shapes to fewer
cells than it spans, `x` is past the last shaped cell and the loop walks off
the end:

```
thread 60552 panic: index out of bounds: index 5, len 5
src\renderer\generic.zig:2565:32 in rebuildCells
                self.rebuildRow(
src\renderer\generic.zig:1387:34 in updateFrame
                self.rebuildCells(
src\renderer\Thread.zig:667:30 in renderOnce
    self.renderer.updateFrame(
libxev\src\watcher\async.zig:579:34 in callback
libxev\src\backend\iocp.zig:304:46 in tick
std\Thread.zig:622:30 in entryFn
```

(Line 2565 is against `b1739a731`, the main I first hit it on; the same block
is around line 2993 on current main.)

This kills the renderer thread, so the window disappears with no dump and no
Windows Error Reporting record — a Zig panic aborts via `ExitProcess(3)`
without raising SEH, so there is nothing for WER to catch. The only trace is
whatever captured stderr.

**Why `x` can be past the end.** The preceding run search only guarantees that
the run *spans* `x` by cell count:

```zig
while (shaper_run) |run| {
    if (run.offset + run.cells > x) break;
    ...
}
```

`run.cells` is how many grid cells the run covers, which says nothing about how
many cells the shaper produced for it.

**Why stopping at the end is right.** The surrounding logic already expects the
index to be able to reach the end. Further down, `shaper_cells_i >= len`
advances to the next run for this same cell:

```zig
if (shaper_cells != null and shaper_cells_i >= shaper_cells.?.len) {
    shaper_run = try run_iter.next(self.alloc);
    shaper_cells = null;
    shaper_cells_i = 0;
}
```

and the main glyph loop is already written with the bound:

```zig
while (shaper_cells_i < shaped_cells.len and
    run.offset + shaped_cells[shaper_cells_i].x == x) : ({
```

That guard arrived with `ebc8bff8f` ("renderer: switch to using render state");
the preedit path was missed.

**When it fires.** Whenever an IME composition is on screen. The block runs on
the preedit row, at the cell immediately after the preedit range, so it is
reached on every frame while composing — which is why this shows up as "the
window vanished mid-conversion" on a CJK input method rather than as a rare
crash.

The same code exists in upstream Ghostty's `main`. I am only filing it here.

## Validation

- [x] `zig build test -Dtest-filter=renderer` — 41/41 steps succeeded
- [x] `zig build test -Dtest-filter=win32` — 41/41 steps succeeded
- [x] `zig build test -Dtest-filter=scroll` — 41/41 steps succeeded
- [x] `zig build test -Dtest-filter=keybind` — 41/41 steps succeeded
- [x] `zig build -Demit-exe=true` — ReleaseSafe, native MSVC target
- [x] Full suite `zig build test -Demit-test-exe=true` — 4184 passed, 76 skipped, 0 failed

(The filtered runs hit the build cache and so reported step counts without
per-test counts; the full-suite line above is the one with numbers in it.)

Manual Windows checks, per CONTRIBUTING — this touches rendering. Windows 11
build 26200, integrated titlebar, ReleaseSafe, shell is WSL, IBus/SKK Japanese
input in the guest:

- Before: reproduced as a renderer-thread panic ending a session with exit
  code 3 while composing Japanese text.
- After: this fix has been in my daily-driver build since 2026-09-02, with
  Japanese composition in constant use, and no renderer panic has recurred.

## Risks / Follow-ups

- The change only adds a bound to an existing loop; when the index is already
  in range the behavior is unchanged, and reaching the end now falls through to
  the run-advance path the code below already implements.
- I could not find a way to hit this from a unit test without standing up a
  shaper plus a live preedit range, so this is covered by the runtime
  reproduction above rather than by a new test. Happy to add one if you can
  point me at the right seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent renderer-thread crashes during IME preedit rendering when shaped cells do not cover the full span of a run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented an out-of-bounds error when processing preedit text whose shaped runs contain fewer cells than expected.
  - Improved handling of shaped text at run boundaries so subsequent runs are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->