### PR TITLE
fix(bench): keep the adapter candidate list an array

### DIFF
--- a/test/windows/bench-windows.ps1
+++ b/test/windows/bench-windows.ps1
@@ -502,13 +502,16 @@ function Get-BenchWindowsTerminalCandidate {
 function Get-BenchTargetAdapter {
     param([Parameter(Mandatory)] [string] $Name)
 
-    $candidates = switch ($Name) {
+    # `switch` unrolls a single-element array into a scalar, and the noctty
+    # branch has exactly one candidate. Without @() around it, the fallback
+    # below indexes a string and resolves to its first character.
+    $candidates = @(switch ($Name) {
         'noctty' { @(Get-InteractiveWin11ExePath -RepoRoot $repoRoot) }
         'alacritty' { @('C:\Program Files\Alacritty\alacritty.exe') }
         'windows-terminal' { @((Get-BenchWindowsTerminalCandidate), 'wt.exe') }
         'tabby' { @('tabby.exe', (Join-Path $env:LOCALAPPDATA 'Programs\Tabby\Tabby.exe')) }
         'wave' { @('wave.exe', (Join-Path $env:LOCALAPPDATA 'Programs\Wave\Wave.exe')) }
-    }
+    })
     $resolved = $null
     foreach ($candidate in $candidates) {
         if ([string]::IsNullOrWhiteSpace($candidate)) { continue }


### PR DESCRIPTION
## Summary

- `Get-BenchTargetAdapter` builds its candidate list with `switch`. PowerShell unrolls a single-element array returned from a `switch` into a scalar, and the `noctty` branch has exactly one candidate, so `$candidates` is a **string** there.
- The not-found fallback then indexes it:

  ```powershell
  $resolved = [IO.Path]::GetFullPath($candidates[0])
  ```

  `"C:\...\noctty.exe"[0]` is `C`, which `GetFullPath` resolves against the current directory, so the run dies on a path that reads like a typo instead of on the missing exe it was trying to report:

  ```
  Missing noctty.exe at C:\...\<repo>\C
  ```

- Only the `noctty` branch is affected. Every other target lists two candidates and stays an array.
- Wrapping the `switch` in `@()` keeps it an array in every branch.

## When it surfaces

Only when `zig-out\bin\noctty.exe` does not exist yet, which is why an incremental checkout never hits it. A fresh worktree does: the first `-Target noctty` run resolves the adapter at line 1585, before `Invoke-InteractiveWin11Build` at line 1687 has produced the exe.

I hit this running `bench-windows.ps1 -Target noctty -Metric cold-start` in a newly created worktree.

## Validation

- [x] Reproduced the unrolling directly:

  ```
  $one = switch ("a") { "a" { @("C:\path\noctty.exe") } }
  # type=String    [0]=C
  $one = @(switch ("a") { "a" { @("C:\path\noctty.exe") } })
  # type=Object[]  [0]=C:\path\noctty.exe
  ```

- [x] `pwsh -NoProfile -File scripts/check-source-format.ps1` — `PowerShell syntax and JSON validity checks passed`, exit 0
- [x] `pwsh -NoProfile -File test/windows/flagship/Test-VerificationContracts.ps1` — `flagship verification contracts: PASS (2 scenarios)`, exit 0
- [x] `bench-windows.ps1 -Target noctty -Metric cold-start -Runs 5` completes on a fresh worktree after the change; before it, it failed on the mangled path

Windows 11 26200, Zig 0.15.2, `ReleaseFast`.

The format and contract checks above were run on a branch that also carries unrelated work in progress; this PR contains only the three-line change plus its comment.

## Risks / Follow-ups

- None known. The change is confined to one expression and every other branch already produced an array, so their behaviour is unchanged.

## AI assistance

Written with Claude Code. I understand the change, reproduced the underlying PowerShell behaviour myself, and can justify it without further assistance. Per `AI_POLICY.md`.

## Summary by Sourcery

Bug Fixes:
- Preserve the benchmark adapter candidate list as an array so missing `noctty.exe` errors report the correct path instead of indexing the path string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows benchmark target selection when only one candidate is available.
  - Ensured the complete executable path is preserved instead of being reduced to its first character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->