### PR TITLE
release: mark a promoted stable release as latest

### DIFF
--- a/scripts/release-publish-github.ps1
+++ b/scripts/release-publish-github.ps1
@@ -106,7 +106,15 @@ if ($LASTEXITCODE -ne 0) {
         throw "Failed to create GitHub release $Tag."
     }
 } else {
-    & gh release edit $Tag --repo $Repository --title $Title "--prerelease=$Prerelease"
+    # Promoting an existing prerelease must also move the "Latest" pointer:
+    # GitHub keeps the previous stable release as latest when a release that
+    # was created as a prerelease is edited to stable. Keep a prerelease off
+    # the latest pointer.
+    $latestArgs = @()
+    if ($Prerelease -ne 'true') {
+        $latestArgs += '--latest'
+    }
+    & gh release edit $Tag --repo $Repository --title $Title "--prerelease=$Prerelease" @latestArgs
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to edit GitHub release $Tag."
     }

--- a/test/windows/flagship/contracts/Contracts.80-Release.ps1
+++ b/test/windows/flagship/contracts/Contracts.80-Release.ps1
@@ -1446,7 +1446,7 @@ $protectedReleaseScriptSpecs = @(
         Context = $releaseGithubPublisher
         Content = $releaseGithubPublisherText
         ExpectedSha256 =
-            'bdd1d01feac86ee799f2d0292e342dfc00e87e95a07ff6eb25f87e0e1c68efb6'
+            '704f06449994762ac43977a7e01005c5b335bc2e06d0e6bdc89c1af76541b173'
         CriticalStatement = '& gh release view $Tag --repo $Repository *> $null'
     }
     [pscustomobject] @{
@@ -1774,8 +1774,12 @@ if ($releaseArtifactVerifierText -notmatch
     throw 'Local artifact verification must require exactly the setup and portable checksum entries before comparing hashes.'
 }
 if ($releaseGithubPublisherText -notmatch
-        '(?m)^\s*& gh release edit \$Tag --repo \$Repository --title \$Title "--prerelease=\$Prerelease"\s*$') {
+        '(?m)^\s*& gh release edit \$Tag --repo \$Repository --title \$Title "--prerelease=\$Prerelease" @latestArgs\s*$') {
     throw 'Existing GitHub releases must explicitly reconcile prerelease true and false.'
+}
+if ($releaseGithubPublisherText -notmatch
+        '(?ms)\$latestArgs = @\(\)\s*if \(\$Prerelease -ne ''true''\) \{\s*\$latestArgs \+= ''--latest''\s*\}') {
+    throw 'Promoting an existing release to stable must also mark it as the latest release.'
 }
 $wingetTokens = $null
 $wingetParseErrors = $null


### PR DESCRIPTION
## Summary

Promoting v1.3.125 from prerelease to stable (Release run 33836778202) published correctly but failed at "Verify published release copy and assets": GitHub does not move the Latest pointer when a release that was created as a prerelease is edited to stable, so `releases/latest` still returned v1.3.123 and the verifier reported the README version and every expected asset as mismatched. The pointer was moved by hand (`gh release edit v1.3.125 --latest`) and the re-run (33838153378) passed end to end, including Scoop and WinGet.

Fix: `scripts/release-publish-github.ps1` passes `--latest` on the existing-release edit path when `Prerelease` is not `true`, and never on the prerelease path, so a prerelease republish cannot claim latest. The protected-script pin in `Contracts.80-Release.ps1` is recomputed and a new contract asserts the reconciliation.

## Validation

- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`: PASS (2 scenarios)
- `pwsh -NoProfile -File scripts/check-source-format.ps1`: passed
- `node --test "site/tests/**/*.test.mjs"`: 43 pass, 0 fail
- Live evidence: `releases/latest` now resolves to v1.3.125 with 10 assets after the manual `--latest` edit, and the re-run's published verifier passed (10 assets, 9 attestations, 12 signed files).

AI assistance: Claude diagnosed the failure from the run log and wrote the fix and contract; verified against the contracts and the live re-run.

## Summary by Sourcery

Keep GitHub’s latest release pointer synchronized when promoting an existing release to stable.

Bug Fixes:
- Ensure existing GitHub releases promoted from prerelease to stable are marked as the latest release while prereleases remain excluded from the latest pointer.

Enhancements:
- Extend release contracts to verify the latest-pointer reconciliation behavior.

Chores:
- Update the protected release publisher script checksum after the release workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub releases promoted from prerelease status now correctly appear as the latest release.
  * Releases that remain prereleases are no longer marked as the latest release.
* **Tests**
  * Updated release publishing checks to verify the correct latest-release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->