### PR TITLE
fix(win32): repaint chrome children that a relayout moved

### DIFF
--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -17802,7 +17802,7 @@ const Host = struct {
                 if (i >= tab_range.start and i < tab_range.start + tab_range.count) {
                     const visible_index: i32 = @intCast(i - tab_range.start);
                     const tab_left = visible_index * button_width;
-                    changed.* = applyChildRect(
+                    changed.* = applyChromeChildRect(
                         button_hwnd,
                         &tab.button_placement,
                         childRect(
@@ -17839,7 +17839,7 @@ const Host = struct {
         if (self.tab_container_hwnd) |container_hwnd| {
             const visible_tabs: i32 = @intCast(tab_range.count);
             if (visible_tabs > 0) {
-                changed.* = applyChildRect(
+                changed.* = applyChromeChildRect(
                     container_hwnd,
                     &self.tab_container_placement,
                     childRect(
@@ -17865,7 +17865,7 @@ const Host = struct {
             const inspector_offset: i32 = if (self.inspectorPanelVisible()) self.scaled(host_inspector_panel_height) else 0;
             const banner_y: i32 = self.tabBarHeight() + overlay_offset + inspector_offset + self.scaled(2);
             const banner_x = self.scaled(16);
-            changed.* = applyChildRect(
+            changed.* = applyChromeChildRect(
                 banner_hwnd,
                 &self.banner_placement,
                 childRect(
@@ -17887,7 +17887,7 @@ const Host = struct {
         if (self.overflow_hwnd) |button_hwnd| {
             const overflow_width = if (titlebar_actions) action_size else self.scaled(host_tab_overflow_button_width);
             button_x -= overflow_width;
-            changed.* = applyChildRect(
+            changed.* = applyChromeChildRect(
                 button_hwnd,
                 &self.overflow_placement,
                 childRect(
@@ -17903,7 +17903,7 @@ const Host = struct {
         if (self.new_tab_hwnd) |button_hwnd| {
             const new_tab_width = if (titlebar_actions) action_size else self.scaled(host_tab_small_button_width);
             button_x -= new_tab_width;
-            changed.* = applyChildRect(
+            changed.* = applyChromeChildRect(
                 button_hwnd,
                 &self.new_tab_placement,
                 childRect(
@@ -17949,13 +17949,13 @@ const Host = struct {
                 self.current_dpi,
             );
             const edit_rect = overlayEditChildRectFromFrame(edit_frame, self.scaled(8), self.scaled(6));
-            changed.* = applyChildRect(
+            changed.* = applyChromeChildRect(
                 edit_hwnd,
                 &self.overlay_edit_placement,
                 edit_rect,
             ) or changed.*;
             if (action_layout.accept_visible) {
-                changed.* = applyChildRect(
+                changed.* = applyChromeChildRect(
                     accept_hwnd,
                     &self.overlay_accept_placement,
                     childRect(
@@ -17978,7 +17978,7 @@ const Host = struct {
                 ) or changed.*;
             }
             if (action_layout.cancel_visible) {
-                changed.* = applyChildRect(
+                changed.* = applyChromeChildRect(
                     cancel_hwnd,
                     &self.overlay_cancel_placement,
                     childRect(
@@ -18045,7 +18045,7 @@ const Host = struct {
                         self.scaled(palette_row_height),
                         visible_rows * self.scaled(palette_row_height),
                     );
-                    changed.* = applyChildRect(
+                    changed.* = applyChromeChildRect(
                         list_hwnd,
                         &self.palette_list_placement,
                         paletteListRect(width, list_x, padding, list_y, list_height),
@@ -20209,6 +20209,37 @@ fn applyChildRect(hwnd: HWND, placement: *ChildPlacement, rect: RECT) bool {
     );
     placement.rect = rect;
     placement.rect_known = true;
+    return true;
+}
+
+/// `applyChildRect` for chrome children, which have to repaint themselves
+/// after a move.
+///
+/// `MoveWindow` runs with `bRepaint = FALSE` so a relayout never forces a
+/// paint of the terminal surfaces, and the host carries `WS_CLIPCHILDREN`, so
+/// the parent's own chrome-band repaint is clipped out of every child rect. A
+/// moved chrome child therefore keeps whatever pixels happened to be on screen
+/// at its new position -- the strip background, or the stale image of the
+/// button that used to sit there -- until something else invalidates it.
+///
+/// `Host.layout` covers the moves it makes itself via
+/// `invalidateChromeChildPaint`, but `Host.refreshChrome` and
+/// `Surface.refreshWindowTitle` also relayout the tab strip through
+/// `syncTabButtons` and invalidate only the parent. Whichever of them runs
+/// first after a tab is inserted does the move, and the placement cache then
+/// makes the miss permanent: the next `layout` sees no rect change and skips
+/// the child invalidation, so the button stays unpainted at its new slot while
+/// its old image survives underneath the neighbour that took its place.
+///
+/// Tying the invalidation to the move keeps correctness from depending on
+/// which caller happens to relayout the strip first. It costs one
+/// `InvalidateRect` per child that actually moved, so idle repaints are
+/// unaffected.
+fn applyChromeChildRect(hwnd: HWND, placement: *ChildPlacement, rect: RECT) bool {
+    if (!applyChildRect(hwnd, placement, rect)) return false;
+    // Chrome children are owner-drawn over their full client area, so the
+    // erase pass would only add a flash of background under the new paint.
+    _ = sys.InvalidateRect(hwnd, null, 0);
     return true;
 }
 
@@ -40018,6 +40049,68 @@ test "win32 searchBarGroupRect ignores hidden placements" {
         .right = 42,
         .bottom = 31,
     }, rect);
+}
+
+test "win32 chrome child placement invalidates a moved button" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // Off-screen so the fixture never flashes over the desktop. An update
+    // region is per-window bookkeeping, so it survives being off-screen.
+    const hinstance = sys.GetModuleHandleW(null);
+    const parent = sys.CreateWindowExW(
+        0,
+        prompt_label_class,
+        std.unicode.utf8ToUtf16LeStringLiteral(""),
+        c.WS_POPUP | c.WS_VISIBLE | c.WS_CLIPCHILDREN,
+        -4000,
+        -4000,
+        1280,
+        64,
+        null,
+        null,
+        hinstance,
+        null,
+    ) orelse return lastError();
+    defer _ = sys.DestroyWindow(parent);
+
+    const button = sys.CreateWindowExW(
+        0,
+        prompt_button_class,
+        std.unicode.utf8ToUtf16LeStringLiteral("2: tab"),
+        c.WS_CHILD | c.WS_VISIBLE | c.BS_OWNERDRAW,
+        0,
+        0,
+        220,
+        32,
+        parent,
+        null,
+        hinstance,
+        null,
+    ) orelse return lastError();
+    defer _ = sys.DestroyWindow(button);
+
+    var placement: ChildPlacement = .{};
+    _ = applyChromeChildRect(button, &placement, childRect(0, 0, 220, 32));
+
+    // Baseline: the plain helper moves with `bRepaint = FALSE` and leaves
+    // nothing to repaint. That is what the terminal surfaces want, and it is
+    // why a tab button shifted right by a mid-strip insert stayed unpainted
+    // at its new slot while its old image survived under its neighbour.
+    var update: RECT = undefined;
+    _ = sys.ValidateRect(button, null);
+    try std.testing.expect(applyChildRect(button, &placement, childRect(220, 0, 220, 32)));
+    try std.testing.expectEqual(@as(BOOL, 0), sys.GetUpdateRect(button, &update, 0));
+
+    // The chrome variant leaves the button invalidated wherever it lands.
+    _ = sys.ValidateRect(button, null);
+    try std.testing.expect(applyChromeChildRect(button, &placement, childRect(440, 0, 210, 32)));
+    try std.testing.expect(sys.GetUpdateRect(button, &update, 0) != 0);
+
+    // An unchanged rect stays a no-op, so a settled strip does not repaint on
+    // every chrome sync.
+    _ = sys.ValidateRect(button, null);
+    try std.testing.expect(!applyChromeChildRect(button, &placement, childRect(440, 0, 210, 32)));
+    try std.testing.expectEqual(@as(BOOL, 0), sys.GetUpdateRect(button, &update, 0));
 }
 
 test "win32 scrollbarProxyPointFromSurfaceCursor tracks the right-edge hover band" {

--- a/src/apprt/win32/sys.zig
+++ b/src/apprt/win32/sys.zig
@@ -322,6 +322,12 @@ pub extern "user32" fn MessageBeep(uType: UINT) callconv(.winapi) BOOL;
 
 pub extern "user32" fn InvalidateRect(hWnd: HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 
+// Update-region readback. Only the placement regression tests need this:
+// they assert that repositioning a chrome child leaves it invalidated.
+pub extern "user32" fn GetUpdateRect(hWnd: HWND, lpRect: ?*RECT, bErase: BOOL) callconv(.winapi) BOOL;
+
+pub extern "user32" fn ValidateRect(hWnd: HWND, lpRect: ?*const RECT) callconv(.winapi) BOOL;
+
 pub extern "user32" fn MoveWindow(hWnd: HWND, X: i32, Y: i32, nWidth: i32, nHeight: i32, bRepaint: BOOL) callconv(.winapi) BOOL;
 
 pub extern "user32" fn PeekMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT, wRemoveMsg: UINT) callconv(.winapi) BOOL;


### PR DESCRIPTION
## Summary

With `window-new-tab-position = current` (the default), opening a tab in the middle of the strip
leaves the tab it displaced unpainted, so the new tab looks like it is drawn on top of its
neighbour.

Repro on `main` (1.3.126):

1. Open a few tabs
2. Close them
3. Go back to the first tab
4. `ctrl+shift+t`

The tab that was second vanishes and the new tab appears exactly where its image was. Nothing is
actually lost: resizing the window (or minimize/restore) brings the tab back at the correct slot.
It is a missed repaint, not lost state.

**What the pixels show.** From a screen recording (1266 px client, 96 dpi, so `tab_area_width` is
~1052 px and `button_width = min(tab_area / tab_count, 220)`), the focused-tab underline is painted
by the host, not by a child, so it always reflects the current layout:

| tabs open | underline (left, width) | implied `button_width` | tab buttons actually painted |
| --- | --- | --- | --- |
| 5 | 841, 209 | 210 | 5 |
| 3 (right after the repro) | 221, 219 | 220 | 2 |
| 4 | 441, 219 | 220 | 3 |
| 5 | 631, 209 | 210 | 4 |

The last row is the giveaway: the underline says five tabs at a 210 px pitch, but only four buttons
are on screen, and that same frame contains buttons drawn on two incompatible grids — `0..219` and
`222..439` (220 px pitch) next to `422..629` and `632..839` (210 px pitch). One layout pass gives
every button the same width, so the 220 px pair cannot be where those windows are; they are leftover
pixels. The first tab's label is visibly double-struck for the same reason: it was repainted at a
new width over the old image.

**Root cause.** `applyChildRect` moves children with `MoveWindow(..., bRepaint = FALSE)`. That is
what the terminal surfaces want — `Host.layout` batches their repaints deliberately — but the host
carries `WS_CLIPCHILDREN`, so the parent's chrome-band repaint is clipped out of every child rect and
nobody paints a moved chrome child at its new position.

The only follow-up invalidation is in `Host.layout`, and only for the moves that same call made:

```zig
if (chrome_layout_changed or content_layout_changed) {
    self.repaintFullHost();
    const child_paint = layoutChildPaintPlan(chrome_layout_changed, content_layout_changed);
    if (child_paint.chrome) self.invalidateChromeChildPaint();
```

`Host.refreshChrome` and `Surface.refreshWindowTitle` also relayout the strip, through
`syncTabButtons` → `layoutChromeForRect`, but both invalidate only the parent
(`invalidateTopChromeText`). Whichever of the three runs first after a tab is inserted performs the
move, and the placement cache then makes the miss permanent: the next `layout` sees no rect change,
so `chrome_layout_changed` stays false and the child invalidation is skipped. The button stays
unpainted at its new slot while its old image survives under the neighbour that took its place.

This only bites on a mid-strip insert. While you keep opening tabs the active tab is the last one,
so `active_tab + 1` is the end and no existing button moves — which is why the repro needs the close
and the jump back to tab 1.

## Fix

`applyChromeChildRect` ties the invalidation to the move, and `layoutChromeForRect` uses it for the
chrome children (tab buttons, tab container, banner, `[+]` / `[▾]`, the overlay row, the palette
list):

```zig
fn applyChromeChildRect(hwnd: HWND, placement: *ChildPlacement, rect: RECT) bool {
    if (!applyChildRect(hwnd, placement, rect)) return false;
    _ = sys.InvalidateRect(hwnd, null, 0);
    return true;
}
```

Correctness no longer depends on which caller happens to relayout the strip first. An unchanged rect
is still a no-op, so a settled strip costs nothing and the idle-repaint work from #214 is unaffected.
The terminal surfaces keep the plain helper.

## Validation

- [x] Full suite `zig build test -Demit-test-exe=true` — 4347 passed, 78 skipped, 0 failed
- [x] `zig build test -Dtest-filter=ConPTY -Dtest-filter=invalidates` — 95 passed, 4 skipped (the new test)
- [x] `zig build test -Dtest-filter=ConPTY -Dtest-filter=tab -Dtest-filter=chrome -Dtest-filter=placement -Dtest-filter=layout` — 529 passed, 6 skipped
- [x] `zig build -Demit-exe=true -Doptimize=ReleaseSafe` — 75/75 steps succeeded, native MSVC
- [x] `zig fmt --check` on both touched files — clean

New test `win32 chrome child placement invalidates a moved button` creates an off-screen popup and an
owner-draw child and pins three things: the plain helper leaves nothing to repaint, the chrome variant
leaves the child invalidated wherever it lands, and an unchanged rect stays a no-op. I confirmed it
actually runs by temporarily inverting one assertion and watching it fail.

A note on the template's filter lines, since I hit it here: `zig build test -Dtest-filter=win32`
(same for `scroll` and `keybind`) builds a test binary containing **zero** tests on this tree. The
test root is `src/main.zig`, and only its own `test "ConPTY transport probe child dispatch only"`
pulls the app module graph in via `_ = entrypoint;`, so a filter that misses that test analyses
nothing and still reports `Build Summary: 41/41 steps succeeded` with exit 0. The tells are the
missing `N/M tests passed` on the summary line and a 1–4 s / 260 MB `compile test` step instead of
~45 s / 3 GB. Pairing any targeted filter with `-Dtest-filter=ConPTY` makes it run for real. Happy to
send a follow-up PR for `HACKING.md` and the PR template if that is useful.

Manual check on Windows 11 build 26200, integrated titlebar, ReleaseSafe, bundled ConPTY, WSL shell:

- Before: reproduced exactly as described above, including the double-struck label on the first tab.
- After: the displaced tab shifts right and stays painted, the new tab lands between the two, and no
  resize is needed to recover the strip.

## Risks / Follow-ups

- Behaviour changes only for chrome children whose rect actually changed, so this adds no repaints to
  an idle window.
- `Host.layout` still calls `invalidateChromeChildPaint()`. It is now redundant for rect changes but
  still covers visibility flips, so I left it alone to keep the diff to the defect.
- The search-bar child controls take the same `MoveWindow(..., bRepaint = FALSE)` path through
  `layoutSearchBarControls` and rely on `layout()`'s `invalidateVisibleSurfaceChildPaint`. That looks
  like the same shape of hazard, but I have no reproduction for it and did not want to widen an
  unverified fix — flagging it rather than changing it.
- Separately, `create_tab` appends to `window.tabs` in the shell reducer while the native side inserts
  at `active_tab + 1`, so the model and native tab orders diverge on every mid-strip insert (Debug
  `validateShellNativeMapping` would report `TabOrderMismatch`). Independent of this repaint bug; I
  can open a separate PR if you would like it fixed.

## AI assistance

Written with Claude Code. I understand the change, reproduced the fault and verified the fix on my
own daily-driver build, and can justify the design without asking the AI again. Per `AI_POLICY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Invalidate Win32 chrome children whenever relayout moves them so tab-strip controls remain correctly painted after mid-strip tab insertion.

Bug Fixes:
- Ensure moved Win32 chrome children repaint after tab-strip relayouts, preventing displaced tabs and other controls from remaining visually stale.

Enhancements:
- Keep repainting limited to chrome children whose placement actually changes, while preserving non-repainting moves for terminal surfaces.

Tests:
- Add a Windows regression test verifying moved chrome children are invalidated while unchanged placements remain a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows desktop rendering when repositioning Chrome child controls by ensuring moved owner-drawn controls are properly refreshed.
  * Preserved existing behavior for terminal surfaces and unchanged control positions.

* **Tests**
  * Added Windows-specific coverage for control invalidation after movement and no-op behavior when positions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->