### PR TITLE
docs(signing): certificate decision record, rotation runbook, signing policy (#137)

### DIFF
--- a/docs/adr/0006-code-signing-certificate-decision.md
+++ b/docs/adr/0006-code-signing-certificate-decision.md
@@ -1,0 +1,214 @@
+# Code signing certificate decision
+
+Noctty releases are signed with a self-signed certificate
+(`CN=winghostty Local Dev Signing`, valid to 2029-04-30). That gives a valid
+cryptographic signature and, through the SPKI pin described in
+[ADR 0005](0005-pin-updater-publisher-public-keys.md), a real trust anchor for
+the in-app updater. It gives no Windows publisher identity. Closing that gap
+needs a certificate the repository cannot produce, so this record picks which
+one to get. Every fact below was checked on 2026-09-03; each is cited.
+
+## The thing none of the options buy
+
+No option removes the SmartScreen warning on day one. Microsoft states that
+Azure Artifact Signing "does **not** provide instant SmartScreen trust" and
+that reputation "can take several weeks and hundreds of clean installs from a
+wide audience", and that "EV certificates no longer bypass SmartScreen ... this
+behavior no longer exists", a change its comparison table dates to 2024
+(<https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation>,
+<https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options>,
+both checked 2026-09-03). Microsoft's own table rates SmartScreen behaviour
+identically for Azure Artifact Signing and a purchased OV certificate. So this
+decision is about publisher identity, cost, and what it does to the release
+pipeline — not about making the warning go away faster.
+
+## The options
+
+**Azure Artifact Signing** was renamed from Azure Trusted Signing (and before
+that Azure Code Signing) during 2026; the docs are at `/azure/artifact-signing/`,
+the client package is `Microsoft.ArtifactSigning.Client`, and the action is
+`azure/artifact-signing-action`. An individual developer is eligible, but only
+with an Azure billing account whose Account Type is "Individual", only in the
+US and Canada, and only on a paid subscription — "Artifact Signing doesn't
+support free, trial, or sponsored Azure subscriptions"
+(<https://learn.microsoft.com/en-us/azure/artifact-signing/faq>, checked
+2026-09-03). Identity validation runs through Microsoft Entra Verified ID with
+a third-party verifier and takes 1 to 20 business days, cannot be expedited,
+allows three document-upload attempts, and must be renewed on a 60-day window
+before it expires
+(<https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart>,
+<https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-renew-identity-validation>,
+checked 2026-09-03). The often-quoted "three years of verifiable history" rule
+was an organization-path rule from the 2025 preview and does not appear in the
+current docs; it never applied to the individual path, and no Microsoft
+statement formally rescinding it was found. The Basic SKU is **$9.99 per month**
+for 5,000 signatures per month, $0.005 per signature over that, not pro-rated
+and billed from account creation
+(<https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/artifact-signing/how-to-change-sku.md>,
+corroborated by the code-signing-options page; the rendered pricing page shows
+`$-` placeholders, checked 2026-09-03). The certificate subject is the
+subscriber's validated legal name plus city, state, and country; custom CN or O
+values are not possible and EV is never issued. Signing is `signtool` with the
+Artifact Signing dlib rather than a key file:
+
+```
+signtool sign /v /debug /fd SHA256 /tr "http://timestamp.acs.microsoft.com" /td SHA256 ^
+  /dlib "<dlib bin>\x64\Azure.CodeSigning.Dlib.dll" /dmdf "<path>\metadata.json" <file>
+```
+
+verbatim from
+<https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations>
+(checked 2026-09-03), where `metadata.json` names the regional `Endpoint`, the
+`CodeSigningAccountName`, and the `CertificateProfileName`. There is an official
+`azure/artifact-signing-action` (v2) that runs on Windows runners only and
+authenticates through OIDC workload identity federation via `azure/login`, so no
+long-lived secret is stored (<https://github.com/azure/artifact-signing-action>,
+checked 2026-09-03). Timestamping is not optional: certificates "are renewed
+daily and are valid for only 72 hours".
+
+**SignPath Foundation** costs nothing and is the obvious first thought for an
+OSS project, and it is the one this decision rejects most firmly. Three of its
+published rules are fatal here, all quoted from
+<https://signpath.org/terms.html> (checked 2026-09-03). First, "the code signing
+certificate is issued to SignPath Foundation ... SignPath Foundation is the
+publisher of the OSS project" — Windows would show a publisher that is not the
+maintainer, which is most of what this exercise is trying to obtain. Second,
+"every release needs manual approval for signing", so a tag-triggered release
+can never complete unattended; the maintainer must click Approve in SignPath's
+web UI mid-workflow. Third, signing a modified upstream is allowed only if "the
+upstream project publishes signed builds" and the project performs "code reviews
+for all changes of the upstream code base" — a solo-maintainer fork does not do
+upstream code review, and whether upstream Ghostty publishes signed builds in
+the sense SignPath means is not confirmed. On top of that, acceptance is openly
+discretionary ("we require a certain verifiable reputation", "there is no
+independent arbitration mechanism"), and the certificate's issuing CA, its type,
+its term, and whether its key survives renewal are all unstated by SignPath;
+Microsoft describes it as OV-level. The public "Code signing policy" page it
+requires is worth having regardless, so this branch wrote one anyway:
+[docs/code-signing-policy.md](../code-signing-policy.md).
+
+**A purchased OV certificate** is the only option that leaves the current
+pinning design untouched, and it is the most expensive and the most awkward to
+automate. Since 2023-06-01, CA/Browser Forum Code Signing Baseline Requirements
+ballots CSC-13 and CSC-17 require private keys to live in FIPS 140-2 Level 2 or
+Common Criteria EAL4+ hardware
+(<https://cabforum.org/2022/04/06/ballot-csc-13-update-to-subscriber-key-protection-requirements/>,
+<https://cabforum.org/2022/09/27/ballot-csc-17-subscriber-private-key-extension/>,
+<https://cabforum.org/working-groups/code-signing/requirements/>, with DigiCert
+and SSL.com confirming in their own documentation, checked 2026-09-03). A new
+OV certificate therefore cannot be exported as a PFX at all, which retires
+`WINDOWS_CODESIGN_PFX_BASE64` as a mechanism no matter which vendor is chosen. The cheapest CI-viable path found is SSL.com OV at $129/year
+plus eSigner Tier 1 at $180/year ($309 year one, 240 signatures) with a
+first-party GitHub Action; DigiCert OV with KeyLocker is $996/year; Sectigo's
+own list price is $715/year. Certum's Open Source certificate is cheapest at
+EUR 49-69 but has no official unattended-signing path and names the publisher
+"Open Source Developer". Every cloud-signing path except Azure Key Vault stores
+a long-lived credential — and for eSigner a TOTP seed — in GitHub Actions
+secrets, which is strictly weaker than OIDC.
+
+| Option                        | Year-1 cost | Unattended release | Publisher shown         | Leaf SPKI pin survives |
+| ----------------------------- | ----------- | ------------------ | ----------------------- | ---------------------- |
+| Azure Artifact Signing, Basic | ~$120       | yes, via OIDC      | maintainer's legal name | no — rotates daily     |
+| SignPath Foundation           | $0          | no, manual approve | "SignPath Foundation"   | unconfirmed            |
+| SSL.com OV + eSigner Tier 1   | $309        | yes, secret + TOTP | maintainer's legal name | unconfirmed            |
+| DigiCert OV + KeyLocker       | $996        | yes, API           | maintainer's legal name | unconfirmed            |
+
+## Decision
+
+Take **Azure Artifact Signing on the Basic SKU**. It is the only option that
+puts the maintainer's own validated identity on the signature, keeps the release
+workflow unattended, and does so without storing a long-lived signing credential
+anywhere — the GitHub OIDC federation the release workflow already has
+`id-token: write` for is enough. $120/year is the lowest recurring cost of any
+option that satisfies all three.
+
+The price is that it invalidates the pinning design in ADR 0005. Microsoft is
+explicit: because certificates are renewed daily, "pinning trust or validation
+to an end-entity certificate that uses certificate attributes (for example, the
+public key) or a certificate's thumbprint ... isn't durable", and subject DN
+values can change too
+(<https://learn.microsoft.com/en-us/azure/artifact-signing/concept-certificate-management>,
+checked 2026-09-03). Microsoft's prescribed replacement, given for anti-malware
+vendors facing the same problem in its FAQ, is to pin the issuing PCA
+certificate's TBS hash **and** require the subscriber's unique custom EKU, which
+carries the prefix `1.3.6.1.4.1.311.97.` followed by octets unique to the
+identity-validation resource. Microsoft never writes the sentence "a new key
+pair is generated per renewal"; it states the operational conclusion instead.
+Treat the leaf public key as rotating.
+
+## What this implies in the repository
+
+Nothing here is implemented on this branch. It is the work the decision commits
+to, read out of the code as it stands.
+
+`src/update/github_releases.zig` — `verifyPinnedPublisherIdentityFromState`
+hashes the SPKI of `signer.pasCertChain[0].pCert`, the leaf, and compares it
+against `pinned_publisher_spki_sha256`. Under Artifact Signing that comparison
+fails within three days of every release. It must become a conjunction: the
+issuing PCA, identified from further up the same `pasCertChain`, must match a
+pinned hash, **and** the leaf must carry the subscriber's
+`1.3.6.1.4.1.311.97.<octets>` EKU, which means parsing extension `2.5.29.37` on
+the leaf. Both must be allowlists rather than single values, for the same reason
+ADR 0005 made the key pin an allowlist: the PCA will roll over, and the FAQ says
+re-creating an identity validation can change the EKU. `certificateSpkiSha256`
+and the DER reader beside it already do most of the parsing work.
+
+`scripts/signing-trust.ps1` — `Get-UpdaterPublisherSpkiPins` and
+`Assert-ReleaseSignature` mirror the updater's rule and change with it.
+`Assert-CodeSigningCertificatePolicy` cannot survive in its current form at all:
+it loads a PFX, requires a private key, and demands at least 180 days of
+remaining validity, none of which a 72-hour certificate obtained through a dlib
+can satisfy. `Import-CodeSigningCertificate` loses its only caller in the
+release path.
+
+`scripts/release-preflight.ps1` — the signing gate must move from "inspect the
+key before signing" to "inspect the signature after signing", because there is
+no key to inspect. `Assert-ReleaseSignature` already performs exactly that check
+on produced artifacts and is where the guarantee should live.
+`Assert-TimestampUrlConfigured` stays and gets stricter: timestamping becomes
+unconditional at `http://timestamp.acs.microsoft.com`, and
+`WINDOWS_CODESIGN_TRUST_SELF_SIGNED` — along with the whole self-signed branch
+it guards — is deleted. `WINDOWS_CODESIGN_MIN_VALIDITY_DAYS` becomes meaningless.
+
+`scripts/package-windows.ps1` — `Get-SigningConfig` requires a PFX and password
+and constructs an `X509Certificate2`; `Invoke-SignFile` passes `/f <pfx>` and
+`/p <password>`. Both must gain an Artifact Signing mode that passes `/dlib` and
+`/dmdf` and no key material, with `/tr` and `/td SHA256` unconditional rather
+than conditional on `TimestampUrl`. The runner also needs SignTool 10.0.2261.755
+or newer (the 20348 SDK is documented as unsupported with the dlib), the .NET 8
+runtime, and the client tools. Two further points are load-bearing and
+**unverified**: the portable payload manifest is signed at line 595 with
+`Set-AuthenticodeSignature`, which needs a certificate object holding a private
+key that will not exist, so `.ps1` signing must move to `signtool` and be proven
+to work against the PowerShell subject-interface package before this backend is
+committed to; and `Assert-ValidSignature`'s self-signed branch compares a
+thumbprint that now changes daily, so it must compare against the new pin rule
+instead.
+
+`release` environment — delete `WINDOWS_CODESIGN_PFX_BASE64`,
+`WINDOWS_CODESIGN_PFX_PASSWORD`, and `WINDOWS_CODESIGN_TRUST_SELF_SIGNED`. Add
+the Artifact Signing endpoint, signing account name, and certificate profile
+name; these are configuration, not secrets, so they belong in environment
+variables. Add `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_SUBSCRIPTION_ID`
+as variables and configure a federated credential on the Entra application
+scoped to this repository's `release` environment — no client secret.
+`.github/workflows/release.yml` already declares `id-token: write`. The service
+principal needs the Artifact Signing Certificate Profile Signer role.
+`WINDOWS_CODESIGN_TIMESTAMP_URL` stays, repointed and mandatory.
+
+The migration itself follows
+[the rotation runbook](../signing-rotation-runbook.md): the overlap release
+must ship the new pin rule while still signed by the current self-signed key,
+because an install that only knows today's leaf-SPKI pin will reject anything
+signed by Artifact Signing.
+
+## Owner prerequisite
+
+One thing must happen outside the repository before any of the above is worth
+writing: complete Azure Artifact Signing **individual** identity validation on a
+paid Azure subscription whose billing account Account Type is "Individual", in
+the US or Canada. It takes 1 to 20 business days, cannot be expedited, and
+allows three document-upload attempts. Nothing in this repository can substitute
+for it, and no code should be written against this decision until it succeeds —
+if eligibility fails, the fallback is a purchased OV certificate, which is the
+one option that leaves the existing pin design intact.

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -15,9 +15,12 @@ Signing only happens inside the `Release` GitHub Actions workflow
 (`.github/workflows/release.yml`) on a GitHub-hosted `windows-latest` runner,
 triggered by a `v*` tag push or a manual dispatch by the maintainer. That job
 runs in the repository's `release` environment, which is where the signing
-secrets live; no other workflow in the repository can read them. There is no
-local signing path for published artifacts: a build signed on a workstation is
-not a Noctty release.
+secrets live. One other workflow enters that environment and can read the same
+two secrets: `release-readiness.yml`, which passes them to
+`scripts/release-preflight.ps1` so it can check the certificate before a
+release is attempted. It packages and signs nothing. No other workflow in the
+repository can read them. There is no local signing path for published
+artifacts: a build signed on a workstation is not a Noctty release.
 
 ## Where the key lives
 
@@ -58,9 +61,18 @@ describes the live state. The migration itself follows
 For each release and each architecture (`x64`, `arm64`):
 
 - the installer, `noctty-<version>-windows-<arch>-setup.exe`
-- every `.exe`, `.com`, and `.dll` inside the portable tree
+- every `.exe`, `.com`, and `.dll` that this project builds, inside the
+  portable tree
 - the portable payload manifest,
   `noctty-<version>-windows-<arch>-portable.manifest.ps1`
+
+The bundled ConPTY redistributable — `conpty.dll` and `OpenConsole.exe` — is
+**not** signed with this key. Those two files keep Microsoft's own Authenticode
+signature, and the release verifier checks them against the SHA-256 values
+pinned in `dist/windows/conpty-redist.json` rather than against the publisher
+pin.
+Seeing a Microsoft signer on those two files is expected, not a release-integrity
+failure.
 
 The portable ZIP container itself is not Authenticode-signed — a ZIP cannot
 carry an Authenticode signature — and is covered instead by its published

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -1,0 +1,121 @@
+# Code signing policy
+
+This page states who signs Noctty releases, where the signing key lives, what
+is signed, how you can check it, and what happens if the key is compromised.
+It describes the project as it is today. Where a decision has been made but not
+yet carried out, it says so.
+
+## Who may sign
+
+Aman Thanvi (GitHub `amanthanvi`), the sole maintainer, is the only person who
+may sign a Noctty release. No other person, organisation, or automated system
+is authorised to sign anything under the Noctty name.
+
+Signing only happens inside the `Release` GitHub Actions workflow
+(`.github/workflows/release.yml`) on a GitHub-hosted `windows-latest` runner,
+triggered by a `v*` tag push or a manual dispatch by the maintainer. That job
+runs in the repository's `release` environment, which is where the signing
+secrets live; no other workflow in the repository can read them. There is no
+local signing path for published artifacts: a build signed on a workstation is
+not a Noctty release.
+
+## Where the key lives
+
+Today the release identity is a **self-signed** certificate,
+`CN=winghostty Local Dev Signing` (the subject predates the project's rename
+and is kept because the trust anchor is the key, not the name), valid until
+2029-04-30. Its private key exists as a password-protected PFX held by the
+maintainer offline and as two GitHub Actions secrets in the `release`
+environment, `WINDOWS_CODESIGN_PFX_BASE64` and
+`WINDOWS_CODESIGN_PFX_PASSWORD`. It is not in the repository, not in any
+container image, and not on any always-on machine.
+
+Because the certificate is self-signed, Windows shows no publisher identity
+and SmartScreen warns on first run. That warning does not fade over time.
+Noctty compensates with a key pin rather than pretending otherwise: the SPKI
+SHA-256 of the signing key is compiled into the application
+(`pinned_publisher_spki_sha256` in `src/update/github_releases.zig`), and both
+the in-app updater and the release verifier refuse an artifact signed by any
+other key.
+
+| Field               | Value                                                              |
+| ------------------- | ------------------------------------------------------------------ |
+| Certificate subject | `CN=winghostty Local Dev Signing`                                  |
+| SPKI SHA-256        | `671ec822c41f39b1d79c31d27169b37486333c008c7a038261b4fae53818ce2a` |
+
+**Planned, not yet done.** The project intends to move to a certificate from a
+publicly trusted certificate authority; the options and the recommendation are
+in [ADR 0006](adr/0006-code-signing-certificate-decision.md). Under that
+arrangement the private key would be non-exportable and held in a
+FIPS-validated hardware or cloud key store operated by the issuing service,
+not in a PFX, and the GitHub Actions secrets would be signing-service
+credentials rather than a key. Until that migration ships, everything above
+describes the live state. The migration itself follows
+[the rotation runbook](signing-rotation-runbook.md).
+
+## What is signed
+
+For each release and each architecture (`x64`, `arm64`):
+
+- the installer, `noctty-<version>-windows-<arch>-setup.exe`
+- every `.exe`, `.com`, and `.dll` inside the portable tree
+- the portable payload manifest,
+  `noctty-<version>-windows-<arch>-portable.manifest.ps1`
+
+The portable ZIP container itself is not Authenticode-signed — a ZIP cannot
+carry an Authenticode signature — and is covered instead by its published
+SHA-256 and by GitHub build-provenance attestation. Nothing else published
+under the Noctty name is signed with this key: not source archives, not the
+website, not package-manager manifests.
+
+Signatures use SHA-256 (`signtool /fd SHA256`). RFC 3161 timestamping
+(`/tr <url> /td SHA256`) is requested whenever a timestamp URL is in effect and
+is mandatory for any non-self-signed certificate; release preflight fails
+closed if one is missing. The current self-signed releases are deliberately not
+timestamped, because the pin, not certificate validity, is what makes them
+acceptable.
+
+## How to verify a signature
+
+[docs/verify-release.md](verify-release.md) has the full procedure: checksum,
+GitHub build provenance, and the repository verifier that checks every asset's
+signature against the compiled pin. The short version is
+`scripts/verify-published-release.ps1 -Version <version>`, run from a tag
+checkout of this repository.
+
+Verifying by eye is not enough while the certificate is self-signed: Windows
+will report the signature as untrusted, and `Get-AuthenticodeSignature` may
+report `UnknownError`. Compare the signer's SPKI SHA-256 against the value
+above, or let the verifier do it.
+
+## Reporting a problem
+
+Report a suspected key compromise, a signed artifact you cannot account for, or
+any other signing problem through the process in
+[SECURITY.md](../SECURITY.md). Do not open a public issue for a suspected
+compromise.
+
+## Revocation
+
+There is nothing to revoke today: a self-signed certificate has no issuer to
+revoke it, and no CRL or OCSP responder that Windows would consult. The
+project's revocation mechanism is the pin. If the current key were
+compromised, the response would be to withdraw the affected releases from the
+release page, publish a security advisory naming the affected versions, and
+ship a release that simultaneously adds the replacement key's pin and removes
+the compromised one. That deliberately strands anyone still on a compromised
+build: they must reinstall by hand, which is the intended outcome, because
+in-place update from a compromised build cannot be trusted.
+
+Once the certificate is CA-issued, revocation through the CA is added to that
+list and becomes the step that protects users who never update, but it does
+not replace any of it: a revoked certificate does not remove installers from
+the release page, and revocation does not invalidate a signature that carries a
+valid RFC 3161 timestamp from before the revocation date unless the CA
+back-dates it. Pin removal remains the mechanism that stops the in-app updater.
+
+## Changes to this policy
+
+This page is version-controlled in the Noctty repository. Every change to it
+goes through a pull request against `main` and is visible in that file's git
+history.

--- a/docs/signing-rotation-runbook.md
+++ b/docs/signing-rotation-runbook.md
@@ -14,6 +14,26 @@ requires `X509CertificateLoader` (.NET 9) and refuses to run without it. Never
 paste a PFX, a PFX password, or a signing account credential into a file, a
 log, or a commit.
 
+## Scope
+
+This is the procedure for the signing backend the repository has today: a
+PFX loaded from `WINDOWS_CODESIGN_PFX_BASE64`, a leaf-SPKI pin, and the
+`signtool /f /p` path in `scripts/package-windows.ps1`. It carries a rotation
+to any replacement key that is also delivered as a PFX — which, since
+2023-06-01, means a self-signed key or an existing certificate, not a newly
+issued OV one.
+
+It is **not**, on its own, the migration to
+[ADR 0006](adr/0006-code-signing-certificate-decision.md)'s recommendation.
+Azure Artifact Signing has no PFX to load, no stable leaf public key to pin,
+and no `/f` argument. Steps 1, 2, and the `release`-secret commands in step 5
+do not apply to it. Migrating there needs three repository changes to land
+first — the `/dlib` + `/dmdf` signing mode, OIDC credentials in place of the
+PFX secrets, and the pin rule rewritten to require the issuing PCA plus the
+subscriber's custom EKU — and then steps 3, 4, 6, and 7 carry the rollout, with
+"the new pin" meaning that PCA-plus-EKU rule rather than an SPKI hash. ADR 0006
+lists those changes; none of them exist yet.
+
 ## 0. Before you start
 
 You need the new certificate, and you need the old one to keep working. Do not
@@ -124,12 +144,15 @@ it at all.
 
 ## 5. Switch the `release` environment to the new key
 
-Set the new secrets and clear the self-signed escape hatch:
+Set the new secrets and clear the self-signed escape hatch. These commands are
+the PFX-backed form, and only that form. A hardware-token or
+cloud-signing backend has no PFX to encode; under Azure Artifact Signing these
+two secrets are deleted rather than replaced, and the endpoint, account name,
+certificate profile name, and OIDC federation described in ADR 0006 are set
+instead.
 
 ```powershell
 $repo = "amanthanvi/noctty"
-# PFX-backed certificate only. A hardware-token or cloud-signing backend needs
-# the packaging change described in ADR 0006 instead of these two secrets.
 [Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\secure\noctty-next.pfx")) |
   gh secret set WINDOWS_CODESIGN_PFX_BASE64 --repo $repo --env release
 gh secret set WINDOWS_CODESIGN_PFX_PASSWORD --repo $repo --env release

--- a/docs/signing-rotation-runbook.md
+++ b/docs/signing-rotation-runbook.md
@@ -144,8 +144,18 @@ it at all.
 
 ## 5. Switch the `release` environment to the new key
 
-Set the new secrets and clear the self-signed escape hatch. These commands are
-the PFX-backed form, and only that form. A hardware-token or
+Set the new secrets. What happens to `WINDOWS_CODESIGN_TRUST_SELF_SIGNED`
+depends on which kind of replacement PFX this is:
+
+- **CA-issued replacement:** delete the variable and set the timestamp URL,
+  as the commands below do.
+- **Self-signed replacement** (a renewed local dev key): keep the variable
+  set and skip the `gh variable delete` line. Preflight then keeps reporting
+  `Signer identity: self-signed; updater-pin constrained` and
+  `Timestamp URL: disabled (WINDOWS_CODESIGN_TRUST_SELF_SIGNED is set)`, and
+  the CA-issued expectations in the verify block below do not apply.
+
+These commands are the PFX-backed form, and only that form. A hardware-token or
 cloud-signing backend has no PFX to encode; under Azure Artifact Signing these
 two secrets are deleted rather than replaced, and the endpoint, account name,
 certificate profile name, and OIDC federation described in ADR 0006 are set
@@ -160,8 +170,9 @@ gh variable delete WINDOWS_CODESIGN_TRUST_SELF_SIGNED --repo $repo --env release
 gh variable set WINDOWS_CODESIGN_TIMESTAMP_URL --repo $repo --env release --body "http://timestamp.digicert.com"
 ```
 
-**Verify.** Rerun preflight. `Signer SPKI SHA-256` must now be the new pin,
-`Signer identity` must read `CA-issued; updater-pin constrained`, and
+**Verify (CA-issued replacement).** Rerun preflight. `Signer SPKI SHA-256`
+must now be the new pin, `Signer identity` must read
+`CA-issued; updater-pin constrained`, and
 `Timestamp URL` must print the URL instead of
 `disabled (WINDOWS_CODESIGN_TRUST_SELF_SIGNED is set)`.
 

--- a/docs/signing-rotation-runbook.md
+++ b/docs/signing-rotation-runbook.md
@@ -1,0 +1,190 @@
+# Rotate the release signing key
+
+The in-app updater refuses any installer whose Authenticode signer public key
+is not in the allowlist compiled into `src/update/github_releases.zig`
+(`pinned_publisher_spki_sha256`). Changing the signing key therefore changes
+what already-installed copies will accept, so the new key has to reach users
+_before_ it starts signing releases. That is the overlap procedure in
+[ADR 0005](adr/0005-pin-updater-publisher-public-keys.md), written out here as
+steps. Every step is an owner action in the `release` environment or an
+ordinary pull request; none of it is automated.
+
+Run every command in PowerShell 7.5 or newer. `Import-CodeSigningCertificate`
+requires `X509CertificateLoader` (.NET 9) and refuses to run without it. Never
+paste a PFX, a PFX password, or a signing account credential into a file, a
+log, or a commit.
+
+## 0. Before you start
+
+You need the new certificate, and you need the old one to keep working. Do not
+revoke or delete the old certificate, and do not let it expire, until step 7.
+The old key signs the overlap release; without it, existing installs can never
+be updated in place and every user has to reinstall by hand.
+
+## 1. Get the new certificate and its public key
+
+Obtain the certificate per
+[ADR 0006](adr/0006-code-signing-certificate-decision.md). Then export the
+**public** certificate only (`.cer`). You never need the private key on your
+workstation to compute the pin, and with a hardware token or a cloud signing
+service you cannot export it at all.
+
+## 2. Compute the new SPKI SHA-256
+
+From a public certificate file:
+
+```powershell
+. .\scripts\signing-trust.ps1
+$certificate = [System.Security.Cryptography.X509Certificates.X509CertificateLoader]::LoadCertificateFromFile('C:\secure\noctty-next.cer')
+try { $pin = Get-CertificateSpkiSha256 -Certificate $certificate; $pin } finally { $certificate.Dispose() }
+```
+
+From a PFX, if that is all you have (prompted, never echoed):
+
+```powershell
+. .\scripts\signing-trust.ps1
+$secure = Read-Host -Prompt 'PFX password' -AsSecureString
+$certificate = Import-CodeSigningCertificate `
+  -PfxPath 'C:\secure\noctty-next.pfx' `
+  -Password ([System.Net.NetworkCredential]::new('', $secure).Password)
+try { $pin = Get-CertificateSpkiSha256 -Certificate $certificate; $pin } finally { $certificate.Dispose() }
+```
+
+The result is 64 lowercase hex characters. It hashes a public key, so it is
+safe to publish; the pin already in `docs/verify-release.md` is the same kind
+of value.
+
+**Verify.** The string is 64 hex characters and differs from the current pin.
+If it matches, you loaded the old certificate.
+
+## 3. Add the new pin as the second element
+
+Render the pin as Zig bytes in the layout `zig fmt` keeps:
+
+```powershell
+0..3 | ForEach-Object {
+    $row = $_
+    $bytes = 0..7 | ForEach-Object { '0x' + $pin.Substring((($row * 8) + $_) * 2, 2) + ',' }
+    '        ' + ($bytes -join ' ')
+}
+```
+
+Paste the four lines as a **second** `.{ ... }` entry in
+`pinned_publisher_spki_sha256`, after the current one, with a comment naming
+the certificate subject and its validity window, as the existing entry does.
+Keep the current entry: this step adds, it does not replace.
+
+**Verify.**
+
+```powershell
+. .\scripts\signing-trust.ps1
+Get-UpdaterPublisherSpkiPins -SourcePath .\src\update\github_releases.zig
+pwsh -NoProfile -File scripts\check-zig-format.ps1
+zig build test -Dtest-filter="publisher"
+```
+
+The first command must print exactly two pins, old first. It throws if an
+entry is not 32 bytes or the array is empty.
+
+**Skip this step** and sign a release with the new key anyway, and the
+updater's `verifyPinnedPublisherIdentityFromState` returns
+`UntrustedUpdatePublisher` on every existing install: the download is rejected
+and no staged install runs. Preflight catches it earlier —
+`Assert-CodeSigningCertificatePolicy` in `scripts/signing-trust.ps1` throws
+"Signing certificate SPKI SHA-256 ... is absent from the updater publisher-pin
+allowlist" before packaging starts.
+
+## 4. Ship the overlap release, still signed by the old key
+
+Release the two-pin build with the `release` environment unchanged: old PFX,
+old password, `WINDOWS_CODESIGN_TRUST_SELF_SIGNED` exactly as it is now. This
+release exists only to distribute the new pin.
+
+**Verify.**
+
+```powershell
+pwsh -NoProfile -File scripts\release-preflight.ps1 -Version <version> -RequireSigning
+pwsh -NoProfile -File scripts\verify-published-release.ps1 -Version <version>
+```
+
+Preflight prints `Signer SPKI SHA-256`; it must be the **old** pin. The
+published-release verifier reads the allowlist out of
+`src/update/github_releases.zig`, so it accepts a release signed by either
+pinned key — read the printed SPKI rather than trusting the exit code alone.
+
+**Skip this step** and go straight to the new key, and users on the previous
+release have only the old pin compiled in. They can never accept the new
+installer and must reinstall by hand. Nothing in the application can recover
+from it.
+
+Give this release time to reach installs before step 5. The updater checks at
+most once every 24 hours (`throttle_seconds` in
+`src/update/github_releases.zig`), and users who turned the check off never see
+it at all.
+
+## 5. Switch the `release` environment to the new key
+
+Set the new secrets and clear the self-signed escape hatch:
+
+```powershell
+$repo = "amanthanvi/noctty"
+# PFX-backed certificate only. A hardware-token or cloud-signing backend needs
+# the packaging change described in ADR 0006 instead of these two secrets.
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\secure\noctty-next.pfx")) |
+  gh secret set WINDOWS_CODESIGN_PFX_BASE64 --repo $repo --env release
+gh secret set WINDOWS_CODESIGN_PFX_PASSWORD --repo $repo --env release
+gh variable delete WINDOWS_CODESIGN_TRUST_SELF_SIGNED --repo $repo --env release
+gh variable set WINDOWS_CODESIGN_TIMESTAMP_URL --repo $repo --env release --body "http://timestamp.digicert.com"
+```
+
+**Verify.** Rerun preflight. `Signer SPKI SHA-256` must now be the new pin,
+`Signer identity` must read `CA-issued; updater-pin constrained`, and
+`Timestamp URL` must print the URL instead of
+`disabled (WINDOWS_CODESIGN_TRUST_SELF_SIGNED is set)`.
+
+**Leave `WINDOWS_CODESIGN_TRUST_SELF_SIGNED` set** and
+`scripts/package-windows.ps1` forces `TimestampUrl` to `$null`, so nothing is
+timestamped; it then throws "WINDOWS_CODESIGN_TRUST_SELF_SIGNED=true is only
+supported for a self-signed PFX" as soon as the certificate's subject and
+issuer differ. An untimestamped CA-issued signature stops verifying the day the
+certificate expires.
+
+**Clear it but leave no timestamp URL** and `Assert-TimestampUrlConfigured` in
+`scripts/release-preflight.ps1` throws before the PFX is loaded at all.
+
+## 6. Release again, signed by the new key
+
+Nothing in the repository changes for this release. It is the first one users
+accept through the _second_ pin.
+
+**Verify.** Run `scripts\verify-published-release.ps1 -Version <version>` with
+`WINDOWS_CODESIGN_TRUST_SELF_SIGNED` absent from the environment. Once the
+certificate is CA-issued the verifier no longer needs that variable, and
+`docs/verify-release.md` should stop telling readers to set it.
+
+## 7. Retire the old pin
+
+In a later release, delete the old `.{ ... }` entry so the allowlist holds only
+the new key.
+
+**Verify.** `Get-UpdaterPublisherSpkiPins` prints one pin and `zig build test
+-Dtest-filter="publisher"` passes. Never delete both: an empty array makes
+`verifyPinnedPublisherIdentityFromState` return
+`UpdatePublisherPinUnavailable`, which disables verified download and apply
+entirely.
+
+**Retire the old pin too early** and anyone who never installed the overlap
+release from step 4 is stranded on their current version, because the only
+release the updater offers them is signed by a key they do not trust. Wait
+until step 4's release has been the recommended download long enough that you
+accept stranding whoever is left.
+
+## What rotation does not cover
+
+Revocation. If the private key is compromised, revoking the certificate
+invalidates untimestamped signatures made with it, and the pin does not help:
+the installers on the release page are still signed by the compromised key and
+still match the pin. Handling that means withdrawing the affected releases and
+running steps 1-7 with the compromised pin removed in the same release that
+adds the replacement, which strands anyone on a compromised build on purpose.
+[The signing policy](code-signing-policy.md) states that as policy.

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -79,7 +79,13 @@ fade with time.
 The subject name predates the Noctty rename and proves nothing by itself. The
 pinned public key is the constraint that matters: the in-app updater and the
 verifier both refuse an installer signed by any other key. Its rotation rules
-are in [ADR 0005](adr/0005-pin-updater-publisher-public-keys.md).
+are in [ADR 0005](adr/0005-pin-updater-publisher-public-keys.md), and the
+operator steps that carry a rotation out are in
+[the rotation runbook](signing-rotation-runbook.md).
+
+Who may sign, where the key is held, what is signed, and what would happen if
+the key were compromised are in
+[the code signing policy](code-signing-policy.md).
 
 PowerShell may report an otherwise valid signature as `UnknownError` because
 Windows does not trust the self-signed root. The verifier accepts that case

--- a/scripts/test-signing-trust.ps1
+++ b/scripts/test-signing-trust.ps1
@@ -134,6 +134,60 @@ const pinned_publisher_spki_sha256 = [_][Sha256.digest_length]u8{
         Assert-CodeSigningCertificatePolicy -Certificate $certificate -UpdaterSourcePath $updaterSource -MinimumValidityDays 366
     }
 
+    # ADR-0005 overlap: a rotation release compiles the retiring key and the
+    # incoming key at the same time, so the parser must return both, in order.
+    $rotationPin = 'b3' * 32
+    $rotationPinBytes = for ($offset = 0; $offset -lt $rotationPin.Length; $offset += 2) { "0x$($rotationPin.Substring($offset, 2))" }
+    $rotationSource = Join-Path $tempRoot 'rotation.zig'
+    @"
+const pinned_publisher_spki_sha256 = [_][Sha256.digest_length]u8{
+    // Retiring key.
+    .{
+        $($pinBytes -join ', '),
+    },
+    // Incoming key.
+    .{
+        $($rotationPinBytes -join ', '),
+    },
+};
+"@ | Set-Content -LiteralPath $rotationSource -Encoding utf8NoBOM
+
+    $rotationPins = @(Get-UpdaterPublisherSpkiPins -SourcePath $rotationSource)
+    if ($rotationPins.Count -ne 2) {
+        throw "Expected a two-element overlap allowlist, got $($rotationPins.Count) pin(s)."
+    }
+    if ($rotationPins[0] -ne $pin -or $rotationPins[1] -ne $rotationPin) {
+        throw "Two-element pin allowlist parsed incorrectly: $($rotationPins -join ', ')."
+    }
+    $rotationPolicy = Assert-CodeSigningCertificatePolicy `
+        -Certificate $certificate `
+        -UpdaterSourcePath $rotationSource `
+        -MinimumValidityDays 180
+    if ($rotationPolicy.SpkiSha256 -ne $pin) {
+        throw 'Overlap allowlist rejected the still-configured signing key.'
+    }
+
+    $shortEntrySource = Join-Path $tempRoot 'short-entry.zig'
+    @"
+const pinned_publisher_spki_sha256 = [_][Sha256.digest_length]u8{
+    .{
+        $(($rotationPinBytes | Select-Object -First 31) -join ', '),
+    },
+};
+"@ | Set-Content -LiteralPath $shortEntrySource -Encoding utf8NoBOM
+    Assert-ThrowsLike -Pattern '*exactly 32 bytes*' -Script {
+        Get-UpdaterPublisherSpkiPins -SourcePath $shortEntrySource
+    }
+
+    $emptyAllowlistSource = Join-Path $tempRoot 'empty-allowlist.zig'
+    @"
+const pinned_publisher_spki_sha256 = [_][Sha256.digest_length]u8{
+};
+"@ | Set-Content -LiteralPath $emptyAllowlistSource -Encoding utf8NoBOM
+    Assert-ThrowsLike -Pattern '*must not be empty*' -Script {
+        Get-UpdaterPublisherSpkiPins -SourcePath $emptyAllowlistSource
+    }
+
     $signedPath = Join-Path $tempRoot 'signed-host.exe'
     Copy-Item -LiteralPath (Get-Process -Id $PID).Path -Destination $signedPath
     $signedResult = Set-AuthenticodeSignature `

--- a/site/why-noctty.html
+++ b/site/why-noctty.html
@@ -288,6 +288,11 @@ pwsh .\scripts\verify-published-release.ps1 -Version $version</code></pre>
           open-source signing application or a purchase. Neither has happened
           yet.
         </p>
+        <p>
+          Who may sign a release, where the key is held, what is signed, and
+          what would happen if the key were compromised are in
+          <a href="https://github.com/amanthanvi/noctty/blob/main/docs/code-signing-policy.md" target="_blank" rel="noopener noreferrer">the code signing policy</a>.
+        </p>
       </div>
     </section>
 

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -2786,7 +2786,16 @@ fn verifyPinnedPublisherIdentityFromState(
 }
 
 fn publisherSpkiHashAllowed(spki_hash: *const [Sha256.digest_length]u8) bool {
-    for (pinned_publisher_spki_sha256) |pinned| {
+    return spkiHashInPinSet(&pinned_publisher_spki_sha256, spki_hash);
+}
+
+/// Membership test over an arbitrary pin set so rotation-sized allowlists
+/// (old key plus next key) are testable without editing the compiled pins.
+fn spkiHashInPinSet(
+    pins: []const [Sha256.digest_length]u8,
+    spki_hash: *const [Sha256.digest_length]u8,
+) bool {
+    for (pins) |pinned| {
         if (std.mem.eql(u8, &pinned, spki_hash)) return true;
     }
     return false;
@@ -5183,6 +5192,32 @@ test "windows updater publisher SPKI pin allowlist is fail closed" {
     var rejected = allowed;
     rejected[0] ^= 0xff;
     try std.testing.expect(!publisherSpkiHashAllowed(&rejected));
+}
+
+test "windows updater publisher SPKI pin allowlist accepts every rotation pin" {
+    // ADR-0005 rotation ships the next publisher key as a second pin before
+    // release signing moves to it, so both entries must be accepted at once.
+    var pins = [_][Sha256.digest_length]u8{
+        pinned_publisher_spki_sha256[0],
+        pinned_publisher_spki_sha256[0],
+    };
+    pins[1][0] ^= 0xff;
+    try std.testing.expect(!std.mem.eql(u8, &pins[0], &pins[1]));
+
+    for (&pins) |*pin| {
+        try std.testing.expect(spkiHashInPinSet(&pins, pin));
+    }
+
+    var outsider = pins[0];
+    outsider[Sha256.digest_length - 1] ^= 0xff;
+    try std.testing.expect(!spkiHashInPinSet(&pins, &outsider));
+
+    // Retiring the old pin must stop accepting it, and an empty allowlist
+    // must accept nothing.
+    try std.testing.expect(spkiHashInPinSet(pins[1..], &pins[1]));
+    try std.testing.expect(!spkiHashInPinSet(pins[1..], &pins[0]));
+    const empty: []const [Sha256.digest_length]u8 = &.{};
+    try std.testing.expect(!spkiHashInPinSet(empty, &pins[0]));
 }
 
 test "WinTrust certificate chain entry matches SDK ABI" {


### PR DESCRIPTION
## Summary

Issue #137's remaining scope is an owner decision the repository cannot make for itself: which code-signing certificate replaces the self-signed `CN=winghostty Local Dev Signing` key. This branch records that decision, writes out the rotation that carries it, publishes the signing policy that any of the options would need, and closes a real gap in the test coverage of the pin allowlist. **No signing backend is implemented and no production behaviour changes.**

The load-bearing finding is that the recommended option invalidates part of ADR 0005. Azure Trusted Signing was renamed to **Azure Artifact Signing** during 2026, and Microsoft documents that its certificates "are renewed daily and are valid for only 72 hours" and that, because of this, "pinning trust or validation to an end-entity certificate that uses certificate attributes (for example, the public key) or a certificate's thumbprint ... isn't durable" ([concept-certificate-management](https://learn.microsoft.com/en-us/azure/artifact-signing/concept-certificate-management), checked 2026-09-03). `verifyPinnedPublisherIdentityFromState` in `src/update/github_releases.zig` pins exactly that — the SPKI of `signer.pasCertChain[0].pCert`. Microsoft's prescribed replacement is to pin the issuing PCA plus the subscriber's unique `1.3.6.1.4.1.311.97.*` EKU. ADR 0006 says so and reads the consequences out of the current scripts; it does not implement them.

The second finding applies to every option: the CA/Browser Forum hardware-key requirement effective 2023-06-01 (ballots [CSC-13](https://cabforum.org/2022/04/06/ballot-csc-13-update-to-subscriber-key-protection-requirements/) and [CSC-17](https://cabforum.org/2022/09/27/ballot-csc-17-subscriber-private-key-extension/)) means a newly issued OV certificate cannot be exported as a PFX at all. `WINDOWS_CODESIGN_PFX_BASE64` stops applying no matter which option wins.

Refs #137

## Changes

**`docs/adr/0006-code-signing-certificate-decision.md`** (new)

Compares Azure Artifact Signing, SignPath Foundation, and a purchased OV certificate, with every fact cited and dated 2026-09-03, and recommends Azure Artifact Signing on the Basic SKU (~$120/year; official Windows-only GitHub Action authenticating through OIDC, so no long-lived signing credential is stored; certificate subject is the maintainer's validated legal name).

SignPath is rejected on three of its own published rules, not on cost: the certificate "is issued to SignPath Foundation ... SignPath Foundation is the publisher of the OSS project", "every release needs manual approval for signing" (so a tag-triggered release can never complete unattended), and signing a modified upstream requires "the upstream project publishes signed builds" plus "code reviews for all changes of the upstream code base", which a solo-maintainer fork does not do. A purchased OV certificate is the only option that preserves the current leaf-SPKI pin, and is 2.5x-8x the cost with a long-lived credential (and, for SSL.com eSigner, a TOTP seed) in Actions secrets.

Nothing removes the SmartScreen warning on day one, including EV. Microsoft's own comparison table rates Artifact Signing and purchased OV identically, and states that "EV certificates no longer bypass SmartScreen ... this behavior no longer exists". The ADR opens with that so the decision is not sold on a benefit it does not deliver.

The "what this implies in the repository" section names file and function: `Get-SigningConfig` and `Invoke-SignFile` must gain a `/dlib` + `/dmdf` mode with unconditional `/tr`; `Assert-CodeSigningCertificatePolicy` cannot survive at all (it loads a PFX, requires a private key, and demands 180 days of remaining validity against a 72-hour certificate); preflight's signing gate moves from inspecting the key to inspecting the produced signature, where `Assert-ReleaseSignature` already lives; the `release` environment drops the two PFX secrets and `WINDOWS_CODESIGN_TRUST_SELF_SIGNED` and gains OIDC federation. Two items are flagged **unverified** rather than asserted: whether `signtool` will sign the portable manifest `.ps1` (today `Set-AuthenticodeSignature` at `scripts/package-windows.ps1:595` needs a private key that will not exist), and the exact per-vendor leaf-key stability.

**`docs/signing-rotation-runbook.md`** (new)

ADR 0005's overlap procedure as eight operator steps, each with the exact command to run and the failure mode if it is skipped, derived from the code rather than described in the abstract — for example, skipping the overlap pin makes `Assert-CodeSigningCertificatePolicy` throw "absent from the updater publisher-pin allowlist" at preflight and, past that, makes every existing install return `UntrustedUpdatePublisher`; retiring the old pin early strands anyone who never installed the overlap release, because the only release the updater offers them is signed by a key they do not trust. The pin-to-Zig-bytes snippet was checked against the committed array and reproduces it exactly.

**`docs/code-signing-policy.md`** (new)

The public "Code signing policy" page SignPath requires, written truthfully for today's self-signed state with the CA-issued arrangement marked as planned-not-done. Worth publishing whether or not SignPath is ever applied to. Its revocation section states plainly that there is nothing to revoke today and that the project's revocation mechanism is pin removal, which strands anyone on a compromised build on purpose.

**`docs/verify-release.md`, `site/why-noctty.html`**

Link the two new documents. The trust-page link was added only after `scripts/check-site-copy.ps1` and the site node tests were confirmed to still pass.

**Review round 1 (`182167b6a`, `811832c4b`)**

Three findings, all verified as real and fixed. `release-readiness.yml:24` also declares `environment: release` and lines 43-44 pass both PFX secrets to preflight, so the policy's "no other workflow can read them" was false; it now names that workflow and says it signs nothing. And `Install-ConPtyRedist` stages `conpty.dll` and `OpenConsole.exe` into the portable tree *after* the loop that signs the built runtime files, with `verify-published-release.ps1` checking them against `dist/windows/conpty-redist.json` SHA-256 pins instead of the publisher pin, so "every `.exe`, `.com`, and `.dll` inside the portable tree" overstated the coverage. Both corrections are documentation only. CodeRabbit then pointed out that the rotation runbook read as the migration to ADR 0006's recommendation while its steps used `Import-CodeSigningCertificate`, a leaf-SPKI pin and `gh secret set WINDOWS_CODESIGN_PFX_BASE64` — none of which Azure Artifact Signing has; the runbook now opens with a Scope section naming which steps are backend-independent and which repository changes must land first.

**`src/update/github_releases.zig`, `scripts/test-signing-trust.ps1`**

ADR 0005 requires a two-element allowlist during rotation, and nothing proved one works. The Zig test only checked `pinned_publisher_spki_sha256[0]`, and the PowerShell parser had only ever been exercised against a single-element array. `publisherSpkiHashAllowed` now delegates to `spkiHashInPinSet`, which takes the pin set as a slice so a test can build a rotation-sized allowlist without editing the compiled pins; the only caller still passes `&pinned_publisher_spki_sha256`, so behaviour is identical. New coverage: a two-element set accepts both members, rejects a non-member, stops accepting a retired pin once removed, and accepts nothing when empty; `Get-UpdaterPublisherSpkiPins` returns both pins in order from a two-element array, `Assert-CodeSigningCertificatePolicy` accepts the still-configured key while both are live, and a 31-byte entry or an empty array throws.

## Validation

All on head `811832c4b`, rebased onto `main` at `1bcf91044`.

| Gate                                                | Result                                 |
| --------------------------------------------------- | -------------------------------------- |
| `zig build -Demit-exe=true`                          | exit 0                                 |
| `zig build test -Demit-test-exe=true`                | **4322 passed, 72 skipped, 0 failed**  |
| `zig build test -Dtest-filter=publisher`             | exit 0                                 |
| `scripts/check-zig-format.ps1`                       | passed (700 tracked sources)           |
| `scripts/check-source-format.ps1`                    | passed                                 |
| `scripts/test-signing-trust.ps1`                     | PASS                                   |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios)                   |
| `scripts/check-site-copy.ps1`                        | passed                                 |
| `node --test "site/tests/**/*.test.mjs"`             | 43 passed, 0 failed                    |
| `prettier@3 --check` on the four touched Markdown files | clean                               |

## What this deliberately does not do

- No signing backend is implemented, no `/dlib` path is added, and no `release` environment secret or variable is created or changed. Those are owner actions gated on the prerequisite below.
- The compiled pin array is not touched. Adding a second element is step 3 of the runbook and belongs to an actual rotation, not to this PR.
- Issue #137 is not edited or closed. The decision is recorded; the owner action it names is still outstanding, hence `Refs`, not `Fixes`.
- The ConPTY finding surfaced what looks like a genuine defect elsewhere: `verifyPortablePayloadBinaries` (`src/update/github_releases.zig:2491`) walks every `.exe`/`.com`/`.dll` under the extracted payload and calls `verifyAuthenticodeSignature`, which requires the publisher pin, with no exclusion for the two Microsoft-signed ConPTY files that `verify-published-release.ps1` deliberately exempts. Against a real portable ZIP that path should return `UntrustedUpdatePublisher`. It belongs to the portable-apply work in #138, not to a docs branch, so it is flagged rather than fixed here.
- Whether `signtool` can sign the portable manifest `.ps1` under the Artifact Signing dlib was not tested — there is no account to test against. The ADR flags it as a blocking unknown for the implementation PR rather than assuming it works.

## Owner prerequisite

Complete Azure Artifact Signing **individual** identity validation on a paid Azure subscription whose billing account Account Type is "Individual", in the US or Canada. 1 to 20 business days, cannot be expedited, three document-upload attempts. Nothing in this repository substitutes for it. If eligibility fails, the fallback is a purchased OV certificate, which is the one option that leaves the existing pin design intact.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Document the code-signing certificate decision and rotation policy while strengthening publisher-pin allowlist coverage without changing production signing behavior.

New Features:
- Record the recommended code-signing certificate and document the implications for a future Azure Artifact Signing migration.
- Publish the current code-signing policy and an operator runbook for safely rotating signing keys.

Bug Fixes:
- Correct the documented coverage of ConPTY binaries and the workflows that can access signing secrets.
- Close test coverage gaps for multi-key publisher-pin rotation allowlists.

Enhancements:
- Document the tradeoffs, prerequisites, and repository changes required for replacing the self-signed certificate without implementing the new signing backend.

Documentation:
- Link the new signing policy and rotation runbook from release verification documentation and the project website.

Tests:
- Add Zig and PowerShell coverage for accepting, parsing, and retiring entries in two-element publisher-pin allowlists, including malformed and empty configurations.