### PR TITLE
fix(update): verify the bundled ConPTY pair by pinned hash and Microsoft signature in portable apply (#138)

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -38,7 +38,9 @@ That file records the exact NuGet URL, package SHA256, and the x64/ARM64
 archive entry paths and SHA256 values for `conpty.dll` and `OpenConsole.exe`.
 The release verification contract in
 `test/windows/flagship/Test-VerificationContracts.ps1` independently pins the
-same values, so a pin refresh must update both files.
+same values, so a pin refresh must update both files. The in-app portable
+updater embeds `dist/windows/conpty-redist.json` itself
+(`src/update/conpty_redist.zig`), so it needs no separate pin refresh.
 
 The release workflow builds the Windows executable, stages runtime files,
 then produces:
@@ -55,7 +57,10 @@ Release workflow requires signing and fails closed when signing is absent.
 The release installer, portable payload manifest, and noctty-built Windows PE
 files inside the portable ZIP are Authenticode-signed; the pinned Microsoft
 `conpty.dll` and `OpenConsole.exe` remain byte-for-byte vendor artifacts and
-are not re-signed. The ZIP container itself is checksummed and bound to the
+are not re-signed. Because they cannot satisfy the updater's publisher pin,
+the release verifier and the in-app portable updater both check them against
+their `dist/windows/conpty-redist.json` SHA-256 and Microsoft's own signature
+instead. The ZIP container itself is checksummed and bound to the
 canonical release workflow by a GitHub build provenance attestation. Every
 published asset except the static icon is attested.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -692,6 +692,11 @@ entries cover every extracted file, and every extracted `.exe`, `.com`, and
 generic: the signer's public key must match a SHA-256 SPKI pin compiled into
 the app, so a binary signed by any other key is rejected even when its
 signature is otherwise valid. Unsigned binaries fail that verification too.
+The bundled Microsoft `conpty.dll` and `OpenConsole.exe` are the two
+exceptions, because noctty never re-signs them: each must match the SHA-256
+pinned in `dist/windows/conpty-redist.json` and carry a signature that chains
+to a trusted root, which is stricter about the chain than the pinned-publisher
+path. Every other PE keeps the publisher pin.
 See
 [ADR 0005](adr/0005-pin-updater-publisher-public-keys.md) for the pinning
 and key-rotation rules.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -10191,6 +10191,7 @@ fn updateStageFailureMessage(alloc: Allocator, err: anyerror) ![]u8 {
         error.InstallerVersionOlderThanRelease => "the installer version was older than the release feed version",
         error.InstallerChecksumMismatch => "the downloaded Windows asset did not match SHA256SUMS.txt",
         error.InvalidAuthenticodeSignature => "an executable Authenticode signature could not be trusted",
+        error.UntrustedConPtyRedistributable => "a bundled ConPTY file did not match its pinned SHA-256",
         error.UnsafePortableArchiveEntry => "the portable ZIP contains an unsafe path",
         error.DuplicatePortableArchiveEntry => "the portable ZIP contains duplicate paths",
         error.InvalidPortableArchive, error.InvalidPortableArchiveRoot => "the portable ZIP layout is invalid",

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -101,6 +101,14 @@ pub fn add(
     // Every exe needs the terminal options
     self.config.terminalOptions().add(b, step.root_module);
 
+    // The bundled ConPTY pin document. scripts/conpty-redist.ps1 stages the
+    // Microsoft pair from this file and the portable updater verifies the
+    // same two files against it, so both sides have to read one document.
+    // @embedFile cannot escape the src/ module root, hence the named import.
+    step.root_module.addAnonymousImport("conpty_redist_json", .{
+        .root_source_file = b.path("dist/windows/conpty-redist.json"),
+    });
+
     // C imports for locale constants and functions
     {
         const c = b.addTranslateC(.{

--- a/src/update/conpty_redist.zig
+++ b/src/update/conpty_redist.zig
@@ -1,0 +1,281 @@
+//! Compile-time view of `dist/windows/conpty-redist.json`, the single pin
+//! document for Microsoft's bundled ConPTY pair.
+//!
+//! `scripts/conpty-redist.ps1` stages `conpty.dll` and `OpenConsole.exe` from
+//! this file, `scripts/verify-published-release.ps1` re-checks the published
+//! portable ZIP against it, and the in-app portable updater checks the same
+//! two files against the table below. Embedding the packaging script's own
+//! document is what keeps the updater's pins from drifting away from the
+//! bytes the release actually shipped.
+//!
+//! The pair is deliberately outside `Get-WindowsSignedRuntimePayloads` in
+//! `scripts/common.ps1`: noctty never re-signs it, so it can never satisfy
+//! the updater's publisher pin.
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+/// The raw pin document. `@embedFile` cannot escape the `src/` module root,
+/// so `dist/windows/conpty-redist.json` arrives as the `conpty_redist_json`
+/// anonymous import wired in `src/build/SharedDeps.zig`.
+pub const document = @embedFile("conpty_redist_json");
+
+pub const schema_version = "1";
+pub const package_id = "Microsoft.Windows.Console.ConPTY";
+pub const license = "MIT";
+
+pub const Entry = struct {
+    /// Path relative to the portable payload root, which is the `noctty`
+    /// directory inside the portable ZIP.
+    payload_relative_path: []const u8,
+    /// Key holding this file's pin inside an `architectures.<arch>` object.
+    pin_key: []const u8,
+    sha256: [Sha256.digest_length]u8,
+};
+
+/// The names `Install-ConPtyRedist` writes into the portable root, paired
+/// with the pin object that holds each one's hash.
+const staged_files = [_]struct {
+    pin_key: []const u8,
+    payload_relative_path: []const u8,
+}{
+    .{ .pin_key = "conptyDll", .payload_relative_path = "conpty.dll" },
+    .{ .pin_key = "openConsoleExe", .payload_relative_path = "OpenConsole.exe" },
+};
+
+pub const x64: [staged_files.len]Entry = entriesFor("x64");
+pub const arm64: [staged_files.len]Entry = entriesFor("arm64");
+
+/// The pins for the architecture this build targets.
+pub const entries: [staged_files.len]Entry = switch (builtin.cpu.arch) {
+    .x86_64 => x64,
+    .aarch64 => arm64,
+    else => @compileError("unsupported Windows architecture for the bundled ConPTY pin"),
+};
+
+/// The pin for a payload-relative path, or null when the path is not one of
+/// the bundled Microsoft files. Matching is exact: a differently cased name
+/// falls through to the publisher-pinned path and fails closed there.
+pub fn find(payload_relative_path: []const u8) ?Entry {
+    for (entries) |entry| {
+        if (std.mem.eql(u8, entry.payload_relative_path, payload_relative_path)) {
+            return entry;
+        }
+    }
+    return null;
+}
+
+fn entriesFor(comptime arch: []const u8) [staged_files.len]Entry {
+    comptime {
+        // Scanning a ~1 KB document byte by byte costs far more than the
+        // default budget.
+        @setEvalBranchQuota(100_000);
+        const root = skipWs(document, 0);
+        // The same three guards Install-ConPtyRedist applies before it will
+        // stage anything out of this document.
+        if (!std.mem.eql(
+            u8,
+            rawAt(document, objectField(document, root, "schemaVersion")),
+            schema_version,
+        )) {
+            @compileError("conpty-redist.json: unsupported schemaVersion");
+        }
+        if (!std.mem.eql(
+            u8,
+            stringAt(document, objectField(document, root, "packageId")),
+            package_id,
+        )) {
+            @compileError("conpty-redist.json: unexpected packageId");
+        }
+        if (!std.mem.eql(
+            u8,
+            stringAt(document, objectField(document, root, "license")),
+            license,
+        )) {
+            @compileError("conpty-redist.json: unexpected license");
+        }
+
+        const architectures = objectField(document, root, "architectures");
+        const architecture = objectField(document, architectures, arch);
+
+        var result: [staged_files.len]Entry = undefined;
+        for (staged_files, 0..) |staged, index| {
+            const pin = objectField(document, architecture, staged.pin_key);
+            const entry_path = stringAt(document, objectField(document, pin, "entryPath"));
+            // Install-ConPtyRedist writes each nupkg entry under its own base
+            // name; asserting that here keeps the staged name and the pinned
+            // hash describing the same file.
+            if (!std.mem.eql(
+                u8,
+                std.fs.path.basenamePosix(entry_path),
+                staged.payload_relative_path,
+            )) {
+                @compileError("conpty-redist.json: " ++ staged.pin_key ++
+                    " entryPath does not end in " ++ staged.payload_relative_path);
+            }
+            result[index] = .{
+                .payload_relative_path = staged.payload_relative_path,
+                .pin_key = staged.pin_key,
+                .sha256 = sha256At(document, objectField(document, pin, "sha256")),
+            };
+        }
+        return result;
+    }
+}
+
+// A JSON reader small enough to run at comptime. It rejects everything the
+// pin document does not need, escapes in particular, instead of guessing.
+
+fn skipWs(comptime src: []const u8, comptime start: usize) usize {
+    var i = start;
+    while (i < src.len) : (i += 1) {
+        switch (src[i]) {
+            ' ', '\t', '\r', '\n' => {},
+            else => return i,
+        }
+    }
+    @compileError("conpty-redist.json: unexpected end of document");
+}
+
+fn stringEnd(comptime src: []const u8, comptime start: usize) usize {
+    if (src[start] != '"') @compileError("conpty-redist.json: expected a string");
+    var i = start + 1;
+    while (i < src.len) : (i += 1) {
+        if (src[i] == '\\') @compileError("conpty-redist.json: string escapes are not supported");
+        if (src[i] == '"') return i + 1;
+    }
+    @compileError("conpty-redist.json: unterminated string");
+}
+
+fn valueEnd(comptime src: []const u8, comptime start: usize) usize {
+    switch (src[start]) {
+        '"' => return stringEnd(src, start),
+        '{', '[' => {
+            var depth: usize = 0;
+            var i = start;
+            while (i < src.len) {
+                switch (src[i]) {
+                    '"' => {
+                        i = stringEnd(src, i);
+                        continue;
+                    },
+                    '{', '[' => depth += 1,
+                    '}', ']' => {
+                        depth -= 1;
+                        if (depth == 0) return i + 1;
+                    },
+                    else => {},
+                }
+                i += 1;
+            }
+            @compileError("conpty-redist.json: unterminated object or array");
+        },
+        else => {
+            var i = start;
+            while (i < src.len) : (i += 1) {
+                switch (src[i]) {
+                    ',', '}', ']', ' ', '\t', '\r', '\n' => return i,
+                    else => {},
+                }
+            }
+            @compileError("conpty-redist.json: unterminated value");
+        },
+    }
+}
+
+/// Offset of the value stored under `key` in the object starting at
+/// `object_start`. A missing key is a compile error, never a default.
+fn objectField(
+    comptime src: []const u8,
+    comptime object_start: usize,
+    comptime key: []const u8,
+) usize {
+    const brace = skipWs(src, object_start);
+    if (src[brace] != '{') {
+        @compileError("conpty-redist.json: expected an object holding \"" ++ key ++ "\"");
+    }
+    var i = skipWs(src, brace + 1);
+    while (src[i] != '}') {
+        const name_end = stringEnd(src, i);
+        const name = src[i + 1 .. name_end - 1];
+        const colon = skipWs(src, name_end);
+        if (src[colon] != ':') @compileError("conpty-redist.json: expected ':' after a key");
+        const value_start = skipWs(src, colon + 1);
+        if (std.mem.eql(u8, name, key)) return value_start;
+        i = skipWs(src, valueEnd(src, value_start));
+        if (src[i] == ',') i = skipWs(src, i + 1);
+    }
+    @compileError("conpty-redist.json: missing key \"" ++ key ++ "\"");
+}
+
+fn stringAt(comptime src: []const u8, comptime start: usize) []const u8 {
+    return src[start + 1 .. stringEnd(src, start) - 1];
+}
+
+fn rawAt(comptime src: []const u8, comptime start: usize) []const u8 {
+    return src[start..valueEnd(src, start)];
+}
+
+fn sha256At(comptime src: []const u8, comptime start: usize) [Sha256.digest_length]u8 {
+    const text = stringAt(src, start);
+    if (text.len != Sha256.digest_length * 2) {
+        @compileError("conpty-redist.json: a pinned sha256 is not 64 hex digits");
+    }
+    var digest: [Sha256.digest_length]u8 = undefined;
+    for (&digest, 0..) |*byte, index| {
+        byte.* = (hexNibble(text[index * 2]) << 4) | hexNibble(text[index * 2 + 1]);
+    }
+    return digest;
+}
+
+fn hexNibble(comptime character: u8) u8 {
+    return switch (character) {
+        '0'...'9' => character - '0',
+        // The packaging scripts compare lowercase hex, so an uppercase digit
+        // means the document and the scripts disagree.
+        'a'...'f' => character - 'a' + 10,
+        else => @compileError("conpty-redist.json: a pinned sha256 is not lowercase hex"),
+    };
+}
+
+test "conpty pins cover exactly the staged pair for every architecture" {
+    try std.testing.expectEqual(@as(usize, 2), staged_files.len);
+    inline for (.{ x64, arm64 }) |architecture| {
+        try std.testing.expectEqual(staged_files.len, architecture.len);
+        try std.testing.expectEqualStrings("conpty.dll", architecture[0].payload_relative_path);
+        try std.testing.expectEqualStrings("OpenConsole.exe", architecture[1].payload_relative_path);
+    }
+    // The two architectures pin different bytes; a copy-paste in the document
+    // would otherwise go unnoticed.
+    try std.testing.expect(!std.mem.eql(u8, &x64[0].sha256, &arm64[0].sha256));
+    try std.testing.expect(!std.mem.eql(u8, &x64[1].sha256, &arm64[1].sha256));
+}
+
+test "conpty pins equal dist/windows/conpty-redist.json" {
+    const alloc = std.testing.allocator;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, document, .{});
+    defer parsed.deinit();
+
+    const architectures = parsed.value.object.get("architectures").?.object;
+    try std.testing.expectEqual(@as(usize, 2), architectures.count());
+    inline for (.{ .{ "x64", x64 }, .{ "arm64", arm64 } }) |pair| {
+        const pinned = architectures.get(pair[0]).?.object;
+        try std.testing.expectEqual(staged_files.len, pinned.count());
+        for (pair[1]) |entry| {
+            const hex = pinned.get(entry.pin_key).?.object.get("sha256").?.string;
+            var expected: [Sha256.digest_length]u8 = undefined;
+            _ = try std.fmt.hexToBytes(&expected, hex);
+            try std.testing.expectEqualSlices(u8, &expected, &entry.sha256);
+        }
+    }
+}
+
+test "conpty pin lookup is exact" {
+    try std.testing.expect(find("conpty.dll") != null);
+    try std.testing.expect(find("OpenConsole.exe") != null);
+    try std.testing.expect(find("noctty.exe") == null);
+    try std.testing.expect(find("ghostty-vt.dll") == null);
+    try std.testing.expect(find("share/conpty.dll") == null);
+    try std.testing.expect(find("CONPTY.DLL") == null);
+}

--- a/src/update/github_releases.zig
+++ b/src/update/github_releases.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const internal_os = @import("../os/main.zig");
+const conpty_redist = @import("conpty_redist.zig");
 pub const portable_apply = @import("portable_apply.zig");
 
 const Allocator = std.mem.Allocator;
@@ -2488,12 +2489,31 @@ fn installedPortablePayloadMatches(
     return true;
 }
 
+/// How a PE inside the portable payload earns trust.
+const PortableBinaryTrust = union(enum) {
+    /// Signed by noctty: the Authenticode signer key must be a pinned one.
+    pinned_publisher,
+    /// Microsoft's bundled ConPTY pair, which noctty never re-signs and which
+    /// therefore can never satisfy the publisher pin. Bound by the exact bytes
+    /// scripts/conpty-redist.ps1 staged, plus a signature that has to chain to
+    /// a trusted root on this machine.
+    pinned_conpty: conpty_redist.Entry,
+};
+
+fn portableBinaryTrust(payload_relative_path: []const u8) PortableBinaryTrust {
+    if (conpty_redist.find(payload_relative_path)) |entry| {
+        return .{ .pinned_conpty = entry };
+    }
+    return .pinned_publisher;
+}
+
 fn verifyPortablePayloadBinaries(alloc: Allocator, payload_root: []const u8) !void {
     var payload_dir = try std.fs.openDirAbsolute(payload_root, .{ .iterate = true });
     defer payload_dir.close();
     var walker = try payload_dir.walk(alloc);
     defer walker.deinit();
     var verified_binary_count: usize = 0;
+    var verified_conpty_count: usize = 0;
     while (try walker.next()) |entry| {
         if (entry.kind == .directory) continue;
         if (entry.kind != .file) return error.InvalidPortablePayload;
@@ -2503,11 +2523,46 @@ fn verifyPortablePayloadBinaries(alloc: Allocator, payload_root: []const u8) !vo
             !std.ascii.eqlIgnoreCase(extension, ".dll")) continue;
         const path = try std.fs.path.join(alloc, &.{ payload_root, entry.path });
         defer alloc.free(path);
+        const relative = try portableRelativePathAlloc(alloc, entry.path);
+        defer alloc.free(relative);
         try verifyPortablePeMachine(path);
-        try verifyAuthenticodeSignature(path, null);
+        switch (portableBinaryTrust(relative)) {
+            .pinned_publisher => try verifyAuthenticodeSignature(path, null),
+            .pinned_conpty => |pin| {
+                try verifyPinnedConPtyBinary(path, &pin.sha256);
+                verified_conpty_count += 1;
+            },
+        }
         verified_binary_count += 1;
     }
     if (verified_binary_count == 0) return error.IncompletePortablePayload;
+    // Every pinned ConPTY file has to be present and verified, so dropping one
+    // from the payload cannot silently produce a ConPTY-less install.
+    if (verified_conpty_count != conpty_redist.entries.len) {
+        return error.IncompletePortablePayload;
+    }
+}
+
+fn verifyPinnedConPtyBinary(
+    path: []const u8,
+    expected_sha256: *const [Sha256.digest_length]u8,
+) !void {
+    try verifyPinnedConPtyHash(path, expected_sha256);
+    // No publisher pin here: this is Microsoft's signature, not ours. The
+    // signature still has to be valid against this machine's trust stores,
+    // and unlike the publisher-pinned path an untrusted root is not accepted,
+    // because there is no pin left to act as the trust anchor.
+    try verifyAuthenticodeSignatureFor(path, null, .trusted_root);
+}
+
+fn verifyPinnedConPtyHash(
+    path: []const u8,
+    expected_sha256: *const [Sha256.digest_length]u8,
+) !void {
+    const actual = try sha256File(path);
+    if (!std.mem.eql(u8, expected_sha256, &actual)) {
+        return error.UntrustedConPtyRedistributable;
+    }
 }
 
 fn verifyPortablePeMachine(path: []const u8) !void {
@@ -2697,9 +2752,28 @@ fn readWindowsFileVersion(alloc: Allocator, path: []const u8) !WindowsFileVersio
     };
 }
 
+/// What an Authenticode verdict has to prove about the signer.
+const AuthenticodeTrust = enum {
+    /// The signer key must be one of `pinned_publisher_spki_sha256`. The pin
+    /// is the trust anchor, so an untrusted root is tolerated.
+    pinned_publisher,
+    /// The signature must be valid against this machine's trust stores. Used
+    /// only where a pinned SHA-256 already fixes the exact bytes, so there is
+    /// no publisher pin left to anchor an untrusted root.
+    trusted_root,
+};
+
 fn verifyAuthenticodeSignature(
     path: []const u8,
     file_handle: ?std.os.windows.HANDLE,
+) !void {
+    return verifyAuthenticodeSignatureFor(path, file_handle, .pinned_publisher);
+}
+
+fn verifyAuthenticodeSignatureFor(
+    path: []const u8,
+    file_handle: ?std.os.windows.HANDLE,
+    trust: AuthenticodeTrust,
 ) !void {
     if (builtin.os.tag != .windows) return error.AuthenticodeRequiresWindows;
 
@@ -2753,14 +2827,19 @@ fn verifyAuthenticodeSignature(
     }
 
     const trust_status = winVerifyTrust(null, &action, &data);
-    if (!authenticodeStatusAllowsPinnedPublisherCheck(trust_status)) {
-        return error.InvalidAuthenticodeSignature;
+    switch (trust) {
+        .pinned_publisher => {
+            if (!authenticodeStatusAllowsPinnedPublisherCheck(trust_status)) {
+                return error.InvalidAuthenticodeSignature;
+            }
+            try verifyPinnedPublisherIdentityFromState(
+                data.hWVTStateData orelse return error.UpdatePublisherIdentityUnavailable,
+                wtHelperProvDataFromStateData,
+                wtHelperGetProvSignerFromChain,
+            );
+        },
+        .trusted_root => if (trust_status != 0) return error.InvalidAuthenticodeSignature,
     }
-    try verifyPinnedPublisherIdentityFromState(
-        data.hWVTStateData orelse return error.UpdatePublisherIdentityUnavailable,
-        wtHelperProvDataFromStateData,
-        wtHelperGetProvSignerFromChain,
-    );
 }
 
 fn verifyPinnedPublisherIdentityFromState(
@@ -5243,4 +5322,67 @@ test "DER element rejects overflowing offsets and lengths" {
         0xff,             0xff,
     };
     try std.testing.expectError(error.InvalidDer, readDerElement(&maximal_length, 0));
+}
+
+test "portable payload PEs are publisher-pinned except the bundled ConPTY pair" {
+    // The pair Microsoft signs, verified against conpty-redist.json instead.
+    for (conpty_redist.entries) |expected| {
+        switch (portableBinaryTrust(expected.payload_relative_path)) {
+            .pinned_conpty => |pin| try std.testing.expectEqualSlices(
+                u8,
+                &expected.sha256,
+                &pin.sha256,
+            ),
+            .pinned_publisher => return error.TestUnexpectedResult,
+        }
+    }
+
+    // Everything noctty builds and signs, plus anything unexpected, keeps the
+    // publisher pin. This list mirrors Get-WindowsSignedRuntimePayloads in
+    // scripts/common.ps1 with the portable-ZIP "noctty/" prefix removed.
+    for ([_][]const u8{
+        "noctty.exe",
+        "noctty.com",
+        "ghostty-vt.dll",
+        "noctty-terminal-handoff-proxy.dll",
+        "share/conpty.dll",
+        "attacker.dll",
+    }) |relative| {
+        switch (portableBinaryTrust(relative)) {
+            .pinned_publisher => {},
+            .pinned_conpty => return error.TestUnexpectedResult,
+        }
+    }
+}
+
+test "portable managed entries cover every pinned ConPTY file" {
+    // A pinned file the payload verifier does not treat as managed would be
+    // rejected as an unmanaged payload file before its pin is ever checked.
+    for (conpty_redist.entries) |entry| {
+        try std.testing.expect(
+            portable_apply.isManagedRelativePath(entry.payload_relative_path),
+        );
+    }
+}
+
+test "portable ConPTY pin rejects bytes that are not the pinned redistributable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const contents = "not the Microsoft ConPTY redistributable";
+    try tmp.dir.writeFile(.{ .sub_path = "conpty.dll", .data = contents });
+    const path = try tmp.dir.realpathAlloc(alloc, "conpty.dll");
+    defer alloc.free(path);
+
+    const pinned = conpty_redist.find("conpty.dll").?;
+    try std.testing.expectError(
+        error.UntrustedConPtyRedistributable,
+        verifyPinnedConPtyHash(path, &pinned.sha256),
+    );
+
+    // The same comparison accepts the bytes the pin actually names.
+    var matching: [Sha256.digest_length]u8 = undefined;
+    Sha256.hash(contents, &matching, .{});
+    try verifyPinnedConPtyHash(path, &matching);
 }

--- a/src/update/portable_apply.zig
+++ b/src/update/portable_apply.zig
@@ -110,10 +110,21 @@ pub fn isSafeZipEntryPath(path: []const u8) bool {
     return true;
 }
 
+/// Every file scripts/package-windows.ps1 puts in the portable root, which is
+/// the same set Write-PortablePayloadManifest allows there. A payload member
+/// missing from this list makes a genuine portable ZIP fail verification as an
+/// unmanaged file, and one listed here but never staged makes apply fail as an
+/// incomplete payload, so the two lists have to stay equal.
 pub const managed_entries = [_][]const u8{
     "noctty.com",
     "ghostty-vt.dll",
+    "noctty-terminal-handoff-proxy.dll",
+    // Microsoft's bundled ConPTY pair. These are the only payload PEs noctty
+    // does not sign; src/update/conpty_redist.zig pins their bytes instead.
+    "conpty.dll",
+    "OpenConsole.exe",
     "LICENSE",
+    "LICENSE-conpty.txt",
     "config-template.ghostty",
     "README.md",
     "noctty.ico",


### PR DESCRIPTION
## Summary

Since #164 the portable ZIP ships Microsoft's `conpty.dll` and `OpenConsole.exe` next to noctty's own binaries. The in-app portable updater was never taught about them, so from v1.3.125 on an in-app portable-ZIP apply fails on a genuine release asset. The installer path is unaffected.

There are two failures on the way, not one. `verifyPortablePayloadBinaries` (`src/update/github_releases.zig`) sends every `.exe`/`.com`/`.dll` in the payload through `verifyAuthenticodeSignature(path, null)`, which requires the signer SPKI to be in `pinned_publisher_spki_sha256` — noctty's own key, which Microsoft-signed files can never match, so that is `UntrustedUpdatePublisher`. But `verifyPortablePayloadAgainstManifest` runs first and rejects any payload file that `portable_apply.isManagedRelativePath` does not know, and `managed_entries` had not been updated since #172: it was missing `conpty.dll`, `OpenConsole.exe`, `LICENSE-conpty.txt` **and** `noctty-terminal-handoff-proxy.dll` (the last one shipped in #188). So the real first failure on `main` is `InvalidPortablePayload`. Fixing only the signature layer would have left dead code behind an earlier rejection, so both are fixed here.

The fix mirrors the release verifier's design, in Zig. `scripts/common.ps1` `Get-WindowsSignedRuntimePayloads` deliberately excludes the ConPTY pair, and `scripts/verify-published-release.ps1` (lines ~248-299) checks it against the pinned SHA-256 from `dist/windows/conpty-redist.json` plus Microsoft's own signature instead. The updater now does the same thing against the same document.

Refs #172 #164

## Changes

**`src/update/conpty_redist.zig`** (new)

Embeds `dist/windows/conpty-redist.json` — the same document `scripts/conpty-redist.ps1` `Install-ConPtyRedist` stages from — and parses it at comptime into one `Entry` per staged file per architecture (`x64`, `arm64`), each carrying the payload-relative name and the pinned SHA-256. Nothing is duplicated by hand, so a pin refresh that updates the JSON updates the updater. It re-applies the three document guards `Install-ConPtyRedist` applies (`schemaVersion`, `packageId`, `license`) and asserts that each pin's `entryPath` base name equals the name the script stages, so the pinned hash and the staged file cannot come apart. A malformed or renamed field is a compile error, never a silent default.

`@embedFile` cannot escape the `src/` module root, so the JSON arrives as a `conpty_redist_json` anonymous import added once in `src/build/SharedDeps.zig` `add()`, which every exe, test and bench module already goes through.

**`src/update/github_releases.zig`**

`verifyPortablePayloadBinaries` now classifies each payload PE through `portableBinaryTrust`:

- `.pinned_conpty` — only the two paths in `conpty_redist.entries`, matched exactly. Verified by PE machine as before, then by the pinned SHA-256, then by `WinVerifyTrust`.
- `.pinned_publisher` — everything else, including anything unexpected. Unchanged behaviour.

The relaxation is bounded on both sides. The publisher pin is replaced by two bindings, not dropped: the exact bytes the release pinned, and a signature verdict that is **stricter** than the pinned-publisher path — `verifyAuthenticodeSignatureFor(..., .trusted_root)` requires `WinVerifyTrust` to return `0`, so `CERT_E_UNTRUSTEDROOT` is not accepted for these two files, because there is no publisher pin left to act as the trust anchor. (`authenticodeStatusAllowsPinnedPublisherCheck` still tolerates it on the pinned path, where the pin is the anchor.) And both ConPTY entries must be present and verified, or the payload fails `IncompletePortablePayload`, so a stripped-down payload cannot quietly produce a ConPTY-less install.

`verifyAuthenticodeSignature` keeps its signature and its meaning; it now delegates to `verifyAuthenticodeSignatureFor(path, handle, .pinned_publisher)`. Every other caller (installer staging, apply, self and helper verification, the portable manifest) is untouched.

**`src/update/portable_apply.zig`**

`managed_entries` now lists exactly the twelve names `scripts/package-windows.ps1` `Write-PortablePayloadManifest` and `scripts/portable-manifest-verification.ps1` `Assert-PortableManifestMatchesPayload` allow in the portable root. This is not a loosening of the payload check in substance: every added file is still bound by the signed manifest's SHA-256, the two ConPTY files are additionally bound by the packaging pin, and the handoff proxy DLL keeps the publisher pin. It also means those files are backed up, swapped and rolled back with the rest of the install instead of being left stale.

**`src/apprt/win32.zig`**

One line: `error.UntrustedConPtyRedistributable` gets a readable staging-failure detail.

**`docs/windows.md`, `PACKAGING.md`**

`docs/windows.md` claimed every extracted PE must match the compiled-in SPKI pin; that is now wrong for two files, so it names the exception and says the chain requirement is stricter there. `PACKAGING.md` notes that the updater embeds the pin document itself (so a pin refresh needs no third edit) and that the release verifier and the updater both check the pair by pinned hash plus Microsoft's signature. `docs/status.md` and `docs/windows-capability-matrix.md` were checked and are still accurate — they describe the signed *manifest*, which is unchanged.

## On the signed manifest (brief item 3)

Confirmed: the manifest already covers both ConPTY files. `Write-PortablePayloadManifest` in `scripts/package-windows.ps1` walks every file under the portable root and lists `conpty.dll`, `OpenConsole.exe` and `LICENSE-conpty.txt` in its own managed set (lines ~400-420), and `Assert-PortableManifestMatchesPayload` in `scripts/portable-manifest-verification.ps1` (lines 8-26) asserts manifest-payload equality over the same twelve names. The manifest is Authenticode-signed with the publisher key and `verifyPortablePayloadAgainstManifest` requires an exact file-set match, so the ConPTY bytes are already bound before the pin table is consulted. The pinned-hash table is therefore defence in depth, and it is kept because it makes the updater's notion of "the right ConPTY" come from `conpty-redist.json` rather than from whatever the manifest happened to be signed over.

## Validation

All on head `13d654098`, branched from `main` at `1bcf91044` (no rebase needed).

| Gate                                                   | Result                                |
| ------------------------------------------------------ | ------------------------------------- |
| `zig build -Demit-exe=true`                             | exit 0                                |
| `zig build test -Demit-test-exe=true`                   | **4327 passed, 72 skipped, 0 failed** |
| `zig build test -Dtest-filter=ConPTY`                   | 75 passed, 3 skipped, 0 failed        |
| `scripts/check-zig-format.ps1`                          | passed (701 tracked sources)          |
| `scripts/check-source-format.ps1`                       | passed                                |
| `scripts/test-signing-trust.ps1`                        | PASS                                  |
| `test/windows/flagship/Test-VerificationContracts.ps1`  | PASS (2 scenarios)                    |
| `prettier@3 --check PACKAGING.md docs/windows.md`       | clean                                 |

New tests: the ConPTY pair classifies as `.pinned_conpty` with the pinned bytes and everything else (`noctty.exe`, `noctty.com`, `ghostty-vt.dll`, `noctty-terminal-handoff-proxy.dll`, `share/conpty.dll`, `attacker.dll`) as `.pinned_publisher`; wrong bytes for a ConPTY entry are rejected with `UntrustedConPtyRedistributable` while the matching bytes pass; `managed_entries` covers every pinned ConPTY path; the comptime table equals a runtime `std.json` parse of the embedded document for both architectures, with exactly two entries each and no cross-architecture hash reuse.

## What this deliberately does not do

- No `WinVerifyTrust` call was exercised against a real Microsoft-signed binary in CI. The hash comparison, the classification and the table are unit-tested; the signature verdict is Windows-side and the same call the pinned path already makes.
- The signer subject is not checked against `Microsoft Corporation` the way `verify-published-release.ps1` does. The pinned SHA-256 already fixes the exact bytes, so a name comparison would add fragility, not coverage.
- A portable ZIP packaged **without** `-RequireConPty` can no longer be applied in-app: the ConPTY files become required payload members. The release workflow always passes `-RequireConPty` for both architectures, and such a local package is unsigned and already fails the manifest signature check, so this only affects the local packaging smoke path.
- Nothing changes for installer-managed installs, and `pinned_publisher_spki_sha256` and its rotation rules are untouched.

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.

## Summary by Sourcery

Make portable updates accept and securely verify the bundled Microsoft ConPTY pair while preserving strict validation for the rest of the payload.

Bug Fixes:
- Fix in-app portable updates for release ZIPs containing Microsoft's bundled ConPTY binaries.
- Prevent portable payloads with missing, unexpected, or tampered ConPTY files from being applied.

Enhancements:
- Verify the ConPTY pair using architecture-specific pinned hashes and trusted-root Authenticode validation while retaining publisher pinning for noctty binaries.
- Keep portable payload management aligned with the packaged file set so ConPTY and handoff-proxy files are backed up, updated, and rolled back correctly.
- Embed and validate the shared ConPTY redistribution pin document at compile time to prevent updater pins from drifting from packaging pins.

Documentation:
- Document the distinct trust requirements for Microsoft-signed ConPTY files and the updater's embedded pin source.

Tests:
- Add coverage for ConPTY classification, hash validation, managed-file coverage, embedded pin consistency, and architecture-specific pins.

Chores:
- Add a user-readable staging error for untrusted ConPTY redistributables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Portable Windows updates now verify bundled Microsoft ConPTY files against pinned SHA-256 values and trusted Microsoft signatures.
  * Update validation ensures all required ConPTY files are present and verified.

* **User Experience**
  * Added a clearer error message when a bundled ConPTY file fails verification.

* **Documentation**
  * Documented ConPTY packaging, signature validation, and updater requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->