### PR TITLE
test(conpty): measure which key encodings survive the pseudo console (#223)

### DIFF
--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -129,6 +129,11 @@ character arrives, and a dead key that cannot combine delivers both
 characters. IME commits remain text without a physical key. These paths have
 unit coverage but have not been exercised on a real non-US keyboard.
 
+Kitty and modifyOtherKeys encodings survive the pseudo console byte for
+byte on both ConPTY sources; noctty does not implement Win32 input mode
+(`CSI ?9001h`), which ConPTY requests at the start of every session. See the
+[key encoding differential](windows-vt-conformance.md#measured-master-to-child-key-encoding-differential).
+
 `key-remap` changes modifier state before focused or in-app keybind matching
 and terminal encoding; it does not change physical key identity. `global:`
 bindings register the literal configured chord through `RegisterHotKey`, so

--- a/docs/windows-capability-matrix.md
+++ b/docs/windows-capability-matrix.md
@@ -129,8 +129,10 @@ character arrives, and a dead key that cannot combine delivers both
 characters. IME commits remain text without a physical key. These paths have
 unit coverage but have not been exercised on a real non-US keyboard.
 
-Kitty and modifyOtherKeys encodings survive the pseudo console byte for
-byte on both ConPTY sources; noctty does not implement Win32 input mode
+Kitty and modifyOtherKeys encodings survive the pseudo console byte for byte
+on the two sources measured here — the in-box conhost of Windows
+`10.0.26200.0` and the bundled OpenConsole `1.24.260710001`; older in-box
+conhosts are unmeasured. noctty does not implement Win32 input mode
 (`CSI ?9001h`), which ConPTY requests at the start of every session. See the
 [key encoding differential](windows-vt-conformance.md#measured-master-to-child-key-encoding-differential).
 

--- a/docs/windows-vt-conformance.md
+++ b/docs/windows-vt-conformance.md
@@ -125,26 +125,36 @@ held waiting for the delimiter behind it.
 Measurement host: Windows `10.0.26200.0`; sources `inbox` and `bundled`
 (`1.24.260710001`). Both sources produced identical results.
 
-| Case                       | Written by the terminal (hex) | Read by the child (hex) | Verdict    |
-| -------------------------- | ----------------------------- | ----------------------- | ---------- |
-| lone `ESC`                 | `1b`                          | `1b`                    | byte-exact |
-| Kitty `CSI 27 u`           | `1b5b323775`                  | `1b5b323775`            | byte-exact |
-| Kitty `CSI 27;5 u`         | `1b5b32373b3575`              | `1b5b32373b3575`        | byte-exact |
-| `0x03`                     | `03`                          | `03`                    | byte-exact |
-| Kitty `CSI 99;5 u`         | `1b5b39393b3575`              | `1b5b39393b3575`        | byte-exact |
-| `TAB`                      | `09`                          | `09`                    | byte-exact |
-| Kitty `CSI 13 u`           | `1b5b313375`                  | `1b5b313375`            | byte-exact |
-| modifyOtherKeys `27;5;27~` | `1b5b32373b353b32377e`        | `1b5b32373b353b32377e`  | byte-exact |
-| `CSI A`                    | `1b5b41`                      | `1b5b41`                | byte-exact |
+A Kitty CSI-u key number is the key's own codepoint, so `Esc` is 27 and
+`Ctrl+[` is 91 with a Ctrl modifier; `CSI 27;5 u` is Ctrl+Esc, not Ctrl+[. The
+`CSI 27;129 u` row is the plain `Esc` noctty writes while Num Lock is on, since
+the Kitty modifier field carries the lock modifiers. Both that form and
+`CSI 91;5 u` were captured from a real Claude Code session in issue #223.
 
-ConPTY does not understand CSI-u, and on these two sources it does not drop it
-either: an unrecognised sequence is flushed to the input queue character by
-character and re-synthesised for the child unchanged. A Kitty-encoded `Esc`,
-`Ctrl+[`, or `Ctrl+C` therefore reaches the application exactly as noctty wrote
-it, and any loss of those keys is above or below this layer, not in it. The
-measurement covers only a child reading the byte stream; a child that reads
-`INPUT_RECORD`s through the console API sees conhost's decoding of those same
-characters instead.
+| Case                                     | Written by the terminal (hex) | Read by the child (hex) | Verdict    |
+| ---------------------------------------- | ----------------------------- | ----------------------- | ---------- |
+| lone `ESC`                               | `1b`                          | `1b`                    | byte-exact |
+| Kitty `CSI 27 u` (Esc)                   | `1b5b323775`                  | `1b5b323775`            | byte-exact |
+| Kitty `CSI 27;129 u` (Esc with Num Lock) | `1b5b32373b31323975`          | `1b5b32373b31323975`    | byte-exact |
+| Kitty `CSI 27;5 u` (Ctrl+Esc)            | `1b5b32373b3575`              | `1b5b32373b3575`        | byte-exact |
+| Kitty `CSI 91;5 u` (Ctrl+[)              | `1b5b39313b3575`              | `1b5b39313b3575`        | byte-exact |
+| `0x03`                                   | `03`                          | `03`                    | byte-exact |
+| Kitty `CSI 99;5 u` (Ctrl+C)              | `1b5b39393b3575`              | `1b5b39393b3575`        | byte-exact |
+| `TAB`                                    | `09`                          | `09`                    | byte-exact |
+| Kitty `CSI 13 u` (Enter)                 | `1b5b313375`                  | `1b5b313375`            | byte-exact |
+| modifyOtherKeys `27;5;27~`               | `1b5b32373b353b32377e`        | `1b5b32373b353b32377e`  | byte-exact |
+| `CSI A`                                  | `1b5b41`                      | `1b5b41`                | byte-exact |
+
+ConPTY does not understand CSI-u, and on the two sources measured here it does
+not drop it either: an unrecognised sequence is flushed to the input queue
+character by character and re-synthesised for the child unchanged. A
+Kitty-encoded `Esc`, `Ctrl+[`, or `Ctrl+C` therefore reaches the application
+exactly as noctty wrote it on this host, and any loss of those keys is above or
+below this layer, not in it. Older in-box conhosts — including the Windows 10
+build 19045 one in issue #223 — were not measured; do not generalise this row
+to every ConPTY. The measurement also covers only a child reading the byte
+stream; a child that reads `INPUT_RECORD`s through the console API sees
+conhost's decoding of those same characters instead.
 
 Every ConPTY session opens by asking the terminal for Win32 input mode
 (`CSI ?9001h`, alongside `CSI ?1004h`). noctty does not implement mode 9001, so

--- a/docs/windows-vt-conformance.md
+++ b/docs/windows-vt-conformance.md
@@ -111,6 +111,47 @@ re-rendered the three markers adjacent to one another inside a synthesized
 clear/home/title/cursor-update stream. This measurement establishes transport
 survival only; it does not close the Kitty pixel-rendering gap listed above.
 
+### Measured master-to-child key encoding differential
+
+The input direction has its own opt-in probe in `src/pty_transport_probe.zig`
+(`NOCTTY_CONPTY_KEY_INPUT_PROBE=1`). The child clears
+`ENABLE_LINE_INPUT`, `ENABLE_ECHO_INPUT`, and `ENABLE_PROCESSED_INPUT`, sets
+`ENABLE_VIRTUAL_TERMINAL_INPUT`, and echoes every byte it reads back as hex.
+The parent writes one key encoding per case followed by a printable delimiter,
+so a case that never arrives is still distinguishable from the next one. ConPTY
+flushes a partial escape at the end of each write, so the lone-`ESC` case is not
+held waiting for the delimiter behind it.
+
+Measurement host: Windows `10.0.26200.0`; sources `inbox` and `bundled`
+(`1.24.260710001`). Both sources produced identical results.
+
+| Case                       | Written by the terminal (hex) | Read by the child (hex) | Verdict    |
+| -------------------------- | ----------------------------- | ----------------------- | ---------- |
+| lone `ESC`                 | `1b`                          | `1b`                    | byte-exact |
+| Kitty `CSI 27 u`           | `1b5b323775`                  | `1b5b323775`            | byte-exact |
+| Kitty `CSI 27;5 u`         | `1b5b32373b3575`              | `1b5b32373b3575`        | byte-exact |
+| `0x03`                     | `03`                          | `03`                    | byte-exact |
+| Kitty `CSI 99;5 u`         | `1b5b39393b3575`              | `1b5b39393b3575`        | byte-exact |
+| `TAB`                      | `09`                          | `09`                    | byte-exact |
+| Kitty `CSI 13 u`           | `1b5b313375`                  | `1b5b313375`            | byte-exact |
+| modifyOtherKeys `27;5;27~` | `1b5b32373b353b32377e`        | `1b5b32373b353b32377e`  | byte-exact |
+| `CSI A`                    | `1b5b41`                      | `1b5b41`                | byte-exact |
+
+ConPTY does not understand CSI-u, and on these two sources it does not drop it
+either: an unrecognised sequence is flushed to the input queue character by
+character and re-synthesised for the child unchanged. A Kitty-encoded `Esc`,
+`Ctrl+[`, or `Ctrl+C` therefore reaches the application exactly as noctty wrote
+it, and any loss of those keys is above or below this layer, not in it. The
+measurement covers only a child reading the byte stream; a child that reads
+`INPUT_RECORD`s through the console API sees conhost's decoding of those same
+characters instead.
+
+Every ConPTY session opens by asking the terminal for Win32 input mode
+(`CSI ?9001h`, alongside `CSI ?1004h`). noctty does not implement mode 9001, so
+ConPTY keeps parsing VT input; Windows Terminal answers it and receives exact
+key records instead. Implementing 9001 would remove ConPTY's VT input parsing
+from the path entirely, at the cost of the Kitty encoding it currently carries.
+
 ### Behavior by sequence class
 
 | Surface                                    | ConPTY v1 byte stream                                                                                                                                                                                                                                                                                                               | ConPTY v2 byte stream                                                                                                                                                                          | Status and mitigation                                                                                                                                                                                                                                                                                                                                                                                                              |

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -458,7 +458,10 @@ Console applications reached through ConPTY see these sequences through
 conhost's own decoder, which does not translate every form back into a
 console key record. `[Console]::ReadKey()` therefore reports less than the
 terminal sent; applications that read the byte stream directly see
-everything.
+everything. Measured on both ConPTY sources, an unrecognised CSI-u key
+encoding is not dropped: ConPTY hands the child the same bytes noctty wrote.
+See the
+[key encoding differential](windows-vt-conformance.md#measured-master-to-child-key-encoding-differential).
 
 `F6` and `Shift+F6` run `cycle_focus_region` and move keyboard focus
 between the terminal pane, the tab strip, the docked search query, and the

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -458,9 +458,10 @@ Console applications reached through ConPTY see these sequences through
 conhost's own decoder, which does not translate every form back into a
 console key record. `[Console]::ReadKey()` therefore reports less than the
 terminal sent; applications that read the byte stream directly see
-everything. Measured on both ConPTY sources, an unrecognised CSI-u key
-encoding is not dropped: ConPTY hands the child the same bytes noctty wrote.
-See the
+everything. Measured on the in-box conhost of Windows `10.0.26200.0` and on
+the bundled OpenConsole `1.24.260710001`, an unrecognised CSI-u key encoding
+is not dropped: ConPTY hands the child the same bytes noctty wrote. Older
+in-box conhosts, including Windows 10 build 19045, were not measured. See the
 [key encoding differential](windows-vt-conformance.md#measured-master-to-child-key-encoding-differential).
 
 `F6` and `Shift+F6` run `cycle_focus_region` and move keyboard focus

--- a/src/pty_transport_probe.zig
+++ b/src/pty_transport_probe.zig
@@ -59,16 +59,25 @@ const KeyInputCase = struct {
 /// The encodings noctty can emit for Esc, Ctrl+[, Ctrl+C, Tab and Enter, plus
 /// one sequence (CSI A) ConPTY is known to understand, as a control case that
 /// proves the input state machine is active.
+///
+/// A Kitty CSI-u key number is the key's own codepoint, so Ctrl+[ is 91 ('[')
+/// with a Ctrl modifier, not 27: `CSI 27;5 u` is Ctrl+Esc and is kept as its
+/// own case. `CSI 27;129 u` is the plain Esc noctty writes while Num Lock is
+/// on, because the Kitty modifier field carries the lock modifiers
+/// (num_lock = 128, reported as bitmask + 1). Both forms were captured from a
+/// real Claude Code session in issue #223.
 const key_input_cases = [_]KeyInputCase{
     .{ .name = "legacy_esc", .payload = "\x1b", .delimiter = 'A', .legacy_equivalent = "\x1b" },
     .{ .name = "kitty_esc", .payload = "\x1b[27u", .delimiter = 'B', .legacy_equivalent = "\x1b" },
-    .{ .name = "kitty_ctrl_bracket", .payload = "\x1b[27;5u", .delimiter = 'C', .legacy_equivalent = "\x1b" },
-    .{ .name = "legacy_ctrl_c", .payload = "\x03", .delimiter = 'D', .legacy_equivalent = "\x03" },
-    .{ .name = "kitty_ctrl_c", .payload = "\x1b[99;5u", .delimiter = 'E', .legacy_equivalent = "\x03" },
-    .{ .name = "legacy_tab", .payload = "\t", .delimiter = 'F', .legacy_equivalent = "\t" },
-    .{ .name = "kitty_enter", .payload = "\x1b[13u", .delimiter = 'G', .legacy_equivalent = "\r" },
-    .{ .name = "modify_other_keys_esc", .payload = "\x1b[27;5;27~", .delimiter = 'H', .legacy_equivalent = "\x1b" },
-    .{ .name = "csi_cursor_up", .payload = "\x1b[A", .delimiter = 'I', .legacy_equivalent = "\x1b[A" },
+    .{ .name = "kitty_esc_num_lock", .payload = "\x1b[27;129u", .delimiter = 'C', .legacy_equivalent = "\x1b" },
+    .{ .name = "kitty_ctrl_esc", .payload = "\x1b[27;5u", .delimiter = 'D', .legacy_equivalent = "\x1b" },
+    .{ .name = "kitty_ctrl_bracket", .payload = "\x1b[91;5u", .delimiter = 'E', .legacy_equivalent = "\x1b" },
+    .{ .name = "legacy_ctrl_c", .payload = "\x03", .delimiter = 'F', .legacy_equivalent = "\x03" },
+    .{ .name = "kitty_ctrl_c", .payload = "\x1b[99;5u", .delimiter = 'G', .legacy_equivalent = "\x03" },
+    .{ .name = "legacy_tab", .payload = "\t", .delimiter = 'H', .legacy_equivalent = "\t" },
+    .{ .name = "kitty_enter", .payload = "\x1b[13u", .delimiter = 'I', .legacy_equivalent = "\r" },
+    .{ .name = "modify_other_keys_esc", .payload = "\x1b[27;5;27~", .delimiter = 'J', .legacy_equivalent = "\x1b" },
+    .{ .name = "csi_cursor_up", .payload = "\x1b[A", .delimiter = 'K', .legacy_equivalent = "\x1b[A" },
 };
 
 pub fn runChildIfRequested() void {
@@ -1024,6 +1033,10 @@ test "Windows ConPTY input transport probe reports key encoding survival" {
                 // key encoder has to work around.
                 if (survival != .passed_through) failures += 1;
             }
+            // Nothing may follow the last delimiter. A trailing byte means the
+            // child read something no case accounts for, which would otherwise
+            // pass silently.
+            try std.testing.expectEqual(received.len, cursor);
             try std.testing.expectEqual(@as(usize, 0), failures);
 
             try readUntilMarker(&pty, &output, key_input_end_marker, std.time.ns_per_s);

--- a/src/pty_transport_probe.zig
+++ b/src/pty_transport_probe.zig
@@ -28,6 +28,49 @@ const sixel_dcs = "\x1bPqNOCTTYSIXEL~\x1b\\";
 const graphics_payload = graphics_begin_marker ++ kitty_apc ++
     graphics_middle_marker ++ sixel_dcs ++ graphics_end_marker;
 
+// The key-input differential below is a third child mode: it measures which
+// terminal-to-application key encodings survive the ConPTY input pipe. ConPTY
+// parses the bytes we write into INPUT_RECORDs and re-synthesises them for the
+// child, so an encoding its input state machine does not know is dropped
+// entirely rather than passed through.
+const key_input_child_mode = "keyinput";
+const key_input_run_env_name = "NOCTTY_CONPTY_KEY_INPUT_PROBE";
+const key_input_ready_marker = "NOCTTY-KEYS-READY";
+const key_input_begin_marker = "NOCTTY-KEYS-BEGIN";
+const key_input_end_marker = "NOCTTY-KEYS-END";
+
+/// Terminating byte the parent writes once every case has been sent. It is
+/// never part of a case payload or delimiter.
+const key_input_sentinel: u8 = 'Z';
+
+const KeyInputCase = struct {
+    name: []const u8,
+    /// Bytes the parent writes into the ConPTY input pipe.
+    payload: []const u8,
+    /// Printable byte written after the payload so the child can tell one
+    /// case from the next even when the payload is dropped outright.
+    delimiter: u8,
+    /// The bytes conhost would hand the application for this key when no
+    /// keyboard protocol is negotiated, i.e. what the app sees in plain
+    /// conhost. Used to tell a passthrough apart from a rewrite.
+    legacy_equivalent: []const u8,
+};
+
+/// The encodings noctty can emit for Esc, Ctrl+[, Ctrl+C, Tab and Enter, plus
+/// one sequence (CSI A) ConPTY is known to understand, as a control case that
+/// proves the input state machine is active.
+const key_input_cases = [_]KeyInputCase{
+    .{ .name = "legacy_esc", .payload = "\x1b", .delimiter = 'A', .legacy_equivalent = "\x1b" },
+    .{ .name = "kitty_esc", .payload = "\x1b[27u", .delimiter = 'B', .legacy_equivalent = "\x1b" },
+    .{ .name = "kitty_ctrl_bracket", .payload = "\x1b[27;5u", .delimiter = 'C', .legacy_equivalent = "\x1b" },
+    .{ .name = "legacy_ctrl_c", .payload = "\x03", .delimiter = 'D', .legacy_equivalent = "\x03" },
+    .{ .name = "kitty_ctrl_c", .payload = "\x1b[99;5u", .delimiter = 'E', .legacy_equivalent = "\x03" },
+    .{ .name = "legacy_tab", .payload = "\t", .delimiter = 'F', .legacy_equivalent = "\t" },
+    .{ .name = "kitty_enter", .payload = "\x1b[13u", .delimiter = 'G', .legacy_equivalent = "\r" },
+    .{ .name = "modify_other_keys_esc", .payload = "\x1b[27;5;27~", .delimiter = 'H', .legacy_equivalent = "\x1b" },
+    .{ .name = "csi_cursor_up", .payload = "\x1b[A", .delimiter = 'I', .legacy_equivalent = "\x1b[A" },
+};
+
 pub fn runChildIfRequested() void {
     if (comptime builtin.os.tag != .windows) return;
 
@@ -72,6 +115,97 @@ pub fn runChildIfRequested() void {
         };
 
         GraphicsChild.run();
+    }
+    if (std.mem.eql(u8, child, key_input_child_mode)) {
+        const KeyInputChild = struct {
+            const enable_processed_input: windows.DWORD = 0x0001;
+            const enable_line_input: windows.DWORD = 0x0002;
+            const enable_echo_input: windows.DWORD = 0x0004;
+            const enable_virtual_terminal_input: windows.DWORD = 0x0200;
+            const enable_processed_output: windows.DWORD = 0x0001;
+            const enable_virtual_terminal_processing: windows.DWORD = 0x0004;
+            const max_received = 512;
+
+            extern "kernel32" fn GetConsoleMode(
+                console: windows.HANDLE,
+                mode: *windows.DWORD,
+            ) callconv(.winapi) c_int;
+            extern "kernel32" fn SetConsoleMode(
+                console: windows.HANDLE,
+                mode: windows.DWORD,
+            ) callconv(.winapi) c_int;
+
+            fn writeAll(handle: windows.HANDLE, bytes: []const u8) void {
+                var offset: usize = 0;
+                while (offset < bytes.len) {
+                    var written: windows.DWORD = 0;
+                    if (windows.kernel32.WriteFile(
+                        handle,
+                        bytes[offset..].ptr,
+                        @intCast(bytes.len - offset),
+                        &written,
+                        null,
+                    ) == 0 or written == 0) std.process.exit(83);
+                    offset += written;
+                }
+            }
+
+            fn run() noreturn {
+                const stdin = std.fs.File.stdin().handle;
+                const stdout = std.fs.File.stdout().handle;
+
+                // Raw VT input: no line editing, no echo, and no processed
+                // input so Ctrl+C arrives as a 0x03 byte instead of a console
+                // control event. This is the mode a full-screen TUI uses.
+                var input_mode: windows.DWORD = 0;
+                if (GetConsoleMode(stdin, &input_mode) == 0) std.process.exit(81);
+                input_mode |= enable_virtual_terminal_input;
+                input_mode &= ~(enable_line_input |
+                    enable_echo_input |
+                    enable_processed_input);
+                if (SetConsoleMode(stdin, input_mode) == 0) std.process.exit(82);
+
+                var output_mode: windows.DWORD = 0;
+                if (GetConsoleMode(stdout, &output_mode) == 0) std.process.exit(84);
+                if (SetConsoleMode(
+                    stdout,
+                    output_mode |
+                        enable_processed_output |
+                        enable_virtual_terminal_processing,
+                ) == 0) std.process.exit(85);
+
+                writeAll(stdout, key_input_ready_marker ++ "\r\n");
+
+                var received: [max_received]u8 = undefined;
+                var len: usize = 0;
+                while (true) {
+                    var byte: [1]u8 = undefined;
+                    var read: windows.DWORD = 0;
+                    if (windows.kernel32.ReadFile(
+                        stdin,
+                        &byte,
+                        1,
+                        &read,
+                        null,
+                    ) == 0 or read != 1) std.process.exit(86);
+                    if (byte[0] == key_input_sentinel) break;
+                    if (len == received.len) std.process.exit(87);
+                    received[len] = byte[0];
+                    len += 1;
+                }
+
+                writeAll(stdout, key_input_begin_marker);
+                const digits = "0123456789abcdef";
+                for (received[0..len]) |byte| {
+                    const hex = [2]u8{ digits[byte >> 4], digits[byte & 0x0f] };
+                    writeAll(stdout, &hex);
+                }
+                writeAll(stdout, key_input_end_marker ++ "\r\n");
+                std.process.exit(0);
+            }
+        };
+
+        KeyInputChild.run();
     }
     if (!std.mem.eql(u8, child, "1")) return;
 
@@ -171,6 +305,85 @@ pub fn runChildIfRequested() void {
     Child.run();
 }
 
+fn cancelAndDrainWrite(
+    pipe: windows.HANDLE,
+    overlapped: *std.os.windows.OVERLAPPED,
+) !void {
+    var cancel_error: ?std.os.windows.Win32Error = null;
+    if (std.os.windows.kernel32.CancelIoEx(pipe, overlapped) == 0) {
+        const err = std.os.windows.kernel32.GetLastError();
+        if (err != .NOT_FOUND) cancel_error = err;
+    }
+
+    var ignored: windows.DWORD = 0;
+    if (std.os.windows.kernel32.GetOverlappedResult(
+        pipe,
+        overlapped,
+        &ignored,
+        windows.TRUE,
+    ) == 0) {
+        const result_error = std.os.windows.kernel32.GetLastError();
+        if (result_error != .OPERATION_ABORTED) {
+            return windows.unexpectedError(result_error);
+        }
+    }
+    if (cancel_error) |err| return windows.unexpectedError(err);
+}
+
+fn writeFragment(
+    pipe: windows.HANDLE,
+    bytes: []const u8,
+    timeout_ms: windows.DWORD,
+) !void {
+    const event = try std.os.windows.CreateEventEx(
+        null,
+        "",
+        0,
+        std.os.windows.EVENT_ALL_ACCESS,
+    );
+    defer _ = windows.CloseHandle(event);
+
+    var overlapped: std.os.windows.OVERLAPPED = .{
+        .Internal = 0,
+        .InternalHigh = 0,
+        .DUMMYUNIONNAME = .{ .DUMMYSTRUCTNAME = .{
+            .Offset = 0,
+            .OffsetHigh = 0,
+        } },
+        .hEvent = event,
+    };
+    const write_result = std.os.windows.kernel32.WriteFile(
+        pipe,
+        bytes.ptr,
+        @intCast(bytes.len),
+        null,
+        &overlapped,
+    );
+    if (write_result == 0) {
+        const write_error = std.os.windows.kernel32.GetLastError();
+        if (write_error != .IO_PENDING) return windows.unexpectedError(write_error);
+
+        switch (std.os.windows.kernel32.WaitForSingleObject(event, timeout_ms)) {
+            std.os.windows.WAIT_OBJECT_0 => {},
+            std.os.windows.WAIT_TIMEOUT => {
+                try cancelAndDrainWrite(pipe, &overlapped);
+                return error.ConptyWriteTimeout;
+            },
+            std.os.windows.WAIT_FAILED => {
+                const wait_error = std.os.windows.kernel32.GetLastError();
+                try cancelAndDrainWrite(pipe, &overlapped);
+                return windows.unexpectedError(wait_error);
+            },
+            else => {
+                try cancelAndDrainWrite(pipe, &overlapped);
+                return error.UnexpectedConptyWriteWait;
+            },
+        }
+    }
+    const written = try std.os.windows.GetOverlappedResult(pipe, &overlapped, false);
+    if (written != bytes.len) return error.ShortConptyWrite;
+}
+
 pub fn runParentIfRequested() !void {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -181,85 +394,6 @@ pub fn runParentIfRequested() !void {
         extern "kernel32" fn GetProcessId(
             process: windows.HANDLE,
         ) callconv(.winapi) windows.DWORD;
-
-        fn cancelAndDrainWrite(
-            pipe: windows.HANDLE,
-            overlapped: *std.os.windows.OVERLAPPED,
-        ) !void {
-            var cancel_error: ?std.os.windows.Win32Error = null;
-            if (std.os.windows.kernel32.CancelIoEx(pipe, overlapped) == 0) {
-                const err = std.os.windows.kernel32.GetLastError();
-                if (err != .NOT_FOUND) cancel_error = err;
-            }
-
-            var ignored: windows.DWORD = 0;
-            if (std.os.windows.kernel32.GetOverlappedResult(
-                pipe,
-                overlapped,
-                &ignored,
-                windows.TRUE,
-            ) == 0) {
-                const result_error = std.os.windows.kernel32.GetLastError();
-                if (result_error != .OPERATION_ABORTED) {
-                    return windows.unexpectedError(result_error);
-                }
-            }
-            if (cancel_error) |err| return windows.unexpectedError(err);
-        }
-
-        fn writeFragment(
-            pipe: windows.HANDLE,
-            bytes: []const u8,
-            timeout_ms: windows.DWORD,
-        ) !void {
-            const event = try std.os.windows.CreateEventEx(
-                null,
-                "",
-                0,
-                std.os.windows.EVENT_ALL_ACCESS,
-            );
-            defer _ = windows.CloseHandle(event);
-
-            var overlapped: std.os.windows.OVERLAPPED = .{
-                .Internal = 0,
-                .InternalHigh = 0,
-                .DUMMYUNIONNAME = .{ .DUMMYSTRUCTNAME = .{
-                    .Offset = 0,
-                    .OffsetHigh = 0,
-                } },
-                .hEvent = event,
-            };
-            const write_result = std.os.windows.kernel32.WriteFile(
-                pipe,
-                bytes.ptr,
-                @intCast(bytes.len),
-                null,
-                &overlapped,
-            );
-            if (write_result == 0) {
-                const write_error = std.os.windows.kernel32.GetLastError();
-                if (write_error != .IO_PENDING) return windows.unexpectedError(write_error);
-
-                switch (std.os.windows.kernel32.WaitForSingleObject(event, timeout_ms)) {
-                    std.os.windows.WAIT_OBJECT_0 => {},
-                    std.os.windows.WAIT_TIMEOUT => {
-                        try cancelAndDrainWrite(pipe, &overlapped);
-                        return error.ConptyWriteTimeout;
-                    },
-                    std.os.windows.WAIT_FAILED => {
-                        const wait_error = std.os.windows.kernel32.GetLastError();
-                        try cancelAndDrainWrite(pipe, &overlapped);
-                        return windows.unexpectedError(wait_error);
-                    },
-                    else => {
-                        try cancelAndDrainWrite(pipe, &overlapped);
-                        return error.UnexpectedConptyWriteWait;
-                    },
-                }
-            }
-            const written = try std.os.windows.GetOverlappedResult(pipe, &overlapped, false);
-            if (written != bytes.len) return error.ShortConptyWrite;
-        }
 
         fn readUntil(
             pty: *ptypkg.Pty,
@@ -655,6 +789,254 @@ test "Windows ConPTY transport probe reports APC and DCS survival" {
     const enabled = std.process.getEnvVarOwned(
         std.testing.allocator,
         graphics_run_env_name,
+    ) catch return error.SkipZigTest;
+    defer std.testing.allocator.free(enabled);
+    if (!std.mem.eql(u8, enabled, "1")) return error.SkipZigTest;
+
+    try Probe.run();
+}
+test "Windows ConPTY input transport probe reports key encoding survival" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const Probe = struct {
+        const Command = @import("Command.zig");
+        const settle_ms = 200;
+        const wait_timeout: windows.DWORD = 258;
+
+        const Survival = enum {
+            /// The child read exactly the bytes we wrote: ConPTY carried the
+            /// encoding through without understanding it.
+            passed_through,
+            /// ConPTY rewrote the encoding into the legacy bytes.
+            rewritten_to_legacy,
+            /// The child read something else entirely.
+            altered,
+            /// The child read nothing at all for this case.
+            dropped,
+        };
+
+        extern "kernel32" fn GetProcessId(
+            process: windows.HANDLE,
+        ) callconv(.winapi) windows.DWORD;
+
+        fn classify(
+            observed: []const u8,
+            payload: []const u8,
+            legacy_equivalent: []const u8,
+        ) Survival {
+            if (observed.len == 0) return .dropped;
+            if (std.mem.eql(u8, observed, payload)) return .passed_through;
+            if (std.mem.eql(u8, observed, legacy_equivalent)) return .rewritten_to_legacy;
+            return .altered;
+        }
+
+        fn printHex(label: []const u8, bytes: []const u8) void {
+            std.debug.print("{s}=", .{label});
+            for (bytes) |byte| std.debug.print("{x:0>2}", .{byte});
+            std.debug.print("", .{});
+        }
+
+        /// Drain whatever the pseudo console has already emitted without
+        /// blocking, so the output pipe never backs up mid-run.
+        fn pump(
+            pty: *ptypkg.Pty,
+            output: *std.ArrayList(u8),
+        ) !void {
+            while (true) {
+                var available: windows.DWORD = 0;
+                if (windows.exp.kernel32.PeekNamedPipe(
+                    pty.out_pipe,
+                    null,
+                    0,
+                    null,
+                    &available,
+                    null,
+                ) == 0) {
+                    if (windows.kernel32.GetLastError() == .BROKEN_PIPE) return;
+                    return windows.unexpectedError(windows.kernel32.GetLastError());
+                }
+                if (available == 0) return;
+                var buffer: [1024]u8 = undefined;
+                var read: windows.DWORD = 0;
+                if (windows.kernel32.ReadFile(
+                    pty.out_pipe,
+                    &buffer,
+                    @min(@as(windows.DWORD, buffer.len), available),
+                    &read,
+                    null,
+                ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+                if (output.items.len + read > max_output_bytes) {
+                    return error.KeyInputProbeOutputTooLarge;
+                }
+                try output.appendSlice(std.testing.allocator, buffer[0..read]);
+            }
+        }
+
+        fn readUntilMarker(
+            pty: *ptypkg.Pty,
+            output: *std.ArrayList(u8),
+            marker: []const u8,
+            timeout_ns: u64,
+        ) !void {
+            var timer = try std.time.Timer.start();
+            while (timer.read() < timeout_ns) {
+                try pump(pty, output);
+                if (std.mem.indexOf(u8, output.items, marker) != null) return;
+                std.Thread.sleep(10 * std.time.ns_per_ms);
+            }
+            return error.KeyInputProbeReadTimeout;
+        }
+
+        fn terminateAndConfirm(process: windows.HANDLE) !void {
+            switch (windows.kernel32.WaitForSingleObject(process, 0)) {
+                std.os.windows.WAIT_OBJECT_0 => return,
+                std.os.windows.WAIT_TIMEOUT => {},
+                std.os.windows.WAIT_FAILED => return windows.unexpectedError(
+                    windows.kernel32.GetLastError(),
+                ),
+                else => return error.KeyInputProbeUnexpectedWait,
+            }
+            if (windows.kernel32.TerminateProcess(process, 0xEE) == 0) {
+                return windows.unexpectedError(windows.kernel32.GetLastError());
+            }
+            if (windows.kernel32.WaitForSingleObject(process, 5000) != 0) {
+                return error.KeyInputProbeChildCleanupTimeout;
+            }
+        }
+
+        fn decodeHex(allocator: std.mem.Allocator, hex: []const u8) ![]u8 {
+            if (hex.len % 2 != 0) return error.KeyInputProbeOddHexLength;
+            const bytes = try allocator.alloc(u8, hex.len / 2);
+            errdefer allocator.free(bytes);
+            for (bytes, 0..) |*byte, index| {
+                byte.* = try std.fmt.parseInt(u8, hex[index * 2 ..][0..2], 16);
+            }
+            return bytes;
+        }
+
+        fn run() !void {
+            const allocator = std.testing.allocator;
+            const self_path = try std.fs.selfExePathAlloc(allocator);
+            defer allocator.free(self_path);
+            const self_path_z = try allocator.dupeZ(u8, self_path);
+            defer allocator.free(self_path_z);
+            var child_env = try std.process.getEnvMap(allocator);
+            defer child_env.deinit();
+            try child_env.put(child_env_name, key_input_child_mode);
+
+            var pty = try ptypkg.Pty.open(.{ .ws_row = 25, .ws_col = 200 });
+            defer pty.deinit();
+
+            var command: Command = .{
+                .path = self_path_z,
+                .args = &.{self_path_z},
+                .env = &child_env,
+                .pseudo_console = pty.pseudoConsole().?,
+                .os_pre_exec = null,
+                .rt_pre_exec = null,
+                .rt_post_fork = null,
+                .rt_pre_exec_info = undefined,
+                .rt_post_fork_info = undefined,
+            };
+            try command.start(allocator);
+            const process = command.pid.?;
+            var child_finished = false;
+            defer {
+                if (!child_finished) terminateAndConfirm(process) catch |err| {
+                    std.debug.print("key-input-probe cleanup failed err={}\n", .{err});
+                };
+                _ = windows.CloseHandle(process);
+            }
+            std.debug.print("key-input-probe parent_pid={d} child_pid={d}\n", .{
+                windows.GetCurrentProcessId(),
+                GetProcessId(process),
+            });
+
+            var output: std.ArrayList(u8) = .empty;
+            defer output.deinit(allocator);
+            try readUntilMarker(
+                &pty,
+                &output,
+                key_input_ready_marker,
+                10 * std.time.ns_per_s,
+            );
+
+            // Each payload is written on its own, then the delimiter is
+            // written on its own. ConPTY's input state machine flushes a
+            // partial escape at the end of every write, so a lone ESC is not
+            // held waiting for the delimiter that follows it.
+            for (key_input_cases) |case| {
+                try writeFragment(pty.in_pipe, case.payload, 2000);
+                std.Thread.sleep(settle_ms * std.time.ns_per_ms);
+                try pump(&pty, &output);
+                try writeFragment(pty.in_pipe, &[_]u8{case.delimiter}, 2000);
+                std.Thread.sleep(settle_ms * std.time.ns_per_ms);
+                try pump(&pty, &output);
+            }
+            try writeFragment(pty.in_pipe, &[_]u8{key_input_sentinel}, 2000);
+
+            try readUntilMarker(
+                &pty,
+                &output,
+                key_input_end_marker,
+                10 * std.time.ns_per_s,
+            );
+
+            const begin = std.mem.indexOf(u8, output.items, key_input_begin_marker).? +
+                key_input_begin_marker.len;
+            const end = begin + (std.mem.indexOf(
+                u8,
+                output.items[begin..],
+                key_input_end_marker,
+            ) orelse return error.KeyInputProbeEndMarkerMissing);
+            const received = try decodeHex(allocator, output.items[begin..end]);
+            defer allocator.free(received);
+
+            const info = ptypkg.conPtyInfo().?;
+            std.debug.print("key-input-probe source={t}\n", .{info.source});
+            printHex("key-input-probe received_hex", received);
+            std.debug.print("\n", .{});
+
+            var cursor: usize = 0;
+            var failures: usize = 0;
+            for (key_input_cases) |case| {
+                const relative = std.mem.indexOfScalar(
+                    u8,
+                    received[cursor..],
+                    case.delimiter,
+                ) orelse return error.KeyInputProbeDelimiterMissing;
+                const observed = received[cursor..][0..relative];
+                cursor += relative + 1;
+                const survival = classify(observed, case.payload, case.legacy_equivalent);
+                std.debug.print("key-input-probe case={s} verdict={t} ", .{
+                    case.name,
+                    survival,
+                });
+                printHex("wrote_hex", case.payload);
+                std.debug.print(" ", .{});
+                printHex("legacy_hex", case.legacy_equivalent);
+                std.debug.print(" ", .{});
+                printHex("observed_hex", observed);
+                std.debug.print("\n", .{});
+                // Every case must reach the child byte for byte. ConPTY parses
+                // our bytes into INPUT_RECORDs and re-synthesises them, so a
+                // dropped or rewritten case is a transport limit that noctty's
+                // key encoder has to work around.
+                if (survival != .passed_through) failures += 1;
+            }
+            try std.testing.expectEqual(@as(usize, 0), failures);
+
+            try readUntilMarker(&pty, &output, key_input_end_marker, std.time.ns_per_s);
+            switch (windows.kernel32.WaitForSingleObject(process, 5000)) {
+                std.os.windows.WAIT_OBJECT_0 => child_finished = true,
+                else => {},
+            }
+        }
+    };
+
+    const enabled = std.process.getEnvVarOwned(
+        std.testing.allocator,
+        key_input_run_env_name,
     ) catch return error.SkipZigTest;
     defer std.testing.allocator.free(enabled);
     if (!std.mem.eql(u8, enabled, "1")) return error.SkipZigTest;


### PR DESCRIPTION
Investigating #223 (Esc not delivered to Claude Code's full-screen panels) produced a measurement that refutes the working hypothesis, so this PR lands the measurement and the corrected documentation rather than a speculative fix.

## What was believed

Claude Code enables the Kitty keyboard protocol; noctty then encodes Esc as `CSI 27 u`, and ConPTY — which has no CSI-u handler — drops it, so the app never sees Esc. Tab and printable keys keep their legacy bytes, which matched the reported symptom set exactly.

## What was measured

**1. Claude Code does enable the protocol.** With an env-gated hex trace on both sides of the pseudo console, the bytes the child writes right after noctty answers XTVERSION with `ghostty 1.3.2-dev+windows` are:

```
1b5b3c75 1b5b3e3575 1b5b3e343b326d      ESC[<u  ESC[>5u  ESC[>4;2m
```

That is a Kitty pop, a Kitty push with flags 5 (disambiguate + report_alternates), and modifyOtherKeys mode 2. noctty honours the push, so with the `/usage` panel open the keys go out as:

| Key      | Written to the pseudo console                      |
| -------- | -------------------------------------------------- |
| `Esc`    | `1b5b323775` (`ESC[27u`), `1b5b32373b31323975` (`ESC[27;129u`) with Num Lock on |
| `Ctrl+[` | `1b5b39313b3575` (`ESC[91;5u`)                      |
| `Ctrl+C` | `1b5b39393b3575` (`ESC[99;5u`)                      |
| `Tab`    | `09`                                               |

Exactly the split the reporter describes: everything lost is CSI-u, and the one key that works is the one that stays legacy.

**2. ConPTY does not drop CSI-u.** New opt-in probe (`NOCTTY_CONPTY_KEY_INPUT_PROBE=1` in `src/pty_transport_probe.zig`): a child clears `ENABLE_LINE_INPUT`/`ENABLE_ECHO_INPUT`/`ENABLE_PROCESSED_INPUT`, sets `ENABLE_VIRTUAL_TERMINAL_INPUT`, and echoes every byte it reads back as hex. Each payload is written on its own, followed by a printable delimiter, so a dropped case is still distinguishable from the next one.

```
key-input-probe source=inbox
case=legacy_esc            verdict=passed_through wrote_hex=1b                   observed_hex=1b
case=kitty_esc             verdict=passed_through wrote_hex=1b5b323775           observed_hex=1b5b323775
case=kitty_esc_num_lock    verdict=passed_through wrote_hex=1b5b32373b31323975   observed_hex=1b5b32373b31323975
case=kitty_ctrl_esc        verdict=passed_through wrote_hex=1b5b32373b3575       observed_hex=1b5b32373b3575
case=kitty_ctrl_bracket    verdict=passed_through wrote_hex=1b5b39313b3575       observed_hex=1b5b39313b3575
case=legacy_ctrl_c         verdict=passed_through wrote_hex=03                   observed_hex=03
case=kitty_ctrl_c          verdict=passed_through wrote_hex=1b5b39393b3575       observed_hex=1b5b39393b3575
case=legacy_tab            verdict=passed_through wrote_hex=09                   observed_hex=09
case=kitty_enter           verdict=passed_through wrote_hex=1b5b313375           observed_hex=1b5b313375
case=modify_other_keys_esc verdict=passed_through wrote_hex=1b5b32373b353b32377e observed_hex=1b5b32373b353b32377e
case=csi_cursor_up         verdict=passed_through wrote_hex=1b5b41               observed_hex=1b5b41
```

A Kitty CSI-u key number is the key's own codepoint, so `Ctrl+[` is `CSI 91;5 u` and `CSI 27;5 u` is Ctrl+Esc; `CSI 27;129 u` is the plain Esc noctty writes with Num Lock on. Both of the forms the repro captured are probed. Identical output with `source=bundled` (`1.24.260710001`). ConPTY has no CSI-u handler, but an unrecognised sequence is flushed to the input queue character by character and re-synthesised for the child unchanged, so a Kitty-encoded `Esc`, `Ctrl+[`, or `Ctrl+C` arrives byte for byte.

**3. The bug does not reproduce on this host.** Windows `10.0.26200.0`, Claude Code `2.1.260` (the reported version), `/usage` panel confirmed open by its rendered `Settings │ Status Config │ Usage │ Stats │ Session … Esc to cancel` frame, Num Lock on so Esc went out as `ESC[27;129u`. The next frame is the normal REPL prompt: the panel closed. Repeated with the bundled ConPTY, with `claude` launched inside `cmd.exe` exactly as reported, with Num Lock off (`ESC[27u`), and with `2.1.261` — the panel closes on Esc every time, and `ESC[99;5u` produces claude's `Press Ctrl-C again to exit`.

So both the transport and the current Claude Code build handle CSI-u here. The variable this host cannot cover is the reporter's OS: Windows 10 build 19045, whose in-box conhost is a different ConPTY generation. The follow-up on #223 asks for that.

## What this PR changes

- `src/pty_transport_probe.zig`: third probe child mode measuring the master-to-child direction, eleven key-encoding cases, per-case `passed_through` / `rewritten_to_legacy` / `altered` / `dropped` verdicts, opt-in behind `NOCTTY_CONPTY_KEY_INPUT_PROBE=1` like the existing probes. The overlapped write helpers move to file scope so both parent probes share one implementation; no behavior change there.
- `docs/windows-vt-conformance.md`: new "Measured master-to-child key encoding differential" section with the table above, scoped to the two sources actually measured (in-box conhost of Windows `10.0.26200.0`, bundled OpenConsole `1.24.260710001`; older in-box conhosts including the reporter's 19045 explicitly unmeasured), and the note that every ConPTY session opens by asking the terminal for Win32 input mode (`CSI ?9001h`) — which noctty does not implement, and Windows Terminal does.
- `docs/windows.md`, `docs/windows-capability-matrix.md`: one sentence each pointing at that measurement, named to those two sources rather than "both ConPTY sources", replacing the previously unqualified claim about conhost's decoder.

No terminal, encoder, or termio behavior changes. The env-gated PTY byte trace used to capture the traces above was temporary and is not in this diff.

## Deliberately not done

- **No Kitty decline / CSI-u translation under ConPTY.** That was the planned fix and the measurement removed its justification: the transport carries CSI-u intact, and declining the protocol would cost working Kitty behavior for every other Windows TUI to work around a bug that does not reproduce.
- **No Win32 input mode (`CSI ?9001h`) implementation.** It is the structural fix for this whole class of ambiguity — ConPTY would stop parsing VT input and receive exact key records — but it also removes the Kitty encoding from the path end to end. That is a design decision worth its own issue, not a side effect of this one.
- **No interactive harness.** `test/windows/interactive-win11-kitty-esc.ps1` was scoped, but with no noctty-side change to guard and the transport already covered by the Zig probe, it would assert behavior that already passes. The reproduction was driven ad hoc instead.
- **Not fixed:** noctty reports the Num Lock bit in Kitty modifiers, so a plain Esc goes out as `ESC[27;129u` rather than `ESC[27u` whenever Num Lock is on (`KittyMods.fromInput`, `src/input/key_encode.zig:903`). That follows the Kitty spec and upstream Ghostty, and Claude Code parsed it correctly here, so it is left alone — but it is the kind of deviation an app-side parser trips on and worth remembering if #223 turns out to be app-side.

## Validation

| Gate                                                  | Result                             |
| ----------------------------------------------------- | ---------------------------------- |
| `zig build -Demit-exe=true`                            | exit 0                             |
| `zig build test -Demit-test-exe=true`                  | 4345 passed / 73 skipped / 0 failed |
| test exe with `NOCTTY_CONPTY_KEY_INPUT_PROBE=1`        | 4346 passed / 72 skipped / 0 failed, all 11 cases `passed_through` on `source=inbox` and `source=bundled` |
| `scripts/check-zig-format.ps1`                         | pass (701 tracked sources)         |
| `scripts/check-source-format.ps1`                      | pass                               |
| `test/windows/flagship/Test-VerificationContracts.ps1` | PASS (2 scenarios)                 |
| `prettier@3 --check` on the changed Markdown           | pass                               |

Rebased on `main` at `c8fc5dcdb`. The interactive key-input certification harness was not run: this branch changes no key-encoding or input code.

Refs #223

Per AI_POLICY.md: prepared with AI assistance (Claude Code); every claim above was verified against the code and the gate output.
