### PR TITLE
release: prepare 1.3.125

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ compares it feature by feature with upstream Ghostty.
 
 You need Windows 10 version 1809 (build 17763) or newer, or Windows 11, on
 x64 or ARM64, and a GPU driver with OpenGL 4.3 or newer. Latest release:
-[noctty 1.3.124](https://github.com/amanthanvi/noctty/releases/tag/v1.3.124),
-published 2026-09-02.
+[noctty 1.3.125](https://github.com/amanthanvi/noctty/releases/tag/v1.3.125),
+published 2026-09-04.
 
 With Scoop (the WinGet package is pending bootstrap):
 
@@ -65,14 +65,14 @@ portable ZIPs run from any folder.
 
 | File                                                                                                                                                     | What it is      |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| [`noctty-1.3.124-windows-x64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-x64-setup.exe)           | x64 installer   |
-| [`noctty-1.3.124-windows-arm64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-arm64-setup.exe)       | ARM64 installer |
-| [`noctty-1.3.124-windows-x64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-x64-portable.zip)     | x64 portable    |
-| [`noctty-1.3.124-windows-arm64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-arm64-portable.zip) | ARM64 portable  |
+| [`noctty-1.3.125-windows-x64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-x64-setup.exe)           | x64 installer   |
+| [`noctty-1.3.125-windows-arm64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-arm64-setup.exe)       | ARM64 installer |
+| [`noctty-1.3.125-windows-x64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-x64-portable.zip)     | x64 portable    |
+| [`noctty-1.3.125-windows-arm64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-arm64-portable.zip) | ARM64 portable  |
 
 Each release also ships signed manifests of the portable ZIP contents
-(`noctty-1.3.124-windows-x64-portable.manifest.ps1`,
-`noctty-1.3.124-windows-arm64-portable.manifest.ps1`) and checksums
+(`noctty-1.3.125-windows-x64-portable.manifest.ps1`,
+`noctty-1.3.125-windows-arm64-portable.manifest.ps1`) and checksums
 (`SHA256SUMS-windows-x64.txt`, `SHA256SUMS-windows-arm64.txt`, plus
 `SHA256SUMS.txt`, an x64 alias kept for older auto-update clients).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Then skip to [First launch](#first-launch).
 
 ## Install by hand
 
-The current stable release is `1.3.124`. Every release ships these files for
+The current stable release is `1.3.125`. Every release ships these files for
 `<arch>` = `x64` and `arm64`:
 
 | File                                                    | What it is                        |

--- a/site/index.html
+++ b/site/index.html
@@ -97,8 +97,8 @@
               Download for Windows
             </a>
             <span class="nc-hero__meta">
-              <span class="nc-sr-only" id="nc-version-summary">Version 1.3.124, latest release, for Windows 10 and 11 on x64 and ARM64, MIT licensed.</span>
-              <span aria-hidden="true"><span id="nc-version">v1.3.124</span>, Windows 10 and 11, x64 and ARM64</span>
+              <span class="nc-sr-only" id="nc-version-summary">Version 1.3.125, latest release, for Windows 10 and 11 on x64 and ARM64, MIT licensed.</span>
+              <span aria-hidden="true"><span id="nc-version">v1.3.125</span>, Windows 10 and 11, x64 and ARM64</span>
             </span>
           </div>
 
@@ -300,8 +300,8 @@ scoop install noctty/noctty</code></pre>
   </footer>
 
   <script type="module" src="app.js?v=98916ae44c47820a7a796236e272181592d780769a90b706acea8eeb8eead2d1"></script>
-  <script type="module" src="version.js?v=9c98ba6d2242f28da78ce39427ce30506dfa38c1a79372c598faa62159f5742f"></script>
+  <script type="module" src="version.js?v=481a363baf804c085f821a3f280ea2a5c0c0b9bcc3d605c109b5d8b2c777cd22"></script>
   <script type="module" src="install.js?v=7d814eb53693cfdd38356f41fca1fbbe1111beccbae7eb87aa2f8c3e82527ca5"></script>
-  <script type="module" src="terminal.js?v=a55e658f1ec05d001bc84be193a95c35dfd7c4f21d3b3a275fe72848729eca89"></script>
+  <script type="module" src="terminal.js?v=0ba273e5424e7118c5804122d90841b1287021d699d980c70212eb6c5f364746"></script>
 </body>
 </html>

--- a/site/terminal.js
+++ b/site/terminal.js
@@ -29,7 +29,7 @@ export function observeElementVisibility(Observer, element, onChange) {
 const NC_REPO = 'amanthanvi/noctty';
 const PROMPT = 'PS C:\\Users\\dev>';
 
-let NC_VERSION = (typeof window !== 'undefined' && window.NC_VERSION) || '1.3.124';
+let NC_VERSION = (typeof window !== 'undefined' && window.NC_VERSION) || '1.3.125';
 
 export function buildScenes(v) {
   return [

--- a/site/version.js
+++ b/site/version.js
@@ -2,7 +2,7 @@
 // refreshes from GitHub Releases when the browser is idle. Never downgrades
 // below the compiled version.
 
-const DEFAULT_NC_VERSION = '1.3.124';
+const DEFAULT_NC_VERSION = '1.3.125';
 const NC_REPO = 'amanthanvi/noctty';
 const CACHE_KEY = 'nc-latest-release-v1';
 const CACHE_TTL_MS = 30 * 60 * 1000;

--- a/site/why-noctty.html
+++ b/site/why-noctty.html
@@ -359,6 +359,6 @@ pwsh .\scripts\verify-published-release.ps1 -Version $version</code></pre>
   </footer>
 
   <script type="module" src="/app.js?v=98916ae44c47820a7a796236e272181592d780769a90b706acea8eeb8eead2d1"></script>
-  <script type="module" src="/version.js?v=9c98ba6d2242f28da78ce39427ce30506dfa38c1a79372c598faa62159f5742f"></script>
+  <script type="module" src="/version.js?v=481a363baf804c085f821a3f280ea2a5c0c0b9bcc3d605c109b5d8b2c777cd22"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Release copy 1.3.124 -> 1.3.125, published date 2026-09-03 UTC, generated by `scripts/update-release-copy.ps1` (README, getting-started, site index/trust page, version.js, terminal.js).
- No product code changes. This PR merges last, immediately before the `v1.3.125` tag, so the README date matches the GitHub published date that the stable path verifies.

## Release sequence

1. Merge the three open issue PRs (#137 signing decision, #141 upstream window, #145 caption-button UIA), then rebase and merge this.
2. Produce exact-head interactive evidence on final `main` (ephemeral `noctty-interactive` runner, Test dispatch with `run_interactive_win11=true`).
3. Release Readiness for 1.3.125, then tag or dispatch Release. Stable if `AmanThanvi.noctty` is bootstrapped in winget-pkgs (microsoft/winget-pkgs#428388) and the repo variable is switched; otherwise prerelease, as with 1.3.124.

## Validation

- `pwsh -NoProfile -File scripts/check-release-copy.ps1 -ExpectedVersion 1.3.125`: passed
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`: passed
- `node --test "site/tests/**/*.test.mjs"`: 43 pass, 0 fail
- `node scripts/build-site-assets.mjs --check`: current
- `pwsh -NoProfile -File scripts/test-release-copy-date.ps1`: 5 cases passed
- `pwsh -NoProfile -File scripts/check-source-format.ps1`: passed
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`: PASS (2 scenarios)

AI assistance: Claude ran the generation script and gates; the copy is script-generated and verified by the checks above.

## Summary by Sourcery

Prepare the repository for the 1.3.125 release by updating published version, date, and download references across user-facing documentation and site assets.

Enhancements:
- Update release references across the README, getting-started guide, and website to version 1.3.125.
- Refresh website asset references and release metadata for the 1.3.125 release.

Documentation:
- Update user-facing release documentation and download links for 1.3.125.

Chores:
- Prepare the repository’s release copy for version 1.3.125 without changing product functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release references and installation instructions to version 1.3.125.
  * Refreshed download links, signed manifest filenames, and the release announcement link.

* **Website**
  * Updated displayed and fallback version information to 1.3.125.
  * Refreshed cached website assets so pages load the current release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->