### PR TITLE
release: prepare 1.3.126

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ compares it feature by feature with upstream Ghostty.
 
 You need Windows 10 version 1809 (build 17763) or newer, or Windows 11, on
 x64 or ARM64, and a GPU driver with OpenGL 4.3 or newer. Latest release:
-[noctty 1.3.125](https://github.com/amanthanvi/noctty/releases/tag/v1.3.125),
-published 2026-09-04.
+[noctty 1.3.126](https://github.com/amanthanvi/noctty/releases/tag/v1.3.126),
+published 2026-09-05.
 
 With Scoop (the WinGet package is pending bootstrap):
 
@@ -65,14 +65,14 @@ portable ZIPs run from any folder.
 
 | File                                                                                                                                                     | What it is      |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| [`noctty-1.3.125-windows-x64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-x64-setup.exe)           | x64 installer   |
-| [`noctty-1.3.125-windows-arm64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-arm64-setup.exe)       | ARM64 installer |
-| [`noctty-1.3.125-windows-x64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-x64-portable.zip)     | x64 portable    |
-| [`noctty-1.3.125-windows-arm64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.125/noctty-1.3.125-windows-arm64-portable.zip) | ARM64 portable  |
+| [`noctty-1.3.126-windows-x64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.126/noctty-1.3.126-windows-x64-setup.exe)           | x64 installer   |
+| [`noctty-1.3.126-windows-arm64-setup.exe`](https://github.com/amanthanvi/noctty/releases/download/v1.3.126/noctty-1.3.126-windows-arm64-setup.exe)       | ARM64 installer |
+| [`noctty-1.3.126-windows-x64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.126/noctty-1.3.126-windows-x64-portable.zip)     | x64 portable    |
+| [`noctty-1.3.126-windows-arm64-portable.zip`](https://github.com/amanthanvi/noctty/releases/download/v1.3.126/noctty-1.3.126-windows-arm64-portable.zip) | ARM64 portable  |
 
 Each release also ships signed manifests of the portable ZIP contents
-(`noctty-1.3.125-windows-x64-portable.manifest.ps1`,
-`noctty-1.3.125-windows-arm64-portable.manifest.ps1`) and checksums
+(`noctty-1.3.126-windows-x64-portable.manifest.ps1`,
+`noctty-1.3.126-windows-arm64-portable.manifest.ps1`) and checksums
 (`SHA256SUMS-windows-x64.txt`, `SHA256SUMS-windows-arm64.txt`, plus
 `SHA256SUMS.txt`, an x64 alias kept for older auto-update clients).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Then skip to [First launch](#first-launch).
 
 ## Install by hand
 
-The current stable release is `1.3.125`. Every release ships these files for
+The current stable release is `1.3.126`. Every release ships these files for
 `<arch>` = `x64` and `arm64`:
 
 | File                                                    | What it is                        |

--- a/site/index.html
+++ b/site/index.html
@@ -97,8 +97,8 @@
               Download for Windows
             </a>
             <span class="nc-hero__meta">
-              <span class="nc-sr-only" id="nc-version-summary">Version 1.3.125, latest release, for Windows 10 and 11 on x64 and ARM64, MIT licensed.</span>
-              <span aria-hidden="true"><span id="nc-version">v1.3.125</span>, Windows 10 and 11, x64 and ARM64</span>
+              <span class="nc-sr-only" id="nc-version-summary">Version 1.3.126, latest release, for Windows 10 and 11 on x64 and ARM64, MIT licensed.</span>
+              <span aria-hidden="true"><span id="nc-version">v1.3.126</span>, Windows 10 and 11, x64 and ARM64</span>
             </span>
           </div>
 
@@ -300,8 +300,8 @@ scoop install noctty/noctty</code></pre>
   </footer>
 
   <script type="module" src="app.js?v=98916ae44c47820a7a796236e272181592d780769a90b706acea8eeb8eead2d1"></script>
-  <script type="module" src="version.js?v=481a363baf804c085f821a3f280ea2a5c0c0b9bcc3d605c109b5d8b2c777cd22"></script>
+  <script type="module" src="version.js?v=430763f985a073a8b2692249b43a653a74f4c49ee1f5941428808bf8908733ab"></script>
   <script type="module" src="install.js?v=7d814eb53693cfdd38356f41fca1fbbe1111beccbae7eb87aa2f8c3e82527ca5"></script>
-  <script type="module" src="terminal.js?v=0ba273e5424e7118c5804122d90841b1287021d699d980c70212eb6c5f364746"></script>
+  <script type="module" src="terminal.js?v=0436cdd9175f9782182e860e7fe85aec5a73034400a641f3cba37d81d571ce9d"></script>
 </body>
 </html>

--- a/site/terminal.js
+++ b/site/terminal.js
@@ -29,7 +29,7 @@ export function observeElementVisibility(Observer, element, onChange) {
 const NC_REPO = 'amanthanvi/noctty';
 const PROMPT = 'PS C:\\Users\\dev>';
 
-let NC_VERSION = (typeof window !== 'undefined' && window.NC_VERSION) || '1.3.125';
+let NC_VERSION = (typeof window !== 'undefined' && window.NC_VERSION) || '1.3.126';
 
 export function buildScenes(v) {
   return [

--- a/site/version.js
+++ b/site/version.js
@@ -2,7 +2,7 @@
 // refreshes from GitHub Releases when the browser is idle. Never downgrades
 // below the compiled version.
 
-const DEFAULT_NC_VERSION = '1.3.125';
+const DEFAULT_NC_VERSION = '1.3.126';
 const NC_REPO = 'amanthanvi/noctty';
 const CACHE_KEY = 'nc-latest-release-v1';
 const CACHE_TTL_MS = 30 * 60 * 1000;

--- a/site/why-noctty.html
+++ b/site/why-noctty.html
@@ -359,6 +359,6 @@ pwsh .\scripts\verify-published-release.ps1 -Version $version</code></pre>
   </footer>
 
   <script type="module" src="/app.js?v=98916ae44c47820a7a796236e272181592d780769a90b706acea8eeb8eead2d1"></script>
-  <script type="module" src="/version.js?v=481a363baf804c085f821a3f280ea2a5c0c0b9bcc3d605c109b5d8b2c777cd22"></script>
+  <script type="module" src="/version.js?v=430763f985a073a8b2692249b43a653a74f4c49ee1f5941428808bf8908733ab"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Release copy 1.3.125 -> 1.3.126, published date 2026-09-05 UTC, generated by `scripts/update-release-copy.ps1` on main `a76021991`.
- No product code changes in this PR. It merges last, immediately before the `v1.3.126` tag.

## What 1.3.126 carries over 1.3.125

- #225: bounded post-show first-frame handshake for Win32 (Refs #224, the Windows 10 blank-window-until-keypress report).
- #226: ConPTY key-encoding transport probe and documentation (Refs #223).
- #222: promoted stable releases are marked latest.

## Validation

- `pwsh -NoProfile -File scripts/check-release-copy.ps1 -ExpectedVersion 1.3.126`: passed
- `pwsh -NoProfile -File scripts/check-site-copy.ps1`: passed
- `node --test "site/tests/**/*.test.mjs"`: 43 pass, 0 fail
- `node scripts/build-site-assets.mjs --check`: current
- `pwsh -NoProfile -File scripts/test-release-copy-date.ps1`: 5 cases passed
- `pwsh -NoProfile -File scripts/check-source-format.ps1`: passed
- `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1`: PASS (2 scenarios)

AI assistance: Claude ran the generation script and gates; the copy is script-generated and verified by the checks above.

## Summary by Sourcery

Prepare the 1.3.126 release by updating all documented and website-visible version references without changing product code.

Documentation:
- Update user-facing release references and download links to version 1.3.126, published September 5, 2026.

Chores:
- Refresh the website’s generated release metadata and cache-busting assets for version 1.3.126.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release references and installation instructions to version 1.3.126.
  * Refreshed download links, installer listings, portable archives, and signed manifest references.

* **Website**
  * Updated the displayed and default release version to 1.3.126.
  * Download links now point to the latest release.
  * Refreshed browser cache-busting references for updated site assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->